### PR TITLE
feat: redesign campaign timeline widget

### DIFF
--- a/app/components/mainview/widgets/CampaignTimelineWidget.stories.tsx
+++ b/app/components/mainview/widgets/CampaignTimelineWidget.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof CampaignTimelineWidget> = {
   decorators: [
     (Story) => (
       <div className="min-h-screen bg-[#080A12] p-6">
-        <div className="max-w-md">
+        <div className="max-w-6xl">
           <Story />
         </div>
       </div>

--- a/app/components/mainview/widgets/CampaignTimelineWidget.tsx
+++ b/app/components/mainview/widgets/CampaignTimelineWidget.tsx
@@ -8,6 +8,8 @@ import {
 export type { TimelineEvent }
 
 export interface CampaignTimelineWidgetProps {
+  // Timeline events are provided most-recent first; we render oldest -> newest
+  // so the horizontal rail reads naturally from left to right.
   events?: ReadonlyArray<Readonly<TimelineEvent>>
   className?: string
 }
@@ -16,6 +18,11 @@ function getEventTone(event: TimelineEvent) {
   if (event.isCurrent) return 'current'
   if (event.importance === 'major') return 'major'
   return 'normal'
+}
+
+function toDisplayOrder(events: ReadonlyArray<TimelineEvent>) {
+  // Mock/service data is most-recent first; reverse it so the rail reads left-to-right.
+  return [...events].reverse()
 }
 
 export function CampaignTimelineWidget({
@@ -56,7 +63,7 @@ export function CampaignTimelineWidget({
     }
   }, [events])
 
-  const displayEvents = resolvedEvents ? [...resolvedEvents].reverse() : []
+  const displayEvents = resolvedEvents ? toDisplayOrder(resolvedEvents) : []
 
   return (
     <Widget title="Campaign Timeline" className={className}>
@@ -76,6 +83,8 @@ export function CampaignTimelineWidget({
         <div
           data-testid="timeline-scroll"
           className="relative overflow-x-auto overflow-y-hidden pb-2"
+          tabIndex={0}
+          aria-label="Campaign timeline, horizontally scrollable events"
         >
           <div className="relative min-w-[760px] pt-8">
             <div

--- a/app/components/mainview/widgets/CampaignTimelineWidget.tsx
+++ b/app/components/mainview/widgets/CampaignTimelineWidget.tsx
@@ -99,7 +99,7 @@ export function CampaignTimelineWidget({
                 const isMajor = tone === 'major'
 
                 const dotClasses = isCurrent
-                  ? 'h-4 w-4 bg-primary ring-[12px] ring-primary/10 animate-pulse'
+                  ? 'h-4 w-4 bg-primary ring-[12px] ring-primary/10 animate-pulse motion-reduce:animate-none'
                   : isMajor
                     ? 'h-4 w-4 bg-blue-light ring-8 ring-blue-light/10'
                     : 'h-3 w-3 bg-slate-500 ring-4 ring-white/[0.05]'

--- a/app/components/mainview/widgets/CampaignTimelineWidget.tsx
+++ b/app/components/mainview/widgets/CampaignTimelineWidget.tsx
@@ -12,6 +12,12 @@ export interface CampaignTimelineWidgetProps {
   className?: string
 }
 
+function getEventTone(event: TimelineEvent) {
+  if (event.isCurrent) return 'current'
+  if (event.importance === 'major') return 'major'
+  return 'normal'
+}
+
 export function CampaignTimelineWidget({
   events,
   className = '',
@@ -50,6 +56,8 @@ export function CampaignTimelineWidget({
     }
   }, [events])
 
+  const displayEvents = resolvedEvents ? [...resolvedEvents].reverse() : []
+
   return (
     <Widget title="Campaign Timeline" className={className}>
       {resolvedEvents === null ? (
@@ -67,28 +75,82 @@ export function CampaignTimelineWidget({
       ) : (
         <div
           data-testid="timeline-scroll"
-          className="relative max-h-[500px] overflow-y-auto pr-1"
+          className="relative overflow-x-auto overflow-y-hidden pb-2"
         >
-          <div
-            aria-hidden="true"
-            className="absolute bottom-0 left-[5px] top-0 border-l border-white/[0.07]"
-          />
+          <div className="relative min-w-[760px] pt-8">
+            <div
+              aria-hidden="true"
+              className="absolute left-4 right-4 top-4 h-px bg-white/[0.08]"
+            />
 
-          <div className="space-y-4">
-            {resolvedEvents.map((event) => (
-              <article key={event.id} className="relative pl-7">
-                <div
-                  aria-hidden="true"
-                  className="absolute left-[0px] top-1 h-3 w-3 rounded-full bg-[#2563EB]"
-                />
+            <ol className="grid grid-flow-col auto-cols-[minmax(10.5rem,1fr)] gap-4">
+              {displayEvents.map((event) => {
+                const tone = getEventTone(event)
+                const isCurrent = tone === 'current'
+                const isMajor = tone === 'major'
 
-                <p className="font-pixel text-xs text-slate-500">{event.calendarDate}</p>
-                <h3 className="mt-1 font-pixel text-xs text-white">{event.sessionName}</h3>
-                <p className="mt-1 font-pixel text-xs leading-relaxed text-slate-400">
-                  {event.summary}
-                </p>
-              </article>
-            ))}
+                const dotClasses = isCurrent
+                  ? 'h-4 w-4 bg-[#85adff] ring-[12px] ring-[#85adff]/10 animate-pulse'
+                  : isMajor
+                    ? 'h-4 w-4 bg-tertiary ring-8 ring-tertiary/10'
+                    : 'h-3 w-3 bg-slate-500 ring-4 ring-white/[0.05]'
+
+                const dateClasses = isCurrent
+                  ? 'text-[#85adff]'
+                  : isMajor
+                    ? 'text-tertiary'
+                    : 'text-slate-500'
+
+                const titleClasses = isCurrent
+                  ? 'text-white'
+                  : isMajor
+                    ? 'text-slate-100'
+                    : 'text-slate-500'
+
+                const labelClasses = isCurrent
+                  ? 'text-[#85adff]'
+                  : isMajor
+                    ? 'text-tertiary'
+                    : 'text-slate-600'
+
+                return (
+                  <li
+                    key={event.id}
+                    data-tone={tone}
+                    className="relative min-h-[11rem] px-1 pt-4 text-center"
+                  >
+                    <span
+                      aria-hidden="true"
+                      className={`absolute left-1/2 top-4 z-10 -translate-x-1/2 -translate-y-1/2 rounded-full ${dotClasses}`}
+                    />
+
+                    <div className="flex h-full flex-col items-center justify-start">
+                      <p className={`font-pixel text-[0.6rem] tracking-[0.16em] ${dateClasses}`}>
+                        {event.calendarDate}
+                      </p>
+
+                      <h3
+                        className={`mt-2 max-w-[9rem] font-pixel text-xs font-bold uppercase leading-tight ${titleClasses}`}
+                      >
+                        {event.sessionName}
+                      </h3>
+
+                      {isCurrent ? (
+                        <p className={`mt-2 font-pixel text-[0.5rem] font-bold tracking-[0.18em] ${labelClasses}`}>
+                          CURRENT SESSION
+                        </p>
+                      ) : isMajor ? (
+                        <p className={`mt-2 font-pixel text-[0.5rem] font-bold tracking-[0.18em] ${labelClasses}`}>
+                          MAJOR EVENT
+                        </p>
+                      ) : null}
+
+                      <p className="sr-only">{event.summary}</p>
+                    </div>
+                  </li>
+                )
+              })}
+            </ol>
           </div>
         </div>
       )}

--- a/app/components/mainview/widgets/CampaignTimelineWidget.tsx
+++ b/app/components/mainview/widgets/CampaignTimelineWidget.tsx
@@ -90,28 +90,34 @@ export function CampaignTimelineWidget({
                 const isMajor = tone === 'major'
 
                 const dotClasses = isCurrent
-                  ? 'h-4 w-4 bg-[#85adff] ring-[12px] ring-[#85adff]/10 animate-pulse'
+                  ? 'h-4 w-4 bg-primary ring-[12px] ring-primary/10 animate-pulse'
                   : isMajor
-                    ? 'h-4 w-4 bg-tertiary ring-8 ring-tertiary/10'
+                    ? 'h-4 w-4 bg-blue-light ring-8 ring-blue-light/10'
                     : 'h-3 w-3 bg-slate-500 ring-4 ring-white/[0.05]'
 
                 const dateClasses = isCurrent
-                  ? 'text-[#85adff]'
+                  ? 'text-primary'
                   : isMajor
-                    ? 'text-tertiary'
+                    ? 'text-blue-light'
                     : 'text-slate-500'
 
                 const titleClasses = isCurrent
                   ? 'text-white'
                   : isMajor
-                    ? 'text-slate-100'
+                    ? 'text-blue-light'
                     : 'text-slate-500'
 
                 const labelClasses = isCurrent
-                  ? 'text-[#85adff]'
+                  ? 'text-primary'
                   : isMajor
-                    ? 'text-tertiary'
+                    ? 'text-blue-light'
                     : 'text-slate-600'
+
+                const summaryClasses = isCurrent
+                  ? 'text-slate-300'
+                  : isMajor
+                    ? 'text-slate-300'
+                    : 'text-slate-400'
 
                 return (
                   <li
@@ -145,7 +151,12 @@ export function CampaignTimelineWidget({
                         </p>
                       ) : null}
 
-                      <p className="sr-only">{event.summary}</p>
+                      <p
+                        className={`mt-2 max-w-[9rem] text-[0.58rem] leading-relaxed line-clamp-3 ${summaryClasses}`}
+                        title={event.summary}
+                      >
+                        {event.summary}
+                      </p>
                     </div>
                   </li>
                 )

--- a/app/services/mocks/timelineService.ts
+++ b/app/services/mocks/timelineService.ts
@@ -8,6 +8,7 @@ export const mockTimelineEvents: ReadonlyArray<Readonly<TimelineEvent>> = Object
     calendarDate: '2nd of Frostmark, Year 3',
     sessionName: 'The Bell Beneath the Chapel',
     summary: 'A hidden reliquary opened under Emberfall Chapel when the black bell tolled at dawn.',
+    isCurrent: true,
   }),
   Object.freeze({
     id: 'timeline-1',
@@ -26,6 +27,7 @@ export const mockTimelineEvents: ReadonlyArray<Readonly<TimelineEvent>> = Object
     calendarDate: '11th of Longshade, Year 2',
     sessionName: 'A Crown of Hollow Iron',
     summary: 'Parley with the barrow knights collapsed when the false heir claimed the iron circlet.',
+    importance: 'major',
   }),
   Object.freeze({
     id: 'timeline-5',

--- a/app/services/mocks/types.ts
+++ b/app/services/mocks/types.ts
@@ -32,7 +32,7 @@ export interface TimelineEvent {
   calendarDate: string
   sessionName: string
   summary: string
-  importance?: 'normal' | 'major'
+  importance?: 'major'
   isCurrent?: boolean
 }
 

--- a/app/services/mocks/types.ts
+++ b/app/services/mocks/types.ts
@@ -32,6 +32,8 @@ export interface TimelineEvent {
   calendarDate: string
   sessionName: string
   summary: string
+  importance?: 'normal' | 'major'
+  isCurrent?: boolean
 }
 
 export interface RecentlyUpdatedItem {
@@ -41,4 +43,3 @@ export interface RecentlyUpdatedItem {
   updatedAt: string
   summary: string
 }
-

--- a/tests/components/mainview/widgets/CampaignTimelineWidget.test.tsx
+++ b/tests/components/mainview/widgets/CampaignTimelineWidget.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { describe, expect, it } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import { CampaignTimelineWidget, type TimelineEvent } from '~/components/mainview/widgets/CampaignTimelineWidget'
+import { CampaignTimelineWidget } from '~/components/mainview/widgets/CampaignTimelineWidget'
+import type { TimelineEvent } from '~/services/mocks/types'
 import { getTimelineEvents } from '~/services/mocks/timelineService'
 
 const mockEvents: ReadonlyArray<Readonly<TimelineEvent>> = [
@@ -69,6 +70,11 @@ describe('CampaignTimelineWidget', () => {
     const scroll = screen.getByTestId('timeline-scroll')
     expect(scroll).toHaveClass('overflow-x-auto')
     expect(scroll).toHaveClass('overflow-y-hidden')
+    expect(scroll).toHaveAttribute('tabindex', '0')
+    expect(scroll).toHaveAttribute(
+      'aria-label',
+      'Campaign timeline, horizontally scrollable events',
+    )
 
     expect(scroll.querySelector('ol')).toHaveClass('grid-flow-col')
     expect(scroll.querySelector('[data-tone="current"]')).toHaveTextContent(

--- a/tests/components/mainview/widgets/CampaignTimelineWidget.test.tsx
+++ b/tests/components/mainview/widgets/CampaignTimelineWidget.test.tsx
@@ -1,21 +1,29 @@
 import React from 'react'
 import { describe, expect, it } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import { CampaignTimelineWidget } from '~/components/mainview/widgets/CampaignTimelineWidget'
+import { CampaignTimelineWidget, type TimelineEvent } from '~/components/mainview/widgets/CampaignTimelineWidget'
 import { getTimelineEvents } from '~/services/mocks/timelineService'
 
-const mockEvents = [
+const mockEvents: ReadonlyArray<Readonly<TimelineEvent>> = [
   {
-    id: 'timeline-1',
-    calendarDate: '14th of Ashfall, Year 3',
-    sessionName: 'Ashes at Emberfall',
-    summary: 'The party sealed the kiln gate and bound the cinder spirit.',
-  },
-  {
-    id: 'timeline-2',
+    id: 'timeline-3',
     calendarDate: '2nd of Frostmark, Year 3',
     sessionName: 'The Bell Beneath the Chapel',
     summary: 'A reliquary opened beneath the chapel after the second toll.',
+    isCurrent: true,
+  },
+  {
+    id: 'timeline-2',
+    calendarDate: '14th of Ashfall, Year 3',
+    sessionName: 'Ashes at Emberfall',
+    summary: 'The party sealed the kiln gate and bound the cinder spirit.',
+    importance: 'major',
+  },
+  {
+    id: 'timeline-1',
+    calendarDate: '27th of Hearthwane, Year 2',
+    sessionName: 'Smoke Over Glassmere',
+    summary: 'Raiders from the reed marsh torched the market while the wizard tracked a stolen wardstone.',
   },
 ]
 
@@ -35,15 +43,14 @@ describe('CampaignTimelineWidget', () => {
     }
   })
 
-  it('renders summaries', () => {
-    render(<CampaignTimelineWidget events={mockEvents} />)
+  it('renders current and major emphasis states', () => {
+    const { container } = render(<CampaignTimelineWidget events={mockEvents} />)
 
-    expect(
-      screen.getByText('The party sealed the kiln gate and bound the cinder spirit.')
-    ).toBeInTheDocument()
-    expect(
-      screen.getByText('A reliquary opened beneath the chapel after the second toll.')
-    ).toBeInTheDocument()
+    expect(screen.getByText('CURRENT SESSION')).toBeInTheDocument()
+    expect(screen.getByText('MAJOR EVENT')).toBeInTheDocument()
+
+    expect(container.querySelector('[data-tone="current"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-tone="major"]')).toBeInTheDocument()
   })
 
   it('shows the empty state when there are no events', () => {
@@ -52,12 +59,14 @@ describe('CampaignTimelineWidget', () => {
     expect(screen.getByText('No timeline events')).toBeInTheDocument()
   })
 
-  it('renders a scrollable container', () => {
+  it('renders a horizontal scrollable container', () => {
     render(<CampaignTimelineWidget events={mockEvents} />)
 
     const scroll = screen.getByTestId('timeline-scroll')
-    expect(scroll).toHaveClass('max-h-[500px]')
-    expect(scroll).toHaveClass('overflow-y-auto')
+    expect(scroll).toHaveClass('overflow-x-auto')
+    expect(scroll).toHaveClass('overflow-y-hidden')
+
+    expect(scroll.querySelector('ol')).toHaveClass('grid-flow-col')
   })
 
   it('mock service returns defensive copies (new array and new objects)', async () => {

--- a/tests/components/mainview/widgets/CampaignTimelineWidget.test.tsx
+++ b/tests/components/mainview/widgets/CampaignTimelineWidget.test.tsx
@@ -45,9 +45,13 @@ describe('CampaignTimelineWidget', () => {
 
   it('renders current and major emphasis states', () => {
     const { container } = render(<CampaignTimelineWidget events={mockEvents} />)
+    const currentSummary = 'A reliquary opened beneath the chapel after the second toll.'
+    const majorSummary = 'The party sealed the kiln gate and bound the cinder spirit.'
 
     expect(screen.getByText('CURRENT SESSION')).toBeInTheDocument()
     expect(screen.getByText('MAJOR EVENT')).toBeInTheDocument()
+    expect(screen.getByTitle(currentSummary)).toBeInTheDocument()
+    expect(screen.getByTitle(majorSummary)).toBeInTheDocument()
 
     expect(container.querySelector('[data-tone="current"]')).toBeInTheDocument()
     expect(container.querySelector('[data-tone="major"]')).toBeInTheDocument()
@@ -67,6 +71,9 @@ describe('CampaignTimelineWidget', () => {
     expect(scroll).toHaveClass('overflow-y-hidden')
 
     expect(scroll.querySelector('ol')).toHaveClass('grid-flow-col')
+    expect(scroll.querySelector('[data-tone="current"]')).toHaveTextContent(
+      'A reliquary opened beneath the chapel after the second toll.',
+    )
   })
 
   it('mock service returns defensive copies (new array and new objects)', async () => {

--- a/tests/components/mainview/widgets/CatchUpWidget.test.tsx
+++ b/tests/components/mainview/widgets/CatchUpWidget.test.tsx
@@ -36,8 +36,8 @@ describe('CatchUpWidget', () => {
     const markdownDiv = screen.getByTestId('catchup-markdown')
     expect(markdownDiv).toBeInTheDocument()
     expect(markdownDiv).toHaveClass('w-full')
-    expect(markdownDiv).toHaveClass('max-w-none')
-    expect(markdownDiv).not.toHaveClass('max-w-3xl')
+    // Ensure no Tailwind max-w-* utilities are applied (full-width layout regression guard)
+    expect(markdownDiv.className).not.toMatch(/\bmax-w-\S*/)
     expect(screen.getByText(/Where We Left Off/)).toBeInTheDocument()
   })
 

--- a/tests/components/mainview/widgets/CatchUpWidget.test.tsx
+++ b/tests/components/mainview/widgets/CatchUpWidget.test.tsx
@@ -36,8 +36,8 @@ describe('CatchUpWidget', () => {
     const markdownDiv = screen.getByTestId('catchup-markdown')
     expect(markdownDiv).toBeInTheDocument()
     expect(markdownDiv).toHaveClass('w-full')
-    // Ensure no Tailwind max-w-* utilities are applied (full-width layout regression guard)
-    expect(markdownDiv.className).not.toMatch(/\bmax-w-\S*/)
+    expect(markdownDiv).toHaveClass('max-w-none')
+    expect(markdownDiv).not.toHaveClass('max-w-3xl')
     expect(screen.getByText(/Where We Left Off/)).toBeInTheDocument()
   })
 


### PR DESCRIPTION
## Summary
- redesign `CampaignTimelineWidget` into a horizontal campaign timeline that matches the provided mockup more closely
- add current and major event emphasis states so the timeline reads like the epic rail in the reference
- keep the implementation in React and preserve the repo's existing styling system

## Verification
- `npm run lint`
- `npm run build`
- `npm run test:ci`

## Risks / Follow-ups
- the repo still has pre-existing warnings in `app/components/campaign/ExternalLinkList.tsx` and in package/CSS build output
- if the timeline data model changes later, the current/major emphasis flags may need to be revisited

Closes #266