### PR TITLE
fix: prevent Mongoose from leaking into play route client bundle (#336)

### DIFF
--- a/app/routes/campaigns/$campaignId/play.tsx
+++ b/app/routes/campaigns/$campaignId/play.tsx
@@ -1,6 +1,10 @@
 import { z } from 'zod'
 import { createFileRoute, redirect } from '@tanstack/react-router'
 import { getMe } from '~/server/functions/auth'
+// Import GM Screen server functions so TanStack Start's compiler processes them.
+// Without this, they end up in the route component chunk (uncompiled) and pull
+// Mongoose into the client bundle, crashing the browser.
+import '~/server/functions/gmscreens'
 import { useCampaign } from '~/hooks/useCampaigns'
 import { CampaignHeader } from '~/components/mainview/CampaignHeader'
 import { DashboardView } from '~/components/mainview/DashboardView'


### PR DESCRIPTION
## Summary

- Fix runtime crash: `TypeError: Class extends value undefined is not a constructor or null`
- Play route client bundle reduced from **2.78MB → 884KB**
- Zero Mongoose references in any client bundle

## Root Cause

TanStack Start's server function compiler only processes **route definition chunks** (beforeLoad/loader), not **route component chunks**. The `useGMScreens` hook imports server functions from `gmscreens.ts`, and since that entire import chain lives only in the component chunk (PlayPage), the compiler never transforms them. The raw server code — including Mongoose model initialization (`new mongoose.Schema()`) — ends up in the client bundle, crashing on load.

## Fix

Add a side-effect import `import '~/server/functions/gmscreens'` in the route definition (alongside `beforeLoad`). This forces TanStack Start's compiler to process `gmscreens.ts` and generate RPC stubs. The compiled stubs then become available to the component chunk too, keeping Mongoose server-only.

This is a **4-line change** in `play.tsx`.

## Note

The previous PR (#358) was a red herring — `SUPPORTED_COLLECTIONS` and `removeDocumentRefsFromScreens` weren't the cause, though moving them was still good hygiene. The real issue was the compiler not running on the route component chunk.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test:ci` — 984 pass
- [x] `npm run build` — play bundle 884KB, zero mongoose in client assets
- [ ] Verify play route loads without crash on Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)