### PR TITLE
fix: prevent Mongoose models from leaking into client bundle (#336)

### DIFF
--- a/app/server/functions/gmscreens-helpers.ts
+++ b/app/server/functions/gmscreens-helpers.ts
@@ -1,0 +1,50 @@
+import { GMScreen } from '../db/models/GMScreen'
+
+// ---------------------------------------------------------------------------
+// removeDocumentRefsFromScreens — cleanup when a referenced document is deleted
+//
+// Lives in a separate file from the createServerFn exports so that importing
+// it from other server modules (e.g. notes.ts) doesn't force the bundler to
+// pull the full gmscreens.ts module into any client chunk.
+// ---------------------------------------------------------------------------
+
+/**
+ * Remove all window and stack-item references to a given document from every
+ * GM Screen in the campaign. Returns the number of distinct screens that were
+ * modified and refreshes `updatedAt` on each touched screen.
+ */
+export async function removeDocumentRefsFromScreens(
+  campaignId: string,
+  collection: string,
+  documentId: string,
+): Promise<number> {
+  // Find all distinct screens that reference this document (windows OR stacks)
+  const affectedScreens = await GMScreen.find(
+    {
+      campaignId,
+      $or: [
+        { 'windows.collection': collection, 'windows.documentId': documentId },
+        { 'stacks.items.collection': collection, 'stacks.items.documentId': documentId },
+      ],
+    },
+    '_id',
+  ).lean() as Array<{ _id: unknown }>
+
+  if (affectedScreens.length === 0) return 0
+
+  const now = new Date()
+
+  // Pull matching refs and refresh updatedAt in parallel
+  await Promise.all([
+    GMScreen.updateMany(
+      { campaignId, 'windows.collection': collection, 'windows.documentId': documentId },
+      { $pull: { windows: { collection, documentId } }, $set: { updatedAt: now } },
+    ),
+    GMScreen.updateMany(
+      { campaignId, 'stacks.items.collection': collection, 'stacks.items.documentId': documentId },
+      { $pull: { 'stacks.$[].items': { collection, documentId } }, $set: { updatedAt: now } },
+    ),
+  ])
+
+  return affectedScreens.length
+}

--- a/app/server/functions/gmscreens.ts
+++ b/app/server/functions/gmscreens.ts
@@ -162,8 +162,17 @@ const COLLECTION_REGISTRY: Record<string, CollectionFetcher> = {
   },
 }
 
-/** Collection names that can be opened as windows or referenced in stacks. */
-export const SUPPORTED_COLLECTIONS = Object.keys(COLLECTION_REGISTRY) as [string, ...string[]]
+/**
+ * Collection names that can be opened as windows or referenced in stacks.
+ *
+ * IMPORTANT: This must be a static literal — NOT derived from COLLECTION_REGISTRY.
+ * TanStack Start keeps `.validator()` chains in the client bundle. If this value
+ * transitively references Mongoose models (via COLLECTION_REGISTRY → Note.find),
+ * it pulls mongoose into the browser and crashes at module-load time.
+ *
+ * When adding a new collection, update BOTH this array and COLLECTION_REGISTRY.
+ */
+export const SUPPORTED_COLLECTIONS = ['note'] as [string, ...string[]]
 
 /**
  * Batch-hydrate a set of `{ collection, documentId }` refs.
@@ -1383,47 +1392,5 @@ export const removeStackItem = createServerFn({ method: 'POST' })
     }
   })
 
-// ---------------------------------------------------------------------------
-// removeDocumentRefsFromScreens — cleanup when a referenced document is deleted
-// ---------------------------------------------------------------------------
-
-/**
- * Remove all window and stack-item references to a given document from every
- * GM Screen in the campaign. Returns the number of distinct screens that were
- * modified and refreshes `updatedAt` on each touched screen.
- */
-export async function removeDocumentRefsFromScreens(
-  campaignId: string,
-  collection: string,
-  documentId: string,
-): Promise<number> {
-  // Find all distinct screens that reference this document (windows OR stacks)
-  const affectedScreens = await GMScreen.find(
-    {
-      campaignId,
-      $or: [
-        { 'windows.collection': collection, 'windows.documentId': documentId },
-        { 'stacks.items.collection': collection, 'stacks.items.documentId': documentId },
-      ],
-    },
-    '_id',
-  ).lean() as Array<{ _id: unknown }>
-
-  if (affectedScreens.length === 0) return 0
-
-  const now = new Date()
-
-  // Pull matching refs and refresh updatedAt in parallel
-  await Promise.all([
-    GMScreen.updateMany(
-      { campaignId, 'windows.collection': collection, 'windows.documentId': documentId },
-      { $pull: { windows: { collection, documentId } }, $set: { updatedAt: now } },
-    ),
-    GMScreen.updateMany(
-      { campaignId, 'stacks.items.collection': collection, 'stacks.items.documentId': documentId },
-      { $pull: { 'stacks.$[].items': { collection, documentId } }, $set: { updatedAt: now } },
-    ),
-  ])
-
-  return affectedScreens.length
-}
+// removeDocumentRefsFromScreens moved to ./gmscreens-helpers.ts to avoid
+// pulling Mongoose models into the client bundle when notes.ts imports it.

--- a/app/server/functions/notes.ts
+++ b/app/server/functions/notes.ts
@@ -7,7 +7,7 @@ import { Campaign } from '../db/models/Campaign'
 import { Note } from '../db/models/Note'
 import { serverCaptureException, serverCaptureEvent } from '../utils/posthog'
 import { normalizeTags } from '../utils/helpers'
-import { removeDocumentRefsFromScreens } from './gmscreens'
+import { removeDocumentRefsFromScreens } from './gmscreens-helpers'
 
 export interface NoteData {
   id: string

--- a/tests/server/functions/gmscreens.test.ts
+++ b/tests/server/functions/gmscreens.test.ts
@@ -78,7 +78,6 @@ import {
   deleteStack,
   addStackItem,
   removeStackItem,
-  removeDocumentRefsFromScreens,
   listGMScreensSchema,
   createGMScreenSchema,
   renameGMScreenSchema,
@@ -97,6 +96,7 @@ import {
   SUPPORTED_COLLECTIONS,
 } from '~/server/functions/gmscreens'
 import type { GMScreenData, GMScreenDetailData, WindowData, StackData, StackItemData } from '~/server/functions/gmscreens'
+import { removeDocumentRefsFromScreens } from '~/server/functions/gmscreens-helpers'
 import { serverCaptureEvent, serverCaptureException } from '~/server/utils/posthog'
 
 // ---------------------------------------------------------------------------

--- a/tests/server/functions/notes.test.ts
+++ b/tests/server/functions/notes.test.ts
@@ -31,7 +31,7 @@ vi.mock('~/server/utils/posthog', () => ({
   serverCaptureException: vi.fn(),
   serverCaptureEvent: vi.fn(),
 }))
-vi.mock('~/server/functions/gmscreens', () => ({
+vi.mock('~/server/functions/gmscreens-helpers', () => ({
   removeDocumentRefsFromScreens: vi.fn().mockResolvedValue(0),
 }))
 
@@ -42,7 +42,7 @@ import { Note } from '~/server/db/models/Note'
 import { createNote, updateNote, deleteNote, listNotes, getNote, createNoteSchema, updateNoteSchema, listNotesSchema } from '~/server/functions/notes'
 import type { NoteListItem } from '~/server/functions/notes'
 import { serverCaptureEvent, serverCaptureException } from '~/server/utils/posthog'
-import { removeDocumentRefsFromScreens } from '~/server/functions/gmscreens'
+import { removeDocumentRefsFromScreens } from '~/server/functions/gmscreens-helpers'
 
 const mockSession = {
   id: 'session-user-1',


### PR DESCRIPTION
## Summary

- Fix runtime crash on the play route: `TypeError: Class extends value undefined is not a constructor or null`
- `SUPPORTED_COLLECTIONS` was derived from `COLLECTION_REGISTRY` which transitively pulled Mongoose models into the browser bundle via TanStack Start's `.validator()` chains
- Move `removeDocumentRefsFromScreens` to a separate helper file so `notes.ts` importing it doesn't force-bundle the full `gmscreens.ts` module

## Root Cause

TanStack Start keeps `.validator()` chains in the client bundle for RPC validation. Two server functions use `z.enum(SUPPORTED_COLLECTIONS)` in their validators. `SUPPORTED_COLLECTIONS = Object.keys(COLLECTION_REGISTRY)` → `COLLECTION_REGISTRY` references `Note.find()` → pulls in Mongoose → `new mongoose.Schema()` executes in browser → crash.

## Changes

1. **`SUPPORTED_COLLECTIONS`** — static `['note']` literal instead of `Object.keys(COLLECTION_REGISTRY)`
2. **`removeDocumentRefsFromScreens`** — moved to `gmscreens-helpers.ts` to isolate Mongoose usage from the `createServerFn` module

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` — 0 errors
- [x] 187 affected tests pass (gmscreens + notes)
- [ ] Verify play route loads without crash on Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)