### PR TITLE
fix: align CampaignTimelineWidget markers above the horizontal rail

### DIFF
--- a/app/components/mainview/widgets/CampaignTimelineWidget.tsx
+++ b/app/components/mainview/widgets/CampaignTimelineWidget.tsx
@@ -178,7 +178,7 @@ export function CampaignTimelineWidget({
               <div
                 aria-hidden="true"
                 data-part="timeline-rail"
-                className="absolute left-4 right-4 top-[3.5rem] z-0 h-px bg-white/[0.08]"
+                className="absolute left-4 right-4 top-16 z-0 h-px bg-white/[0.08]"
               />
 
               <ol className="grid grid-flow-col auto-cols-[minmax(10.5rem,1fr)] gap-4">
@@ -207,7 +207,10 @@ export function CampaignTimelineWidget({
                         </p>
                       </div>
 
-                      <div className="relative z-10 flex items-center justify-center">
+                      <div
+                        data-part="timeline-marker-row"
+                        className="relative z-10 flex items-center justify-center"
+                      >
                         <span
                           aria-hidden="true"
                           data-part="timeline-marker"

--- a/tests/components/mainview/widgets/CampaignTimelineWidget.test.tsx
+++ b/tests/components/mainview/widgets/CampaignTimelineWidget.test.tsx
@@ -95,6 +95,9 @@ describe('CampaignTimelineWidget', () => {
     )
     const rail = scroll.querySelector('[data-part="timeline-rail"]')
     expect(rail).toBeInTheDocument()
+    if (!rail) {
+      return
+    }
     expect(rail).toHaveClass('top-16')
     expect(rail).toHaveClass('z-0')
 

--- a/tests/components/mainview/widgets/CampaignTimelineWidget.test.tsx
+++ b/tests/components/mainview/widgets/CampaignTimelineWidget.test.tsx
@@ -93,7 +93,19 @@ describe('CampaignTimelineWidget', () => {
     expect(scroll.querySelector('[data-layout="horizontal"][data-tone="current"]')).toHaveTextContent(
       'A reliquary opened beneath the chapel after the second toll.',
     )
-    expect(scroll.querySelector('[data-part="timeline-rail"]')).toBeInTheDocument()
+    const rail = scroll.querySelector('[data-part="timeline-rail"]')
+    expect(rail).toBeInTheDocument()
+    expect(rail).toHaveClass('top-16')
+    expect(rail).toHaveClass('z-0')
+
+    const markerRows = scroll.querySelectorAll('[data-layout="horizontal"] [data-part="timeline-marker-row"]')
+    expect(markerRows).toHaveLength(mockEvents.length)
+    markerRows.forEach((markerRow) => {
+      expect(markerRow).toHaveClass('relative')
+      expect(markerRow).toHaveClass('z-10')
+      expect(markerRow).toHaveClass('items-center')
+    })
+
     expect(scroll.querySelectorAll('[data-layout="horizontal"] [data-part="timeline-marker"]')).toHaveLength(
       mockEvents.length,
     )


### PR DESCRIPTION
## Summary

Fixes the horizontal `CampaignTimelineWidget` marker layout so the timeline rail passes through the marker center and the markers render visually above the rail, matching the approved mockup more closely.

## Changes

- adjusted horizontal timeline rail positioning in `CampaignTimelineWidget`
- added an explicit horizontal marker-row hook so the stacking contract is easier to test and maintain
- added regression coverage for the horizontal rail/marker layout contract

## Verification

- `npm test -- --project unit tests/components/mainview/widgets/CampaignTimelineWidget.test.tsx`
- `npm run build`

## Closes

Fixes #285