### PR TITLE
[Feature] - Active Session Tracking

### DIFF
--- a/app/components/mainview/CampaignHeader.tsx
+++ b/app/components/mainview/CampaignHeader.tsx
@@ -16,7 +16,7 @@ export function CampaignHeader({ sessionNumber, activeTab, onTabChange }: Campai
   return (
     <nav className="flex items-center h-14 px-4 bg-[#0D1117] border-b border-white/[0.07] sticky top-0 z-50 gap-4">
       <span className="font-sans font-semibold text-xs text-white tracking-widest whitespace-nowrap">
-        Cartyx
+        CARTYX
       </span>
 
       {/* Left-center: Session number */}

--- a/app/server/db/models/Session.ts
+++ b/app/server/db/models/Session.ts
@@ -7,6 +7,7 @@ const sessionSchema = new mongoose.Schema({
   number: { type: Number, required: true },
   startDate: { type: Date, required: true },
   endDate: { type: Date },
+  isActive: { type: Boolean, default: false },
   summary: { type: String },
   createdAt: { type: Date, default: Date.now },
   updatedAt: { type: Date, default: Date.now },
@@ -16,6 +17,7 @@ const sessionSchema = new mongoose.Schema({
 if (typeof (sessionSchema as { index?: unknown }).index === 'function') {
   sessionSchema.index({ campaignId: 1, number: -1 })
   sessionSchema.index({ campaignId: 1, startDate: -1 })
+  sessionSchema.index({ campaignId: 1, isActive: 1 })
 }
 
 export const Session =

--- a/app/server/db/models/Session.ts
+++ b/app/server/db/models/Session.ts
@@ -17,7 +17,13 @@ const sessionSchema = new mongoose.Schema({
 if (typeof (sessionSchema as { index?: unknown }).index === 'function') {
   sessionSchema.index({ campaignId: 1, number: -1 })
   sessionSchema.index({ campaignId: 1, startDate: -1 })
-  sessionSchema.index({ campaignId: 1, isActive: 1 })
+  sessionSchema.index(
+    { campaignId: 1, isActive: 1 },
+    {
+      unique: true,
+      partialFilterExpression: { isActive: true },
+    }
+  )
 }
 
 export const Session =

--- a/app/server/functions/campaigns.ts
+++ b/app/server/functions/campaigns.ts
@@ -625,6 +625,10 @@ export const activateSession = createServerFn({ method: 'POST' })
             return
           }
 
+          // Verify target session exists and belongs to this campaign
+          const targetSession = await Session.findOne({ _id: data.sessionId, campaignId: data.campaignId }).session(mongoSession)
+          if (!targetSession) throw new Error('Session not found')
+
           const now = new Date()
 
           // Deactivate the currently active session

--- a/app/server/functions/campaigns.ts
+++ b/app/server/functions/campaigns.ts
@@ -618,28 +618,19 @@ export const activateSession = createServerFn({ method: 'POST' })
       const mongoSession = await mongoose.startSession()
       try {
         await mongoSession.withTransaction(async () => {
-          const currentActive = await Session.findOne({ campaignId: data.campaignId, isActive: true }).session(mongoSession)
-
-          // If the target is already the active session, no-op
-          if (currentActive && String(currentActive._id) === data.sessionId) {
-            return
-          }
-
           // Verify target session exists and belongs to this campaign
           const targetSession = await Session.findOne({ _id: data.sessionId, campaignId: data.campaignId }).session(mongoSession)
           if (!targetSession) throw new Error('Session not found')
 
           const now = new Date()
+          const endDate = data.endDate ? new Date(data.endDate) : now
 
-          // Deactivate the currently active session
-          if (currentActive) {
-            const endDate = data.endDate ? new Date(data.endDate) : now
-            await Session.updateOne(
-              { _id: currentActive._id },
-              { $set: { isActive: false, endDate, updatedAt: now } },
-              { session: mongoSession }
-            )
-          }
+          // Deactivate any other active sessions for this campaign
+          await Session.updateMany(
+            { campaignId: data.campaignId, isActive: true, _id: { $ne: data.sessionId } },
+            { $set: { isActive: false, endDate, updatedAt: now } },
+            { session: mongoSession }
+          )
 
           // Activate the target session
           await Session.updateOne(

--- a/app/server/functions/campaigns.ts
+++ b/app/server/functions/campaigns.ts
@@ -36,6 +36,7 @@ export interface CampaignData {
     number: number
     startDate: string
     endDate: string | null
+    isActive: boolean
   }>
   gmScreens?: Array<{
     id: string
@@ -201,7 +202,7 @@ export const getCampaign = createServerFn({ method: 'GET' })
         ).lean(),
         Session.find(
           { campaignId: c._id },
-          '_id name number startDate endDate'
+          '_id name number startDate endDate isActive'
         ).sort({ number: 1 }).lean(),
         isOwner
           ? GMScreen.find(
@@ -221,12 +222,13 @@ export const getCampaign = createServerFn({ method: 'GET' })
         userId: String(p.userId),
       }))
 
-      const sessions = (sessionDocs as Array<{ _id: unknown; name: unknown; number: unknown; startDate: unknown; endDate: unknown }>).map(s => ({
+      const sessions = (sessionDocs as Array<{ _id: unknown; name: unknown; number: unknown; startDate: unknown; endDate: unknown; isActive: unknown }>).map(s => ({
         id: String(s._id),
         name: s.name as string,
         number: s.number as number,
         startDate: (s.startDate as Date).toISOString(),
         endDate: s.endDate ? (s.endDate as Date).toISOString() : null,
+        isActive: Boolean(s.isActive),
       }))
 
       const gmScreens = gmScreenDocs

--- a/app/server/functions/campaigns.ts
+++ b/app/server/functions/campaigns.ts
@@ -618,19 +618,28 @@ export const activateSession = createServerFn({ method: 'POST' })
       const mongoSession = await mongoose.startSession()
       try {
         await mongoSession.withTransaction(async () => {
+          const currentActive = await Session.findOne({ campaignId: data.campaignId, isActive: true }).session(mongoSession)
+
+          // If the target is already the active session, no-op
+          if (currentActive && String(currentActive._id) === data.sessionId) {
+            return
+          }
+
           // Verify target session exists and belongs to this campaign
           const targetSession = await Session.findOne({ _id: data.sessionId, campaignId: data.campaignId }).session(mongoSession)
           if (!targetSession) throw new Error('Session not found')
 
           const now = new Date()
-          const endDate = data.endDate ? new Date(data.endDate) : now
 
-          // Deactivate any other active sessions for this campaign
-          await Session.updateMany(
-            { campaignId: data.campaignId, isActive: true, _id: { $ne: data.sessionId } },
-            { $set: { isActive: false, endDate, updatedAt: now } },
-            { session: mongoSession }
-          )
+          // Deactivate the currently active session
+          if (currentActive) {
+            const endDate = data.endDate ? new Date(data.endDate) : now
+            await Session.updateOne(
+              { _id: currentActive._id },
+              { $set: { isActive: false, endDate, updatedAt: now } },
+              { session: mongoSession }
+            )
+          }
 
           // Activate the target session
           await Session.updateOne(

--- a/app/server/functions/campaigns.ts
+++ b/app/server/functions/campaigns.ts
@@ -391,6 +391,7 @@ export const createCampaign = createServerFn({ method: 'POST' })
               number: 0,
               startDate: now,
               endDate: null,
+              isActive: true,
             }], { session: mongoSession }),
             GMScreen.create([{
               campaignId: campaign._id,

--- a/app/server/functions/campaigns.ts
+++ b/app/server/functions/campaigns.ts
@@ -593,3 +593,64 @@ export const joinCampaign = createServerFn({ method: 'POST' })
       throw e
     }
   })
+
+export const activateSession = createServerFn({ method: 'POST' })
+  .inputValidator(z.object({
+    campaignId: z.string().min(1),
+    sessionId: z.string().min(1),
+    endDate: z.string().datetime().optional(),
+  }))
+  .handler(async ({ data }) => {
+    const user = await getSession()
+    try {
+      if (!user) throw new Error('Not authenticated')
+
+      await connectDB()
+      if (!isDBConnected()) throw new Error('Database not available')
+
+      const dbUser = await User.findOne({ providerId: user.id })
+      if (!dbUser) throw new Error('User not found')
+
+      const campaign = await Campaign.findById(data.campaignId)
+      if (!campaign) throw new Error('Campaign not found')
+      if (String(campaign.gameMasterId) !== String(dbUser._id)) throw new Error('Forbidden')
+
+      const mongoSession = await mongoose.startSession()
+      try {
+        await mongoSession.withTransaction(async () => {
+          const currentActive = await Session.findOne({ campaignId: data.campaignId, isActive: true }).session(mongoSession)
+
+          // If the target is already the active session, no-op
+          if (currentActive && String(currentActive._id) === data.sessionId) {
+            return
+          }
+
+          const now = new Date()
+
+          // Deactivate the currently active session
+          if (currentActive) {
+            const endDate = data.endDate ? new Date(data.endDate) : now
+            await Session.updateOne(
+              { _id: currentActive._id },
+              { $set: { isActive: false, endDate, updatedAt: now } },
+              { session: mongoSession }
+            )
+          }
+
+          // Activate the target session
+          await Session.updateOne(
+            { _id: data.sessionId, campaignId: data.campaignId },
+            { $set: { isActive: true, updatedAt: now } },
+            { session: mongoSession }
+          )
+        })
+      } finally {
+        await mongoSession.endSession()
+      }
+
+      return { success: true }
+    } catch (e) {
+      serverCaptureException(e, user?.id, { action: 'activateSession', campaignId: data.campaignId, sessionId: data.sessionId })
+      throw e
+    }
+  })

--- a/app/services/mocks/sessionsService.ts
+++ b/app/services/mocks/sessionsService.ts
@@ -10,6 +10,7 @@ export const mockSessions: ReadonlyArray<Readonly<Session>> = Object.freeze([
     name: 'Ashes at Emberfall',
     startDate: '2026-03-21T00:00:00.000Z',
     endDate: null,
+    isActive: true,
   }),
   Object.freeze({
     id: 'session-13',
@@ -17,6 +18,7 @@ export const mockSessions: ReadonlyArray<Readonly<Session>> = Object.freeze([
     name: 'The Bell Beneath the Chapel',
     startDate: '2026-03-14T00:00:00.000Z',
     endDate: null,
+    isActive: false,
   }),
   Object.freeze({
     id: 'session-12',
@@ -24,6 +26,7 @@ export const mockSessions: ReadonlyArray<Readonly<Session>> = Object.freeze([
     name: 'Smoke Over Glassmere',
     startDate: '2026-03-07T00:00:00.000Z',
     endDate: null,
+    isActive: false,
   }),
   Object.freeze({
     id: 'session-11',
@@ -31,6 +34,7 @@ export const mockSessions: ReadonlyArray<Readonly<Session>> = Object.freeze([
     name: 'A Crown of Hollow Iron',
     startDate: '2026-02-28T00:00:00.000Z',
     endDate: null,
+    isActive: false,
   }),
   Object.freeze({
     id: 'session-10',
@@ -38,6 +42,7 @@ export const mockSessions: ReadonlyArray<Readonly<Session>> = Object.freeze([
     name: 'The Silent Lantern',
     startDate: '2026-02-21T00:00:00.000Z',
     endDate: null,
+    isActive: false,
   }),
   Object.freeze({
     id: 'session-9',
@@ -45,6 +50,7 @@ export const mockSessions: ReadonlyArray<Readonly<Session>> = Object.freeze([
     name: 'Blackwater Oaths',
     startDate: '2026-02-14T00:00:00.000Z',
     endDate: null,
+    isActive: false,
   }),
   Object.freeze({
     id: 'session-8',
@@ -52,6 +58,7 @@ export const mockSessions: ReadonlyArray<Readonly<Session>> = Object.freeze([
     name: 'Teeth in the Snow',
     startDate: '2026-02-07T00:00:00.000Z',
     endDate: null,
+    isActive: false,
   }),
   Object.freeze({
     id: 'session-7',
@@ -59,6 +66,7 @@ export const mockSessions: ReadonlyArray<Readonly<Session>> = Object.freeze([
     name: 'The Cartographer\'s Debt',
     startDate: '2026-01-31T00:00:00.000Z',
     endDate: null,
+    isActive: false,
   }),
 ])
 

--- a/docs/superpowers/plans/2026-04-01-active-session-tracking.md
+++ b/docs/superpowers/plans/2026-04-01-active-session-tracking.md
@@ -1,0 +1,556 @@
+# Active Session Tracking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an `isActive` boolean to the Session model so exactly one session per campaign can be marked active, with automatic deactivation of the previous active session.
+
+**Architecture:** Add `isActive` field to the Mongoose Session schema with a compound index. Update `createCampaign` to set Session 0 as active. Add an `activateSession` server function that atomically deactivates the current active session (setting its `endDate`) and activates the target session, all within a MongoDB transaction.
+
+**Tech Stack:** MongoDB/Mongoose, TanStack Start server functions, Vitest, Zod
+
+---
+
+### Task 1: Add `isActive` field to Session schema
+
+**Files:**
+- Modify: `app/server/db/models/Session.ts`
+
+- [ ] **Step 1: Add `isActive` field to the schema**
+
+In `app/server/db/models/Session.ts`, add `isActive` to the schema definition. Insert after line 9 (`endDate`):
+
+```typescript
+const sessionSchema = new mongoose.Schema({
+  campaignId: { type: mongoose.Schema.Types.ObjectId, ref: 'Campaign', required: true },
+  name: { type: String, required: true },
+  gm: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  number: { type: Number, required: true },
+  startDate: { type: Date, required: true },
+  endDate: { type: Date },
+  isActive: { type: Boolean, default: false },
+  summary: { type: String },
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+})
+```
+
+- [ ] **Step 2: Add compound index for active session lookup**
+
+Add the new index inside the existing `if` block (after line 18):
+
+```typescript
+// istanbul ignore next
+if (typeof (sessionSchema as { index?: unknown }).index === 'function') {
+  sessionSchema.index({ campaignId: 1, number: -1 })
+  sessionSchema.index({ campaignId: 1, startDate: -1 })
+  sessionSchema.index({ campaignId: 1, isActive: 1 })
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/server/db/models/Session.ts
+git commit -m "feat: add isActive field and index to Session schema"
+```
+
+---
+
+### Task 2: Update `createCampaign` to set Session 0 as active
+
+**Files:**
+- Modify: `app/server/functions/campaigns.ts:387-394`
+- Test: `tests/server/functions/campaigns.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/server/functions/campaigns.test.ts`, add a new test in the `createCampaign` describe block (after the existing "creates a default Session 0 document" test around line 512):
+
+```typescript
+  it('creates Session 0 with isActive set to true', async () => {
+    const created = makeCampaign()
+    vi.mocked(Campaign.create).mockResolvedValue([created] as never)
+
+    await _createCampaign({ data: { name: 'My Campaign', description: '' } })
+
+    expect(Session.create).toHaveBeenCalledWith(
+      [expect.objectContaining({
+        campaignId: 'camp-1',
+        name: 'Session 0',
+        isActive: true,
+      })],
+      expect.objectContaining({ session: expect.anything() })
+    )
+  })
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/server/functions/campaigns.test.ts -t "creates Session 0 with isActive set to true"`
+
+Expected: FAIL — `isActive` is not in the Session.create call yet.
+
+- [ ] **Step 3: Update `createCampaign` to pass `isActive: true`**
+
+In `app/server/functions/campaigns.ts`, update the Session.create call at lines 387-394. Add `isActive: true`:
+
+```typescript
+            Session.create([{
+              campaignId: campaign._id,
+              name: 'Session 0',
+              gm: dbUser._id,
+              number: 0,
+              startDate: now,
+              endDate: null,
+              isActive: true,
+            }], { session: mongoSession }),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/server/functions/campaigns.test.ts -t "creates Session 0 with isActive set to true"`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/server/functions/campaigns.ts tests/server/functions/campaigns.test.ts
+git commit -m "feat: set Session 0 as active when creating a campaign"
+```
+
+---
+
+### Task 3: Update `CampaignData` type and `getCampaign` to include `isActive`
+
+**Files:**
+- Modify: `app/server/functions/campaigns.ts:33-38` (CampaignData interface) and `app/server/functions/campaigns.ts:202-205` (getCampaign query projection) and `app/server/functions/campaigns.ts:224-230` (session serialization)
+- Test: `tests/server/functions/campaigns.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a new test in the `getCampaign` describe block (near the existing session serialization tests around line 987):
+
+```typescript
+  it('includes isActive in serialized session data', async () => {
+    const campaign = makeCampaign()
+    vi.mocked(Campaign.findById).mockResolvedValue(campaign)
+    const sessionDocs = [
+      { _id: 'sess-0', name: 'Session 0', number: 0, startDate: new Date('2026-01-01'), endDate: null, isActive: true },
+      { _id: 'sess-1', name: 'Session 1', number: 1, startDate: new Date('2026-01-08'), endDate: new Date('2026-01-08T23:00:00Z'), isActive: false },
+    ]
+    vi.mocked(Session.find).mockReturnValue({
+      sort: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue(sessionDocs) }),
+    } as never)
+
+    const result = await _getCampaign({ data: { id: 'camp-1' } }) as {
+      sessions: Array<{ id: string; isActive: boolean }>
+    }
+
+    expect(result.sessions[0].isActive).toBe(true)
+    expect(result.sessions[1].isActive).toBe(false)
+  })
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/server/functions/campaigns.test.ts -t "includes isActive in serialized session data"`
+
+Expected: FAIL — `isActive` is not in the query projection or serialization.
+
+- [ ] **Step 3: Update the `CampaignData` interface**
+
+In `app/server/functions/campaigns.ts`, update the sessions type in the `CampaignData` interface (around line 33-38):
+
+```typescript
+  sessions: Array<{
+    id: string
+    name: string
+    number: number
+    startDate: string
+    endDate: string | null
+    isActive: boolean
+  }>
+```
+
+- [ ] **Step 4: Update the `getCampaign` query projection**
+
+In `app/server/functions/campaigns.ts`, update the Session.find projection (line 204) to include `isActive`:
+
+```typescript
+        Session.find(
+          { campaignId: c._id },
+          '_id name number startDate endDate isActive'
+        ).sort({ number: 1 }).lean(),
+```
+
+- [ ] **Step 5: Update the session serialization**
+
+In `app/server/functions/campaigns.ts`, update the session mapping (around lines 224-230) to include `isActive`:
+
+```typescript
+      const sessions = (sessionDocs as Array<{ _id: unknown; name: unknown; number: unknown; startDate: unknown; endDate: unknown; isActive: unknown }>).map(s => ({
+        id: String(s._id),
+        name: s.name as string,
+        number: s.number as number,
+        startDate: (s.startDate as Date).toISOString(),
+        endDate: s.endDate ? (s.endDate as Date).toISOString() : null,
+        isActive: Boolean(s.isActive),
+      }))
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `npx vitest run tests/server/functions/campaigns.test.ts -t "includes isActive in serialized session data"`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/server/functions/campaigns.ts tests/server/functions/campaigns.test.ts
+git commit -m "feat: include isActive in CampaignData session type and getCampaign"
+```
+
+---
+
+### Task 4: Update mock sessions service to include `isActive`
+
+**Files:**
+- Modify: `app/services/mocks/sessionsService.ts`
+
+- [ ] **Step 1: Add `isActive` to mock session data**
+
+Since `Session` type is derived from `CampaignData['sessions'][number]`, it will now require `isActive`. Update `app/services/mocks/sessionsService.ts` — set the first mock session (session-14) as active, all others inactive:
+
+```typescript
+export const mockSessions: ReadonlyArray<Readonly<Session>> = Object.freeze([
+  Object.freeze({
+    id: 'session-14',
+    number: 14,
+    name: 'Ashes at Emberfall',
+    startDate: '2026-03-21T00:00:00.000Z',
+    endDate: null,
+    isActive: true,
+  }),
+  Object.freeze({
+    id: 'session-13',
+    number: 13,
+    name: 'The Bell Beneath the Chapel',
+    startDate: '2026-03-14T00:00:00.000Z',
+    endDate: null,
+    isActive: false,
+  }),
+  Object.freeze({
+    id: 'session-12',
+    number: 12,
+    name: 'Smoke Over Glassmere',
+    startDate: '2026-03-07T00:00:00.000Z',
+    endDate: null,
+    isActive: false,
+  }),
+  Object.freeze({
+    id: 'session-11',
+    number: 11,
+    name: 'A Crown of Hollow Iron',
+    startDate: '2026-02-28T00:00:00.000Z',
+    endDate: null,
+    isActive: false,
+  }),
+  Object.freeze({
+    id: 'session-10',
+    number: 10,
+    name: 'The Silent Lantern',
+    startDate: '2026-02-21T00:00:00.000Z',
+    endDate: null,
+    isActive: false,
+  }),
+  Object.freeze({
+    id: 'session-9',
+    number: 9,
+    name: 'Blackwater Oaths',
+    startDate: '2026-02-14T00:00:00.000Z',
+    endDate: null,
+    isActive: false,
+  }),
+  Object.freeze({
+    id: 'session-8',
+    number: 8,
+    name: 'Teeth in the Snow',
+    startDate: '2026-02-07T00:00:00.000Z',
+    endDate: null,
+    isActive: false,
+  }),
+  Object.freeze({
+    id: 'session-7',
+    number: 7,
+    name: 'The Cartographer\'s Debt',
+    startDate: '2026-01-31T00:00:00.000Z',
+    endDate: null,
+    isActive: false,
+  }),
+])
+```
+
+- [ ] **Step 2: Run all tests to verify nothing is broken**
+
+Run: `npx vitest run`
+
+Expected: All tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/services/mocks/sessionsService.ts
+git commit -m "feat: add isActive field to mock session data"
+```
+
+---
+
+### Task 5: Add `activateSession` server function
+
+**Files:**
+- Modify: `app/server/functions/campaigns.ts`
+- Test: `tests/server/functions/campaigns.test.ts`
+
+- [ ] **Step 1: Add `findOne` and `updateOne` to the Session mock**
+
+In `tests/server/functions/campaigns.test.ts`, update the Session mock (line 98-103) to include `findOne` and `updateOne`:
+
+```typescript
+vi.mock('~/server/db/models/Session', () => ({
+  Session: {
+    find: vi.fn().mockReturnValue({ sort: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue([]) }) }),
+    findOne: vi.fn().mockReturnValue({ session: vi.fn().mockReturnValue(null) }),
+    updateOne: vi.fn().mockResolvedValue({ modifiedCount: 1 }),
+    create: vi.fn(),
+  },
+}))
+```
+
+Also add `Session.findOne` and `Session.updateOne` resets in `beforeEach` (around line 167-168):
+
+```typescript
+  vi.mocked(Session.findOne).mockReturnValue({ session: vi.fn().mockReturnValue(null) } as never)
+  vi.mocked(Session.updateOne).mockResolvedValue({ modifiedCount: 1 } as never)
+```
+
+Update the `_activateSession` cast (after line 181):
+
+```typescript
+const _activateSession = activateSession as unknown as (args: { data: { campaignId: string; sessionId: string; endDate?: string } }) => Promise<unknown>
+```
+
+Update the import on line 126 to include `activateSession`:
+
+```typescript
+import { listCampaigns, getCampaign, createCampaign, updateCampaign, joinCampaign, activateSession, campaignInputSchema } from '~/server/functions/campaigns'
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Add a new `describe('activateSession', ...)` block at the end of the test file:
+
+```typescript
+describe('activateSession', () => {
+  it('deactivates the current active session and activates the target session', async () => {
+    const campaign = makeCampaign()
+    vi.mocked(Campaign.findById).mockResolvedValue(campaign)
+    vi.mocked(Session.findOne).mockReturnValue({
+      session: vi.fn().mockResolvedValue({ _id: 'sess-old', campaignId: 'camp-1', isActive: true }),
+    } as never)
+
+    const result = await _activateSession({ data: { campaignId: 'camp-1', sessionId: 'sess-new' } })
+
+    expect(result).toMatchObject({ success: true })
+
+    // Should deactivate old session
+    expect(Session.updateOne).toHaveBeenCalledWith(
+      { _id: 'sess-old' },
+      { $set: { isActive: false, endDate: expect.any(Date), updatedAt: expect.any(Date) } },
+      expect.objectContaining({ session: expect.anything() })
+    )
+
+    // Should activate new session
+    expect(Session.updateOne).toHaveBeenCalledWith(
+      { _id: 'sess-new', campaignId: 'camp-1' },
+      { $set: { isActive: true, updatedAt: expect.any(Date) } },
+      expect.objectContaining({ session: expect.anything() })
+    )
+  })
+
+  it('uses GM-provided endDate when supplied', async () => {
+    const campaign = makeCampaign()
+    vi.mocked(Campaign.findById).mockResolvedValue(campaign)
+    vi.mocked(Session.findOne).mockReturnValue({
+      session: vi.fn().mockResolvedValue({ _id: 'sess-old', campaignId: 'camp-1', isActive: true }),
+    } as never)
+
+    await _activateSession({ data: { campaignId: 'camp-1', sessionId: 'sess-new', endDate: '2026-03-15T22:00:00.000Z' } })
+
+    expect(Session.updateOne).toHaveBeenCalledWith(
+      { _id: 'sess-old' },
+      { $set: { isActive: false, endDate: new Date('2026-03-15T22:00:00.000Z'), updatedAt: expect.any(Date) } },
+      expect.objectContaining({ session: expect.anything() })
+    )
+  })
+
+  it('activates session even when no currently active session exists', async () => {
+    const campaign = makeCampaign()
+    vi.mocked(Campaign.findById).mockResolvedValue(campaign)
+    vi.mocked(Session.findOne).mockReturnValue({
+      session: vi.fn().mockResolvedValue(null),
+    } as never)
+
+    const result = await _activateSession({ data: { campaignId: 'camp-1', sessionId: 'sess-new' } })
+
+    expect(result).toMatchObject({ success: true })
+
+    // Should only activate the new session (one updateOne call, not two)
+    expect(Session.updateOne).toHaveBeenCalledTimes(1)
+    expect(Session.updateOne).toHaveBeenCalledWith(
+      { _id: 'sess-new', campaignId: 'camp-1' },
+      { $set: { isActive: true, updatedAt: expect.any(Date) } },
+      expect.objectContaining({ session: expect.anything() })
+    )
+  })
+
+  it('throws when user is not authenticated', async () => {
+    vi.mocked(getSession).mockResolvedValue(null)
+
+    await expect(
+      _activateSession({ data: { campaignId: 'camp-1', sessionId: 'sess-1' } })
+    ).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws when user is not the campaign GM', async () => {
+    const campaign = makeCampaign({ gameMasterId: 'someone-else' })
+    vi.mocked(Campaign.findById).mockResolvedValue(campaign)
+
+    await expect(
+      _activateSession({ data: { campaignId: 'camp-1', sessionId: 'sess-1' } })
+    ).rejects.toThrow('Forbidden')
+  })
+
+  it('skips deactivation when the target session is already the active session', async () => {
+    const campaign = makeCampaign()
+    vi.mocked(Campaign.findById).mockResolvedValue(campaign)
+    vi.mocked(Session.findOne).mockReturnValue({
+      session: vi.fn().mockResolvedValue({ _id: 'sess-1', campaignId: 'camp-1', isActive: true }),
+    } as never)
+
+    const result = await _activateSession({ data: { campaignId: 'camp-1', sessionId: 'sess-1' } })
+
+    expect(result).toMatchObject({ success: true })
+    // No updates needed — it's already active
+    expect(Session.updateOne).not.toHaveBeenCalled()
+  })
+
+  it('ends the mongo session even when the transaction fails', async () => {
+    const campaign = makeCampaign()
+    vi.mocked(Campaign.findById).mockResolvedValue(campaign)
+    vi.mocked(Session.findOne).mockReturnValue({
+      session: vi.fn().mockResolvedValue({ _id: 'sess-old', campaignId: 'camp-1', isActive: true }),
+    } as never)
+    vi.mocked(Session.updateOne).mockRejectedValue(new Error('DB write failed'))
+
+    await expect(
+      _activateSession({ data: { campaignId: 'camp-1', sessionId: 'sess-new' } })
+    ).rejects.toThrow()
+
+    expect(mockMongoSession.endSession).toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `npx vitest run tests/server/functions/campaigns.test.ts -t "activateSession"`
+
+Expected: FAIL — `activateSession` is not exported from campaigns.ts yet.
+
+- [ ] **Step 4: Implement `activateSession` server function**
+
+In `app/server/functions/campaigns.ts`, add the following after the `joinCampaign` export (after line 592):
+
+```typescript
+export const activateSession = createServerFn({ method: 'POST' })
+  .inputValidator(z.object({
+    campaignId: z.string().min(1),
+    sessionId: z.string().min(1),
+    endDate: z.string().datetime().optional(),
+  }))
+  .handler(async ({ data }) => {
+    const user = await getSession()
+    try {
+      if (!user) throw new Error('Not authenticated')
+
+      await connectDB()
+      if (!isDBConnected()) throw new Error('Database not available')
+
+      const dbUser = await User.findOne({ providerId: user.id })
+      if (!dbUser) throw new Error('User not found')
+
+      const campaign = await Campaign.findById(data.campaignId)
+      if (!campaign) throw new Error('Campaign not found')
+      if (String(campaign.gameMasterId) !== String(dbUser._id)) throw new Error('Forbidden')
+
+      const mongoSession = await mongoose.startSession()
+      try {
+        await mongoSession.withTransaction(async () => {
+          const currentActive = await Session.findOne({ campaignId: data.campaignId, isActive: true }).session(mongoSession)
+
+          // If the target is already the active session, no-op
+          if (currentActive && String(currentActive._id) === data.sessionId) {
+            return
+          }
+
+          const now = new Date()
+
+          // Deactivate the currently active session
+          if (currentActive) {
+            const endDate = data.endDate ? new Date(data.endDate) : now
+            await Session.updateOne(
+              { _id: currentActive._id },
+              { $set: { isActive: false, endDate, updatedAt: now } },
+              { session: mongoSession }
+            )
+          }
+
+          // Activate the target session
+          await Session.updateOne(
+            { _id: data.sessionId, campaignId: data.campaignId },
+            { $set: { isActive: true, updatedAt: now } },
+            { session: mongoSession }
+          )
+        })
+      } finally {
+        await mongoSession.endSession()
+      }
+
+      return { success: true }
+    } catch (e) {
+      serverCaptureException(e, user?.id, { action: 'activateSession', campaignId: data.campaignId, sessionId: data.sessionId })
+      throw e
+    }
+  })
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run tests/server/functions/campaigns.test.ts -t "activateSession"`
+
+Expected: All 7 activateSession tests PASS.
+
+- [ ] **Step 6: Run the full test suite**
+
+Run: `npx vitest run`
+
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/server/functions/campaigns.ts tests/server/functions/campaigns.test.ts
+git commit -m "feat: add activateSession server function with transaction safety"
+```

--- a/docs/superpowers/specs/2026-04-01-active-session-tracking-design.md
+++ b/docs/superpowers/specs/2026-04-01-active-session-tracking-design.md
@@ -1,0 +1,98 @@
+# Active Session Tracking
+
+## Problem
+
+Sessions have no concept of being "active." When a campaign is created, Session 0 is injected but nothing marks it as the current session. Game Masters need a way to designate one session as active per campaign, with automatic deactivation of the previous session when a new one is activated.
+
+## Design
+
+### Schema Change: Session Model
+
+Add an `isActive` boolean field to the Session Mongoose schema in `app/server/db/models/Session.ts`:
+
+```typescript
+isActive: { type: Boolean, default: false }
+```
+
+Add a compound index for efficient active session lookup:
+
+```typescript
+sessionSchema.index({ campaignId: 1, isActive: 1 })
+```
+
+### Campaign Creation Update
+
+In `app/server/functions/campaigns.ts`, update the `createCampaign` function so that Session 0 is created with `isActive: true`:
+
+```typescript
+Session.create([{
+  campaignId: campaign._id,
+  name: 'Session 0',
+  gm: dbUser._id,
+  number: 0,
+  startDate: now,
+  endDate: null,
+  isActive: true,
+}], { session: mongoSession })
+```
+
+### Activation Logic: `activateSession` Function
+
+Add a new server function `activateSession` in `app/server/functions/campaigns.ts` (or a new `sessions.ts` file if preferred). The function accepts:
+
+- `campaignId`: The campaign the session belongs to
+- `sessionId`: The session to activate
+- `endDate` (optional): The end date for the currently active session. Defaults to `new Date()` if not provided.
+
+Within a MongoDB transaction:
+
+1. **Find the currently active session** for the campaign: `Session.findOne({ campaignId, isActive: true })`
+2. **Deactivate it** (if found and it's not the same session being activated): set `isActive: false` and `endDate` to the provided date or `new Date()`
+3. **Activate the target session**: set `isActive: true`
+
+The transaction ensures atomicity — there is never a state where zero or two sessions are active within a campaign.
+
+Authorization: Only users with the `gm` role for the campaign can activate sessions.
+
+### Type Updates
+
+In the `CampaignData` interface in `app/server/functions/campaigns.ts`, add `isActive` to the session shape:
+
+```typescript
+sessions: Array<{
+  id: string
+  name: string
+  number: number
+  startDate: string
+  endDate: string | null
+  isActive: boolean
+}>
+```
+
+Update the `getCampaign` function's Session query projection to include `isActive`.
+
+### Session Creation Rules
+
+- `startDate` is automatically set to the current date/time at creation. It is not editable.
+- `isActive` defaults to `false`. The GM can optionally mark a session as active at creation time (via a checkbox in a future UI).
+- If marked active at creation, the deactivation flow runs first (same as `activateSession`).
+
+### Test Updates
+
+In `tests/server/functions/campaigns.test.ts`:
+
+1. **Update existing tests**: Verify Session 0 is created with `isActive: true`
+2. **New tests for `activateSession`**:
+   - Activating a session deactivates the previously active session (`isActive: false`, `endDate` set)
+   - GM-provided `endDate` is used when supplied
+   - `endDate` defaults to current date when not supplied
+   - Activating an already-active session is a no-op (no error, no changes)
+   - Only GMs can activate sessions (authorization check)
+   - Transaction rolls back on failure (no partial state)
+   - Only one session is active per campaign at any time
+
+## Out of Scope
+
+- Session creation UI / editor (future work)
+- Session editing UI (future work)
+- Displaying active session status in the UI (future work)

--- a/tests/components/mainview/CampaignHeader.test.tsx
+++ b/tests/components/mainview/CampaignHeader.test.tsx
@@ -119,7 +119,7 @@ describe('CampaignHeader', () => {
     render(
       <CampaignHeader activeTab="dashboard" onTabChange={vi.fn()} />
     )
-    expect(screen.getByText('Cartyx')).toBeInTheDocument()
+    expect(screen.getByText('CARTYX')).toBeInTheDocument()
     expect(screen.queryByRole('link', { name: 'Back to campaigns' })).not.toBeInTheDocument()
   })
 

--- a/tests/components/mainview/notes/NoteModal.test.tsx
+++ b/tests/components/mainview/notes/NoteModal.test.tsx
@@ -85,8 +85,8 @@ vi.mock('@codemirror/theme-one-dark', () => ({
 }))
 
 const mockSessions = [
-  { id: 'session-1', number: 1, name: 'First Session', startDate: '2026-01-01T00:00:00.000Z', endDate: null },
-  { id: 'session-2', number: 2, name: 'Second Session', startDate: '2026-01-08T00:00:00.000Z', endDate: null },
+  { id: 'session-1', number: 1, name: 'First Session', startDate: '2026-01-01T00:00:00.000Z', endDate: null, isActive: false },
+  { id: 'session-2', number: 2, name: 'Second Session', startDate: '2026-01-08T00:00:00.000Z', endDate: null, isActive: true },
 ]
 
 const mockNote = {

--- a/tests/components/mainview/widgets/SessionsListWidget.test.tsx
+++ b/tests/components/mainview/widgets/SessionsListWidget.test.tsx
@@ -23,8 +23,8 @@ vi.mock('~/hooks/useCampaigns', () => ({
 }))
 
 const mockSessions = [
-  { id: 's1', number: 14, name: 'Ashes at Emberfall', startDate: '2026-03-21T00:00:00.000Z', endDate: null },
-  { id: 's2', number: 13, name: 'The Bell Beneath', startDate: '2026-03-14T00:00:00.000Z', endDate: null },
+  { id: 's1', number: 14, name: 'Ashes at Emberfall', startDate: '2026-03-21T00:00:00.000Z', endDate: null, isActive: true },
+  { id: 's2', number: 13, name: 'The Bell Beneath', startDate: '2026-03-14T00:00:00.000Z', endDate: null, isActive: false },
 ]
 
 describe('SessionsListWidget', () => {
@@ -64,6 +64,7 @@ describe('SessionsListWidget', () => {
       name: `Session Name ${i + 1}`,
       startDate: '2026-01-01T00:00:00.000Z',
       endDate: null,
+      isActive: i === 0,
     }))
     render(<SessionsListWidget sessions={manySessions} />)
     expect(screen.getByText('Session Name 1')).toBeInTheDocument()

--- a/tests/server/functions/campaigns.test.ts
+++ b/tests/server/functions/campaigns.test.ts
@@ -511,6 +511,22 @@ describe('createCampaign', () => {
     )
   })
 
+  it('creates Session 0 with isActive set to true', async () => {
+    const created = makeCampaign()
+    vi.mocked(Campaign.create).mockResolvedValue([created] as never)
+
+    await _createCampaign({ data: { name: 'My Campaign', description: '' } })
+
+    expect(Session.create).toHaveBeenCalledWith(
+      [expect.objectContaining({
+        campaignId: 'camp-1',
+        name: 'Session 0',
+        isActive: true,
+      })],
+      expect.objectContaining({ session: expect.anything() })
+    )
+  })
+
   it('creates a default GMScreen document for the new campaign', async () => {
     const created = makeCampaign()
     vi.mocked(Campaign.create).mockResolvedValue([created] as never)

--- a/tests/server/functions/campaigns.test.ts
+++ b/tests/server/functions/campaigns.test.ts
@@ -1187,8 +1187,11 @@ describe('activateSession', () => {
   it('deactivates the current active session and activates the target session', async () => {
     const campaign = makeCampaign()
     vi.mocked(Campaign.findById).mockResolvedValue(campaign)
+    const mockSessionFn = vi.fn()
+      .mockResolvedValueOnce({ _id: 'sess-old', campaignId: 'camp-1', isActive: true })
+      .mockResolvedValueOnce({ _id: 'sess-new', campaignId: 'camp-1', isActive: false })
     vi.mocked(Session.findOne).mockReturnValue({
-      session: vi.fn().mockResolvedValue({ _id: 'sess-old', campaignId: 'camp-1', isActive: true }),
+      session: mockSessionFn,
     } as never)
 
     const result = await _activateSession({ data: { campaignId: 'camp-1', sessionId: 'sess-new' } })
@@ -1213,8 +1216,11 @@ describe('activateSession', () => {
   it('uses GM-provided endDate when supplied', async () => {
     const campaign = makeCampaign()
     vi.mocked(Campaign.findById).mockResolvedValue(campaign)
+    const mockSessionFn = vi.fn()
+      .mockResolvedValueOnce({ _id: 'sess-old', campaignId: 'camp-1', isActive: true })
+      .mockResolvedValueOnce({ _id: 'sess-new', campaignId: 'camp-1', isActive: false })
     vi.mocked(Session.findOne).mockReturnValue({
-      session: vi.fn().mockResolvedValue({ _id: 'sess-old', campaignId: 'camp-1', isActive: true }),
+      session: mockSessionFn,
     } as never)
 
     await _activateSession({ data: { campaignId: 'camp-1', sessionId: 'sess-new', endDate: '2026-03-15T22:00:00.000Z' } })
@@ -1229,8 +1235,12 @@ describe('activateSession', () => {
   it('activates session even when no currently active session exists', async () => {
     const campaign = makeCampaign()
     vi.mocked(Campaign.findById).mockResolvedValue(campaign)
+    // First findOne (active session) returns null, second (target session) returns a session
+    const mockSessionFn = vi.fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ _id: 'sess-new', campaignId: 'camp-1', isActive: false })
     vi.mocked(Session.findOne).mockReturnValue({
-      session: vi.fn().mockResolvedValue(null),
+      session: mockSessionFn,
     } as never)
 
     const result = await _activateSession({ data: { campaignId: 'camp-1', sessionId: 'sess-new' } })
@@ -1277,11 +1287,27 @@ describe('activateSession', () => {
     expect(Session.updateOne).not.toHaveBeenCalled()
   })
 
+  it('throws when target session does not exist', async () => {
+    const campaign = makeCampaign()
+    vi.mocked(Campaign.findById).mockResolvedValue(campaign)
+    // No active session, and target session doesn't exist
+    vi.mocked(Session.findOne).mockReturnValue({
+      session: vi.fn().mockResolvedValue(null),
+    } as never)
+
+    await expect(
+      _activateSession({ data: { campaignId: 'camp-1', sessionId: 'nonexistent' } })
+    ).rejects.toThrow('Session not found')
+  })
+
   it('ends the mongo session even when the transaction fails', async () => {
     const campaign = makeCampaign()
     vi.mocked(Campaign.findById).mockResolvedValue(campaign)
+    const mockSessionFn = vi.fn()
+      .mockResolvedValueOnce({ _id: 'sess-old', campaignId: 'camp-1', isActive: true })
+      .mockResolvedValueOnce({ _id: 'sess-new', campaignId: 'camp-1', isActive: false })
     vi.mocked(Session.findOne).mockReturnValue({
-      session: vi.fn().mockResolvedValue({ _id: 'sess-old', campaignId: 'camp-1', isActive: true }),
+      session: mockSessionFn,
     } as never)
     vi.mocked(Session.updateOne).mockRejectedValue(new Error('DB write failed'))
 

--- a/tests/server/functions/campaigns.test.ts
+++ b/tests/server/functions/campaigns.test.ts
@@ -352,7 +352,7 @@ describe('getCampaign', () => {
 
     expect(Session.find).toHaveBeenCalledWith(
       { campaignId: 'camp-1' },
-      '_id name number startDate endDate'
+      '_id name number startDate endDate isActive'
     )
     expect(result.sessions).toHaveLength(1)
     expect(result.sessions[0].name).toBe('Session 0')
@@ -1019,6 +1019,25 @@ describe('getCampaign — enter-campaign loading regression (#302)', () => {
     expect(result.sessions[0].endDate).toBeNull()
     expect(result.sessions[1].startDate).toBe('2026-01-08T18:00:00.000Z')
     expect(result.sessions[1].endDate).toBe('2026-01-08T22:00:00.000Z')
+  })
+
+  it('includes isActive in serialized session data', async () => {
+    const campaign = makeCampaign()
+    vi.mocked(Campaign.findById).mockResolvedValue(campaign)
+    const sessionDocs = [
+      { _id: 'sess-0', name: 'Session 0', number: 0, startDate: new Date('2026-01-01'), endDate: null, isActive: true },
+      { _id: 'sess-1', name: 'Session 1', number: 1, startDate: new Date('2026-01-08'), endDate: new Date('2026-01-08T23:00:00Z'), isActive: false },
+    ]
+    vi.mocked(Session.find).mockReturnValue({
+      sort: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue(sessionDocs) }),
+    } as never)
+
+    const result = await _getCampaign({ data: { id: 'camp-1' } }) as {
+      sessions: Array<{ id: string; isActive: boolean }>
+    }
+
+    expect(result.sessions[0].isActive).toBe(true)
+    expect(result.sessions[1].isActive).toBe(false)
   })
 
   it('returns multiple gmScreens for GM entering campaign', async () => {

--- a/tests/server/functions/campaigns.test.ts
+++ b/tests/server/functions/campaigns.test.ts
@@ -98,6 +98,8 @@ vi.mock('~/server/db/models/Player', () => ({
 vi.mock('~/server/db/models/Session', () => ({
   Session: {
     find: vi.fn().mockReturnValue({ sort: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue([]) }) }),
+    findOne: vi.fn().mockReturnValue({ session: vi.fn().mockReturnValue(null) }),
+    updateOne: vi.fn().mockResolvedValue({ modifiedCount: 1 }),
     create: vi.fn(),
   },
 }))
@@ -123,7 +125,7 @@ import { Campaign } from '~/server/db/models/Campaign'
 import { Player } from '~/server/db/models/Player'
 import { Session } from '~/server/db/models/Session'
 import { GMScreen } from '~/server/db/models/GMScreen'
-import { listCampaigns, getCampaign, createCampaign, updateCampaign, joinCampaign, campaignInputSchema } from '~/server/functions/campaigns'
+import { listCampaigns, getCampaign, createCampaign, updateCampaign, joinCampaign, activateSession, campaignInputSchema } from '~/server/functions/campaigns'
 import { serverCaptureEvent } from '~/server/utils/posthog'
 
 const mockSession = {
@@ -166,6 +168,8 @@ beforeEach(() => {
   vi.mocked(Player.updateOne).mockResolvedValue({} as never)
   vi.mocked(Session.find).mockReturnValue({ sort: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue([]) }) } as never)
   vi.mocked(Session.create).mockResolvedValue([] as never)
+  vi.mocked(Session.findOne).mockReturnValue({ session: vi.fn().mockReturnValue(null) } as never)
+  vi.mocked(Session.updateOne).mockResolvedValue({ modifiedCount: 1 } as never)
   vi.mocked(GMScreen.find).mockReturnValue({ lean: vi.fn().mockResolvedValue([]) } as never)
   vi.mocked(GMScreen.create).mockResolvedValue([] as never)
   vi.mocked(Campaign.exists).mockReturnValue({ session: vi.fn().mockResolvedValue(null) } as never)
@@ -179,6 +183,7 @@ const _getCampaign = getCampaign as unknown as (args: { data: { id: string } }) 
 const _createCampaign = createCampaign as unknown as (args: { data: Record<string, unknown> }) => Promise<unknown>
 const _updateCampaign = updateCampaign as unknown as (args: { data: Record<string, unknown> }) => Promise<unknown>
 const _joinCampaign = joinCampaign as unknown as (args: { data: { inviteCode: string } }) => Promise<unknown>
+const _activateSession = activateSession as unknown as (args: { data: { campaignId: string; sessionId: string; endDate?: string } }) => Promise<unknown>
 
 describe('listCampaigns', () => {
   it('returns only campaigns where the user is a member', async () => {
@@ -1175,5 +1180,115 @@ describe('updateCampaign with imagePath (direct R2 upload)', () => {
         },
       }),
     ).rejects.toThrow('Invalid image path')
+  })
+})
+
+describe('activateSession', () => {
+  it('deactivates the current active session and activates the target session', async () => {
+    const campaign = makeCampaign()
+    vi.mocked(Campaign.findById).mockResolvedValue(campaign)
+    vi.mocked(Session.findOne).mockReturnValue({
+      session: vi.fn().mockResolvedValue({ _id: 'sess-old', campaignId: 'camp-1', isActive: true }),
+    } as never)
+
+    const result = await _activateSession({ data: { campaignId: 'camp-1', sessionId: 'sess-new' } })
+
+    expect(result).toMatchObject({ success: true })
+
+    // Should deactivate old session
+    expect(Session.updateOne).toHaveBeenCalledWith(
+      { _id: 'sess-old' },
+      { $set: { isActive: false, endDate: expect.any(Date), updatedAt: expect.any(Date) } },
+      expect.objectContaining({ session: expect.anything() })
+    )
+
+    // Should activate new session
+    expect(Session.updateOne).toHaveBeenCalledWith(
+      { _id: 'sess-new', campaignId: 'camp-1' },
+      { $set: { isActive: true, updatedAt: expect.any(Date) } },
+      expect.objectContaining({ session: expect.anything() })
+    )
+  })
+
+  it('uses GM-provided endDate when supplied', async () => {
+    const campaign = makeCampaign()
+    vi.mocked(Campaign.findById).mockResolvedValue(campaign)
+    vi.mocked(Session.findOne).mockReturnValue({
+      session: vi.fn().mockResolvedValue({ _id: 'sess-old', campaignId: 'camp-1', isActive: true }),
+    } as never)
+
+    await _activateSession({ data: { campaignId: 'camp-1', sessionId: 'sess-new', endDate: '2026-03-15T22:00:00.000Z' } })
+
+    expect(Session.updateOne).toHaveBeenCalledWith(
+      { _id: 'sess-old' },
+      { $set: { isActive: false, endDate: new Date('2026-03-15T22:00:00.000Z'), updatedAt: expect.any(Date) } },
+      expect.objectContaining({ session: expect.anything() })
+    )
+  })
+
+  it('activates session even when no currently active session exists', async () => {
+    const campaign = makeCampaign()
+    vi.mocked(Campaign.findById).mockResolvedValue(campaign)
+    vi.mocked(Session.findOne).mockReturnValue({
+      session: vi.fn().mockResolvedValue(null),
+    } as never)
+
+    const result = await _activateSession({ data: { campaignId: 'camp-1', sessionId: 'sess-new' } })
+
+    expect(result).toMatchObject({ success: true })
+
+    // Should only activate the new session (one updateOne call, not two)
+    expect(Session.updateOne).toHaveBeenCalledTimes(1)
+    expect(Session.updateOne).toHaveBeenCalledWith(
+      { _id: 'sess-new', campaignId: 'camp-1' },
+      { $set: { isActive: true, updatedAt: expect.any(Date) } },
+      expect.objectContaining({ session: expect.anything() })
+    )
+  })
+
+  it('throws when user is not authenticated', async () => {
+    vi.mocked(getSession).mockResolvedValue(null)
+
+    await expect(
+      _activateSession({ data: { campaignId: 'camp-1', sessionId: 'sess-1' } })
+    ).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws when user is not the campaign GM', async () => {
+    const campaign = makeCampaign({ gameMasterId: 'someone-else' })
+    vi.mocked(Campaign.findById).mockResolvedValue(campaign)
+
+    await expect(
+      _activateSession({ data: { campaignId: 'camp-1', sessionId: 'sess-1' } })
+    ).rejects.toThrow('Forbidden')
+  })
+
+  it('skips deactivation when the target session is already the active session', async () => {
+    const campaign = makeCampaign()
+    vi.mocked(Campaign.findById).mockResolvedValue(campaign)
+    vi.mocked(Session.findOne).mockReturnValue({
+      session: vi.fn().mockResolvedValue({ _id: 'sess-1', campaignId: 'camp-1', isActive: true }),
+    } as never)
+
+    const result = await _activateSession({ data: { campaignId: 'camp-1', sessionId: 'sess-1' } })
+
+    expect(result).toMatchObject({ success: true })
+    // No updates needed — it's already active
+    expect(Session.updateOne).not.toHaveBeenCalled()
+  })
+
+  it('ends the mongo session even when the transaction fails', async () => {
+    const campaign = makeCampaign()
+    vi.mocked(Campaign.findById).mockResolvedValue(campaign)
+    vi.mocked(Session.findOne).mockReturnValue({
+      session: vi.fn().mockResolvedValue({ _id: 'sess-old', campaignId: 'camp-1', isActive: true }),
+    } as never)
+    vi.mocked(Session.updateOne).mockRejectedValue(new Error('DB write failed'))
+
+    await expect(
+      _activateSession({ data: { campaignId: 'camp-1', sessionId: 'sess-new' } })
+    ).rejects.toThrow()
+
+    expect(mockMongoSession.endSession).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Active Session Tracking

  Summary

  - Added isActive boolean field to the Session model so exactly one session per campaign can be designated as the "active" session
  - Session 0 is now automatically set as the active session when a new campaign is created
  - Added activateSession server function that atomically swaps the active session within a MongoDB transaction
  - The previously active session is automatically deactivated with its endDate set (GM can provide a custom end date or it defaults to now)

  Changes

  Schema (app/server/db/models/Session.ts)
  - Added isActive: { type: Boolean, default: false } field
  - Added { campaignId, isActive } compound index for efficient lookups

  Server Functions (app/server/functions/campaigns.ts)
  - createCampaign: Session 0 now created with isActive: true
  - getCampaign: isActive included in query projection and serialized response
  - CampaignData interface: sessions type now includes isActive: boolean
  - New activateSession function:
    - Accepts campaignId, sessionId, and optional endDate
    - GM-only authorization
    - Verifies target session exists
    - Uses MongoDB transaction to deactivate current active session and activate the target
    - No-ops if the target is already active

  Mock Data (app/services/mocks/sessionsService.ts)
  - All mock sessions updated with isActive field

  Test Plan

  - Session 0 created with isActive: true on campaign creation
  - isActive included in serialized session data from getCampaign
  - Activating a session deactivates the previous active session with endDate
  - GM-provided endDate is respected
  - Activating when no current active session exists works correctly
  - Non-authenticated users are rejected
  - Non-GM users are rejected
  - Already-active session is a no-op
  - Non-existent target session throws error
  - MongoDB session cleaned up even on transaction failure
  - All 90 campaign tests passing