### PR TITLE
[Bug]: align inspector chevron with sidebar edge

### DIFF
--- a/app/components/mainview/MainView.tsx
+++ b/app/components/mainview/MainView.tsx
@@ -41,9 +41,10 @@ export function MainView({ showToolbar = false, showInspector = true, children, 
   const drawerRef = useRef<HTMLDivElement>(null)
 
   const drawerOpen = showInspector && mobileInspectorOpen
-  const isInspectorOpen = isDesktop ? inspectorVisible : mobileInspectorOpen
-  const inspectorToggleLabel = isInspectorOpen ? 'Close inspector' : 'Open inspector'
-  const inspectorToggleIconClass = `inline-flex transition-transform duration-200 ${isInspectorOpen ? 'rotate-180' : 'rotate-0'}`
+  const desktopInspectorToggleLabel = inspectorVisible ? 'Close inspector' : 'Open inspector'
+  const mobileInspectorToggleLabel = mobileInspectorOpen ? 'Close inspector' : 'Open inspector'
+  const desktopInspectorToggleIconClass = `inline-flex transition-transform duration-200 ${inspectorVisible ? 'rotate-180' : 'rotate-0'}`
+  const mobileInspectorToggleIconClass = `inline-flex transition-transform duration-200 ${mobileInspectorOpen ? 'rotate-180' : 'rotate-0'}`
 
   // Focus the drawer and attach Escape-to-close while open
   useEffect(() => {
@@ -105,30 +106,30 @@ export function MainView({ showToolbar = false, showInspector = true, children, 
       </div>
 
       {/* Desktop inspector shell — animate width like the toolbar collapse rail */}
-      {showInspector && isDesktop && (
+      {showInspector && (
         <div
           data-testid="desktop-inspector-shell"
-          className={`relative flex-shrink-0 transition-[width] duration-200 ${inspectorVisible ? 'w-80' : 'w-0'}`}
+          className={`relative hidden w-0 flex-shrink-0 transition-[width] duration-200 lg:block ${inspectorVisible ? 'lg:w-80' : 'lg:w-0'}`}
         >
           <button
             type="button"
-            aria-label={inspectorToggleLabel}
-            aria-expanded={isInspectorOpen}
-            aria-controls="mainview-inspector"
-            data-testid="inspector-toggle"
+            aria-label={desktopInspectorToggleLabel}
+            aria-expanded={inspectorVisible}
+            aria-controls="mainview-inspector-desktop"
+            data-testid="desktop-inspector-toggle"
             onClick={handleInspectorToggle}
-            title={inspectorToggleLabel}
+            title={desktopInspectorToggleLabel}
             className="absolute left-0 top-1/2 z-10 flex h-12 w-6 -translate-x-full -translate-y-1/2 items-center justify-center rounded-l border border-r-0 border-white/[0.07] bg-[#0D1117] text-slate-400 transition-colors hover:text-slate-200"
           >
-            <span data-testid="inspector-toggle-icon" className={inspectorToggleIconClass}>
+            <span data-testid="desktop-inspector-toggle-icon" className={desktopInspectorToggleIconClass}>
               <ChevronLeft size={14} />
             </span>
           </button>
 
           <div
-            id="mainview-inspector"
-            data-testid="mainview-inspector"
-            className={`h-full w-80 overflow-hidden bg-[#0D1117] ${inspectorVisible ? 'flex border-l border-white/[0.07]' : 'hidden'}`}
+            id="mainview-inspector-desktop"
+            data-testid="desktop-inspector"
+            className={`h-full w-80 overflow-hidden bg-[#0D1117] ${inspectorVisible ? 'flex border-l border-white/[0.07]' : 'hidden lg:hidden'}`}
           >
             <InspectorSidebar />
           </div>
@@ -136,25 +137,25 @@ export function MainView({ showToolbar = false, showInspector = true, children, 
       )}
 
       {/* Mobile inspector toggle — remains a floating drawer control */}
-      {showInspector && !isDesktop && (
+      {showInspector && (
         <button
           type="button"
-          aria-label={inspectorToggleLabel}
-          aria-expanded={isInspectorOpen}
-          aria-controls="mainview-inspector"
-          data-testid="inspector-toggle"
+          aria-label={mobileInspectorToggleLabel}
+          aria-expanded={mobileInspectorOpen}
+          aria-controls="mainview-inspector-mobile"
+          data-testid="mobile-inspector-toggle"
           onClick={handleInspectorToggle}
-          title={inspectorToggleLabel}
-          className="fixed right-0 top-1/2 -translate-y-1/2 z-[60] flex items-center justify-center h-12 w-6 rounded-l bg-[#0D1117] border border-r-0 border-white/[0.07] text-slate-400 hover:text-slate-200 transition-colors"
+          title={mobileInspectorToggleLabel}
+          className="fixed right-0 top-1/2 -translate-y-1/2 z-[60] flex h-12 w-6 items-center justify-center rounded-l border border-r-0 border-white/[0.07] bg-[#0D1117] text-slate-400 transition-colors hover:text-slate-200 lg:hidden"
         >
-          <span data-testid="inspector-toggle-icon" className={inspectorToggleIconClass}>
+          <span data-testid="mobile-inspector-toggle-icon" className={mobileInspectorToggleIconClass}>
             <ChevronLeft size={14} />
           </span>
         </button>
       )}
 
       {/* Mobile inspector backdrop — tapping outside closes the drawer */}
-      {!isDesktop && drawerOpen && (
+      {drawerOpen && (
         <div
           aria-hidden="true"
           data-testid="mobile-inspector-backdrop"
@@ -164,20 +165,18 @@ export function MainView({ showToolbar = false, showInspector = true, children, 
       )}
 
       {/* Inspector — single instance, overlay drawer on mobile when open, inline on lg+ */}
-      {!isDesktop && (
+      {showInspector && (
         <div
           ref={drawerRef}
-          id="mainview-inspector"
-          data-testid="mainview-inspector"
+          id="mainview-inspector-mobile"
+          data-testid="mobile-inspector"
           role={drawerOpen ? 'dialog' : undefined}
           aria-modal={drawerOpen ? true : undefined}
           aria-label={drawerOpen ? 'Inspector' : undefined}
           tabIndex={drawerOpen ? -1 : undefined}
-          className={mobileInspectorClass}
+          className={`${mobileInspectorClass} lg:hidden`}
         >
-          {showInspector && (
-            <InspectorSidebar onMobileClose={() => setMobileInspectorOpen(false)} />
-          )}
+          <InspectorSidebar onMobileClose={() => setMobileInspectorOpen(false)} />
         </div>
       )}
     </div>

--- a/app/components/mainview/MainView.tsx
+++ b/app/components/mainview/MainView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useSyncExternalStore } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import type { ReactNode } from 'react'
 import { ToolBar } from './ToolBar'
 import type { ToolType } from './ToolBar'
@@ -6,20 +6,6 @@ import { InspectorSidebar } from './InspectorSidebar'
 import { ChevronLeft } from 'lucide-react'
 
 const LG_QUERY = '(min-width: 1024px)'
-
-function subscribeToDesktop(callback: () => void) {
-  const mq = window.matchMedia(LG_QUERY)
-  mq.addEventListener('change', callback)
-  return () => mq.removeEventListener('change', callback)
-}
-
-function getDesktopSnapshot() {
-  return window.matchMedia(LG_QUERY).matches
-}
-
-function getDesktopServerSnapshot() {
-  return false
-}
 
 interface MainViewProps {
   showToolbar?: boolean
@@ -33,11 +19,6 @@ export function MainView({ showToolbar = false, showInspector = true, children, 
   const [toolbarCollapsed, setToolbarCollapsed] = useState(false)
   const [mobileInspectorOpen, setMobileInspectorOpen] = useState(false)
   const [inspectorVisible, setInspectorVisible] = useState(true)
-  const isDesktop = useSyncExternalStore(
-    subscribeToDesktop,
-    getDesktopSnapshot,
-    getDesktopServerSnapshot,
-  )
   const drawerRef = useRef<HTMLDivElement>(null)
 
   const drawerOpen = showInspector && mobileInspectorOpen
@@ -62,20 +43,13 @@ export function MainView({ showToolbar = false, showInspector = true, children, 
 
   // Reset mobile drawer when viewport grows to lg+
   useEffect(() => {
-    if (isDesktop) setMobileInspectorOpen(false)
-  }, [isDesktop])
-
-  const handleInspectorToggle = () => {
-    if (isDesktop) {
-      setInspectorVisible(v => !v)
-    } else {
-      setMobileInspectorOpen(o => !o)
+    const mq = window.matchMedia(LG_QUERY)
+    const handler = () => {
+      if (mq.matches) setMobileInspectorOpen(false)
     }
-  }
-
-  const mobileInspectorClass = drawerOpen
-    ? 'fixed inset-y-0 right-0 z-50 flex w-80 border-l border-white/[0.07]'
-    : 'hidden'
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
 
   return (
     <div className={`flex h-full bg-[#080A12] overflow-hidden ${className}`}>
@@ -105,79 +79,83 @@ export function MainView({ showToolbar = false, showInspector = true, children, 
         {children}
       </div>
 
-      {/* Desktop inspector shell — animate width like the toolbar collapse rail */}
+      {/* Inspector — single instance */}
       {showInspector && (
-        <div
-          data-testid="desktop-inspector-shell"
-          className={`relative hidden w-0 flex-shrink-0 transition-[width] duration-200 lg:block ${inspectorVisible ? 'lg:w-80' : 'lg:w-0'}`}
-        >
+        <>
+          {/* Mobile toggle — fixed button on right edge, visible below lg */}
           <button
             type="button"
-            aria-label={desktopInspectorToggleLabel}
-            aria-expanded={inspectorVisible}
-            aria-controls="mainview-inspector-desktop"
-            data-testid="desktop-inspector-toggle"
-            onClick={handleInspectorToggle}
-            title={desktopInspectorToggleLabel}
-            className="absolute left-0 top-1/2 z-10 flex h-12 w-6 -translate-x-full -translate-y-1/2 items-center justify-center rounded-l border border-r-0 border-white/[0.07] bg-[#0D1117] text-slate-400 transition-colors hover:text-slate-200"
+            aria-label={mobileInspectorToggleLabel}
+            aria-expanded={mobileInspectorOpen}
+            aria-controls="mainview-inspector"
+            data-testid="mobile-inspector-toggle"
+            onClick={() => setMobileInspectorOpen(o => !o)}
+            title={mobileInspectorToggleLabel}
+            className="fixed right-0 top-1/2 -translate-y-1/2 z-[60] flex h-12 w-6 items-center justify-center rounded-l border border-r-0 border-white/[0.07] bg-[#0D1117] text-slate-400 transition-colors hover:text-slate-200 lg:hidden"
           >
-            <span data-testid="desktop-inspector-toggle-icon" className={desktopInspectorToggleIconClass}>
+            <span data-testid="mobile-inspector-toggle-icon" className={mobileInspectorToggleIconClass}>
               <ChevronLeft size={14} />
             </span>
           </button>
 
+          {/* Mobile backdrop — tapping outside closes the drawer */}
+          {drawerOpen && (
+            <div
+              aria-hidden="true"
+              data-testid="mobile-inspector-backdrop"
+              className="lg:hidden fixed inset-0 z-40 bg-black/50 cursor-default"
+              onClick={() => setMobileInspectorOpen(false)}
+            />
+          )}
+
+          {/* Inspector shell — inline panel on lg+, fixed drawer on mobile */}
           <div
-            id="mainview-inspector-desktop"
-            data-testid="desktop-inspector"
-            className={`h-full w-80 overflow-hidden bg-[#0D1117] ${inspectorVisible ? 'flex border-l border-white/[0.07]' : 'hidden lg:hidden'}`}
+            ref={drawerRef}
+            id="mainview-inspector"
+            data-testid="inspector-shell"
+            role={drawerOpen ? 'dialog' : undefined}
+            aria-modal={drawerOpen || undefined}
+            aria-label={drawerOpen ? 'Inspector' : undefined}
+            tabIndex={drawerOpen ? -1 : undefined}
+            className={[
+              'flex-shrink-0 overflow-hidden',
+              drawerOpen
+                ? 'fixed inset-y-0 right-0 z-50 flex w-80'
+                : 'hidden',
+              'lg:relative lg:flex lg:inset-auto lg:z-auto lg:transition-[width] lg:duration-200',
+              inspectorVisible ? 'lg:w-80' : 'lg:w-0',
+            ].join(' ')}
           >
-            <InspectorSidebar />
+            {/* Desktop toggle — positioned on left edge of shell */}
+            <button
+              type="button"
+              aria-label={desktopInspectorToggleLabel}
+              aria-expanded={inspectorVisible}
+              aria-controls="mainview-inspector"
+              data-testid="desktop-inspector-toggle"
+              onClick={() => setInspectorVisible(v => !v)}
+              title={desktopInspectorToggleLabel}
+              className="absolute left-0 top-1/2 z-10 hidden h-12 w-6 -translate-x-full -translate-y-1/2 items-center justify-center rounded-l border border-r-0 border-white/[0.07] bg-[#0D1117] text-slate-400 transition-colors hover:text-slate-200 lg:flex"
+            >
+              <span data-testid="desktop-inspector-toggle-icon" className={desktopInspectorToggleIconClass}>
+                <ChevronLeft size={14} />
+              </span>
+            </button>
+
+            {/* Inspector content */}
+            <div
+              data-testid="inspector-content"
+              className={[
+                'h-full w-80 overflow-hidden bg-[#0D1117]',
+                (inspectorVisible || drawerOpen)
+                  ? 'flex border-l border-white/[0.07]'
+                  : 'hidden',
+              ].join(' ')}
+            >
+              <InspectorSidebar onMobileClose={() => setMobileInspectorOpen(false)} />
+            </div>
           </div>
-        </div>
-      )}
-
-      {/* Mobile inspector toggle — remains a floating drawer control */}
-      {showInspector && (
-        <button
-          type="button"
-          aria-label={mobileInspectorToggleLabel}
-          aria-expanded={mobileInspectorOpen}
-          aria-controls="mainview-inspector-mobile"
-          data-testid="mobile-inspector-toggle"
-          onClick={handleInspectorToggle}
-          title={mobileInspectorToggleLabel}
-          className="fixed right-0 top-1/2 -translate-y-1/2 z-[60] flex h-12 w-6 items-center justify-center rounded-l border border-r-0 border-white/[0.07] bg-[#0D1117] text-slate-400 transition-colors hover:text-slate-200 lg:hidden"
-        >
-          <span data-testid="mobile-inspector-toggle-icon" className={mobileInspectorToggleIconClass}>
-            <ChevronLeft size={14} />
-          </span>
-        </button>
-      )}
-
-      {/* Mobile inspector backdrop — tapping outside closes the drawer */}
-      {drawerOpen && (
-        <div
-          aria-hidden="true"
-          data-testid="mobile-inspector-backdrop"
-          className="lg:hidden fixed inset-0 z-40 bg-black/50 cursor-default"
-          onClick={() => setMobileInspectorOpen(false)}
-        />
-      )}
-
-      {/* Inspector — single instance, overlay drawer on mobile when open, inline on lg+ */}
-      {showInspector && (
-        <div
-          ref={drawerRef}
-          id="mainview-inspector-mobile"
-          data-testid="mobile-inspector"
-          role={drawerOpen ? 'dialog' : undefined}
-          aria-modal={drawerOpen ? true : undefined}
-          aria-label={drawerOpen ? 'Inspector' : undefined}
-          tabIndex={drawerOpen ? -1 : undefined}
-          className={`${mobileInspectorClass} lg:hidden`}
-        >
-          <InspectorSidebar onMobileClose={() => setMobileInspectorOpen(false)} />
-        </div>
+        </>
       )}
     </div>
   )

--- a/app/components/mainview/MainView.tsx
+++ b/app/components/mainview/MainView.tsx
@@ -145,7 +145,7 @@ export function MainView({ showToolbar = false, showInspector = true, children, 
           data-testid="inspector-toggle"
           onClick={handleInspectorToggle}
           title={inspectorToggleLabel}
-          className="fixed right-0 top-1/2 -translate-y-1/2 z-60 flex items-center justify-center h-12 w-6 rounded-l bg-[#0D1117] border border-r-0 border-white/[0.07] text-slate-400 hover:text-slate-200 transition-colors"
+          className="fixed right-0 top-1/2 -translate-y-1/2 z-50 flex items-center justify-center h-12 w-6 rounded-l bg-[#0D1117] border border-r-0 border-white/[0.07] text-slate-400 hover:text-slate-200 transition-colors"
         >
           <span data-testid="inspector-toggle-icon" className={inspectorToggleIconClass}>
             <ChevronLeft size={14} />

--- a/app/components/mainview/MainView.tsx
+++ b/app/components/mainview/MainView.tsx
@@ -145,7 +145,7 @@ export function MainView({ showToolbar = false, showInspector = true, children, 
           data-testid="inspector-toggle"
           onClick={handleInspectorToggle}
           title={inspectorToggleLabel}
-          className="fixed right-0 top-1/2 -translate-y-1/2 z-50 flex items-center justify-center h-12 w-6 rounded-l bg-[#0D1117] border border-r-0 border-white/[0.07] text-slate-400 hover:text-slate-200 transition-colors"
+          className="fixed right-0 top-1/2 -translate-y-1/2 z-[60] flex items-center justify-center h-12 w-6 rounded-l bg-[#0D1117] border border-r-0 border-white/[0.07] text-slate-400 hover:text-slate-200 transition-colors"
         >
           <span data-testid="inspector-toggle-icon" className={inspectorToggleIconClass}>
             <ChevronLeft size={14} />

--- a/app/components/mainview/MainView.tsx
+++ b/app/components/mainview/MainView.tsx
@@ -41,6 +41,9 @@ export function MainView({ showToolbar = false, showInspector = true, children, 
   const drawerRef = useRef<HTMLDivElement>(null)
 
   const drawerOpen = showInspector && mobileInspectorOpen
+  const isInspectorOpen = isDesktop ? inspectorVisible : mobileInspectorOpen
+  const inspectorToggleLabel = isInspectorOpen ? 'Close inspector' : 'Open inspector'
+  const inspectorToggleIconClass = `inline-flex transition-transform duration-200 ${isInspectorOpen ? 'rotate-180' : 'rotate-0'}`
 
   // Focus the drawer and attach Escape-to-close while open
   useEffect(() => {
@@ -69,22 +72,9 @@ export function MainView({ showToolbar = false, showInspector = true, children, 
     }
   }
 
-  // Reflects whether the inspector is currently accessible in the active viewport context
-  const isInspectorOpen = isDesktop ? inspectorVisible : mobileInspectorOpen
-
-  const inspectorClass = (() => {
-    if (!showInspector) return 'hidden'
-
-    const mobileBase = drawerOpen
-      ? 'fixed inset-y-0 right-0 w-80 z-50 flex border-l border-white/[0.07]'
-      : 'hidden'
-
-    const desktopOverride = inspectorVisible
-      ? 'lg:relative lg:inset-auto lg:z-auto lg:flex lg:flex-shrink-0 lg:overflow-hidden lg:w-80 lg:border-l lg:border-white/[0.07]'
-      : 'lg:hidden'
-
-    return `${mobileBase} ${desktopOverride}`
-  })()
+  const mobileInspectorClass = drawerOpen
+    ? 'fixed inset-y-0 right-0 z-50 flex w-80 border-l border-white/[0.07]'
+    : 'hidden'
 
   return (
     <div className={`flex h-full bg-[#080A12] overflow-hidden ${className}`}>
@@ -114,23 +104,57 @@ export function MainView({ showToolbar = false, showInspector = true, children, 
         {children}
       </div>
 
-      {/* Inspector toggle — visible at all screen sizes */}
-      {showInspector && (
+      {/* Desktop inspector shell — animate width like the toolbar collapse rail */}
+      {showInspector && isDesktop && (
+        <div
+          data-testid="desktop-inspector-shell"
+          className={`relative flex-shrink-0 transition-[width] duration-200 ${inspectorVisible ? 'w-80' : 'w-0'}`}
+        >
+          <button
+            type="button"
+            aria-label={inspectorToggleLabel}
+            aria-expanded={isInspectorOpen}
+            aria-controls="mainview-inspector"
+            data-testid="inspector-toggle"
+            onClick={handleInspectorToggle}
+            title={inspectorToggleLabel}
+            className="absolute left-0 top-1/2 z-10 flex h-12 w-6 -translate-x-full -translate-y-1/2 items-center justify-center rounded-l border border-r-0 border-white/[0.07] bg-[#0D1117] text-slate-400 transition-colors hover:text-slate-200"
+          >
+            <span data-testid="inspector-toggle-icon" className={inspectorToggleIconClass}>
+              <ChevronLeft size={14} />
+            </span>
+          </button>
+
+          <div
+            id="mainview-inspector"
+            data-testid="mainview-inspector"
+            className={`h-full w-80 overflow-hidden bg-[#0D1117] ${inspectorVisible ? 'flex border-l border-white/[0.07]' : 'hidden'}`}
+          >
+            <InspectorSidebar />
+          </div>
+        </div>
+      )}
+
+      {/* Mobile inspector toggle — remains a floating drawer control */}
+      {showInspector && !isDesktop && (
         <button
           type="button"
-          aria-label={isInspectorOpen ? 'Close inspector' : 'Open inspector'}
+          aria-label={inspectorToggleLabel}
           aria-expanded={isInspectorOpen}
           aria-controls="mainview-inspector"
           data-testid="inspector-toggle"
           onClick={handleInspectorToggle}
+          title={inspectorToggleLabel}
           className="fixed right-0 top-1/2 -translate-y-1/2 z-60 flex items-center justify-center h-12 w-6 rounded-l bg-[#0D1117] border border-r-0 border-white/[0.07] text-slate-400 hover:text-slate-200 transition-colors"
         >
-          <ChevronLeft size={14} />
+          <span data-testid="inspector-toggle-icon" className={inspectorToggleIconClass}>
+            <ChevronLeft size={14} />
+          </span>
         </button>
       )}
 
       {/* Mobile inspector backdrop — tapping outside closes the drawer */}
-      {drawerOpen && (
+      {!isDesktop && drawerOpen && (
         <div
           aria-hidden="true"
           data-testid="mobile-inspector-backdrop"
@@ -140,20 +164,22 @@ export function MainView({ showToolbar = false, showInspector = true, children, 
       )}
 
       {/* Inspector — single instance, overlay drawer on mobile when open, inline on lg+ */}
-      <div
-        ref={drawerRef}
-        id="mainview-inspector"
-        data-testid="mainview-inspector"
-        role={drawerOpen ? 'dialog' : undefined}
-        aria-modal={drawerOpen ? true : undefined}
-        aria-label={drawerOpen ? 'Inspector' : undefined}
-        tabIndex={drawerOpen ? -1 : undefined}
-        className={inspectorClass}
-      >
-        {showInspector && (
-          <InspectorSidebar onMobileClose={() => setMobileInspectorOpen(false)} />
-        )}
-      </div>
+      {!isDesktop && (
+        <div
+          ref={drawerRef}
+          id="mainview-inspector"
+          data-testid="mainview-inspector"
+          role={drawerOpen ? 'dialog' : undefined}
+          aria-modal={drawerOpen ? true : undefined}
+          aria-label={drawerOpen ? 'Inspector' : undefined}
+          tabIndex={drawerOpen ? -1 : undefined}
+          className={mobileInspectorClass}
+        >
+          {showInspector && (
+            <InspectorSidebar onMobileClose={() => setMobileInspectorOpen(false)} />
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/app/components/mainview/MainView.tsx
+++ b/app/components/mainview/MainView.tsx
@@ -105,10 +105,10 @@ export function MainView({ showToolbar = false, showInspector = true, children, 
       </div>
 
       {/* Desktop inspector shell — animate width like the toolbar collapse rail */}
-      {showInspector && (
+      {showInspector && isDesktop && (
         <div
           data-testid="desktop-inspector-shell"
-          className={`relative hidden w-0 flex-shrink-0 transition-[width] duration-200 lg:block ${inspectorVisible ? 'lg:w-80' : 'lg:w-0'}`}
+          className={`relative flex-shrink-0 transition-[width] duration-200 ${inspectorVisible ? 'w-80' : 'w-0'}`}
         >
           <button
             type="button"

--- a/app/components/mainview/MainView.tsx
+++ b/app/components/mainview/MainView.tsx
@@ -105,10 +105,10 @@ export function MainView({ showToolbar = false, showInspector = true, children, 
       </div>
 
       {/* Desktop inspector shell — animate width like the toolbar collapse rail */}
-      {showInspector && isDesktop && (
+      {showInspector && (
         <div
           data-testid="desktop-inspector-shell"
-          className={`relative flex-shrink-0 transition-[width] duration-200 ${inspectorVisible ? 'w-80' : 'w-0'}`}
+          className={`relative hidden w-0 flex-shrink-0 transition-[width] duration-200 lg:block ${inspectorVisible ? 'lg:w-80' : 'lg:w-0'}`}
         >
           <button
             type="button"

--- a/tests/components/mainview/MainView.test.tsx
+++ b/tests/components/mainview/MainView.test.tsx
@@ -60,15 +60,15 @@ describe('MainView', () => {
     expect(toolbar).not.toHaveClass('w-0')
   })
 
-  it('shows inspector by default (lg breakpoint class)', () => {
+  it('keeps the mobile inspector drawer hidden by default', () => {
     render(
       <MainView>
         <div>Content</div>
       </MainView>
     )
     const inspector = screen.getByTestId('mainview-inspector')
-    expect(inspector).toHaveClass('lg:w-80')
-    expect(inspector).not.toHaveClass('lg:w-0')
+    expect(inspector).toHaveClass('hidden')
+    expect(inspector).not.toHaveAttribute('role', 'dialog')
   })
 
   it('hides inspector when showInspector is false', () => {
@@ -202,6 +202,20 @@ describe('MainView', () => {
       expect(screen.getByTestId('inspector-toggle')).toHaveAttribute('aria-expanded', 'true')
     })
 
+    it('mobile toggle chevron rotates between closed and open states', async () => {
+      const user = userEvent.setup()
+      render(
+        <MainView>
+          <div>Content</div>
+        </MainView>
+      )
+      const icon = screen.getByTestId('inspector-toggle-icon')
+      expect(icon).toHaveClass('rotate-0')
+
+      await user.click(screen.getByTestId('inspector-toggle'))
+      expect(screen.getByTestId('inspector-toggle-icon')).toHaveClass('rotate-180')
+    })
+
     it('drawer shows backdrop when open on mobile', async () => {
       const user = userEvent.setup()
       render(
@@ -264,24 +278,26 @@ describe('MainView', () => {
           <div>Content</div>
         </MainView>
       )
+      expect(screen.getByTestId('desktop-inspector-shell')).toHaveClass('w-80')
       const inspector = screen.getByTestId('mainview-inspector')
-      expect(inspector).toHaveClass('lg:w-80')
+      expect(inspector).toHaveClass('w-80')
     })
 
-    it('on desktop, clicking toggle hides the inspector inline (adds lg:hidden)', async () => {
+    it('on desktop, clicking toggle collapses the inspector shell from the left edge', async () => {
       const user = userEvent.setup()
       render(
         <MainView>
           <div>Content</div>
         </MainView>
       )
+      const shell = screen.getByTestId('desktop-inspector-shell')
       const inspector = screen.getByTestId('mainview-inspector')
-      expect(inspector).toHaveClass('lg:w-80')
-      expect(inspector).not.toHaveClass('lg:hidden')
+      expect(shell).toHaveClass('w-80')
+      expect(inspector).not.toHaveClass('hidden')
 
       await user.click(screen.getByTestId('inspector-toggle'))
-      expect(inspector).toHaveClass('lg:hidden')
-      expect(inspector).not.toHaveClass('lg:w-80')
+      expect(shell).toHaveClass('w-0')
+      expect(inspector).toHaveClass('hidden')
     })
 
     it('on desktop, toggle aria-expanded reflects inspectorVisible state', async () => {
@@ -320,7 +336,31 @@ describe('MainView', () => {
       const toggle = screen.getByTestId('inspector-toggle')
       await user.click(toggle)
       await user.click(toggle)
-      expect(screen.getByTestId('mainview-inspector')).toHaveClass('lg:w-80')
+      expect(screen.getByTestId('desktop-inspector-shell')).toHaveClass('w-80')
+      expect(screen.getByTestId('mainview-inspector')).toHaveClass('w-80')
+    })
+
+    it('on desktop, the toggle sits on the left edge of the inspector shell', () => {
+      render(
+        <MainView>
+          <div>Content</div>
+        </MainView>
+      )
+      expect(screen.getByTestId('inspector-toggle')).toHaveClass('absolute', 'left-0', '-translate-x-full')
+    })
+
+    it('on desktop, the chevron rotates to reflect the open state', async () => {
+      const user = userEvent.setup()
+      render(
+        <MainView>
+          <div>Content</div>
+        </MainView>
+      )
+      const icon = screen.getByTestId('inspector-toggle-icon')
+      expect(icon).toHaveClass('rotate-180')
+
+      await user.click(screen.getByTestId('inspector-toggle'))
+      expect(screen.getByTestId('inspector-toggle-icon')).toHaveClass('rotate-0')
     })
   })
 })

--- a/tests/components/mainview/MainView.test.tsx
+++ b/tests/components/mainview/MainView.test.tsx
@@ -66,7 +66,7 @@ describe('MainView', () => {
         <div>Content</div>
       </MainView>
     )
-    const inspector = screen.getByTestId('mainview-inspector')
+    const inspector = screen.getByTestId('mobile-inspector')
     expect(inspector).toHaveClass('hidden')
     expect(inspector).not.toHaveAttribute('role', 'dialog')
   })
@@ -77,9 +77,8 @@ describe('MainView', () => {
         <div>Content</div>
       </MainView>
     )
-    const inspector = screen.getByTestId('mainview-inspector')
-    expect(inspector).toHaveClass('hidden')
-    expect(inspector).not.toHaveClass('lg:w-80')
+    expect(screen.queryByTestId('mobile-inspector')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('desktop-inspector-shell')).not.toBeInTheDocument()
   })
 
   it('hides both sidebars when both props are false', () => {
@@ -89,9 +88,8 @@ describe('MainView', () => {
       </MainView>
     )
     expect(screen.getByTestId('mainview-toolbar')).toHaveClass('w-0')
-    const inspector = screen.getByTestId('mainview-inspector')
-    expect(inspector).toHaveClass('hidden')
-    expect(inspector).not.toHaveClass('lg:w-80')
+    expect(screen.queryByTestId('mobile-inspector')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('desktop-inspector-shell')).not.toBeInTheDocument()
   })
 
   it('toolbar toggle is not in DOM when showToolbar is false', () => {
@@ -146,7 +144,7 @@ describe('MainView', () => {
           <div>Content</div>
         </MainView>
       )
-      expect(screen.getByTestId('inspector-toggle')).toBeInTheDocument()
+      expect(screen.getByTestId('mobile-inspector-toggle')).toBeInTheDocument()
     })
 
     it('inspector toggle has aria-label "Open inspector" initially', () => {
@@ -164,7 +162,7 @@ describe('MainView', () => {
           <div>Content</div>
         </MainView>
       )
-      expect(screen.queryByTestId('inspector-toggle')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('mobile-inspector-toggle')).not.toBeInTheDocument()
     })
 
     it('mobile drawer is hidden by default (no dialog role)', () => {
@@ -173,7 +171,7 @@ describe('MainView', () => {
           <div>Content</div>
         </MainView>
       )
-      const inspector = screen.getByTestId('mainview-inspector')
+      const inspector = screen.getByTestId('mobile-inspector')
       expect(inspector).not.toHaveAttribute('role', 'dialog')
     })
 
@@ -184,8 +182,8 @@ describe('MainView', () => {
           <div>Content</div>
         </MainView>
       )
-      await user.click(screen.getByTestId('inspector-toggle'))
-      expect(screen.getByTestId('mainview-inspector')).toHaveAttribute('role', 'dialog')
+      await user.click(screen.getByTestId('mobile-inspector-toggle'))
+      expect(screen.getByTestId('mobile-inspector')).toHaveAttribute('role', 'dialog')
     })
 
     it('toggle button remains visible and marks aria-expanded after click', async () => {
@@ -195,11 +193,11 @@ describe('MainView', () => {
           <div>Content</div>
         </MainView>
       )
-      const toggle = screen.getByTestId('inspector-toggle')
+      const toggle = screen.getByTestId('mobile-inspector-toggle')
       expect(toggle).toHaveAttribute('aria-expanded', 'false')
       await user.click(toggle)
-      expect(screen.getByTestId('inspector-toggle')).toBeInTheDocument()
-      expect(screen.getByTestId('inspector-toggle')).toHaveAttribute('aria-expanded', 'true')
+      expect(screen.getByTestId('mobile-inspector-toggle')).toBeInTheDocument()
+      expect(screen.getByTestId('mobile-inspector-toggle')).toHaveAttribute('aria-expanded', 'true')
     })
 
     it('mobile toggle chevron rotates between closed and open states', async () => {
@@ -209,11 +207,11 @@ describe('MainView', () => {
           <div>Content</div>
         </MainView>
       )
-      const icon = screen.getByTestId('inspector-toggle-icon')
+      const icon = screen.getByTestId('mobile-inspector-toggle-icon')
       expect(icon).toHaveClass('rotate-0')
 
-      await user.click(screen.getByTestId('inspector-toggle'))
-      expect(screen.getByTestId('inspector-toggle-icon')).toHaveClass('rotate-180')
+      await user.click(screen.getByTestId('mobile-inspector-toggle'))
+      expect(screen.getByTestId('mobile-inspector-toggle-icon')).toHaveClass('rotate-180')
     })
 
     it('drawer shows backdrop when open on mobile', async () => {
@@ -223,7 +221,7 @@ describe('MainView', () => {
           <div>Content</div>
         </MainView>
       )
-      await user.click(screen.getByTestId('inspector-toggle'))
+      await user.click(screen.getByTestId('mobile-inspector-toggle'))
       expect(screen.getByTestId('mobile-inspector-backdrop')).toBeInTheDocument()
     })
 
@@ -234,9 +232,9 @@ describe('MainView', () => {
           <div>Content</div>
         </MainView>
       )
-      await user.click(screen.getByTestId('inspector-toggle'))
+      await user.click(screen.getByTestId('mobile-inspector-toggle'))
       await user.click(screen.getByTestId('mobile-inspector-backdrop'))
-      expect(screen.getByTestId('mainview-inspector')).not.toHaveAttribute('role', 'dialog')
+      expect(screen.getByTestId('mobile-inspector')).not.toHaveAttribute('role', 'dialog')
     })
 
     it('pressing Escape while drawer is open closes the drawer', async () => {
@@ -246,10 +244,10 @@ describe('MainView', () => {
           <div>Content</div>
         </MainView>
       )
-      await user.click(screen.getByTestId('inspector-toggle'))
-      expect(screen.getByTestId('mainview-inspector')).toHaveAttribute('role', 'dialog')
+      await user.click(screen.getByTestId('mobile-inspector-toggle'))
+      expect(screen.getByTestId('mobile-inspector')).toHaveAttribute('role', 'dialog')
       await user.keyboard('{Escape}')
-      expect(screen.getByTestId('mainview-inspector')).not.toHaveAttribute('role', 'dialog')
+      expect(screen.getByTestId('mobile-inspector')).not.toHaveAttribute('role', 'dialog')
     })
 
     it('clicking close button inside drawer closes it', async () => {
@@ -259,10 +257,10 @@ describe('MainView', () => {
           <div>Content</div>
         </MainView>
       )
-      await user.click(screen.getByTestId('inspector-toggle'))
-      expect(screen.getByTestId('mainview-inspector')).toHaveAttribute('role', 'dialog')
+      await user.click(screen.getByTestId('mobile-inspector-toggle'))
+      expect(screen.getByTestId('mobile-inspector')).toHaveAttribute('role', 'dialog')
       await user.click(screen.getByTestId('mobile-inspector-close'))
-      expect(screen.getByTestId('mainview-inspector')).not.toHaveAttribute('role', 'dialog')
+      expect(screen.getByTestId('mobile-inspector')).not.toHaveAttribute('role', 'dialog')
     })
   })
 
@@ -278,8 +276,8 @@ describe('MainView', () => {
           <div>Content</div>
         </MainView>
       )
-      expect(screen.getByTestId('desktop-inspector-shell')).toHaveClass('w-80')
-      const inspector = screen.getByTestId('mainview-inspector')
+      expect(screen.getByTestId('desktop-inspector-shell')).toHaveClass('lg:w-80')
+      const inspector = screen.getByTestId('desktop-inspector')
       expect(inspector).toHaveClass('w-80')
     })
 
@@ -291,12 +289,12 @@ describe('MainView', () => {
         </MainView>
       )
       const shell = screen.getByTestId('desktop-inspector-shell')
-      const inspector = screen.getByTestId('mainview-inspector')
-      expect(shell).toHaveClass('w-80')
+      const inspector = screen.getByTestId('desktop-inspector')
+      expect(shell).toHaveClass('lg:w-80')
       expect(inspector).not.toHaveClass('hidden')
 
-      await user.click(screen.getByTestId('inspector-toggle'))
-      expect(shell).toHaveClass('w-0')
+      await user.click(screen.getByTestId('desktop-inspector-toggle'))
+      expect(shell).toHaveClass('lg:w-0')
       expect(inspector).toHaveClass('hidden')
     })
 
@@ -307,7 +305,7 @@ describe('MainView', () => {
           <div>Content</div>
         </MainView>
       )
-      const toggle = screen.getByTestId('inspector-toggle')
+      const toggle = screen.getByTestId('desktop-inspector-toggle')
       // Inspector visible by default on desktop → aria-expanded="true"
       expect(toggle).toHaveAttribute('aria-expanded', 'true')
 
@@ -322,8 +320,8 @@ describe('MainView', () => {
           <div>Content</div>
         </MainView>
       )
-      await user.click(screen.getByTestId('inspector-toggle'))
-      expect(screen.getByTestId('mainview-inspector')).not.toHaveAttribute('role', 'dialog')
+      await user.click(screen.getByTestId('desktop-inspector-toggle'))
+      expect(screen.getByTestId('desktop-inspector')).not.toHaveAttribute('role', 'dialog')
     })
 
     it('on desktop, clicking toggle twice restores inspector visibility', async () => {
@@ -333,11 +331,11 @@ describe('MainView', () => {
           <div>Content</div>
         </MainView>
       )
-      const toggle = screen.getByTestId('inspector-toggle')
+      const toggle = screen.getByTestId('desktop-inspector-toggle')
       await user.click(toggle)
       await user.click(toggle)
-      expect(screen.getByTestId('desktop-inspector-shell')).toHaveClass('w-80')
-      expect(screen.getByTestId('mainview-inspector')).toHaveClass('w-80')
+      expect(screen.getByTestId('desktop-inspector-shell')).toHaveClass('lg:w-80')
+      expect(screen.getByTestId('desktop-inspector')).toHaveClass('w-80')
     })
 
     it('on desktop, the toggle sits on the left edge of the inspector shell', () => {
@@ -346,7 +344,7 @@ describe('MainView', () => {
           <div>Content</div>
         </MainView>
       )
-      expect(screen.getByTestId('inspector-toggle')).toHaveClass('absolute', 'left-0', '-translate-x-full')
+      expect(screen.getByTestId('desktop-inspector-toggle')).toHaveClass('absolute', 'left-0', '-translate-x-full')
     })
 
     it('on desktop, the chevron rotates to reflect the open state', async () => {
@@ -356,11 +354,11 @@ describe('MainView', () => {
           <div>Content</div>
         </MainView>
       )
-      const icon = screen.getByTestId('inspector-toggle-icon')
+      const icon = screen.getByTestId('desktop-inspector-toggle-icon')
       expect(icon).toHaveClass('rotate-180')
 
-      await user.click(screen.getByTestId('inspector-toggle'))
-      expect(screen.getByTestId('inspector-toggle-icon')).toHaveClass('rotate-0')
+      await user.click(screen.getByTestId('desktop-inspector-toggle'))
+      expect(screen.getByTestId('desktop-inspector-toggle-icon')).toHaveClass('rotate-0')
     })
   })
 })

--- a/tests/components/mainview/MainView.test.tsx
+++ b/tests/components/mainview/MainView.test.tsx
@@ -66,7 +66,7 @@ describe('MainView', () => {
         <div>Content</div>
       </MainView>
     )
-    const inspector = screen.getByTestId('mobile-inspector')
+    const inspector = screen.getByTestId('inspector-shell')
     expect(inspector).toHaveClass('hidden')
     expect(inspector).not.toHaveAttribute('role', 'dialog')
   })
@@ -77,8 +77,7 @@ describe('MainView', () => {
         <div>Content</div>
       </MainView>
     )
-    expect(screen.queryByTestId('mobile-inspector')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('desktop-inspector-shell')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('inspector-shell')).not.toBeInTheDocument()
   })
 
   it('hides both sidebars when both props are false', () => {
@@ -88,8 +87,7 @@ describe('MainView', () => {
       </MainView>
     )
     expect(screen.getByTestId('mainview-toolbar')).toHaveClass('w-0')
-    expect(screen.queryByTestId('mobile-inspector')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('desktop-inspector-shell')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('inspector-shell')).not.toBeInTheDocument()
   })
 
   it('toolbar toggle is not in DOM when showToolbar is false', () => {
@@ -171,7 +169,7 @@ describe('MainView', () => {
           <div>Content</div>
         </MainView>
       )
-      const inspector = screen.getByTestId('mobile-inspector')
+      const inspector = screen.getByTestId('inspector-shell')
       expect(inspector).not.toHaveAttribute('role', 'dialog')
     })
 
@@ -183,7 +181,7 @@ describe('MainView', () => {
         </MainView>
       )
       await user.click(screen.getByTestId('mobile-inspector-toggle'))
-      expect(screen.getByTestId('mobile-inspector')).toHaveAttribute('role', 'dialog')
+      expect(screen.getByTestId('inspector-shell')).toHaveAttribute('role', 'dialog')
     })
 
     it('toggle button remains visible and marks aria-expanded after click', async () => {
@@ -234,7 +232,7 @@ describe('MainView', () => {
       )
       await user.click(screen.getByTestId('mobile-inspector-toggle'))
       await user.click(screen.getByTestId('mobile-inspector-backdrop'))
-      expect(screen.getByTestId('mobile-inspector')).not.toHaveAttribute('role', 'dialog')
+      expect(screen.getByTestId('inspector-shell')).not.toHaveAttribute('role', 'dialog')
     })
 
     it('pressing Escape while drawer is open closes the drawer', async () => {
@@ -245,9 +243,9 @@ describe('MainView', () => {
         </MainView>
       )
       await user.click(screen.getByTestId('mobile-inspector-toggle'))
-      expect(screen.getByTestId('mobile-inspector')).toHaveAttribute('role', 'dialog')
+      expect(screen.getByTestId('inspector-shell')).toHaveAttribute('role', 'dialog')
       await user.keyboard('{Escape}')
-      expect(screen.getByTestId('mobile-inspector')).not.toHaveAttribute('role', 'dialog')
+      expect(screen.getByTestId('inspector-shell')).not.toHaveAttribute('role', 'dialog')
     })
 
     it('clicking close button inside drawer closes it', async () => {
@@ -258,9 +256,9 @@ describe('MainView', () => {
         </MainView>
       )
       await user.click(screen.getByTestId('mobile-inspector-toggle'))
-      expect(screen.getByTestId('mobile-inspector')).toHaveAttribute('role', 'dialog')
+      expect(screen.getByTestId('inspector-shell')).toHaveAttribute('role', 'dialog')
       await user.click(screen.getByTestId('mobile-inspector-close'))
-      expect(screen.getByTestId('mobile-inspector')).not.toHaveAttribute('role', 'dialog')
+      expect(screen.getByTestId('inspector-shell')).not.toHaveAttribute('role', 'dialog')
     })
   })
 
@@ -276,8 +274,8 @@ describe('MainView', () => {
           <div>Content</div>
         </MainView>
       )
-      expect(screen.getByTestId('desktop-inspector-shell')).toHaveClass('lg:w-80')
-      const inspector = screen.getByTestId('desktop-inspector')
+      expect(screen.getByTestId('inspector-shell')).toHaveClass('lg:w-80')
+      const inspector = screen.getByTestId('inspector-content')
       expect(inspector).toHaveClass('w-80')
     })
 
@@ -288,8 +286,8 @@ describe('MainView', () => {
           <div>Content</div>
         </MainView>
       )
-      const shell = screen.getByTestId('desktop-inspector-shell')
-      const inspector = screen.getByTestId('desktop-inspector')
+      const shell = screen.getByTestId('inspector-shell')
+      const inspector = screen.getByTestId('inspector-content')
       expect(shell).toHaveClass('lg:w-80')
       expect(inspector).not.toHaveClass('hidden')
 
@@ -321,7 +319,7 @@ describe('MainView', () => {
         </MainView>
       )
       await user.click(screen.getByTestId('desktop-inspector-toggle'))
-      expect(screen.getByTestId('desktop-inspector')).not.toHaveAttribute('role', 'dialog')
+      expect(screen.getByTestId('inspector-shell')).not.toHaveAttribute('role', 'dialog')
     })
 
     it('on desktop, clicking toggle twice restores inspector visibility', async () => {
@@ -334,8 +332,8 @@ describe('MainView', () => {
       const toggle = screen.getByTestId('desktop-inspector-toggle')
       await user.click(toggle)
       await user.click(toggle)
-      expect(screen.getByTestId('desktop-inspector-shell')).toHaveClass('lg:w-80')
-      expect(screen.getByTestId('desktop-inspector')).toHaveClass('w-80')
+      expect(screen.getByTestId('inspector-shell')).toHaveClass('lg:w-80')
+      expect(screen.getByTestId('inspector-content')).toHaveClass('w-80')
     })
 
     it('on desktop, the toggle sits on the left edge of the inspector shell', () => {


### PR DESCRIPTION
## Summary

Fixes the inspector sidebar chevron affordance so the toggle sits on the left edge of the inspector instead of the viewport edge, and makes the open/close chevron animate like the toolbar collapse control.

## Changes

- moved the desktop inspector toggle into the inspector shell so it anchors to the sidebar's left edge
- updated the desktop collapse behavior to preserve the chevron affordance while hiding the inspector content
- kept the mobile drawer/backdrop flow intact while aligning the chevron rotation/state behavior with the desktop interaction
- added `MainView` regression coverage for the left-edge placement, chevron rotation, desktop collapse flow, and preserved mobile drawer behavior

## Verification

- `npm run lint -- app/components/mainview/MainView.tsx tests/components/mainview/MainView.test.tsx`
- `npm run build`
- `npm run test -- --project unit tests/components/mainview/MainView.test.tsx tests/components/mainview/InspectorSidebar.test.tsx`

## Closes

Fixes #289