### PR TITLE
feat: move campaign close into the shared user menu

### DIFF
--- a/app/components/Topbar.tsx
+++ b/app/components/Topbar.tsx
@@ -1,21 +1,9 @@
-import { useState, useEffect, useRef } from 'react'
 import { Link } from '@tanstack/react-router'
 import { useAuth } from '~/hooks/useAuth'
+import { UserMenu } from '~/components/shared/UserMenu'
 
 export function Topbar() {
-  const { user, logout } = useAuth()
-  const [menuOpen, setMenuOpen] = useState(false)
-  const menuRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMenuOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [])
+  const { user } = useAuth()
 
   if (!user) return null
 
@@ -28,50 +16,7 @@ export function Topbar() {
         CARTYX
       </Link>
 
-      <div className="flex items-center gap-3" ref={menuRef}>
-        {user.avatar ? (
-          <img
-            src={user.avatar}
-            alt={`${user.name ?? 'User'} avatar`}
-            className="w-8 h-8 rounded-full border-2 border-white/20 object-cover"
-          />
-        ) : (
-          <div className="w-8 h-8 rounded-full border-2 border-white/20 bg-blue-900/40 flex items-center justify-center text-sm">
-            🧙
-          </div>
-        )}
-
-        <div className="relative">
-          <button
-            type="button"
-            onClick={() => setMenuOpen(v => !v)}
-            aria-expanded={menuOpen}
-            className="flex items-center gap-1.5 text-sm text-slate-300 hover:text-white transition-colors"
-          >
-            <span className="max-w-[140px] truncate">{user.name ?? ''}</span>
-            <span className="text-[10px] text-slate-500">▼</span>
-          </button>
-
-          {menuOpen && (
-            <div className="absolute right-0 top-full mt-2 w-44 bg-[#0D1117] border border-white/10 rounded-xl shadow-2xl overflow-hidden z-50">
-              <Link
-                to="/dashboard"
-                className="flex items-center gap-2 px-4 py-3 text-sm text-slate-300 hover:bg-white/[0.04] hover:text-white transition-colors"
-                onClick={() => setMenuOpen(false)}
-              >
-                ⚙️ Dashboard
-              </Link>
-              <button
-                type="button"
-                onClick={() => { setMenuOpen(false); logout() }}
-                className="w-full flex items-center gap-2 px-4 py-3 text-sm text-red-400 hover:bg-white/[0.04] transition-colors"
-              >
-                🚪 Sign Out
-              </button>
-            </div>
-          )}
-        </div>
-      </div>
+      <UserMenu />
     </nav>
   )
 }

--- a/app/components/mainview/CampaignHeader.tsx
+++ b/app/components/mainview/CampaignHeader.tsx
@@ -1,5 +1,4 @@
 import React, { useRef } from 'react'
-import { Link } from '@tanstack/react-router'
 import { UserMenu } from '~/components/shared/UserMenu'
 import { TABS, handleTabsKeyDown } from './TabNavigation'
 import type { TabId } from './TabNavigation'
@@ -16,14 +15,9 @@ export function CampaignHeader({ sessionNumber, activeTab, onTabChange }: Campai
 
   return (
     <nav className="flex items-center h-14 px-4 bg-[#0D1117] border-b border-white/[0.07] sticky top-0 z-50 gap-4">
-      {/* Left: Back link */}
-      <Link
-        to="/campaigns"
-        className="font-sans font-semibold text-xs text-slate-400 hover:text-white transition-colors whitespace-nowrap"
-        aria-label="Back to campaigns"
-      >
-        ← Back
-      </Link>
+      <span className="font-sans font-semibold text-xs text-white tracking-widest whitespace-nowrap">
+        Cartyx
+      </span>
 
       {/* Left-center: Session number */}
       {sessionNumber !== undefined && (
@@ -74,7 +68,7 @@ export function CampaignHeader({ sessionNumber, activeTab, onTabChange }: Campai
           🔔
         </button>
 
-        <UserMenu />
+        <UserMenu contextualAction={{ label: 'Close Campaign', to: '/campaigns' }} />
       </div>
     </nav>
   )

--- a/app/components/shared/UserMenu.tsx
+++ b/app/components/shared/UserMenu.tsx
@@ -1,12 +1,12 @@
 import { useState, useEffect, useRef } from 'react'
 import { faArrowRightFromBracket, faGear } from '@fortawesome/pro-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { Link } from '@tanstack/react-router'
+import { Link, type LinkProps } from '@tanstack/react-router'
 import { useAuth } from '~/hooks/useAuth'
 
 interface UserMenuAction {
   label: string
-  to: string
+  to: LinkProps['to']
 }
 
 interface UserMenuProps {

--- a/app/components/shared/UserMenu.tsx
+++ b/app/components/shared/UserMenu.tsx
@@ -1,8 +1,19 @@
 import { useState, useEffect, useRef } from 'react'
+import { faArrowRightFromBracket, faGear } from '@fortawesome/pro-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Link } from '@tanstack/react-router'
 import { useAuth } from '~/hooks/useAuth'
 
-export function UserMenu() {
+interface UserMenuAction {
+  label: string
+  to: string
+}
+
+interface UserMenuProps {
+  contextualAction?: UserMenuAction
+}
+
+export function UserMenu({ contextualAction }: UserMenuProps) {
   const { user, logout } = useAuth()
   const [menuOpen, setMenuOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
@@ -47,19 +58,30 @@ export function UserMenu() {
 
         {menuOpen && (
           <div className="absolute right-0 top-full mt-2 w-44 bg-[#0D1117] border border-white/10 rounded-xl shadow-2xl overflow-hidden z-50">
+            {contextualAction ? (
+              <Link
+                to={contextualAction.to}
+                className="flex items-center gap-2 px-4 py-3 text-sm text-slate-300 hover:bg-white/[0.04] hover:text-white transition-colors"
+                onClick={() => setMenuOpen(false)}
+              >
+                {contextualAction.label}
+              </Link>
+            ) : null}
             <Link
               to="/dashboard"
               className="flex items-center gap-2 px-4 py-3 text-sm text-slate-300 hover:bg-white/[0.04] hover:text-white transition-colors"
               onClick={() => setMenuOpen(false)}
             >
-              ⚙️ Dashboard
+              <FontAwesomeIcon icon={faGear} className="h-4 w-4" />
+              <span>User Profile information</span>
             </Link>
             <button
               type="button"
               onClick={() => { setMenuOpen(false); logout() }}
               className="w-full flex items-center gap-2 px-4 py-3 text-sm text-red-400 hover:bg-white/[0.04] transition-colors"
             >
-              🚪 Sign Out
+              <FontAwesomeIcon icon={faArrowRightFromBracket} className="h-4 w-4" />
+              <span>Sign Out</span>
             </button>
           </div>
         )}

--- a/tests/components/Topbar.test.tsx
+++ b/tests/components/Topbar.test.tsx
@@ -71,14 +71,15 @@ describe('Topbar', () => {
     render(<Topbar />)
 
     // Menu not visible initially
-    expect(screen.queryByText('🚪 Sign Out')).not.toBeInTheDocument()
+    expect(screen.queryByText('Sign Out')).not.toBeInTheDocument()
 
     // Click to open
     fireEvent.click(screen.getByText('Dave'))
-    expect(screen.getByText('🚪 Sign Out')).toBeInTheDocument()
+    expect(screen.getByText('User Profile information')).toBeInTheDocument()
+    expect(screen.getByText('Sign Out')).toBeInTheDocument()
 
     // Click sign out calls logout
-    fireEvent.click(screen.getByText('🚪 Sign Out'))
+    fireEvent.click(screen.getByText('Sign Out'))
     expect(logoutMock).toHaveBeenCalled()
   })
 })

--- a/tests/components/mainview/CampaignHeader.test.tsx
+++ b/tests/components/mainview/CampaignHeader.test.tsx
@@ -115,11 +115,12 @@ describe('CampaignHeader', () => {
     expect(screen.queryByTestId('session-number')).not.toBeInTheDocument()
   })
 
-  it('renders back link', () => {
+  it('renders the static Cartyx product name instead of a back link', () => {
     render(
       <CampaignHeader activeTab="dashboard" onTabChange={vi.fn()} />
     )
-    expect(screen.getByRole('link', { name: 'Back to campaigns' })).toBeInTheDocument()
+    expect(screen.getByText('Cartyx')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Back to campaigns' })).not.toBeInTheDocument()
   })
 
   it('opens and closes user menu', () => {
@@ -131,7 +132,9 @@ describe('CampaignHeader', () => {
 
     fireEvent.click(menuButton)
     expect(menuButton).toHaveAttribute('aria-expanded', 'true')
-    expect(screen.getByText('🚪 Sign Out')).toBeInTheDocument()
+    expect(screen.getByText('Close Campaign')).toBeInTheDocument()
+    expect(screen.getByText('User Profile information')).toBeInTheDocument()
+    expect(screen.getByText('Sign Out')).toBeInTheDocument()
 
     fireEvent.click(menuButton)
     expect(menuButton).toHaveAttribute('aria-expanded', 'false')
@@ -142,7 +145,7 @@ describe('CampaignHeader', () => {
       <CampaignHeader activeTab="dashboard" onTabChange={vi.fn()} />
     )
     fireEvent.click(screen.getByRole('button', { name: /User menu for/ }))
-    fireEvent.click(screen.getByText('🚪 Sign Out'))
+    fireEvent.click(screen.getByText('Sign Out'))
     expect(mockLogout).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

Moves the campaign exit action out of `CampaignHeader` and into the shared `UserMenu`, while updating the shared menu copy and icons.

## Changes

- replaces the `← Back` link in `CampaignHeader` with a static `Cartyx` label
- passes a campaign-only `Close Campaign` action into `UserMenu`
- renames the dashboard menu row to `User Profile information`
- swaps the dashboard and sign-out menu rows to Font Awesome icons
- reuses the shared `UserMenu` inside `Topbar` so the menu behavior stays consistent
- updates `CampaignHeader` and `Topbar` tests for the new menu labels and campaign action

## Verification

- unit tests for `CampaignHeader` and `Topbar`
- production build

## Closes

Fixes #286