### PR TITLE
[Feature]:  Update to enable Feature Flags for Chat, Notepad, and Settings in Dev and Production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,14 @@ VITE_PUBLIC_POSTHOG_HOST=https://app.posthog.com
 POSTHOG_KEY=
 POSTHOG_HOST=https://app.posthog.com
 
+# Inspector feature flag names (set per-environment in Vercel)
+# Each value is the PostHog flag name to evaluate — use different flag names
+# in dev vs production so they can be toggled independently.
+# If unset, the tab is hidden.
+VITE_PUBLIC_FF_CHAT=
+VITE_PUBLIC_FF_NOTEPAD=
+VITE_PUBLIC_FF_SETTINGS=
+
 # Cloudflare R2 image storage
 # When CDN_URL is set, images upload directly from browser to R2 (production)
 # When CDN_URL is omitted (local dev), images save to public/uploads/ via server

--- a/app/components/mainview/InspectorSidebar.tsx
+++ b/app/components/mainview/InspectorSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react'
+import React, { useState, useRef, useEffect, useMemo } from 'react'
 import type { IconDefinition } from '@fortawesome/fontawesome-svg-core'
 import { ChatPanel } from './ChatPanel'
 import { NotepadPanel } from './NotepadPanel'
@@ -7,7 +7,7 @@ import { WikiPanel } from './WikiPanel'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faMessage, faBook, faNoteSticky, faGear } from '@fortawesome/pro-solid-svg-icons'
 import { ChevronRight } from 'lucide-react'
-import { useFeatureFlagEnabled } from '~/utils/featureFlags'
+import { useOptionalFeatureFlagEnabled } from '~/utils/featureFlags'
 
 export type InspectorTab = 'chat' | 'wiki' | 'notepad' | 'settings'
 
@@ -36,16 +36,16 @@ export function InspectorSidebar({ defaultTab = 'chat', onMobileClose }: Inspect
   const notepadFlagName = import.meta.env.VITE_PUBLIC_FF_NOTEPAD ?? ''
   const settingsFlagName = import.meta.env.VITE_PUBLIC_FF_SETTINGS ?? ''
 
-  const chatEnabled = useFeatureFlagEnabled(chatFlagName)
-  const notepadEnabled = useFeatureFlagEnabled(notepadFlagName)
-  const settingsEnabled = useFeatureFlagEnabled(settingsFlagName)
+  const chatEnabled = useOptionalFeatureFlagEnabled(chatFlagName)
+  const notepadEnabled = useOptionalFeatureFlagEnabled(notepadFlagName)
+  const settingsEnabled = useOptionalFeatureFlagEnabled(settingsFlagName)
 
-  const tabs = ALL_TABS.filter(tab => {
+  const tabs = useMemo(() => ALL_TABS.filter(tab => {
     if (tab.id === 'chat') return chatEnabled
     if (tab.id === 'notepad') return notepadEnabled
     if (tab.id === 'settings') return settingsEnabled
     return true // wiki is always visible
-  })
+  }), [chatEnabled, notepadEnabled, settingsEnabled])
 
   const initialTab = tabs.some(t => t.id === defaultTab) ? defaultTab : 'wiki'
   const [activeTab, setActiveTab] = useState<InspectorTab>(initialTab)
@@ -56,7 +56,7 @@ export function InspectorSidebar({ defaultTab = 'chat', onMobileClose }: Inspect
     if (!tabs.some(t => t.id === activeTab)) {
       setActiveTab('wiki')
     }
-  }, [chatEnabled, notepadEnabled, settingsEnabled])
+  }, [tabs, activeTab])
 
   function handleKeyDown(e: React.KeyboardEvent) {
     const currentIndex = tabs.findIndex(t => t.id === activeTab)

--- a/app/components/mainview/InspectorSidebar.tsx
+++ b/app/components/mainview/InspectorSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react'
+import React, { useState, useRef, useEffect } from 'react'
 import type { IconDefinition } from '@fortawesome/fontawesome-svg-core'
 import { ChatPanel } from './ChatPanel'
 import { NotepadPanel } from './NotepadPanel'
@@ -7,6 +7,7 @@ import { WikiPanel } from './WikiPanel'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faMessage, faBook, faNoteSticky, faGear } from '@fortawesome/pro-solid-svg-icons'
 import { ChevronRight } from 'lucide-react'
+import { useFeatureFlagEnabled } from '~/utils/featureFlags'
 
 export type InspectorTab = 'chat' | 'wiki' | 'notepad' | 'settings'
 
@@ -15,7 +16,7 @@ export interface InspectorSidebarProps {
   onMobileClose?: () => void
 }
 
-const tabs: { id: InspectorTab; icon: IconDefinition; label: string }[] = [
+const ALL_TABS: { id: InspectorTab; icon: IconDefinition; label: string }[] = [
   { id: 'chat', icon: faMessage, label: 'Chat' },
   { id: 'wiki', icon: faBook, label: 'Wiki' },
   { id: 'notepad', icon: faNoteSticky, label: 'Notepad' },
@@ -31,8 +32,31 @@ function panelId(id: InspectorTab) {
 }
 
 export function InspectorSidebar({ defaultTab = 'chat', onMobileClose }: InspectorSidebarProps) {
-  const [activeTab, setActiveTab] = useState<InspectorTab>(defaultTab)
+  const chatFlagName = import.meta.env.VITE_PUBLIC_FF_CHAT ?? ''
+  const notepadFlagName = import.meta.env.VITE_PUBLIC_FF_NOTEPAD ?? ''
+  const settingsFlagName = import.meta.env.VITE_PUBLIC_FF_SETTINGS ?? ''
+
+  const chatEnabled = useFeatureFlagEnabled(chatFlagName)
+  const notepadEnabled = useFeatureFlagEnabled(notepadFlagName)
+  const settingsEnabled = useFeatureFlagEnabled(settingsFlagName)
+
+  const tabs = ALL_TABS.filter(tab => {
+    if (tab.id === 'chat') return chatEnabled
+    if (tab.id === 'notepad') return notepadEnabled
+    if (tab.id === 'settings') return settingsEnabled
+    return true // wiki is always visible
+  })
+
+  const initialTab = tabs.some(t => t.id === defaultTab) ? defaultTab : 'wiki'
+  const [activeTab, setActiveTab] = useState<InspectorTab>(initialTab)
   const tablistRef = useRef<HTMLDivElement>(null)
+
+  // If the active tab becomes hidden (flag toggled off), fall back to wiki
+  useEffect(() => {
+    if (!tabs.some(t => t.id === activeTab)) {
+      setActiveTab('wiki')
+    }
+  }, [chatEnabled, notepadEnabled, settingsEnabled])
 
   function handleKeyDown(e: React.KeyboardEvent) {
     const currentIndex = tabs.findIndex(t => t.id === activeTab)

--- a/app/components/mainview/InspectorSidebar.tsx
+++ b/app/components/mainview/InspectorSidebar.tsx
@@ -47,7 +47,8 @@ export function InspectorSidebar({ defaultTab = 'chat', onMobileClose }: Inspect
     return true // wiki is always visible
   }), [chatEnabled, notepadEnabled, settingsEnabled])
 
-  const [activeTab, setActiveTab] = useState<InspectorTab>(defaultTab)
+  const initialTab = tabs.some(t => t.id === defaultTab) ? defaultTab : 'wiki'
+  const [activeTab, setActiveTab] = useState<InspectorTab>(initialTab)
   const hasInteracted = useRef(false)
   const tablistRef = useRef<HTMLDivElement>(null)
 

--- a/app/components/mainview/InspectorSidebar.tsx
+++ b/app/components/mainview/InspectorSidebar.tsx
@@ -47,16 +47,20 @@ export function InspectorSidebar({ defaultTab = 'chat', onMobileClose }: Inspect
     return true // wiki is always visible
   }), [chatEnabled, notepadEnabled, settingsEnabled])
 
-  const initialTab = tabs.some(t => t.id === defaultTab) ? defaultTab : 'wiki'
-  const [activeTab, setActiveTab] = useState<InspectorTab>(initialTab)
+  const [activeTab, setActiveTab] = useState<InspectorTab>(defaultTab)
+  const hasInteracted = useRef(false)
   const tablistRef = useRef<HTMLDivElement>(null)
 
-  // If the active tab becomes hidden (flag toggled off), fall back to wiki
   useEffect(() => {
     if (!tabs.some(t => t.id === activeTab)) {
+      // Active tab became unavailable (flag disabled) — fall back to wiki
       setActiveTab('wiki')
+    } else if (!hasInteracted.current && activeTab !== defaultTab && tabs.some(t => t.id === defaultTab)) {
+      // Flags finished loading and defaultTab is now available; restore it
+      // only if the user has not manually navigated away
+      setActiveTab(defaultTab)
     }
-  }, [tabs, activeTab])
+  }, [tabs, activeTab, defaultTab])
 
   function handleKeyDown(e: React.KeyboardEvent) {
     const currentIndex = tabs.findIndex(t => t.id === activeTab)
@@ -78,6 +82,7 @@ export function InspectorSidebar({ defaultTab = 'chat', onMobileClose }: Inspect
       return
     }
 
+    hasInteracted.current = true
     setActiveTab(tabs[nextIndex].id)
     const buttons = tablistRef.current?.querySelectorAll<HTMLButtonElement>('[role="tab"]')
     buttons?.[nextIndex]?.focus()
@@ -107,7 +112,7 @@ export function InspectorSidebar({ defaultTab = 'chat', onMobileClose }: Inspect
                 aria-label={tab.label}
                 tabIndex={isActive ? 0 : -1}
                 data-testid={tabId(tab.id)}
-                onClick={() => setActiveTab(tab.id)}
+                onClick={() => { hasInteracted.current = true; setActiveTab(tab.id) }}
                 className={[
                   'flex flex-1 items-center justify-center text-base transition-colors relative',
                   isActive

--- a/app/utils/featureFlags.tsx
+++ b/app/utils/featureFlags.tsx
@@ -34,10 +34,11 @@ export function useFeatureFlagEnabled(flag: string): boolean {
   return usePostHogFeatureFlagEnabled(flag) ?? false
 }
 
-// Like useFeatureFlagEnabled but returns false immediately when flag name is
-// empty (i.e. the env var is unset), without querying PostHog for an empty key.
+// Like useFeatureFlagEnabled but returns false when the flag name is empty
+// (i.e. the env var is unset). PostHog is never queried with an empty string —
+// a sentinel key is used instead so hook call count stays stable.
 export function useOptionalFeatureFlagEnabled(flag: string): boolean {
-  const enabled = usePostHogFeatureFlagEnabled(flag)
+  const enabled = usePostHogFeatureFlagEnabled(flag || '__ff_disabled__')
   return Boolean(flag) && (enabled ?? false)
 }
 

--- a/app/utils/featureFlags.tsx
+++ b/app/utils/featureFlags.tsx
@@ -34,6 +34,13 @@ export function useFeatureFlagEnabled(flag: string): boolean {
   return usePostHogFeatureFlagEnabled(flag) ?? false
 }
 
+// Like useFeatureFlagEnabled but returns false immediately when flag name is
+// empty (i.e. the env var is unset), without querying PostHog for an empty key.
+export function useOptionalFeatureFlagEnabled(flag: string): boolean {
+  const enabled = usePostHogFeatureFlagEnabled(flag)
+  return Boolean(flag) && (enabled ?? false)
+}
+
 export function useFeatureFlagPayload<TPayload = JsonType>(flag: string): TPayload | null {
   return normalizePayload<TPayload>(usePostHogFeatureFlagPayload(flag))
 }

--- a/tests/components/mainview/InspectorSidebar.test.tsx
+++ b/tests/components/mainview/InspectorSidebar.test.tsx
@@ -19,7 +19,7 @@ const enabledFlags = new Set<string>([
 ])
 
 vi.mock('~/utils/featureFlags', () => ({
-  useFeatureFlagEnabled: (flag: string) => enabledFlags.has(flag),
+  useOptionalFeatureFlagEnabled: (flag: string) => Boolean(flag) && enabledFlags.has(flag),
 }))
 
 beforeEach(() => {

--- a/tests/components/mainview/InspectorSidebar.test.tsx
+++ b/tests/components/mainview/InspectorSidebar.test.tsx
@@ -185,6 +185,29 @@ describe('InspectorSidebar', () => {
       expect(screen.queryByTestId('inspector-tab-settings')).not.toBeInTheDocument()
       expect(screen.getByTestId('inspector-tab-wiki')).toBeInTheDocument()
     })
+
+    it('switches active panel to wiki when the active tab flag is toggled off at runtime', async () => {
+      const user = userEvent.setup()
+      const { rerender } = render(<InspectorSidebar defaultTab="chat" />)
+
+      // Chat tab is active on first render
+      await user.click(screen.getByTestId('inspector-tab-chat'))
+      expect(screen.getByTestId('inspector-tab-chat')).toHaveAttribute('aria-selected', 'true')
+      expect(screen.getByTestId('inspector-panel')).toContainElement(
+        screen.getByRole('combobox', { name: 'Session selector' })
+      )
+
+      // Simulate PostHog toggling the chat flag off
+      enabledFlags.delete(DEV_FLAGS.chat)
+      rerender(<InspectorSidebar defaultTab="chat" />)
+
+      // Chat tab should disappear and wiki panel should now be active
+      expect(screen.queryByTestId('inspector-tab-chat')).not.toBeInTheDocument()
+      expect(screen.getByTestId('inspector-tab-wiki')).toHaveAttribute('aria-selected', 'true')
+      expect(screen.getByTestId('inspector-panel')).toContainElement(
+        screen.getByRole('button', { name: 'Characters' })
+      )
+    })
   })
 
   describe('mobile close button', () => {

--- a/tests/components/mainview/InspectorSidebar.test.tsx
+++ b/tests/components/mainview/InspectorSidebar.test.tsx
@@ -1,8 +1,39 @@
 import React from 'react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { InspectorSidebar } from '~/components/mainview/InspectorSidebar'
+
+// Env var names used per-environment (set in Vercel)
+const DEV_FLAGS = {
+  chat: 'dev-inspector-chat',
+  notepad: 'dev-inspector-notepad',
+  settings: 'dev-inspector-settings',
+}
+
+// Which flags PostHog reports as enabled
+const enabledFlags = new Set<string>([
+  DEV_FLAGS.chat,
+  DEV_FLAGS.notepad,
+  DEV_FLAGS.settings,
+])
+
+vi.mock('~/utils/featureFlags', () => ({
+  useFeatureFlagEnabled: (flag: string) => enabledFlags.has(flag),
+}))
+
+beforeEach(() => {
+  vi.stubEnv('VITE_PUBLIC_FF_CHAT', DEV_FLAGS.chat)
+  vi.stubEnv('VITE_PUBLIC_FF_NOTEPAD', DEV_FLAGS.notepad)
+  vi.stubEnv('VITE_PUBLIC_FF_SETTINGS', DEV_FLAGS.settings)
+  enabledFlags.add(DEV_FLAGS.chat)
+  enabledFlags.add(DEV_FLAGS.notepad)
+  enabledFlags.add(DEV_FLAGS.settings)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
 
 describe('InspectorSidebar', () => {
   it('defaults to the chat tab', () => {
@@ -12,7 +43,7 @@ describe('InspectorSidebar', () => {
     )
   })
 
-  it('renders all 4 tab buttons', () => {
+  it('renders all 4 tab buttons when all flags are enabled', () => {
     render(<InspectorSidebar />)
     expect(screen.getByTestId('inspector-tab-chat')).toBeInTheDocument()
     expect(screen.getByTestId('inspector-tab-wiki')).toBeInTheDocument()
@@ -89,6 +120,67 @@ describe('InspectorSidebar', () => {
     const buttons = screen.getAllByRole('tab')
     buttons.forEach(btn => {
       expect(btn).toHaveAttribute('type', 'button')
+    })
+  })
+
+  describe('feature flags', () => {
+    it('hides chat tab when VITE_PUBLIC_FF_CHAT env var is not set', () => {
+      vi.stubEnv('VITE_PUBLIC_FF_CHAT', '')
+      render(<InspectorSidebar />)
+      expect(screen.queryByTestId('inspector-tab-chat')).not.toBeInTheDocument()
+      expect(screen.getByTestId('inspector-tab-wiki')).toBeInTheDocument()
+    })
+
+    it('hides notepad tab when VITE_PUBLIC_FF_NOTEPAD env var is not set', () => {
+      vi.stubEnv('VITE_PUBLIC_FF_NOTEPAD', '')
+      render(<InspectorSidebar />)
+      expect(screen.queryByTestId('inspector-tab-notepad')).not.toBeInTheDocument()
+      expect(screen.getByTestId('inspector-tab-wiki')).toBeInTheDocument()
+    })
+
+    it('hides settings tab when VITE_PUBLIC_FF_SETTINGS env var is not set', () => {
+      vi.stubEnv('VITE_PUBLIC_FF_SETTINGS', '')
+      render(<InspectorSidebar />)
+      expect(screen.queryByTestId('inspector-tab-settings')).not.toBeInTheDocument()
+      expect(screen.getByTestId('inspector-tab-wiki')).toBeInTheDocument()
+    })
+
+    it('hides chat tab when the PostHog flag is disabled', () => {
+      enabledFlags.delete(DEV_FLAGS.chat)
+      render(<InspectorSidebar />)
+      expect(screen.queryByTestId('inspector-tab-chat')).not.toBeInTheDocument()
+      expect(screen.getByTestId('inspector-tab-wiki')).toBeInTheDocument()
+    })
+
+    it('hides notepad tab when the PostHog flag is disabled', () => {
+      enabledFlags.delete(DEV_FLAGS.notepad)
+      render(<InspectorSidebar />)
+      expect(screen.queryByTestId('inspector-tab-notepad')).not.toBeInTheDocument()
+      expect(screen.getByTestId('inspector-tab-wiki')).toBeInTheDocument()
+    })
+
+    it('hides settings tab when the PostHog flag is disabled', () => {
+      enabledFlags.delete(DEV_FLAGS.settings)
+      render(<InspectorSidebar />)
+      expect(screen.queryByTestId('inspector-tab-settings')).not.toBeInTheDocument()
+      expect(screen.getByTestId('inspector-tab-wiki')).toBeInTheDocument()
+    })
+
+    it('falls back to wiki when defaultTab is chat and chat flag is disabled', () => {
+      enabledFlags.delete(DEV_FLAGS.chat)
+      render(<InspectorSidebar defaultTab="chat" />)
+      expect(screen.getByTestId('inspector-panel')).toContainElement(
+        screen.getByRole('button', { name: 'Characters' })
+      )
+    })
+
+    it('only shows wiki when all flagged tabs are disabled', () => {
+      enabledFlags.clear()
+      render(<InspectorSidebar />)
+      expect(screen.queryByTestId('inspector-tab-chat')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('inspector-tab-notepad')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('inspector-tab-settings')).not.toBeInTheDocument()
+      expect(screen.getByTestId('inspector-tab-wiki')).toBeInTheDocument()
     })
   })
 

--- a/tests/components/mainview/InspectorSidebar.test.tsx
+++ b/tests/components/mainview/InspectorSidebar.test.tsx
@@ -5,19 +5,22 @@ import userEvent from '@testing-library/user-event'
 import { InspectorSidebar } from '~/components/mainview/InspectorSidebar'
 
 // Env var names used per-environment (set in Vercel)
-const DEV_FLAGS = {
-  chat: 'dev-inspector-chat',
-  notepad: 'dev-inspector-notepad',
-  settings: 'dev-inspector-settings',
-}
+const { DEV_FLAGS, enabledFlags } = vi.hoisted(() => {
+  const DEV_FLAGS = {
+    chat: 'dev-inspector-chat',
+    notepad: 'dev-inspector-notepad',
+    settings: 'dev-inspector-settings',
+  }
 
-// Which flags PostHog reports as enabled
-const enabledFlags = new Set<string>([
-  DEV_FLAGS.chat,
-  DEV_FLAGS.notepad,
-  DEV_FLAGS.settings,
-])
+  // Which flags PostHog reports as enabled
+  const enabledFlags = new Set<string>([
+    DEV_FLAGS.chat,
+    DEV_FLAGS.notepad,
+    DEV_FLAGS.settings,
+  ])
 
+  return { DEV_FLAGS, enabledFlags }
+})
 vi.mock('~/utils/featureFlags', () => ({
   useOptionalFeatureFlagEnabled: (flag: string) => Boolean(flag) && enabledFlags.has(flag),
 }))

--- a/tests/utils/featureFlags.test.tsx
+++ b/tests/utils/featureFlags.test.tsx
@@ -6,6 +6,7 @@ import {
   useFeatureFlagEnabled,
   useFeatureFlagPayload,
   useFeatureFlagVariant,
+  useOptionalFeatureFlagEnabled,
 } from '~/utils/featureFlags'
 
 const {
@@ -23,6 +24,11 @@ vi.mock('@posthog/react', () => ({
   useFeatureFlagPayload: mockUsePostHogFeatureFlagPayload,
   useFeatureFlagVariantKey: mockUseFeatureFlagVariantKey,
 }))
+
+function OptionalFlagProbe({ flag }: { flag: string }) {
+  const enabled = useOptionalFeatureFlagEnabled(flag)
+  return <div data-testid="result">{String(enabled)}</div>
+}
 
 function FeatureFlagStateProbe({ flag }: { flag: string }) {
   const state = useFeatureFlag(flag)
@@ -122,6 +128,33 @@ describe('featureFlags utilities', () => {
 
     expect(screen.queryByText('enabled content')).not.toBeInTheDocument()
     expect(screen.getByText('coming soon')).toBeInTheDocument()
+  })
+
+  describe('useOptionalFeatureFlagEnabled', () => {
+    it('returns false for an empty flag name without querying PostHog with an empty string', () => {
+      render(<OptionalFlagProbe flag="" />)
+      expect(screen.getByTestId('result')).toHaveTextContent('false')
+      // PostHog should have been called with the sentinel, not an empty string
+      expect(mockUsePostHogFeatureFlagEnabled).not.toHaveBeenCalledWith('')
+    })
+
+    it('returns false when PostHog returns false for a non-empty flag name', () => {
+      mockUsePostHogFeatureFlagEnabled.mockReturnValue(false)
+      render(<OptionalFlagProbe flag="inspector-chat" />)
+      expect(screen.getByTestId('result')).toHaveTextContent('false')
+    })
+
+    it('returns false when PostHog returns undefined (loading) for a non-empty flag name', () => {
+      mockUsePostHogFeatureFlagEnabled.mockReturnValue(undefined)
+      render(<OptionalFlagProbe flag="inspector-chat" />)
+      expect(screen.getByTestId('result')).toHaveTextContent('false')
+    })
+
+    it('returns true when PostHog returns true for a non-empty flag name', () => {
+      mockUsePostHogFeatureFlagEnabled.mockReturnValue(true)
+      render(<OptionalFlagProbe flag="inspector-chat" />)
+      expect(screen.getByTestId('result')).toHaveTextContent('true')
+    })
   })
 
   it('renders children when a flag is enabled', () => {


### PR DESCRIPTION
## Summary                                                                                                                                                
                                                                                                                                                            
  - Hides the **Chat**, **Notepad**, and **Settings** inspector tabs behind PostHog feature flags; **Wiki** is always visible                               
  - Flag names are injected via Vercel environment variables (`VITE_PUBLIC_FF_CHAT`, `VITE_PUBLIC_FF_NOTEPAD`, `VITE_PUBLIC_FF_SETTINGS`), allowing dev and 
  production to point to separate PostHog flags and be toggled independently                                                                                
  - If an env var is unset or PostHog reports the flag as disabled, the tab is hidden — safe by default                                                     
  - If the active tab's flag is toggled off at runtime, the sidebar falls back to the Wiki tab automatically                                                
                                                                                                                                                            
  ## Vercel Setup Required                                                                                                                                  
                                                                                                                                                            
  Add the following environment variables in Vercel, with different values per environment:                                                                 
                                                                                                                                                            
  | Variable | Dev (dev branch) | Production (main branch) |                                                                                                
  |---|---|---|                                             
  | `VITE_PUBLIC_FF_CHAT` | `dev-inspector-chat` | `inspector-chat` |                                                                                       
  | `VITE_PUBLIC_FF_NOTEPAD` | `dev-inspector-notepad` | `inspector-notepad` |
  | `VITE_PUBLIC_FF_SETTINGS` | `dev-inspector-settings` | `inspector-settings` |                                                                           
                                                            
  Then create matching boolean feature flags in PostHog with those names. Toggle them on/off per environment to control visibility.                         
                                                            
  ## Test Plan                                                                                                                                              
                                                            
  - [ ] All 24 `InspectorSidebar` tests pass (`npm test`)                                                                                                   
  - [ ] With all three env vars set and PostHog flags enabled, all 4 tabs render as before
  - [ ] With a PostHog flag disabled, the corresponding tab disappears from the sidebar                                                                     
  - [ ] With an env var unset/empty, the corresponding tab is hidden                                                                                        
  - [ ] If the active tab's flag is turned off, the sidebar switches to Wiki automatically                                                                  
  - [ ] Wiki tab is always visible regardless of flag state                                                                                                 
                                                                                                                                                            
  Closes #281