### PR TITLE
hotfix: fix OAuth redirect broken after dev→main merge

### DIFF
--- a/app/routes/auth/$provider.tsx
+++ b/app/routes/auth/$provider.tsx
@@ -46,8 +46,12 @@ const initiateOAuth = createServerFn({ method: 'GET' })
         break
     }
 
-    // Use TanStack's redirect with href for external OAuth URLs
-    throw redirect({ href: url })
+    // Use a proper HTTP redirect Response for external OAuth URLs
+    // redirect({ href }) doesn't work in createServerFn handlers on Nitro/Vercel
+    throw new Response(null, {
+      status: 302,
+      headers: { Location: url },
+    })
   })
 
 export const Route = createFileRoute('/auth/$provider')({


### PR DESCRIPTION
## Emergency Hotfix

OAuth login (Google/GitHub) returns a 500 black screen on production after the dev→main merge.

### Root Cause

The dev branch had `throw redirect({ href: url })` for external OAuth redirects, but this doesn't work inside `createServerFn` handlers on Nitro/Vercel — it gets caught as an unhandled error instead of producing a 302 redirect.

Main previously had the correct fix (`throw new Response(null, { status: 302, headers: { Location: url } })`), but the dev→main merge in PR #81 overwrote it with dev's broken version.

### Fix

Replace `throw redirect({ href: url })` with `throw new Response(null, { status: 302, headers: { Location: url } })` in `app/routes/auth/$provider.tsx`.

### Verification
- ✅ 172 tests pass
- ✅ tsc + eslint clean