### PR TITLE
fix: enable inspector sidebar on GM Screens tab

### DIFF
--- a/app/routes/campaigns/$campaignId/play.tsx
+++ b/app/routes/campaigns/$campaignId/play.tsx
@@ -54,7 +54,7 @@ function PlayPage() {
         onTabChange={handleTabChange}
       />
       <div className="flex-1 overflow-hidden">
-        <MainView showToolbar={effectiveTab === 'tabletop'} showInspector={effectiveTab !== 'gmscreens'}>
+        <MainView showToolbar={effectiveTab === 'tabletop'}>
           <div
             className="h-full overflow-y-auto"
             role="tabpanel"


### PR DESCRIPTION
## Summary
- Removed the `showInspector={effectiveTab !== 'gmscreens'}` override in `play.tsx`, letting it default to `true`
- The Inspector sidebar is now available on the GM Screens tab with the same collapsible/drawer behavior as Dashboard and Tabletop

## Test plan
- [ ] Switch to GM Screens tab and verify the Inspector toggle is visible
- [ ] Collapse and expand the Inspector — GM Screen workspace should resize accordingly
- [ ] On mobile, verify the Inspector drawer opens/closes correctly on the GM Screens tab
- [ ] Confirm Dashboard and Tabletop tabs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)