### PR TITLE
Fix campaign timeline responsive layout

### DIFF
--- a/app/components/mainview/widgets/CampaignTimelineWidget.tsx
+++ b/app/components/mainview/widgets/CampaignTimelineWidget.tsx
@@ -20,6 +20,25 @@ function getEventTone(event: TimelineEvent) {
   return 'normal'
 }
 
+function getToneClasses(tone: ReturnType<typeof getEventTone>) {
+  const isCurrent = tone === 'current'
+  const isMajor = tone === 'major'
+
+  return {
+    isCurrent,
+    isMajor,
+    dotClasses: isCurrent
+      ? 'h-4 w-4 bg-primary ring-[12px] ring-primary/10 animate-pulse motion-reduce:animate-none'
+      : isMajor
+        ? 'h-4 w-4 bg-blue-light ring-8 ring-blue-light/10'
+        : 'h-3 w-3 bg-slate-500 ring-4 ring-white/[0.05]',
+    dateClasses: isCurrent ? 'text-primary' : isMajor ? 'text-blue-light' : 'text-slate-500',
+    titleClasses: isCurrent ? 'text-white' : isMajor ? 'text-blue-light' : 'text-slate-500',
+    labelClasses: isCurrent ? 'text-primary' : isMajor ? 'text-blue-light' : 'text-slate-600',
+    summaryClasses: isCurrent || isMajor ? 'text-slate-300' : 'text-slate-400',
+  }
+}
+
 function toDisplayOrder(events: ReadonlyArray<TimelineEvent>) {
   // Mock/service data is most-recent first; reverse it so the rail reads left-to-right.
   return [...events].reverse()
@@ -81,93 +100,73 @@ export function CampaignTimelineWidget({
         </div>
       ) : (
         <>
-          <ol
+          <div
+            className="relative md:hidden"
             data-testid="timeline-vertical"
-            className="relative flex flex-col gap-6 pl-8 md:hidden"
           >
             <div
               aria-hidden="true"
+              data-part="timeline-rail"
               className="absolute bottom-2 left-[0.6875rem] top-2 w-px bg-white/[0.08]"
             />
 
-            {displayEvents.map((event) => {
-              const tone = getEventTone(event)
-              const isCurrent = tone === 'current'
-              const isMajor = tone === 'major'
+            <ol className="relative flex flex-col gap-6 pl-8">
+              {displayEvents.map((event) => {
+                const tone = getEventTone(event)
+                const {
+                  isCurrent,
+                  isMajor,
+                  dotClasses,
+                  dateClasses,
+                  titleClasses,
+                  labelClasses,
+                  summaryClasses,
+                } = getToneClasses(tone)
 
-              const dotClasses = isCurrent
-                ? 'h-4 w-4 bg-primary ring-[12px] ring-primary/10 animate-pulse motion-reduce:animate-none'
-                : isMajor
-                  ? 'h-4 w-4 bg-blue-light ring-8 ring-blue-light/10'
-                  : 'h-3 w-3 bg-slate-500 ring-4 ring-white/[0.05]'
-
-              const dateClasses = isCurrent
-                ? 'text-primary'
-                : isMajor
-                  ? 'text-blue-light'
-                  : 'text-slate-500'
-
-              const titleClasses = isCurrent
-                ? 'text-white'
-                : isMajor
-                  ? 'text-blue-light'
-                  : 'text-slate-500'
-
-              const labelClasses = isCurrent
-                ? 'text-primary'
-                : isMajor
-                  ? 'text-blue-light'
-                  : 'text-slate-600'
-
-              const summaryClasses = isCurrent
-                ? 'text-slate-300'
-                : isMajor
-                  ? 'text-slate-300'
-                  : 'text-slate-400'
-
-              return (
-                <li
-                  key={event.id}
-                  data-layout="vertical"
-                  data-tone={tone}
-                  className="relative pl-4 text-left"
-                >
-                  <span
-                    aria-hidden="true"
-                    data-part="timeline-marker"
-                    className={`absolute left-0 top-1.5 z-10 -translate-x-1/2 rounded-full ${dotClasses}`}
-                  />
-
-                  <p className={`font-pixel text-[0.6rem] tracking-[0.16em] ${dateClasses}`}>
-                    {event.calendarDate}
-                  </p>
-
-                  <h3
-                    className={`mt-2 max-w-[13rem] font-pixel text-xs font-bold uppercase leading-tight ${titleClasses}`}
+                return (
+                  <li
+                    key={event.id}
+                    data-layout="vertical"
+                    data-tone={tone}
+                    className="relative pl-4 text-left"
                   >
-                    {event.sessionName}
-                  </h3>
+                    <span
+                      aria-hidden="true"
+                      data-part="timeline-marker"
+                      className={`absolute left-0 top-1.5 z-10 -translate-x-1/2 rounded-full ${dotClasses}`}
+                    />
 
-                  {isCurrent ? (
-                    <p className={`mt-2 font-pixel text-[0.5rem] font-bold tracking-[0.18em] ${labelClasses}`}>
-                      CURRENT SESSION
+                    <p className={`font-pixel text-[0.6rem] tracking-[0.16em] ${dateClasses}`}>
+                      {event.calendarDate}
                     </p>
-                  ) : isMajor ? (
-                    <p className={`mt-2 font-pixel text-[0.5rem] font-bold tracking-[0.18em] ${labelClasses}`}>
-                      MAJOR EVENT
-                    </p>
-                  ) : null}
 
-                  <p
-                    className={`mt-2 max-w-[15rem] text-[0.58rem] leading-relaxed ${summaryClasses}`}
-                    title={event.summary}
-                  >
-                    {event.summary}
-                  </p>
-                </li>
-              )
-            })}
-          </ol>
+                    <h3
+                      className={`mt-2 max-w-[13rem] font-pixel text-xs font-bold uppercase leading-tight ${titleClasses}`}
+                    >
+                      {event.sessionName}
+                    </h3>
+
+                    {isCurrent ? (
+                      <p className={`mt-2 font-pixel text-[0.5rem] font-bold tracking-[0.18em] ${labelClasses}`}>
+                        CURRENT SESSION
+                      </p>
+                    ) : isMajor ? (
+                      <p className={`mt-2 font-pixel text-[0.5rem] font-bold tracking-[0.18em] ${labelClasses}`}>
+                        MAJOR EVENT
+                      </p>
+                    ) : null}
+
+                    <p
+                      className={`mt-2 max-w-[15rem] text-[0.58rem] leading-relaxed ${summaryClasses}`}
+                      title={event.summary}
+                    >
+                      {event.summary}
+                    </p>
+                  </li>
+                )
+              })}
+            </ol>
+          </div>
 
           <div
             data-testid="timeline-scroll"
@@ -179,44 +178,21 @@ export function CampaignTimelineWidget({
               <div
                 aria-hidden="true"
                 data-part="timeline-rail"
-                className="absolute left-4 right-4 top-[3.5rem] h-px bg-white/[0.08]"
+                className="absolute left-4 right-4 top-[3.5rem] z-0 h-px bg-white/[0.08]"
               />
 
               <ol className="grid grid-flow-col auto-cols-[minmax(10.5rem,1fr)] gap-4">
                 {displayEvents.map((event) => {
                   const tone = getEventTone(event)
-                  const isCurrent = tone === 'current'
-                  const isMajor = tone === 'major'
-
-                  const dotClasses = isCurrent
-                    ? 'h-4 w-4 bg-primary ring-[12px] ring-primary/10 animate-pulse motion-reduce:animate-none'
-                    : isMajor
-                      ? 'h-4 w-4 bg-blue-light ring-8 ring-blue-light/10'
-                      : 'h-3 w-3 bg-slate-500 ring-4 ring-white/[0.05]'
-
-                  const dateClasses = isCurrent
-                    ? 'text-primary'
-                    : isMajor
-                      ? 'text-blue-light'
-                      : 'text-slate-500'
-
-                  const titleClasses = isCurrent
-                    ? 'text-white'
-                    : isMajor
-                      ? 'text-blue-light'
-                      : 'text-slate-500'
-
-                  const labelClasses = isCurrent
-                    ? 'text-primary'
-                    : isMajor
-                      ? 'text-blue-light'
-                      : 'text-slate-600'
-
-                  const summaryClasses = isCurrent
-                    ? 'text-slate-300'
-                    : isMajor
-                      ? 'text-slate-300'
-                      : 'text-slate-400'
+                  const {
+                    isCurrent,
+                    isMajor,
+                    dotClasses,
+                    dateClasses,
+                    titleClasses,
+                    labelClasses,
+                    summaryClasses,
+                  } = getToneClasses(tone)
 
                   return (
                     <li
@@ -231,7 +207,7 @@ export function CampaignTimelineWidget({
                         </p>
                       </div>
 
-                      <div className="relative flex items-center justify-center">
+                      <div className="relative z-10 flex items-center justify-center">
                         <span
                           aria-hidden="true"
                           data-part="timeline-marker"

--- a/app/components/mainview/widgets/CampaignTimelineWidget.tsx
+++ b/app/components/mainview/widgets/CampaignTimelineWidget.tsx
@@ -80,99 +80,196 @@ export function CampaignTimelineWidget({
           <p className="font-pixel text-xs text-slate-500">No timeline events</p>
         </div>
       ) : (
-        <div
-          data-testid="timeline-scroll"
-          className="relative overflow-x-auto overflow-y-hidden pb-2"
-          tabIndex={0}
-          aria-label="Campaign timeline, horizontally scrollable events"
-        >
-          <div className="relative min-w-[760px] pt-8">
+        <>
+          <ol
+            data-testid="timeline-vertical"
+            className="relative flex flex-col gap-6 pl-8 md:hidden"
+          >
             <div
               aria-hidden="true"
-              className="absolute left-4 right-4 top-4 h-px bg-white/[0.08]"
+              className="absolute bottom-2 left-[0.6875rem] top-2 w-px bg-white/[0.08]"
             />
 
-            <ol className="grid grid-flow-col auto-cols-[minmax(10.5rem,1fr)] gap-4">
-              {displayEvents.map((event) => {
-                const tone = getEventTone(event)
-                const isCurrent = tone === 'current'
-                const isMajor = tone === 'major'
+            {displayEvents.map((event) => {
+              const tone = getEventTone(event)
+              const isCurrent = tone === 'current'
+              const isMajor = tone === 'major'
 
-                const dotClasses = isCurrent
-                  ? 'h-4 w-4 bg-primary ring-[12px] ring-primary/10 animate-pulse motion-reduce:animate-none'
-                  : isMajor
-                    ? 'h-4 w-4 bg-blue-light ring-8 ring-blue-light/10'
-                    : 'h-3 w-3 bg-slate-500 ring-4 ring-white/[0.05]'
+              const dotClasses = isCurrent
+                ? 'h-4 w-4 bg-primary ring-[12px] ring-primary/10 animate-pulse motion-reduce:animate-none'
+                : isMajor
+                  ? 'h-4 w-4 bg-blue-light ring-8 ring-blue-light/10'
+                  : 'h-3 w-3 bg-slate-500 ring-4 ring-white/[0.05]'
 
-                const dateClasses = isCurrent
-                  ? 'text-primary'
-                  : isMajor
-                    ? 'text-blue-light'
-                    : 'text-slate-500'
+              const dateClasses = isCurrent
+                ? 'text-primary'
+                : isMajor
+                  ? 'text-blue-light'
+                  : 'text-slate-500'
 
-                const titleClasses = isCurrent
-                  ? 'text-white'
-                  : isMajor
-                    ? 'text-blue-light'
-                    : 'text-slate-500'
+              const titleClasses = isCurrent
+                ? 'text-white'
+                : isMajor
+                  ? 'text-blue-light'
+                  : 'text-slate-500'
 
-                const labelClasses = isCurrent
-                  ? 'text-primary'
-                  : isMajor
-                    ? 'text-blue-light'
-                    : 'text-slate-600'
+              const labelClasses = isCurrent
+                ? 'text-primary'
+                : isMajor
+                  ? 'text-blue-light'
+                  : 'text-slate-600'
 
-                const summaryClasses = isCurrent
+              const summaryClasses = isCurrent
+                ? 'text-slate-300'
+                : isMajor
                   ? 'text-slate-300'
-                  : isMajor
-                    ? 'text-slate-300'
-                    : 'text-slate-400'
+                  : 'text-slate-400'
 
-                return (
-                  <li
-                    key={event.id}
-                    data-tone={tone}
-                    className="relative min-h-[11rem] px-1 pt-4 text-center"
+              return (
+                <li
+                  key={event.id}
+                  data-layout="vertical"
+                  data-tone={tone}
+                  className="relative pl-4 text-left"
+                >
+                  <span
+                    aria-hidden="true"
+                    data-part="timeline-marker"
+                    className={`absolute left-0 top-1.5 z-10 -translate-x-1/2 rounded-full ${dotClasses}`}
+                  />
+
+                  <p className={`font-pixel text-[0.6rem] tracking-[0.16em] ${dateClasses}`}>
+                    {event.calendarDate}
+                  </p>
+
+                  <h3
+                    className={`mt-2 max-w-[13rem] font-pixel text-xs font-bold uppercase leading-tight ${titleClasses}`}
                   >
-                    <span
-                      aria-hidden="true"
-                      className={`absolute left-1/2 top-4 z-10 -translate-x-1/2 -translate-y-1/2 rounded-full ${dotClasses}`}
-                    />
+                    {event.sessionName}
+                  </h3>
 
-                    <div className="flex h-full flex-col items-center justify-start">
-                      <p className={`font-pixel text-[0.6rem] tracking-[0.16em] ${dateClasses}`}>
-                        {event.calendarDate}
-                      </p>
+                  {isCurrent ? (
+                    <p className={`mt-2 font-pixel text-[0.5rem] font-bold tracking-[0.18em] ${labelClasses}`}>
+                      CURRENT SESSION
+                    </p>
+                  ) : isMajor ? (
+                    <p className={`mt-2 font-pixel text-[0.5rem] font-bold tracking-[0.18em] ${labelClasses}`}>
+                      MAJOR EVENT
+                    </p>
+                  ) : null}
 
-                      <h3
-                        className={`mt-2 max-w-[9rem] font-pixel text-xs font-bold uppercase leading-tight ${titleClasses}`}
-                      >
-                        {event.sessionName}
-                      </h3>
+                  <p
+                    className={`mt-2 max-w-[15rem] text-[0.58rem] leading-relaxed ${summaryClasses}`}
+                    title={event.summary}
+                  >
+                    {event.summary}
+                  </p>
+                </li>
+              )
+            })}
+          </ol>
 
-                      {isCurrent ? (
-                        <p className={`mt-2 font-pixel text-[0.5rem] font-bold tracking-[0.18em] ${labelClasses}`}>
-                          CURRENT SESSION
+          <div
+            data-testid="timeline-scroll"
+            className="relative hidden overflow-x-auto overflow-y-hidden pb-2 md:block"
+            tabIndex={0}
+            aria-label="Campaign timeline, horizontally scrollable events"
+          >
+            <div className="relative min-w-[760px] px-4 pt-2">
+              <div
+                aria-hidden="true"
+                data-part="timeline-rail"
+                className="absolute left-4 right-4 top-[3.5rem] h-px bg-white/[0.08]"
+              />
+
+              <ol className="grid grid-flow-col auto-cols-[minmax(10.5rem,1fr)] gap-4">
+                {displayEvents.map((event) => {
+                  const tone = getEventTone(event)
+                  const isCurrent = tone === 'current'
+                  const isMajor = tone === 'major'
+
+                  const dotClasses = isCurrent
+                    ? 'h-4 w-4 bg-primary ring-[12px] ring-primary/10 animate-pulse motion-reduce:animate-none'
+                    : isMajor
+                      ? 'h-4 w-4 bg-blue-light ring-8 ring-blue-light/10'
+                      : 'h-3 w-3 bg-slate-500 ring-4 ring-white/[0.05]'
+
+                  const dateClasses = isCurrent
+                    ? 'text-primary'
+                    : isMajor
+                      ? 'text-blue-light'
+                      : 'text-slate-500'
+
+                  const titleClasses = isCurrent
+                    ? 'text-white'
+                    : isMajor
+                      ? 'text-blue-light'
+                      : 'text-slate-500'
+
+                  const labelClasses = isCurrent
+                    ? 'text-primary'
+                    : isMajor
+                      ? 'text-blue-light'
+                      : 'text-slate-600'
+
+                  const summaryClasses = isCurrent
+                    ? 'text-slate-300'
+                    : isMajor
+                      ? 'text-slate-300'
+                      : 'text-slate-400'
+
+                  return (
+                    <li
+                      key={event.id}
+                      data-layout="horizontal"
+                      data-tone={tone}
+                      className="grid min-h-[12rem] grid-rows-[2.5rem_2rem_1fr] px-1 text-center"
+                    >
+                      <div className="flex items-end justify-center pb-3">
+                        <p className={`font-pixel text-[0.6rem] tracking-[0.16em] ${dateClasses}`}>
+                          {event.calendarDate}
                         </p>
-                      ) : isMajor ? (
-                        <p className={`mt-2 font-pixel text-[0.5rem] font-bold tracking-[0.18em] ${labelClasses}`}>
-                          MAJOR EVENT
-                        </p>
-                      ) : null}
+                      </div>
 
-                      <p
-                        className={`mt-2 max-w-[9rem] text-[0.58rem] leading-relaxed line-clamp-3 ${summaryClasses}`}
-                        title={event.summary}
-                      >
-                        {event.summary}
-                      </p>
-                    </div>
-                  </li>
-                )
-              })}
-            </ol>
+                      <div className="relative flex items-center justify-center">
+                        <span
+                          aria-hidden="true"
+                          data-part="timeline-marker"
+                          className={`rounded-full ${dotClasses}`}
+                        />
+                      </div>
+
+                      <div className="flex flex-col items-center justify-start pt-3">
+                        <h3
+                          className={`max-w-[9rem] font-pixel text-xs font-bold uppercase leading-tight ${titleClasses}`}
+                        >
+                          {event.sessionName}
+                        </h3>
+
+                        {isCurrent ? (
+                          <p className={`mt-2 font-pixel text-[0.5rem] font-bold tracking-[0.18em] ${labelClasses}`}>
+                            CURRENT SESSION
+                          </p>
+                        ) : isMajor ? (
+                          <p className={`mt-2 font-pixel text-[0.5rem] font-bold tracking-[0.18em] ${labelClasses}`}>
+                            MAJOR EVENT
+                          </p>
+                        ) : null}
+
+                        <p
+                          className={`mt-2 max-w-[9rem] text-[0.58rem] leading-relaxed line-clamp-3 ${summaryClasses}`}
+                          title={event.summary}
+                        >
+                          {event.summary}
+                        </p>
+                      </div>
+                    </li>
+                  )
+                })}
+              </ol>
+            </div>
           </div>
-        </div>
+        </>
       )}
     </Widget>
   )

--- a/tests/components/mainview/widgets/CampaignTimelineWidget.test.tsx
+++ b/tests/components/mainview/widgets/CampaignTimelineWidget.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { describe, expect, it } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import { CampaignTimelineWidget } from '~/components/mainview/widgets/CampaignTimelineWidget'
 import type { TimelineEvent } from '~/services/mocks/types'
 import { getTimelineEvents } from '~/services/mocks/timelineService'
@@ -37,10 +37,14 @@ describe('CampaignTimelineWidget', () => {
 
   it('renders all event dates and session names', () => {
     render(<CampaignTimelineWidget events={mockEvents} />)
+    const scroll = screen.getByTestId('timeline-scroll')
+    const verticalTimeline = screen.getByTestId('timeline-vertical')
 
     for (const event of mockEvents) {
-      expect(screen.getAllByText(event.calendarDate)).toHaveLength(2)
-      expect(screen.getAllByText(event.sessionName)).toHaveLength(2)
+      expect(within(scroll).getByText(event.calendarDate)).toBeInTheDocument()
+      expect(within(verticalTimeline).getByText(event.calendarDate)).toBeInTheDocument()
+      expect(within(scroll).getByText(event.sessionName)).toBeInTheDocument()
+      expect(within(verticalTimeline).getByText(event.sessionName)).toBeInTheDocument()
     }
   })
 
@@ -48,11 +52,17 @@ describe('CampaignTimelineWidget', () => {
     const { container } = render(<CampaignTimelineWidget events={mockEvents} />)
     const currentSummary = 'A reliquary opened beneath the chapel after the second toll.'
     const majorSummary = 'The party sealed the kiln gate and bound the cinder spirit.'
+    const scroll = screen.getByTestId('timeline-scroll')
+    const verticalTimeline = screen.getByTestId('timeline-vertical')
 
-    expect(screen.getAllByText('CURRENT SESSION')).toHaveLength(2)
-    expect(screen.getAllByText('MAJOR EVENT')).toHaveLength(2)
-    expect(screen.getAllByTitle(currentSummary)).toHaveLength(2)
-    expect(screen.getAllByTitle(majorSummary)).toHaveLength(2)
+    expect(within(scroll).getByText('CURRENT SESSION')).toBeInTheDocument()
+    expect(within(verticalTimeline).getByText('CURRENT SESSION')).toBeInTheDocument()
+    expect(within(scroll).getByText('MAJOR EVENT')).toBeInTheDocument()
+    expect(within(verticalTimeline).getByText('MAJOR EVENT')).toBeInTheDocument()
+    expect(within(scroll).getByTitle(currentSummary)).toBeInTheDocument()
+    expect(within(verticalTimeline).getByTitle(currentSummary)).toBeInTheDocument()
+    expect(within(scroll).getByTitle(majorSummary)).toBeInTheDocument()
+    expect(within(verticalTimeline).getByTitle(majorSummary)).toBeInTheDocument()
 
     expect(container.querySelector('[data-tone="current"]')).toBeInTheDocument()
     expect(container.querySelector('[data-tone="major"]')).toBeInTheDocument()
@@ -93,13 +103,15 @@ describe('CampaignTimelineWidget', () => {
     render(<CampaignTimelineWidget events={mockEvents} />)
 
     const verticalTimeline = screen.getByTestId('timeline-vertical')
-    expect(verticalTimeline).toHaveClass('flex-col')
+    expect(verticalTimeline).toHaveClass('md:hidden')
+    expect(within(verticalTimeline).getByRole('list')).toHaveClass('flex-col')
     expect(verticalTimeline.querySelectorAll('[data-layout="vertical"]')).toHaveLength(
       mockEvents.length,
     )
     expect(verticalTimeline.querySelector('[data-tone="major"]')).toHaveTextContent(
       'The party sealed the kiln gate and bound the cinder spirit.',
     )
+    expect(verticalTimeline.querySelector('[data-part="timeline-rail"]')).toBeInTheDocument()
   })
 
   it('mock service returns defensive copies (new array and new objects)', async () => {

--- a/tests/components/mainview/widgets/CampaignTimelineWidget.test.tsx
+++ b/tests/components/mainview/widgets/CampaignTimelineWidget.test.tsx
@@ -39,8 +39,8 @@ describe('CampaignTimelineWidget', () => {
     render(<CampaignTimelineWidget events={mockEvents} />)
 
     for (const event of mockEvents) {
-      expect(screen.getByText(event.calendarDate)).toBeInTheDocument()
-      expect(screen.getByText(event.sessionName)).toBeInTheDocument()
+      expect(screen.getAllByText(event.calendarDate)).toHaveLength(2)
+      expect(screen.getAllByText(event.sessionName)).toHaveLength(2)
     }
   })
 
@@ -49,10 +49,10 @@ describe('CampaignTimelineWidget', () => {
     const currentSummary = 'A reliquary opened beneath the chapel after the second toll.'
     const majorSummary = 'The party sealed the kiln gate and bound the cinder spirit.'
 
-    expect(screen.getByText('CURRENT SESSION')).toBeInTheDocument()
-    expect(screen.getByText('MAJOR EVENT')).toBeInTheDocument()
-    expect(screen.getByTitle(currentSummary)).toBeInTheDocument()
-    expect(screen.getByTitle(majorSummary)).toBeInTheDocument()
+    expect(screen.getAllByText('CURRENT SESSION')).toHaveLength(2)
+    expect(screen.getAllByText('MAJOR EVENT')).toHaveLength(2)
+    expect(screen.getAllByTitle(currentSummary)).toHaveLength(2)
+    expect(screen.getAllByTitle(majorSummary)).toHaveLength(2)
 
     expect(container.querySelector('[data-tone="current"]')).toBeInTheDocument()
     expect(container.querySelector('[data-tone="major"]')).toBeInTheDocument()
@@ -68,17 +68,37 @@ describe('CampaignTimelineWidget', () => {
     render(<CampaignTimelineWidget events={mockEvents} />)
 
     const scroll = screen.getByTestId('timeline-scroll')
+    const verticalTimeline = screen.getByTestId('timeline-vertical')
     expect(scroll).toHaveClass('overflow-x-auto')
     expect(scroll).toHaveClass('overflow-y-hidden')
+    expect(scroll).toHaveClass('md:block')
     expect(scroll).toHaveAttribute('tabindex', '0')
     expect(scroll).toHaveAttribute(
       'aria-label',
       'Campaign timeline, horizontally scrollable events',
     )
+    expect(verticalTimeline).toHaveClass('md:hidden')
 
     expect(scroll.querySelector('ol')).toHaveClass('grid-flow-col')
-    expect(scroll.querySelector('[data-tone="current"]')).toHaveTextContent(
+    expect(scroll.querySelector('[data-layout="horizontal"][data-tone="current"]')).toHaveTextContent(
       'A reliquary opened beneath the chapel after the second toll.',
+    )
+    expect(scroll.querySelector('[data-part="timeline-rail"]')).toBeInTheDocument()
+    expect(scroll.querySelectorAll('[data-layout="horizontal"] [data-part="timeline-marker"]')).toHaveLength(
+      mockEvents.length,
+    )
+  })
+
+  it('renders a dedicated vertical mobile timeline', () => {
+    render(<CampaignTimelineWidget events={mockEvents} />)
+
+    const verticalTimeline = screen.getByTestId('timeline-vertical')
+    expect(verticalTimeline).toHaveClass('flex-col')
+    expect(verticalTimeline.querySelectorAll('[data-layout="vertical"]')).toHaveLength(
+      mockEvents.length,
+    )
+    expect(verticalTimeline.querySelector('[data-tone="major"]')).toHaveTextContent(
+      'The party sealed the kiln gate and bound the cinder spirit.',
     )
   })
 


### PR DESCRIPTION
## Summary
- replace the single brittle timeline layout with dedicated mobile and desktop timeline presentations
- keep desktop as a horizontal rail with markers centered on the line and move mobile to a readable vertical timeline
- expand the widget tests to cover both responsive layouts and the rail/marker structure

## Verification
- `npm run lint`
- `npm run build`
- `npm run test:ci`

## Risks / Follow-ups
- the mobile and desktop variants both stay mounted in the DOM and are toggled by responsive utility classes, so future tests should continue to scope assertions when checking unique text
- visual polish against the original mockup should still be spot-checked in Storybook or the app if tighter spacing feedback comes in

Closes #271