### PR TITLE
Fix warning cleanup issues

### DIFF
--- a/app/components/campaign/ExternalLinkList.tsx
+++ b/app/components/campaign/ExternalLinkList.tsx
@@ -16,7 +16,7 @@ export function ExternalLinkList({ links }: ExternalLinkListProps) {
     <div>
       <div className="text-[10px] font-pixel text-slate-500 tracking-wide mb-2">LINKS</div>
       <div className="flex flex-col gap-1">
-        {renderableLinks.map((link, i) => (
+        {renderableLinks.map((link) => (
           <ExternalLinkItem key={`${link.name}:${link.url}`} name={link.name} url={link.url} />
         ))}
       </div>

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -1,6 +1,6 @@
-@import "tailwindcss";
 @import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Inter:wght@300;400;500;600;700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined&display=swap');
+@import "tailwindcss";
 
 @theme {
   --font-pixel: 'Press Start 2P', monospace;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/s3-request-presigner": "^3.1014.0",
         "@fortawesome/fontawesome-svg-core": "6.7.2",
         "@fortawesome/pro-solid-svg-icons": "file:./vendor/pro-solid-svg-icons",
-        "@fortawesome/react-fontawesome": "0.2.2",
+        "@fortawesome/react-fontawesome": "^3.1.1",
         "@posthog/react": "^1.8.2",
         "@tanstack/react-query": "^5.95.2",
         "@tanstack/react-router": "^1.168.3",
@@ -2002,17 +2002,16 @@
       "link": true
     },
     "node_modules/@fortawesome/react-fontawesome": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
-      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
-      "deprecated": "v0.2.x is no longer supported. Unless you are still using FontAwesome 5, please update to v3.1.1 or greater.",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.3.0.tgz",
+      "integrity": "sha512-EHmHeTf8WgO29sdY3iX/7ekE3gNUdlc2RW6mm/FzELlHFKfTrA9S4MlyquRR+RRCRCn8+jXfLFpLGB2l7wCWyw==",
       "license": "MIT",
-      "dependencies": {
-        "prop-types": "^15.8.1"
+      "engines": {
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
-        "react": ">=16.3"
+        "@fortawesome/fontawesome-svg-core": "~6 || ~7",
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -9671,6 +9670,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -11039,6 +11039,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11639,6 +11640,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -11650,6 +11652,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/property-information": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@aws-sdk/s3-request-presigner": "^3.1014.0",
     "@fortawesome/fontawesome-svg-core": "6.7.2",
     "@fortawesome/pro-solid-svg-icons": "file:./vendor/pro-solid-svg-icons",
-    "@fortawesome/react-fontawesome": "0.2.2",
+    "@fortawesome/react-fontawesome": "^3.1.1",
     "@posthog/react": "^1.8.2",
     "@tanstack/react-query": "^5.95.2",
     "@tanstack/react-router": "^1.168.3",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1014.0",
     "@aws-sdk/s3-request-presigner": "^3.1014.0",
-    "@fortawesome/fontawesome-svg-core": "^7.2.0",
+    "@fortawesome/fontawesome-svg-core": "6.7.2",
     "@fortawesome/pro-solid-svg-icons": "file:./vendor/pro-solid-svg-icons",
-    "@fortawesome/react-fontawesome": "^3.3.0",
+    "@fortawesome/react-fontawesome": "0.2.2",
     "@posthog/react": "^1.8.2",
     "@tanstack/react-query": "^5.95.2",
     "@tanstack/react-router": "^1.168.3",
@@ -46,10 +46,7 @@
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
     "vite": "^7.3.1",
-    "zod": "^3.24.1",
-    "@fortawesome/pro-solid-svg-icons": "file:./vendor/pro-solid-svg-icons",
-    "@fortawesome/react-fontawesome": "0.2.2",
-    "@fortawesome/fontawesome-svg-core": "6.7.2"
+    "zod": "^3.24.1"
   },
   "overrides": {
     "h3-v2": "npm:h3@2.0.1-rc.19"


### PR DESCRIPTION
Cleanup repo-originated warning noise so lint, build, and tests run cleanly.

Validation:
- npm run lint
- npm run build
- npm run test:ci

Closes #269