### PR TITLE
chore: reduce CI noise by removing Storybook from required pipeline gates (#340)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,25 +25,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Get Playwright version
-        id: playwright-version
-        run: echo "version=$(node -e 'console.log(require("@playwright/test/package.json").version)')" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
-
-      - name: Install Playwright Chromium
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install chromium --with-deps
-
-      - name: Install Playwright deps (cached)
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
-
       - name: Type check
         run: npm run typecheck
 
@@ -52,14 +33,6 @@ jobs:
 
       - name: Unit tests
         run: npm run test:ci
-        env:
-          SESSION_SECRET: ci-test-secret-at-least-32-characters-long
-          NODE_ENV: test
-
-      - name: Storybook tests
-        run: npm run test:storybook
-        timeout-minutes: 5
-        continue-on-error: ${{ github.event_name == 'push' }}
         env:
           SESSION_SECRET: ci-test-secret-at-least-32-characters-long
           NODE_ENV: test
@@ -97,3 +70,48 @@ jobs:
           SESSION_SECRET: build-placeholder-secret-at-least-32-chars
           NODE_ENV: production
           BASE_URL: https://cartyx.io
+
+  storybook:
+    name: Storybook Tests (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '25'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(node -e 'console.log(require("@playwright/test/package.json").version)')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright Chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium --with-deps
+
+      - name: Install Playwright deps (cached)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      - name: Storybook tests
+        run: npm run test:storybook
+        timeout-minutes: 5
+        env:
+          SESSION_SECRET: ci-test-secret-at-least-32-characters-long
+          NODE_ENV: test

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -550,12 +550,12 @@ Every PR automatically runs two required jobs plus one non-blocking job:
 **Non-blocking (runs in parallel, failures do not block merge):**
 3. **Storybook Tests** — interaction tests via Vitest + Playwright
 
-Storybook tests run as a separate non-blocking job because unit tests and
-Playwright-backed Storybook interaction tests already cover component behavior.
+Storybook tests run as a separate non-blocking job because core component
+behavior is already covered by unit tests and app-level Playwright/E2E tests.
 Storybook's primary value is as a UI showcase and component reference for
-design/development workflows, not as a release gate. Keeping it non-blocking
-preserves visibility into Storybook health without blocking delivery on flaky
-or low-signal failures.
+design/development workflows, not as a release gate. Keeping these interaction
+tests non-blocking preserves visibility into Storybook health without blocking
+delivery on flaky or low-signal failures.
 
 ### Vercel Deployments
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -541,13 +541,21 @@ are the single source of truth.
 
 ### Pull Request Checks (`ci.yml`)
 
-Every PR automatically runs:
-1. **Type check** — `npm run typecheck`
-2. **Lint** — `npm run lint`
-3. **Test** — `npm run test:ci` (with coverage)
-4. **Build** — `npm run build`
+Every PR automatically runs two required jobs plus one non-blocking job:
 
-All must pass before merging.
+**Required (must pass to merge):**
+1. **Lint & Test** — type check, lint, unit tests (with coverage)
+2. **Build** — production build verification
+
+**Non-blocking (runs in parallel, failures do not block merge):**
+3. **Storybook Tests** — interaction tests via Vitest + Playwright
+
+Storybook tests run as a separate non-blocking job because unit tests and
+Playwright-backed Storybook interaction tests already cover component behavior.
+Storybook's primary value is as a UI showcase and component reference for
+design/development workflows, not as a release gate. Keeping it non-blocking
+preserves visibility into Storybook health without blocking delivery on flaky
+or low-signal failures.
 
 ### Vercel Deployments
 


### PR DESCRIPTION
## Summary

- update CI/CD so Storybook is no longer part of the required blocking pipeline path
- keep primary quality gates focused on typecheck, lint, unit tests, and core build validation
- reduce flaky/noisy PR failures caused by Storybook jobs
- align pipeline behavior with Storybook's intended role as UI showcase/reference

## Validation

- npm run typecheck
- npm run lint (warnings only, no errors)
- npm run test:ci

## Closes
Fixes #340