### PR TITLE
Add PostHog feature flag support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ NODE_ENV=development
 # Database
 MONGODB_URI=
 
-# PostHog analytics
+# PostHog analytics and feature flags
 VITE_PUBLIC_POSTHOG_KEY=
 VITE_PUBLIC_POSTHOG_HOST=https://app.posthog.com
 POSTHOG_KEY=

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm run dev            # http://localhost:3000
 - **Session Scheduling** — Weekly/bi-weekly/monthly with timezone support
 - **Image Uploads** — Campaign images stored on Cloudflare R2
 - **Access Control** — GM and player roles with owner-only actions
-- **Product Analytics** — PostHog integration for usage insights
+- **Product Analytics & Feature Flags** — PostHog integration for usage insights and progressive feature rollouts
 
 ## Tech Stack
 
@@ -78,6 +78,33 @@ npm test               # Run tests
 npm run test:watch     # TDD watch mode
 npm run test:coverage  # Coverage report
 ```
+
+## Feature Flags
+
+Client-side feature flags are available through [`app/utils/featureFlags.tsx`](app/utils/featureFlags.tsx), which wraps PostHog's React hooks with a small app-level API:
+
+```tsx
+import { FeatureFlagGate, useFeatureFlag } from '~/utils/featureFlags'
+
+function ExperimentalPanel() {
+  const { isEnabled, isLoading, payload } = useFeatureFlag('experimental-panel')
+
+  if (isLoading) return null
+  if (!isEnabled) return null
+
+  return <section>{JSON.stringify(payload)}</section>
+}
+
+function Page() {
+  return (
+    <FeatureFlagGate flag="experimental-panel" fallback={null}>
+      <ExperimentalPanel />
+    </FeatureFlagGate>
+  )
+}
+```
+
+Set `VITE_PUBLIC_POSTHOG_KEY` locally or in Vercel for client-side flag evaluation. User identification is synchronized through the shared PostHog provider so person-targeted flags refresh after sign-in/sign-out.
 
 ## Component Library
 

--- a/app/providers/PostHogProvider.tsx
+++ b/app/providers/PostHogProvider.tsx
@@ -1,9 +1,8 @@
-import { PostHogProvider as ReactPostHogProvider } from '@posthog/react'
-import posthog from 'posthog-js'
-import { useEffect, useRef, type ReactNode } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { useRouter } from '@tanstack/react-router'
 import { useAuthContext } from './AuthProvider'
 import {
+  getPostHogInstance,
   setPostHogInstance,
   isPostHogReady,
   capturePageView,
@@ -12,30 +11,67 @@ import {
 // Re-export capture helpers so existing imports from PostHogProvider still work
 export { captureException, captureEvent, capturePageView } from '~/utils/posthog-client'
 
-function PostHogInit() {
+type PostHogClient = typeof import('posthog-js').default
+type PostHogProviderComponent = typeof import('@posthog/react').PostHogProvider
+
+export function PostHogProvider({ children }: { children: ReactNode }) {
   const { user } = useAuthContext()
   const router = useRouter()
   const unsubRef = useRef<(() => void) | null>(null)
+  const [client, setClient] = useState<PostHogClient | null>(() =>
+    typeof window === 'undefined' ? null : getPostHogInstance()
+  )
+  const [ProviderComponent, setProviderComponent] = useState<PostHogProviderComponent | null>(null)
 
-  // Initialize PostHog client-side only
   useEffect(() => {
     const key = import.meta.env.VITE_PUBLIC_POSTHOG_KEY
     const host = import.meta.env.VITE_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com'
+    let cancelled = false
 
-    if (!key || isPostHogReady() || typeof window === 'undefined') return
+    if (typeof window === 'undefined') return
 
-    posthog.init(key, {
-      api_host: host,
-      capture_pageview: false, // we capture manually on navigation
-      persistence: 'localStorage+cookie',
-      capture_exceptions: true,
+    void import('@posthog/react').then(({ PostHogProvider: PostHogReactProvider }) => {
+      if (!cancelled) setProviderComponent(() => PostHogReactProvider)
     })
-    setPostHogInstance(posthog)
 
-    // Capture initial pageview
-    capturePageView(window.location.href)
+    if (isPostHogReady()) {
+      const existingClient = getPostHogInstance()
 
-    // Subscribe to route changes for manual pageview tracking
+      if (existingClient) setClient(existingClient)
+
+      return () => {
+        cancelled = true
+      }
+    }
+
+    if (!key) {
+      return () => {
+        cancelled = true
+      }
+    }
+
+    void import('posthog-js').then(({ default: posthog }) => {
+      if (cancelled) return
+
+      posthog.init(key, {
+        api_host: host,
+        capture_pageview: false, // we capture manually on navigation
+        persistence: 'localStorage+cookie',
+        capture_exceptions: true,
+      })
+      setPostHogInstance(posthog)
+      setClient(posthog)
+      capturePageView(window.location.href)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!client) return
+
     unsubRef.current = router.subscribe('onResolved', (event) => {
       capturePageView(window.location.origin + event.toLocation.href)
     })
@@ -44,34 +80,28 @@ function PostHogInit() {
       unsubRef.current?.()
       unsubRef.current = null
     }
-  }, [router])
+  }, [client, router])
 
-  // Identify/reset on auth changes
   useEffect(() => {
-    if (!isPostHogReady()) return
+    if (!client || !isPostHogReady()) return
 
     if (user) {
-      posthog.identify(user.id, {
+      client.identify(user.id, {
         name: user.name,
         email: user.email,
         provider: user.provider,
         role: user.role,
       })
-      posthog.reloadFeatureFlags()
+      client.reloadFeatureFlags()
     } else {
-      posthog.reset()
-      posthog.reloadFeatureFlags()
+      client.reset()
+      client.reloadFeatureFlags()
     }
-  }, [user])
+  }, [client, user])
 
-  return null
-}
+  if (client && ProviderComponent) {
+    return <ProviderComponent client={client}>{children}</ProviderComponent>
+  }
 
-export function PostHogProvider({ children }: { children: ReactNode }) {
-  return (
-    <ReactPostHogProvider client={posthog}>
-      <PostHogInit />
-      {children}
-    </ReactPostHogProvider>
-  )
+  return <>{children}</>
 }

--- a/app/providers/PostHogProvider.tsx
+++ b/app/providers/PostHogProvider.tsx
@@ -1,10 +1,11 @@
+import { PostHogProvider as ReactPostHogProvider } from '@posthog/react'
+import posthog from 'posthog-js'
 import { useEffect, useRef, type ReactNode } from 'react'
 import { useRouter } from '@tanstack/react-router'
 import { useAuthContext } from './AuthProvider'
 import {
   setPostHogInstance,
   isPostHogReady,
-  getPostHogInstance,
   capturePageView,
 } from '~/utils/posthog-client'
 
@@ -15,7 +16,6 @@ function PostHogInit() {
   const { user } = useAuthContext()
   const router = useRouter()
   const unsubRef = useRef<(() => void) | null>(null)
-  const cancelledRef = useRef(false)
 
   // Initialize PostHog client-side only
   useEffect(() => {
@@ -24,31 +24,23 @@ function PostHogInit() {
 
     if (!key || isPostHogReady() || typeof window === 'undefined') return
 
-    cancelledRef.current = false
+    posthog.init(key, {
+      api_host: host,
+      capture_pageview: false, // we capture manually on navigation
+      persistence: 'localStorage+cookie',
+      capture_exceptions: true,
+    })
+    setPostHogInstance(posthog)
 
-    import('posthog-js').then(({ default: posthog }) => {
-      // Guard against unmount during async import
-      if (cancelledRef.current) return
+    // Capture initial pageview
+    capturePageView(window.location.href)
 
-      posthog.init(key, {
-        api_host: host,
-        capture_pageview: false, // we capture manually on navigation
-        persistence: 'localStorage+cookie',
-        capture_exceptions: true,
-      })
-      setPostHogInstance(posthog)
-
-      // Capture initial pageview
-      capturePageView(window.location.href)
-
-      // Subscribe to route changes for manual pageview tracking
-      unsubRef.current = router.subscribe('onResolved', (event) => {
-        capturePageView(window.location.origin + event.toLocation.href)
-      })
+    // Subscribe to route changes for manual pageview tracking
+    unsubRef.current = router.subscribe('onResolved', (event) => {
+      capturePageView(window.location.origin + event.toLocation.href)
     })
 
     return () => {
-      cancelledRef.current = true
       unsubRef.current?.()
       unsubRef.current = null
     }
@@ -56,17 +48,19 @@ function PostHogInit() {
 
   // Identify/reset on auth changes
   useEffect(() => {
-    const ph = getPostHogInstance()
-    if (!isPostHogReady() || !ph) return
+    if (!isPostHogReady()) return
+
     if (user) {
-      ph.identify(user.id, {
+      posthog.identify(user.id, {
         name: user.name,
         email: user.email,
         provider: user.provider,
         role: user.role,
       })
+      posthog.reloadFeatureFlags()
     } else {
-      ph.reset()
+      posthog.reset()
+      posthog.reloadFeatureFlags()
     }
   }, [user])
 
@@ -75,9 +69,9 @@ function PostHogInit() {
 
 export function PostHogProvider({ children }: { children: ReactNode }) {
   return (
-    <>
+    <ReactPostHogProvider client={posthog}>
       <PostHogInit />
       {children}
-    </>
+    </ReactPostHogProvider>
   )
 }

--- a/app/providers/PostHogProvider.tsx
+++ b/app/providers/PostHogProvider.tsx
@@ -26,13 +26,16 @@ export function PostHogProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const key = import.meta.env.VITE_PUBLIC_POSTHOG_KEY
     const host = import.meta.env.VITE_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com'
+    const shouldLoadProvider = isPostHogReady() || Boolean(key)
     let cancelled = false
 
     if (typeof window === 'undefined') return
 
-    void import('@posthog/react').then(({ PostHogProvider: PostHogReactProvider }) => {
-      if (!cancelled) setProviderComponent(() => PostHogReactProvider)
-    })
+    if (shouldLoadProvider) {
+      void import('@posthog/react').then(({ PostHogProvider: PostHogReactProvider }) => {
+        if (!cancelled) setProviderComponent(() => PostHogReactProvider)
+      })
+    }
 
     if (isPostHogReady()) {
       const existingClient = getPostHogInstance()

--- a/app/utils/featureFlags.tsx
+++ b/app/utils/featureFlags.tsx
@@ -13,7 +13,7 @@ export interface FeatureFlagState<TPayload = JsonType> {
   variant: string | boolean | undefined
 }
 
-function normalizePayload<TPayload>(payload: JsonType): TPayload | null {
+function normalizePayload<TPayload>(payload: JsonType | undefined): TPayload | null {
   return (payload ?? null) as TPayload | null
 }
 
@@ -46,10 +46,16 @@ export function FeatureFlagGate({
   flag,
   children,
   fallback = null,
+  showFallbackWhileLoading = false,
 }: {
   flag: string
   children: ReactNode
   fallback?: ReactNode
+  showFallbackWhileLoading?: boolean
 }) {
-  return useFeatureFlagEnabled(flag) ? <>{children}</> : <>{fallback}</>
+  const { isEnabled, isLoading } = useFeatureFlag(flag)
+
+  if (isLoading && !showFallbackWhileLoading) return null
+
+  return isEnabled ? <>{children}</> : <>{fallback}</>
 }

--- a/app/utils/featureFlags.tsx
+++ b/app/utils/featureFlags.tsx
@@ -1,0 +1,55 @@
+import {
+  useFeatureFlagEnabled as usePostHogFeatureFlagEnabled,
+  useFeatureFlagPayload as usePostHogFeatureFlagPayload,
+  useFeatureFlagVariantKey,
+} from '@posthog/react'
+import type { JsonType } from 'posthog-js'
+import type { ReactNode } from 'react'
+
+export interface FeatureFlagState<TPayload = JsonType> {
+  isEnabled: boolean
+  isLoading: boolean
+  payload: TPayload | null
+  variant: string | boolean | undefined
+}
+
+function normalizePayload<TPayload>(payload: JsonType): TPayload | null {
+  return (payload ?? null) as TPayload | null
+}
+
+export function useFeatureFlag(flag: string): FeatureFlagState {
+  const isEnabled = usePostHogFeatureFlagEnabled(flag)
+  const payload = usePostHogFeatureFlagPayload(flag)
+  const variant = useFeatureFlagVariantKey(flag)
+
+  return {
+    isEnabled: isEnabled ?? false,
+    isLoading: isEnabled === undefined,
+    payload: normalizePayload(payload),
+    variant,
+  }
+}
+
+export function useFeatureFlagEnabled(flag: string): boolean {
+  return usePostHogFeatureFlagEnabled(flag) ?? false
+}
+
+export function useFeatureFlagPayload<TPayload = JsonType>(flag: string): TPayload | null {
+  return normalizePayload<TPayload>(usePostHogFeatureFlagPayload(flag))
+}
+
+export function useFeatureFlagVariant(flag: string): string | boolean | undefined {
+  return useFeatureFlagVariantKey(flag)
+}
+
+export function FeatureFlagGate({
+  flag,
+  children,
+  fallback = null,
+}: {
+  flag: string
+  children: ReactNode
+  fallback?: ReactNode
+}) {
+  return useFeatureFlagEnabled(flag) ? <>{children}</> : <>{fallback}</>
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -321,7 +321,7 @@ git push origin dev
 | `CDN_URL` | `https://cdn-dev.cartyx.io` |
 | `POSTHOG_KEY` | dev PostHog project API key (or same as prod) |
 
-### PostHog (Optional)
+### PostHog Analytics and Feature Flags (Optional)
 
 | Variable | Description |
 |---|---|
@@ -329,6 +329,8 @@ git push origin dev
 | `VITE_PUBLIC_POSTHOG_HOST` | PostHog host (default: `https://app.posthog.com`) |
 | `POSTHOG_KEY` | Server-side PostHog project key |
 | `POSTHOG_HOST` | Server-side PostHog host |
+
+Client-side feature flags use the same `VITE_PUBLIC_POSTHOG_*` variables as analytics. When a user signs in or out, the app refreshes their PostHog identity so person-targeted flags update without a redeploy.
 
 ### Local Development Only
 

--- a/tests/providers/PostHogProvider.test.tsx
+++ b/tests/providers/PostHogProvider.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PostHogProvider } from '~/providers/PostHogProvider'
+
+let posthogReady = false
+let routeResolvedHandler: ((event: { toLocation: { href: string } }) => void) | null = null
+
+const {
+  mockSubscribe,
+  mockUseAuthContext,
+  mockReactPostHogProvider,
+  mockPosthog,
+  mockCapturePageView,
+  mockSetPostHogInstance,
+} = vi.hoisted(() => ({
+  mockSubscribe: vi.fn(),
+  mockUseAuthContext: vi.fn(),
+  mockReactPostHogProvider: vi.fn(({ children }: { children: ReactNode }) => (
+    <div data-testid="react-posthog-provider">{children}</div>
+  )),
+  mockPosthog: {
+    init: vi.fn(),
+    identify: vi.fn(),
+    reset: vi.fn(),
+    reloadFeatureFlags: vi.fn(),
+  },
+  mockCapturePageView: vi.fn(),
+  mockSetPostHogInstance: vi.fn(() => {
+    posthogReady = true
+  }),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useRouter: () => ({
+    subscribe: mockSubscribe.mockImplementation((_event: string, handler: typeof routeResolvedHandler) => {
+      routeResolvedHandler = handler
+      return vi.fn()
+    }),
+  }),
+}))
+
+vi.mock('@posthog/react', () => ({
+  PostHogProvider: mockReactPostHogProvider,
+}))
+
+vi.mock('posthog-js', () => ({
+  default: mockPosthog,
+}))
+
+vi.mock('~/providers/AuthProvider', () => ({
+  useAuthContext: mockUseAuthContext,
+}))
+
+vi.mock('~/utils/posthog-client', () => ({
+  captureException: vi.fn(),
+  captureEvent: vi.fn(),
+  capturePageView: mockCapturePageView,
+  isPostHogReady: vi.fn(() => posthogReady),
+  setPostHogInstance: mockSetPostHogInstance,
+}))
+
+describe('PostHogProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+    vi.stubEnv('VITE_PUBLIC_POSTHOG_KEY', 'test-key')
+    vi.stubEnv('VITE_PUBLIC_POSTHOG_HOST', 'https://us.i.posthog.com')
+    posthogReady = false
+    routeResolvedHandler = null
+    mockUseAuthContext.mockReturnValue({
+      user: {
+        id: 'user-1',
+        name: 'Taryon',
+        email: 'taryon@example.com',
+        provider: 'google',
+        role: 'gm',
+      },
+    })
+  })
+
+  it('initializes PostHog, wires the React provider, and tracks page views', () => {
+    render(
+      <PostHogProvider>
+        <div>children</div>
+      </PostHogProvider>
+    )
+
+    expect(mockReactPostHogProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ client: mockPosthog }),
+      undefined
+    )
+    expect(mockPosthog.init).toHaveBeenCalledWith('test-key', {
+      api_host: 'https://us.i.posthog.com',
+      capture_pageview: false,
+      persistence: 'localStorage+cookie',
+      capture_exceptions: true,
+    })
+    expect(mockSetPostHogInstance).toHaveBeenCalledWith(mockPosthog)
+    expect(mockCapturePageView).toHaveBeenCalledWith('http://localhost:3000/')
+    expect(mockSubscribe).toHaveBeenCalledWith('onResolved', expect.any(Function))
+    expect(screen.getByText('children')).toBeInTheDocument()
+
+    routeResolvedHandler?.({ toLocation: { href: '/campaigns/demo' } })
+
+    expect(mockCapturePageView).toHaveBeenLastCalledWith('http://localhost:3000/campaigns/demo')
+  })
+
+  it('identifies authenticated users and refreshes feature flags', () => {
+    render(
+      <PostHogProvider>
+        <div />
+      </PostHogProvider>
+    )
+
+    expect(mockPosthog.identify).toHaveBeenCalledWith('user-1', {
+      name: 'Taryon',
+      email: 'taryon@example.com',
+      provider: 'google',
+      role: 'gm',
+    })
+    expect(mockPosthog.reloadFeatureFlags).toHaveBeenCalledTimes(1)
+  })
+
+  it('resets anonymous sessions and refreshes feature flags', () => {
+    mockUseAuthContext.mockReturnValue({ user: null })
+
+    render(
+      <PostHogProvider>
+        <div />
+      </PostHogProvider>
+    )
+
+    expect(mockPosthog.reset).toHaveBeenCalledTimes(1)
+    expect(mockPosthog.reloadFeatureFlags).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/providers/PostHogProvider.test.tsx
+++ b/tests/providers/PostHogProvider.test.tsx
@@ -147,4 +147,25 @@ describe('PostHogProvider', () => {
     })
     expect(mockPosthog.reloadFeatureFlags).toHaveBeenCalledTimes(1)
   })
+
+  it('skips loading PostHog entirely when the client key is absent', async () => {
+    vi.unstubAllEnvs()
+    vi.stubEnv('VITE_PUBLIC_POSTHOG_HOST', 'https://us.i.posthog.com')
+
+    render(
+      <PostHogProvider>
+        <div>children</div>
+      </PostHogProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('children')).toBeInTheDocument()
+    })
+
+    expect(mockPosthog.init).not.toHaveBeenCalled()
+    expect(mockReactPostHogProvider).not.toHaveBeenCalled()
+    expect(mockSetPostHogInstance).not.toHaveBeenCalled()
+    expect(mockSubscribe).not.toHaveBeenCalled()
+    expect(mockCapturePageView).not.toHaveBeenCalled()
+  })
 })

--- a/tests/providers/PostHogProvider.test.tsx
+++ b/tests/providers/PostHogProvider.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { PostHogProvider } from '~/providers/PostHogProvider'
@@ -12,6 +12,7 @@ const {
   mockReactPostHogProvider,
   mockPosthog,
   mockCapturePageView,
+  mockGetPostHogInstance,
   mockSetPostHogInstance,
 } = vi.hoisted(() => ({
   mockSubscribe: vi.fn(),
@@ -26,6 +27,7 @@ const {
     reloadFeatureFlags: vi.fn(),
   },
   mockCapturePageView: vi.fn(),
+  mockGetPostHogInstance: vi.fn(() => (posthogReady ? mockPosthog : null)),
   mockSetPostHogInstance: vi.fn(() => {
     posthogReady = true
   }),
@@ -56,6 +58,7 @@ vi.mock('~/utils/posthog-client', () => ({
   captureException: vi.fn(),
   captureEvent: vi.fn(),
   capturePageView: mockCapturePageView,
+  getPostHogInstance: mockGetPostHogInstance,
   isPostHogReady: vi.fn(() => posthogReady),
   setPostHogInstance: mockSetPostHogInstance,
 }))
@@ -79,23 +82,29 @@ describe('PostHogProvider', () => {
     })
   })
 
-  it('initializes PostHog, wires the React provider, and tracks page views', () => {
+  it('initializes PostHog, wires the React provider, and tracks page views', async () => {
     render(
       <PostHogProvider>
         <div>children</div>
       </PostHogProvider>
     )
 
-    expect(mockReactPostHogProvider).toHaveBeenCalledWith(
-      expect.objectContaining({ client: mockPosthog }),
-      undefined
-    )
-    expect(mockPosthog.init).toHaveBeenCalledWith('test-key', {
-      api_host: 'https://us.i.posthog.com',
-      capture_pageview: false,
-      persistence: 'localStorage+cookie',
-      capture_exceptions: true,
+    await waitFor(() => {
+      expect(mockPosthog.init).toHaveBeenCalledWith('test-key', {
+        api_host: 'https://us.i.posthog.com',
+        capture_pageview: false,
+        persistence: 'localStorage+cookie',
+        capture_exceptions: true,
+      })
     })
+
+    await waitFor(() => {
+      expect(mockReactPostHogProvider).toHaveBeenCalledWith(
+        expect.objectContaining({ client: mockPosthog, children: expect.anything() }),
+        undefined
+      )
+    })
+
     expect(mockSetPostHogInstance).toHaveBeenCalledWith(mockPosthog)
     expect(mockCapturePageView).toHaveBeenCalledWith('http://localhost:3000/')
     expect(mockSubscribe).toHaveBeenCalledWith('onResolved', expect.any(Function))
@@ -106,23 +115,25 @@ describe('PostHogProvider', () => {
     expect(mockCapturePageView).toHaveBeenLastCalledWith('http://localhost:3000/campaigns/demo')
   })
 
-  it('identifies authenticated users and refreshes feature flags', () => {
+  it('identifies authenticated users and refreshes feature flags', async () => {
     render(
       <PostHogProvider>
         <div />
       </PostHogProvider>
     )
 
-    expect(mockPosthog.identify).toHaveBeenCalledWith('user-1', {
-      name: 'Taryon',
-      email: 'taryon@example.com',
-      provider: 'google',
-      role: 'gm',
+    await waitFor(() => {
+      expect(mockPosthog.identify).toHaveBeenCalledWith('user-1', {
+        name: 'Taryon',
+        email: 'taryon@example.com',
+        provider: 'google',
+        role: 'gm',
+      })
     })
     expect(mockPosthog.reloadFeatureFlags).toHaveBeenCalledTimes(1)
   })
 
-  it('resets anonymous sessions and refreshes feature flags', () => {
+  it('resets anonymous sessions and refreshes feature flags', async () => {
     mockUseAuthContext.mockReturnValue({ user: null })
 
     render(
@@ -131,7 +142,9 @@ describe('PostHogProvider', () => {
       </PostHogProvider>
     )
 
-    expect(mockPosthog.reset).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(mockPosthog.reset).toHaveBeenCalledTimes(1)
+    })
     expect(mockPosthog.reloadFeatureFlags).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/utils/featureFlags.test.tsx
+++ b/tests/utils/featureFlags.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   FeatureFlagGate,
   useFeatureFlag,
@@ -41,6 +41,10 @@ function FeatureFlagStateProbe({ flag }: { flag: string }) {
 }
 
 describe('featureFlags utilities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('surfaces loading state until PostHog resolves a flag', () => {
     mockUsePostHogFeatureFlagEnabled.mockReturnValue(undefined)
     mockUsePostHogFeatureFlagPayload.mockReturnValue(undefined)
@@ -73,6 +77,8 @@ describe('featureFlags utilities', () => {
 
   it('renders fallback content when a flag is disabled', () => {
     mockUsePostHogFeatureFlagEnabled.mockReturnValue(false)
+    mockUsePostHogFeatureFlagPayload.mockReturnValue(undefined)
+    mockUseFeatureFlagVariantKey.mockReturnValue(undefined)
 
     render(
       <FeatureFlagGate flag="campaign-redesign" fallback={<span>coming soon</span>}>
@@ -84,8 +90,44 @@ describe('featureFlags utilities', () => {
     expect(screen.getByText('coming soon')).toBeInTheDocument()
   })
 
+  it('does not render fallback while a flag is loading by default', () => {
+    mockUsePostHogFeatureFlagEnabled.mockReturnValue(undefined)
+    mockUsePostHogFeatureFlagPayload.mockReturnValue(undefined)
+    mockUseFeatureFlagVariantKey.mockReturnValue(undefined)
+
+    render(
+      <FeatureFlagGate flag="campaign-redesign" fallback={<span>coming soon</span>}>
+        <span>enabled content</span>
+      </FeatureFlagGate>
+    )
+
+    expect(screen.queryByText('enabled content')).not.toBeInTheDocument()
+    expect(screen.queryByText('coming soon')).not.toBeInTheDocument()
+  })
+
+  it('can render fallback while a flag is loading when requested', () => {
+    mockUsePostHogFeatureFlagEnabled.mockReturnValue(undefined)
+    mockUsePostHogFeatureFlagPayload.mockReturnValue(undefined)
+    mockUseFeatureFlagVariantKey.mockReturnValue(undefined)
+
+    render(
+      <FeatureFlagGate
+        flag="campaign-redesign"
+        fallback={<span>coming soon</span>}
+        showFallbackWhileLoading
+      >
+        <span>enabled content</span>
+      </FeatureFlagGate>
+    )
+
+    expect(screen.queryByText('enabled content')).not.toBeInTheDocument()
+    expect(screen.getByText('coming soon')).toBeInTheDocument()
+  })
+
   it('renders children when a flag is enabled', () => {
     mockUsePostHogFeatureFlagEnabled.mockReturnValue(true)
+    mockUsePostHogFeatureFlagPayload.mockReturnValue(undefined)
+    mockUseFeatureFlagVariantKey.mockReturnValue(undefined)
 
     render(
       <FeatureFlagGate flag="campaign-redesign" fallback={<span>coming soon</span>}>

--- a/tests/utils/featureFlags.test.tsx
+++ b/tests/utils/featureFlags.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  FeatureFlagGate,
+  useFeatureFlag,
+  useFeatureFlagEnabled,
+  useFeatureFlagPayload,
+  useFeatureFlagVariant,
+} from '~/utils/featureFlags'
+
+const {
+  mockUsePostHogFeatureFlagEnabled,
+  mockUsePostHogFeatureFlagPayload,
+  mockUseFeatureFlagVariantKey,
+} = vi.hoisted(() => ({
+  mockUsePostHogFeatureFlagEnabled: vi.fn(),
+  mockUsePostHogFeatureFlagPayload: vi.fn(),
+  mockUseFeatureFlagVariantKey: vi.fn(),
+}))
+
+vi.mock('@posthog/react', () => ({
+  useFeatureFlagEnabled: mockUsePostHogFeatureFlagEnabled,
+  useFeatureFlagPayload: mockUsePostHogFeatureFlagPayload,
+  useFeatureFlagVariantKey: mockUseFeatureFlagVariantKey,
+}))
+
+function FeatureFlagStateProbe({ flag }: { flag: string }) {
+  const state = useFeatureFlag(flag)
+  const enabled = useFeatureFlagEnabled(flag)
+  const payload = useFeatureFlagPayload<{ beta: boolean }>(flag)
+  const variant = useFeatureFlagVariant(flag)
+
+  return (
+    <>
+      <div data-testid="state">{JSON.stringify(state)}</div>
+      <div data-testid="enabled">{String(enabled)}</div>
+      <div data-testid="payload">{JSON.stringify(payload)}</div>
+      <div data-testid="variant">{String(variant)}</div>
+    </>
+  )
+}
+
+describe('featureFlags utilities', () => {
+  it('surfaces loading state until PostHog resolves a flag', () => {
+    mockUsePostHogFeatureFlagEnabled.mockReturnValue(undefined)
+    mockUsePostHogFeatureFlagPayload.mockReturnValue(undefined)
+    mockUseFeatureFlagVariantKey.mockReturnValue(undefined)
+
+    render(<FeatureFlagStateProbe flag="campaign-redesign" />)
+
+    expect(screen.getByTestId('state')).toHaveTextContent(
+      '{"isEnabled":false,"isLoading":true,"payload":null}'
+    )
+    expect(screen.getByTestId('enabled')).toHaveTextContent('false')
+    expect(screen.getByTestId('payload')).toHaveTextContent('null')
+    expect(screen.getByTestId('variant')).toHaveTextContent('undefined')
+  })
+
+  it('returns enabled flag metadata once PostHog has evaluated the flag', () => {
+    mockUsePostHogFeatureFlagEnabled.mockReturnValue(true)
+    mockUsePostHogFeatureFlagPayload.mockReturnValue({ beta: true })
+    mockUseFeatureFlagVariantKey.mockReturnValue('variant-a')
+
+    render(<FeatureFlagStateProbe flag="campaign-redesign" />)
+
+    expect(screen.getByTestId('state')).toHaveTextContent(
+      '{"isEnabled":true,"isLoading":false,"payload":{"beta":true},"variant":"variant-a"}'
+    )
+    expect(screen.getByTestId('enabled')).toHaveTextContent('true')
+    expect(screen.getByTestId('payload')).toHaveTextContent('{"beta":true}')
+    expect(screen.getByTestId('variant')).toHaveTextContent('variant-a')
+  })
+
+  it('renders fallback content when a flag is disabled', () => {
+    mockUsePostHogFeatureFlagEnabled.mockReturnValue(false)
+
+    render(
+      <FeatureFlagGate flag="campaign-redesign" fallback={<span>coming soon</span>}>
+        <span>enabled content</span>
+      </FeatureFlagGate>
+    )
+
+    expect(screen.queryByText('enabled content')).not.toBeInTheDocument()
+    expect(screen.getByText('coming soon')).toBeInTheDocument()
+  })
+
+  it('renders children when a flag is enabled', () => {
+    mockUsePostHogFeatureFlagEnabled.mockReturnValue(true)
+
+    render(
+      <FeatureFlagGate flag="campaign-redesign" fallback={<span>coming soon</span>}>
+        <span>enabled content</span>
+      </FeatureFlagGate>
+    )
+
+    expect(screen.getByText('enabled content')).toBeInTheDocument()
+    expect(screen.queryByText('coming soon')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- wrap the existing PostHog client in the React provider so feature flags resolve anywhere in the app
- add reusable useFeatureFlag helpers plus FeatureFlagGate in app/utils/featureFlags.tsx
- refresh PostHog feature flags on auth identify/reset and document the new client-side flag setup

## Verification
- npm run lint
- npm run build
- npm run test:unit

## Notes
- npm test still fails in the existing Storybook/browser suite due to unrelated repo-wide Storybook issues, including context.renderToCanvas is not a function and No render function available across many untouched stories

Closes #9