### PR TITLE
fix: login page missing padding (#28)

### DIFF
--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -15,27 +15,23 @@
   --color-blue-light: #60A5FA;
 }
 
-*, *::before, *::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
+@layer base {
+  html {
+    font-size: 16px;
+  }
 
-html {
-  font-size: 16px;
-}
+  body {
+    min-height: 100vh;
+    background: var(--color-bg);
+    color: var(--color-text-primary);
+    font-family: var(--font-sans);
+    display: flex;
+    flex-direction: column;
+  }
 
-body {
-  min-height: 100vh;
-  background: var(--color-bg);
-  color: var(--color-text-primary);
-  font-family: var(--font-sans);
-  display: flex;
-  flex-direction: column;
+  /* ── Pixel-art scrollbar ── */
+  ::-webkit-scrollbar { width: 6px; }
+  ::-webkit-scrollbar-track { background: #0D1117; }
+  ::-webkit-scrollbar-thumb { background: rgba(59,130,246,0.3); border-radius: 3px; }
+  ::-webkit-scrollbar-thumb:hover { background: rgba(59,130,246,0.5); }
 }
-
-/* ── Pixel-art scrollbar ── */
-::-webkit-scrollbar { width: 6px; }
-::-webkit-scrollbar-track { background: #0D1117; }
-::-webkit-scrollbar-thumb { background: rgba(59,130,246,0.3); border-radius: 3px; }
-::-webkit-scrollbar-thumb:hover { background: rgba(59,130,246,0.5); }


### PR DESCRIPTION
## Problem

The login page had missing padding on several components:
- "Enter the Realm" text was clipped at the left edge
- Login buttons stretched edge-to-edge with no breathing room
- Right auth panel padding wasn't taking effect

## Root Cause

`globals.css` had an **un-layered universal CSS reset** (`*, *::before, *::after { padding: 0 }`) that appeared after `@import 'tailwindcss'`.

In Tailwind v4, utility classes live inside `@layer utilities`. Per CSS cascade rules, **un-layered styles always beat layered styles** regardless of specificity. So the reset's `padding: 0` silently overrode every Tailwind padding utility (`px-10`, `p-10`, `py-12`, etc.) across the entire site.

## Fix

- **Removed the duplicate universal reset** — Tailwind v4's Preflight already includes `box-sizing: border-box; margin: 0; padding: 0` inside `@layer base`
- **Moved** remaining `html`, `body`, and scrollbar styles into `@layer base` so they participate in the cascade correctly

## Changes

- `app/styles/globals.css` — 1 file changed

## Testing

- ✅ 75/75 tests passing
- ✅ Lint clean
- ✅ Typecheck clean  
- ✅ Build succeeds

Closes #28