### PR TITLE
fix: inspector sidebar icons and width

### DIFF
--- a/app/components/mainview/ChatPanel.tsx
+++ b/app/components/mainview/ChatPanel.tsx
@@ -41,7 +41,7 @@ export function ChatPanel() {
   }
 
   return (
-    <div className="flex h-full flex-col bg-[#080A12]">
+    <div className="flex h-full w-full flex-col bg-[#080A12]">
       <div className="border-b border-white/[0.07] p-3">
         <label htmlFor="chat-session-selector" className="sr-only">
           Session selector
@@ -107,7 +107,7 @@ export function ChatPanel() {
           role="tabpanel"
           aria-labelledby={`${tabsId}-${channel.id}-tab`}
           hidden={channel.id !== activeChannel}
-          className="flex flex-1 items-center justify-center overflow-y-auto p-4"
+          className="flex flex-1 w-full items-center justify-center overflow-y-auto p-4"
         >
           <span className="font-pixel text-xs text-slate-500">Coming Soon</span>
         </div>

--- a/app/components/mainview/ComingSoonPanel.tsx
+++ b/app/components/mainview/ComingSoonPanel.tsx
@@ -5,12 +5,12 @@ export interface ComingSoonPanelProps {
 
 export function ComingSoonPanel({ title, testId }: ComingSoonPanelProps) {
   return (
-    <div data-testid={testId} className="flex h-full flex-col bg-[#080A12]">
+    <div data-testid={testId} className="flex h-full w-full flex-col bg-[#080A12]">
       <div className="border-b border-white/[0.07] px-4 py-3">
         <h2 className="font-pixel text-xs text-slate-300">{title}</h2>
       </div>
 
-      <div className="flex flex-1 items-center justify-center">
+      <div className="flex w-full flex-1 items-center justify-center">
         <span className="font-pixel text-xs text-slate-500">Coming Soon</span>
       </div>
     </div>

--- a/app/components/mainview/InspectorSidebar.tsx
+++ b/app/components/mainview/InspectorSidebar.tsx
@@ -1,4 +1,7 @@
 import React, { useState, useRef } from 'react'
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core'
+import { faBook, faGear, faMessage, faNoteSticky } from '@fortawesome/pro-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { ChatPanel } from './ChatPanel'
 import { NotepadPanel } from './NotepadPanel'
 import { SettingsPanel } from './SettingsPanel'
@@ -10,11 +13,11 @@ export interface InspectorSidebarProps {
   defaultTab?: InspectorTab
 }
 
-const tabs: { id: InspectorTab; icon: string; label: string }[] = [
-  { id: 'chat', icon: '💬', label: 'Chat' },
-  { id: 'wiki', icon: '📚', label: 'Wiki' },
-  { id: 'notepad', icon: '📝', label: 'Notepad' },
-  { id: 'settings', icon: '⚙️', label: 'Settings' },
+const tabs: { id: InspectorTab; icon: IconDefinition; label: string }[] = [
+  { id: 'chat', icon: faMessage, label: 'Chat' },
+  { id: 'wiki', icon: faBook, label: 'Wiki' },
+  { id: 'notepad', icon: faNoteSticky, label: 'Notepad' },
+  { id: 'settings', icon: faGear, label: 'Settings' },
 ]
 
 function tabId(id: InspectorTab) {
@@ -85,7 +88,7 @@ export function InspectorSidebar({ defaultTab = 'chat' }: InspectorSidebarProps)
                   : 'text-slate-500 hover:text-slate-300',
               ].join(' ')}
             >
-              {tab.icon}
+              <FontAwesomeIcon icon={tab.icon} className="h-4 w-4" />
             </button>
           )
         })}
@@ -102,7 +105,7 @@ export function InspectorSidebar({ defaultTab = 'chat' }: InspectorSidebarProps)
             role="tabpanel"
             aria-labelledby={tabId(tab.id)}
             hidden={!isActive}
-            className="flex flex-1"
+            className="flex w-full flex-1"
           >
             {tab.id === 'chat' ? (
               <ChatPanel />

--- a/app/components/mainview/WikiPanel.tsx
+++ b/app/components/mainview/WikiPanel.tsx
@@ -54,7 +54,7 @@ export function WikiPanel() {
   const [selectedCategory, setSelectedCategory] = useState<WikiCategoryId | null>(null)
 
   return (
-    <div className="h-full flex flex-col bg-[#080A12]">
+    <div className="flex h-full w-full flex-col bg-[#080A12]">
       <div className={selectedCategory ? 'max-h-72 shrink-0 overflow-y-auto' : 'flex-1 overflow-y-auto'}>
         {WIKI_CATEGORIES.map((category, index) => {
           const Icon = category.icon
@@ -86,7 +86,7 @@ export function WikiPanel() {
       </div>
 
       {selectedCategory ? (
-        <div className="flex flex-1 flex-col border-t border-white/[0.07]">
+        <div className="flex w-full flex-1 flex-col border-t border-white/[0.07]">
           <button
             type="button"
             aria-label="Back"
@@ -97,7 +97,7 @@ export function WikiPanel() {
             <span>Back</span>
           </button>
 
-          <div className="flex flex-1 items-center justify-center p-4">
+          <div className="flex w-full flex-1 items-center justify-center p-4">
             <span className="font-pixel text-xs text-slate-500">
               {WIKI_CATEGORIES.find(category => category.id === selectedCategory)?.label} - Coming
               {' '}Soon


### PR DESCRIPTION
## Summary
- replace InspectorSidebar emoji tab icons with Font Awesome icons
- make inspector panels fill the sidebar width to eliminate background bleed
- update shared coming soon panel width behavior for notepad and settings

## Verification
- npm run lint
- npm run build
- npm run test:ci

## Risks / Follow-ups
- lint still reports one unrelated pre-existing warning in app/components/campaign/ExternalLinkList.tsx for an unused parameter
- build and tests emit pre-existing package and CSS warnings, but both complete successfully

Closes #256