### PR TITLE
feat: make session optional on notes

### DIFF
--- a/.storybook/mocks/useNotes.ts
+++ b/.storybook/mocks/useNotes.ts
@@ -38,3 +38,11 @@ export function useUpdateNote() {
     error: null,
   }
 }
+
+export function useDeleteNote() {
+  return {
+    remove: async (_input: unknown) => ({ success: true }),
+    isLoading: false,
+    error: null,
+  }
+}

--- a/app/components/mainview/notes/NoteModal.tsx
+++ b/app/components/mainview/notes/NoteModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useCallback, useId } from 'react'
 import { createPortal } from 'react-dom'
-import { X, Globe, Lock, AlertCircle } from 'lucide-react'
+import { X, Globe, Lock } from 'lucide-react'
 import { FormInput } from '~/components/FormInput'
 import { FormSelect } from '~/components/FormSelect'
 import { PixelButton } from '~/components/PixelButton'
@@ -19,7 +19,6 @@ interface NoteModalProps {
 
 interface FieldErrors {
   title?: string
-  sessionId?: string
   content?: string
 }
 
@@ -53,7 +52,7 @@ export function NoteModal({
   // so stale values from a previous note never flash.
   useEffect(() => {
     setTitle('')
-    setSessionId(noteId ? '' : defaultSessionId || sessions[0]?.id || '')
+    setSessionId(noteId ? '' : defaultSessionId || '')
     setContent('')
     setTags([])
     setIsPublic(false)
@@ -68,27 +67,27 @@ export function NoteModal({
   useEffect(() => {
     if (noteId && fetchedNote) {
       setTitle(fetchedNote.title)
-      setSessionId(fetchedNote.sessionId)
+      setSessionId(fetchedNote.sessionId ?? '')
       setContent(fetchedNote.note)
       setTags(fetchedNote.tags)
       setIsPublic(fetchedNote.isPublic)
     }
   }, [noteId, fetchedNote])
 
-  const sessionOptions = useMemo(() => sessions.map((s) => ({
-    value: s.id,
-    label: `Session ${s.number}: ${s.name}`,
-  })), [sessions])
-
-  const isSessionMissing = sessions.length === 0
+  const sessionOptions = useMemo(() => [
+    { value: '', label: 'No Session' },
+    ...sessions.map((s) => ({
+      value: s.id,
+      label: `Session ${s.number}: ${s.name}`,
+    })),
+  ], [sessions])
 
   const validate = useCallback((): FieldErrors => {
     const errors: FieldErrors = {}
     if (!title.trim()) errors.title = 'Title is required'
-    if (!sessionId) errors.sessionId = 'Session is required'
     if (!content.trim()) errors.content = 'Note body is required'
     return errors
-  }, [title, sessionId, content])
+  }, [title, content])
 
   useEffect(() => {
     if (hasSubmitted) {
@@ -119,8 +118,6 @@ export function NoteModal({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (isSessionMissing) return
-
     setHasSubmitted(true)
     setError(null)
 
@@ -138,13 +135,15 @@ export function NoteModal({
       finalTags = merged
     }
 
-    const input = {
+    const input: Record<string, unknown> = {
       campaignId,
-      sessionId,
       title: title.trim(),
       note: content.trim(),
       tags: finalTags,
       isPublic,
+    }
+    if (sessionId) {
+      input.sessionId = sessionId
     }
 
     let success = false
@@ -216,25 +215,13 @@ export function NoteModal({
             </div>
           )}
 
-          {isSessionMissing && (
-            <div className="p-3 bg-amber-500/10 border border-amber-500/20 rounded-lg flex items-start gap-3">
-              <AlertCircle className="h-4 w-4 text-amber-500 shrink-0 mt-0.5" />
-              <div className="space-y-1">
-                <p className="text-amber-200 text-xs font-bold uppercase tracking-wider">Session Required</p>
-                <p className="text-slate-400 text-[11px] leading-relaxed">
-                  You cannot create a note without a session. Please ensure sessions are loaded before creating notes.
-                </p>
-              </div>
-            </div>
-          )}
-
           <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
             <FormInput
               label="Title"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
               placeholder="e.g. The Traitor's Meeting"
-              disabled={isDisabled || isSessionMissing}
+              disabled={isDisabled}
               error={fieldErrors.title}
             />
             <FormSelect
@@ -242,20 +229,16 @@ export function NoteModal({
               value={sessionId}
               onChange={(e) => setSessionId(e.target.value)}
               options={sessionOptions}
-              disabled={isDisabled || isSessionMissing}
+              disabled={isDisabled}
             />
           </div>
-
-          {fieldErrors.sessionId && (
-            <p className="text-xs text-red-400 -mt-3" role="alert">{fieldErrors.sessionId}</p>
-          )}
 
           <MarkdownEditor
             label="Note"
             value={content}
             onChange={setContent}
             placeholder="What happened? What did you discover?..."
-            disabled={isDisabled || isSessionMissing}
+            disabled={isDisabled}
             error={fieldErrors.content}
             minHeight="16rem"
             id="note-modal-editor"
@@ -270,7 +253,7 @@ export function NoteModal({
               className={[
                 'flex flex-wrap items-center gap-1.5 bg-white/[0.04] border rounded-xl px-3 py-2 min-h-[44px] transition-all',
                 'focus-within:border-blue-500/50 border-white/10',
-                (isDisabled || isSessionMissing) ? 'opacity-50 cursor-not-allowed' : '',
+                isDisabled ? 'opacity-50 cursor-not-allowed' : '',
               ].filter(Boolean).join(' ')}
               onClick={() => document.getElementById(tagInputId)?.focus()}
             >
@@ -288,7 +271,7 @@ export function NoteModal({
                     }}
                     className="ml-0.5 text-blue-400/60 hover:text-blue-300 transition-colors"
                     aria-label={`Remove tag ${tag}`}
-                    disabled={isDisabled || isSessionMissing}
+                    disabled={isDisabled}
                   >
                     <X className="h-3 w-3" />
                   </button>
@@ -304,7 +287,7 @@ export function NoteModal({
                   if (tagInput.trim()) addTag(tagInput)
                 }}
                 placeholder={tags.length === 0 ? 'Type a tag and press Enter' : ''}
-                disabled={isDisabled || isSessionMissing}
+                disabled={isDisabled}
                 className="flex-1 min-w-[120px] bg-transparent border-none outline-none text-slate-200 text-sm placeholder-slate-700"
                 aria-label="Add tag"
               />
@@ -315,14 +298,14 @@ export function NoteModal({
           </div>
 
           <div className="flex items-center gap-6 pt-2">
-            <label className={`flex items-center gap-3 cursor-pointer group ${isSessionMissing ? 'pointer-events-none opacity-50' : ''}`}>
+            <label className="flex items-center gap-3 cursor-pointer group">
               <input
                 type="radio"
                 name="visibility"
                 checked={!isPublic}
                 onChange={() => setIsPublic(false)}
                 className="sr-only"
-                disabled={isDisabled || isSessionMissing}
+                disabled={isDisabled}
               />
               <div className={`h-10 px-4 rounded-xl border flex items-center gap-2.5 transition-all ${
                 !isPublic
@@ -334,14 +317,14 @@ export function NoteModal({
               </div>
             </label>
 
-            <label className={`flex items-center gap-3 cursor-pointer group ${isSessionMissing ? 'pointer-events-none opacity-50' : ''}`}>
+            <label className="flex items-center gap-3 cursor-pointer group">
               <input
                 type="radio"
                 name="visibility"
                 checked={isPublic}
                 onChange={() => setIsPublic(true)}
                 className="sr-only"
-                disabled={isDisabled || isSessionMissing}
+                disabled={isDisabled}
               />
               <div className={`h-10 px-4 rounded-xl border flex items-center gap-2.5 transition-all ${
                 isPublic
@@ -405,7 +388,7 @@ export function NoteModal({
             <PixelButton
               variant="primary"
               size="sm"
-              disabled={isDisabled || isSessionMissing}
+              disabled={isDisabled}
               type="submit"
             >
               {isSaving ? 'Saving...' : isLoadingNote ? 'Loading...' : noteId ? 'Update Note' : 'Create Note'}

--- a/app/components/mainview/notes/NoteModal.tsx
+++ b/app/components/mainview/notes/NoteModal.tsx
@@ -135,15 +135,13 @@ export function NoteModal({
       finalTags = merged
     }
 
-    const input: Record<string, unknown> = {
+    const input = {
       campaignId,
       title: title.trim(),
       note: content.trim(),
       tags: finalTags,
       isPublic,
-    }
-    if (sessionId) {
-      input.sessionId = sessionId
+      ...(sessionId ? { sessionId } : {}),
     }
 
     let success = false

--- a/app/components/mainview/notes/NoteModal.tsx
+++ b/app/components/mainview/notes/NoteModal.tsx
@@ -52,7 +52,8 @@ export function NoteModal({
   // so stale values from a previous note never flash.
   useEffect(() => {
     setTitle('')
-    setSessionId(noteId ? '' : defaultSessionId || '')
+    const safeDefault = defaultSessionId === '__none__' ? '' : defaultSessionId
+    setSessionId(noteId ? '' : safeDefault || '')
     setContent('')
     setTags([])
     setIsPublic(false)

--- a/app/components/mainview/notes/NotesFilterWidget.tsx
+++ b/app/components/mainview/notes/NotesFilterWidget.tsx
@@ -57,6 +57,7 @@ export function NotesFilterWidget({
             className="w-full bg-[#080A12] border border-white/[0.07] rounded px-2 py-1.5 font-sans font-semibold text-[11px] text-slate-300 outline-none focus:border-blue-500/50 transition-colors"
           >
             <option value="">All Sessions</option>
+            <option value="__none__">No Session</option>
             {sessions.map((session) => (
               <option key={session.id} value={session.id}>
                 Session {session.number}: {session.name}

--- a/app/components/mainview/notes/NotesListWidget.tsx
+++ b/app/components/mainview/notes/NotesListWidget.tsx
@@ -65,7 +65,7 @@ export function NotesListWidget({
     <div className="flex-1 overflow-y-auto min-h-0">
       <div className="flex flex-col">
         {notes.map((note) => {
-          const session = sessionMap[note.sessionId]
+          const session = note.sessionId ? sessionMap[note.sessionId] : undefined
           return (
             <button
               key={note.id}

--- a/app/hooks/useNotes.ts
+++ b/app/hooks/useNotes.ts
@@ -103,7 +103,7 @@ export function useNote(id: string, campaignId: string) {
 
 interface CreateNoteInput {
   campaignId: string
-  sessionId: string
+  sessionId?: string
   title: string
   note: string
   tags?: string[]
@@ -141,7 +141,7 @@ export function useCreateNote() {
 interface UpdateNoteInput {
   id: string
   campaignId: string
-  sessionId: string
+  sessionId?: string
   title: string
   note: string
   tags?: string[]

--- a/app/server/db/models/Note.ts
+++ b/app/server/db/models/Note.ts
@@ -10,7 +10,7 @@ const noteSchema = new mongoose.Schema({
   createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   createdAt: { type: Date, default: Date.now },
   updatedAt: { type: Date, default: Date.now },
-  sessionId: { type: mongoose.Schema.Types.ObjectId, ref: 'Session', required: true },
+  sessionId: { type: mongoose.Schema.Types.ObjectId, ref: 'Session', required: false },
   campaignId: { type: mongoose.Schema.Types.ObjectId, ref: 'Campaign', required: true },
 })
 

--- a/app/server/functions/notes.ts
+++ b/app/server/functions/notes.ts
@@ -32,7 +32,7 @@ function serializeNote(n: {
   return {
     id: String(n._id),
     campaignId: String(n.campaignId),
-    sessionId: String(n.sessionId),
+    sessionId: n.sessionId ? String(n.sessionId) : undefined,
     createdBy: String(n.createdBy),
     title: n.title ?? '',
     note: n.note ?? '',
@@ -57,7 +57,7 @@ function serializeNoteListItem(n: {
   return {
     id: String(n._id),
     campaignId: String(n.campaignId),
-    sessionId: String(n.sessionId),
+    sessionId: n.sessionId ? String(n.sessionId) : undefined,
     createdBy: String(n.createdBy),
     title: n.title ?? '',
     tags: n.tags ?? [],
@@ -110,9 +110,8 @@ export const createNote = createServerFn({ method: 'POST' })
       const userId = member.userId
 
       const now = new Date()
-      const doc = await Note.create({
+      const noteData: Record<string, unknown> = {
         campaignId: data.campaignId,
-        sessionId: data.sessionId,
         createdBy: userId,
         title: data.title.trim(),
         note: data.note.trim(),
@@ -120,7 +119,11 @@ export const createNote = createServerFn({ method: 'POST' })
         isPublic: data.isPublic ?? false,
         createdAt: now,
         updatedAt: now,
-      })
+      }
+      if (data.sessionId) {
+        noteData.sessionId = data.sessionId
+      }
+      const doc = await Note.create(noteData)
 
       serverCaptureEvent(sessionUserId, 'note_created', {
         campaign_id: data.campaignId,
@@ -155,7 +158,7 @@ export const updateNote = createServerFn({ method: 'POST' })
       if (String(existing.createdBy) !== userId) throw new Error('Forbidden')
       if (existing.isReadOnly) throw new Error('Note is read-only')
 
-      existing.sessionId = data.sessionId
+      existing.sessionId = data.sessionId ?? undefined
       existing.title = data.title.trim()
       existing.note = data.note.trim()
       existing.tags = normalizeTags(data.tags ?? [])

--- a/app/server/functions/notes.ts
+++ b/app/server/functions/notes.ts
@@ -248,7 +248,9 @@ export const listNotes = createServerFn({ method: 'GET' })
       // Build query filter
       const filter: Record<string, unknown> = { campaignId: data.campaignId }
 
-      if (data.sessionId) {
+      if (data.sessionId === '__none__') {
+        filter.sessionId = { $exists: false }
+      } else if (data.sessionId) {
         filter.sessionId = data.sessionId
       }
 

--- a/app/server/functions/notes.ts
+++ b/app/server/functions/notes.ts
@@ -120,7 +120,7 @@ export const createNote = createServerFn({ method: 'POST' })
         createdAt: now,
         updatedAt: now,
       }
-      if (data.sessionId) {
+      if (data.sessionId && data.sessionId !== '__none__') {
         noteData.sessionId = data.sessionId
       }
       const doc = await Note.create(noteData)
@@ -158,7 +158,7 @@ export const updateNote = createServerFn({ method: 'POST' })
       if (String(existing.createdBy) !== userId) throw new Error('Forbidden')
       if (existing.isReadOnly) throw new Error('Note is read-only')
 
-      existing.sessionId = data.sessionId ?? undefined
+      existing.sessionId = data.sessionId && data.sessionId !== '__none__' ? data.sessionId : undefined
       existing.title = data.title.trim()
       existing.note = data.note.trim()
       existing.tags = normalizeTags(data.tags ?? [])

--- a/app/types/note.ts
+++ b/app/types/note.ts
@@ -1,7 +1,7 @@
 export interface NoteData {
   id: string
   campaignId: string
-  sessionId: string
+  sessionId?: string
   createdBy: string
   title: string
   note: string
@@ -14,7 +14,7 @@ export interface NoteData {
 export interface NoteListItem {
   id: string
   campaignId: string
-  sessionId: string
+  sessionId?: string
   createdBy: string
   title: string
   tags: string[]

--- a/app/types/schemas/notes.ts
+++ b/app/types/schemas/notes.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 export const createNoteSchema = z.object({
   campaignId: z.string().trim().min(1),
-  sessionId: z.string().trim().min(1),
+  sessionId: z.string().trim().min(1).optional(),
   title: z.string().trim().min(1, 'Title is required'),
   note: z.string().trim().min(1, 'Note body is required'),
   tags: z.array(z.string()).optional().default([]),
@@ -12,7 +12,7 @@ export const createNoteSchema = z.object({
 export const updateNoteSchema = z.object({
   id: z.string().trim().min(1),
   campaignId: z.string().trim().min(1),
-  sessionId: z.string().trim().min(1),
+  sessionId: z.string().trim().min(1).optional(),
   title: z.string().trim().min(1, 'Title is required'),
   note: z.string().trim().min(1, 'Note body is required'),
   tags: z.array(z.string()).optional().default([]),

--- a/docs/superpowers/plans/2026-04-03-optional-session-on-notes.md
+++ b/docs/superpowers/plans/2026-04-03-optional-session-on-notes.md
@@ -1,0 +1,472 @@
+# Optional Session on Notes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the session field optional when creating/editing notes, so notes can exist without being tied to a session.
+
+**Architecture:** Change flows bottom-up: MongoDB schema → Zod validation → TypeScript interfaces → server functions → UI components. Each layer removes the `sessionId` requirement and handles the missing value gracefully.
+
+**Tech Stack:** MongoDB/Mongoose, Zod, TypeScript, React, TanStack Start, Vitest
+
+---
+
+### Task 1: Make sessionId optional in Zod schemas and TypeScript interfaces
+
+**Files:**
+- Modify: `app/types/schemas/notes.ts:5,15`
+- Modify: `app/types/note.ts:4,17`
+- Test: `tests/server/functions/notes.test.ts`
+
+- [ ] **Step 1: Update the Zod schemas**
+
+In `app/types/schemas/notes.ts`, change `sessionId` from required to optional in both create and update schemas:
+
+```typescript
+// Line 5 — createNoteSchema
+sessionId: z.string().trim().min(1).optional(),
+
+// Line 15 — updateNoteSchema
+sessionId: z.string().trim().min(1).optional(),
+```
+
+- [ ] **Step 2: Update the TypeScript interfaces**
+
+In `app/types/note.ts`, make `sessionId` optional on both interfaces:
+
+```typescript
+// Line 4 in NoteData
+sessionId?: string
+
+// Line 17 in NoteListItem
+sessionId?: string
+```
+
+- [ ] **Step 3: Update schema tests — sessionId now optional**
+
+In `tests/server/functions/notes.test.ts`, update the two tests that assert sessionId is required. Replace the existing tests:
+
+Replace the test `'rejects whitespace-only sessionId'` (lines 599-607) with:
+
+```typescript
+  it('rejects whitespace-only sessionId when provided', () => {
+    const result = createNoteSchema.safeParse({
+      campaignId: 'camp-1',
+      sessionId: '   ',
+      title: 'Title',
+      note: 'body',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts when sessionId is omitted', () => {
+    const result = createNoteSchema.safeParse({
+      campaignId: 'camp-1',
+      title: 'Title',
+      note: 'body',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.sessionId).toBeUndefined()
+    }
+  })
+```
+
+Replace the test `'rejects when sessionId is missing'` (lines 619-626) — delete it entirely since sessionId is now optional.
+
+- [ ] **Step 4: Run tests to verify schema changes pass**
+
+Run: `npx vitest run tests/server/functions/notes.test.ts`
+Expected: All tests pass (schema tests updated, existing tests still pass since they still provide sessionId)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/types/schemas/notes.ts app/types/note.ts tests/server/functions/notes.test.ts
+git commit -m "feat(notes): make sessionId optional in schemas and types"
+```
+
+---
+
+### Task 2: Make sessionId optional in MongoDB model
+
+**Files:**
+- Modify: `app/server/db/models/Note.ts:13`
+
+- [ ] **Step 1: Update the Mongoose schema**
+
+In `app/server/db/models/Note.ts`, change line 13 from:
+
+```typescript
+sessionId: { type: mongoose.Schema.Types.ObjectId, ref: 'Session', required: true },
+```
+
+to:
+
+```typescript
+sessionId: { type: mongoose.Schema.Types.ObjectId, ref: 'Session', required: false },
+```
+
+- [ ] **Step 2: Run tests to verify nothing breaks**
+
+Run: `npx vitest run tests/server/functions/notes.test.ts`
+Expected: All tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/server/db/models/Note.ts
+git commit -m "feat(notes): make sessionId optional in MongoDB schema"
+```
+
+---
+
+### Task 3: Update server functions to handle optional sessionId
+
+**Files:**
+- Modify: `app/server/functions/notes.ts:20-68,113-115,158`
+- Test: `tests/server/functions/notes.test.ts`
+
+- [ ] **Step 1: Write failing tests for sessionless note creation and updates**
+
+Add these tests to `tests/server/functions/notes.test.ts`:
+
+In the `createNote` describe block, add:
+
+```typescript
+  it('creates a note without sessionId when omitted', async () => {
+    const created = makeNote({ sessionId: undefined })
+    vi.mocked(Note.create).mockResolvedValue(created as never)
+
+    const result = await _createNote({
+      data: {
+        campaignId: 'camp-1',
+        title: 'No Session Note',
+        note: 'body',
+      },
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.note.sessionId).toBeUndefined()
+    const createArg = vi.mocked(Note.create).mock.calls[0][0] as Record<string, unknown>
+    expect(createArg).not.toHaveProperty('sessionId')
+  })
+```
+
+In the `updateNote` describe block, add:
+
+```typescript
+  it('clears sessionId when omitted from update', async () => {
+    const existing = makeNote()
+    vi.mocked(Note.findById).mockResolvedValue(existing as never)
+
+    const result = await _updateNote({
+      data: {
+        id: 'note-1',
+        campaignId: 'camp-1',
+        title: 'Updated Title',
+        note: 'Updated body',
+      },
+    })
+
+    expect(result.success).toBe(true)
+    expect(existing.sessionId).toBeUndefined()
+    expect(existing.save).toHaveBeenCalled()
+  })
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/server/functions/notes.test.ts -t "creates a note without sessionId"`
+Expected: FAIL — sessionId is still being passed to Note.create unconditionally
+
+Run: `npx vitest run tests/server/functions/notes.test.ts -t "clears sessionId when omitted"`
+Expected: FAIL — sessionId is still set from data.sessionId (which is undefined, but it's still assigned)
+
+- [ ] **Step 3: Update serialization functions**
+
+In `app/server/functions/notes.ts`, update `serializeNote` (lines 20-44) and `serializeNoteListItem` (lines 46-68) to handle optional sessionId:
+
+In `serializeNote`, change line 35 from:
+```typescript
+    sessionId: String(n.sessionId),
+```
+to:
+```typescript
+    sessionId: n.sessionId ? String(n.sessionId) : undefined,
+```
+
+In `serializeNoteListItem`, change line 60 from:
+```typescript
+    sessionId: String(n.sessionId),
+```
+to:
+```typescript
+    sessionId: n.sessionId ? String(n.sessionId) : undefined,
+```
+
+- [ ] **Step 4: Update createNote handler**
+
+In `app/server/functions/notes.ts`, replace the `Note.create` call (lines 113-123) with:
+
+```typescript
+      const noteData: Record<string, unknown> = {
+        campaignId: data.campaignId,
+        createdBy: userId,
+        title: data.title.trim(),
+        note: data.note.trim(),
+        tags: normalizeTags(data.tags ?? []),
+        isPublic: data.isPublic ?? false,
+        createdAt: now,
+        updatedAt: now,
+      }
+      if (data.sessionId) {
+        noteData.sessionId = data.sessionId
+      }
+      const doc = await Note.create(noteData)
+```
+
+- [ ] **Step 5: Update updateNote handler**
+
+In `app/server/functions/notes.ts`, replace line 158:
+```typescript
+      existing.sessionId = data.sessionId
+```
+with:
+```typescript
+      existing.sessionId = data.sessionId ?? undefined
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npx vitest run tests/server/functions/notes.test.ts`
+Expected: All tests pass including new sessionless tests
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/server/functions/notes.ts tests/server/functions/notes.test.ts
+git commit -m "feat(notes): handle optional sessionId in server functions"
+```
+
+---
+
+### Task 4: Update NoteModal UI — add "No Session" option and remove session gate
+
+**Files:**
+- Modify: `app/components/mainview/notes/NoteModal.tsx`
+
+- [ ] **Step 1: Update session options to include "No Session"**
+
+In `app/components/mainview/notes/NoteModal.tsx`, replace the `sessionOptions` memo (lines 78-81) with:
+
+```typescript
+  const sessionOptions = useMemo(() => [
+    { value: '', label: 'No Session' },
+    ...sessions.map((s) => ({
+      value: s.id,
+      label: `Session ${s.number}: ${s.name}`,
+    })),
+  ], [sessions])
+```
+
+- [ ] **Step 2: Default sessionId to empty string**
+
+In the reset effect (line 56), change:
+```typescript
+    setSessionId(noteId ? '' : defaultSessionId || sessions[0]?.id || '')
+```
+to:
+```typescript
+    setSessionId(noteId ? '' : defaultSessionId || '')
+```
+
+- [ ] **Step 3: Update populate effect for edit mode**
+
+In the populate effect (lines 68-76), handle optional sessionId:
+
+Change line 71 from:
+```typescript
+      setSessionId(fetchedNote.sessionId)
+```
+to:
+```typescript
+      setSessionId(fetchedNote.sessionId ?? '')
+```
+
+- [ ] **Step 4: Remove isSessionMissing gate and sessionId validation**
+
+Remove the `isSessionMissing` constant (line 83):
+```typescript
+  const isSessionMissing = sessions.length === 0
+```
+
+In the `validate` callback (lines 85-91), remove line 88:
+```typescript
+    if (!sessionId) errors.sessionId = 'Session is required'
+```
+
+Also remove the `sessionId` property from the `FieldErrors` interface (lines 20-24):
+```typescript
+interface FieldErrors {
+  title?: string
+  content?: string
+}
+```
+
+In `handleSubmit` (line 122), remove:
+```typescript
+    if (isSessionMissing) return
+```
+
+- [ ] **Step 5: Update the submit payload to omit empty sessionId**
+
+In `handleSubmit`, replace the input construction (lines 141-148) with:
+
+```typescript
+    const input: Record<string, unknown> = {
+      campaignId,
+      title: title.trim(),
+      note: content.trim(),
+      tags: finalTags,
+      isPublic,
+    }
+    if (sessionId) {
+      input.sessionId = sessionId
+    }
+```
+
+- [ ] **Step 6: Remove isSessionMissing from JSX**
+
+Remove the amber warning block (lines 219-229).
+
+Remove all `isSessionMissing` references from `disabled` props throughout the JSX. There are 7 occurrences — change each `disabled={isDisabled || isSessionMissing}` to `disabled={isDisabled}` and each `isSessionMissing ? 'pointer-events-none opacity-50' : ''` to just `''` (or remove the ternary entirely).
+
+Also remove `isSessionMissing` from the submit button disabled prop (line 408):
+```typescript
+disabled={isDisabled}
+```
+
+Remove the sessionId field error display (lines 249-251):
+```html
+{fieldErrors.sessionId && (
+  <p className="text-xs text-red-400 -mt-3" role="alert">{fieldErrors.sessionId}</p>
+)}
+```
+
+Remove the `AlertCircle` import from line 3 (it's no longer used).
+
+- [ ] **Step 7: Run the full test suite to verify nothing is broken**
+
+Run: `npx vitest run tests/server/functions/notes.test.ts`
+Expected: All tests pass
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/components/mainview/notes/NoteModal.tsx
+git commit -m "feat(notes): add No Session option and remove session requirement from UI"
+```
+
+---
+
+### Task 5: Update NotesFilterWidget — add "No Session" filter option
+
+**Files:**
+- Modify: `app/components/mainview/notes/NotesFilterWidget.tsx:59-64`
+- Modify: `app/server/functions/notes.ts:246-250`
+- Test: `tests/server/functions/notes.test.ts`
+
+- [ ] **Step 1: Write failing test for "no session" filter on the server**
+
+In `tests/server/functions/notes.test.ts`, in the `listNotes` describe block, add:
+
+```typescript
+  it('filters for notes with no session when sessionId is "__none__"', async () => {
+    vi.mocked(Note.find).mockReturnValue({
+      select: vi.fn().mockReturnValue({ sort: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue([]) }) }),
+    } as never)
+
+    await _listNotes({ data: { campaignId: 'camp-1', sessionId: '__none__' } })
+
+    const filter = vi.mocked(Note.find).mock.calls[0][0] as Record<string, unknown>
+    expect(filter.sessionId).toEqual({ $exists: false })
+  })
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/server/functions/notes.test.ts -t "filters for notes with no session"`
+Expected: FAIL — server currently passes `__none__` as a literal sessionId value
+
+- [ ] **Step 3: Update server listNotes to handle "__none__" sentinel**
+
+In `app/server/functions/notes.ts`, replace lines 248-250:
+
+```typescript
+      if (data.sessionId) {
+        filter.sessionId = data.sessionId
+      }
+```
+
+with:
+
+```typescript
+      if (data.sessionId === '__none__') {
+        filter.sessionId = { $exists: false }
+      } else if (data.sessionId) {
+        filter.sessionId = data.sessionId
+      }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/server/functions/notes.test.ts`
+Expected: All tests pass
+
+- [ ] **Step 5: Add "No Session" option to the filter dropdown**
+
+In `app/components/mainview/notes/NotesFilterWidget.tsx`, after the "All Sessions" option (line 59), add:
+
+```tsx
+            <option value="__none__">No Session</option>
+```
+
+So lines 59-65 become:
+
+```tsx
+            <option value="">All Sessions</option>
+            <option value="__none__">No Session</option>
+            {sessions.map((session) => (
+              <option key={session.id} value={session.id}>
+                Session {session.number}: {session.name}
+              </option>
+            ))}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `npx vitest run tests/server/functions/notes.test.ts`
+Expected: All tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/server/functions/notes.ts app/components/mainview/notes/NotesFilterWidget.tsx tests/server/functions/notes.test.ts
+git commit -m "feat(notes): add No Session filter option for listing notes"
+```
+
+---
+
+### Task 6: Final verification
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npx vitest run`
+Expected: All tests pass with no regressions
+
+- [ ] **Step 2: Run TypeScript type checking**
+
+Run: `npx tsc --noEmit`
+Expected: No type errors
+
+- [ ] **Step 3: Commit any remaining fixes if needed**

--- a/docs/superpowers/specs/2026-04-03-optional-session-on-notes-design.md
+++ b/docs/superpowers/specs/2026-04-03-optional-session-on-notes-design.md
@@ -1,0 +1,70 @@
+# Design: Make Session Optional on Notes
+
+## Summary
+
+Notes currently require a session to be selected before they can be created or saved. This change makes the session field optional — notes can exist independently of any session. A "No Session" option is added to the dropdown as the default selection. When "No Session" is selected, the `sessionId` field is omitted from the MongoDB document entirely.
+
+No migration is needed — the system is not yet in production and no notes exist.
+
+## Data Layer Changes
+
+### MongoDB Schema (`app/server/db/models/Note.ts`)
+
+- Change `sessionId` from `required: true` to `required: false`
+- Existing index on `sessionId` remains — MongoDB handles `null`/missing values in indexes
+
+### Zod Schemas (`app/types/schemas/notes.ts`)
+
+- `createNoteSchema`: Change `sessionId` from `z.string().trim().min(1)` to `z.string().trim().min(1).optional()`
+- `updateNoteSchema`: Same change — `sessionId` becomes optional
+- `listNotesSchema`: Already optional, no change needed
+- `deleteNoteSchema`, `getNoteSchema`: No changes needed
+
+### TypeScript Interfaces (`app/types/note.ts`)
+
+- `NoteData`: Change `sessionId: string` to `sessionId?: string`
+- `NoteListItem`: Change `sessionId: string` to `sessionId?: string`
+
+## Server Function Changes (`app/server/functions/notes.ts`)
+
+### `createNote`
+
+- Only include `sessionId` in the `Note.create()` call if a value is provided
+- If `sessionId` is `undefined` or absent, omit it from the document
+
+### `updateNote`
+
+- If `sessionId` is provided, set it on the document
+- If `sessionId` is absent/undefined (user selected "No Session"), unset it from the document using `existing.sessionId = undefined`
+
+### `serializeNote` / `serializeNoteListItem`
+
+- Handle missing `sessionId` — return `undefined` instead of calling `.toString()` on a null/undefined value
+
+## UI Changes
+
+### NoteModal (`app/components/mainview/notes/NoteModal.tsx`)
+
+- Add a "No Session" option (value `""`) as the **first** item in the session dropdown
+- Default `sessionId` state to `""` (No Session) instead of the first available session
+- Remove the `isSessionMissing` check and the amber warning that blocks note creation when no sessions exist
+- Remove the `sessionId` required validation from the form submit handler (`errors.sessionId = 'Session is required'`)
+- When submitting: if `sessionId` is `""`, send `undefined` to the server function
+
+### NotesListWidget (`app/components/mainview/notes/NotesListWidget.tsx`)
+
+- When rendering a note without a `sessionId`, display "No Session" instead of `Session {number}`
+
+### NotesFilterWidget (`app/components/mainview/notes/NotesFilterWidget.tsx`)
+
+- Add a "No Session" filter option so users can find notes not associated with any session
+- The existing "All Sessions" option continues to show all notes regardless of session assignment
+
+## What Stays the Same
+
+- Delete flow — no changes needed
+- `getNoteSchema` / `deleteNoteSchema` — no changes needed
+- MongoDB indexes — work fine with optional fields
+- PostHog tracking — no changes needed
+- Note ownership and permissions — unchanged
+- `FormSelect` component — no changes needed (just receives different options)

--- a/tests/components/mainview/notes/NoteModal.test.tsx
+++ b/tests/components/mainview/notes/NoteModal.test.tsx
@@ -162,10 +162,10 @@ describe('NoteModal', () => {
     expect(sessionSelect).toHaveValue('session-2')
   })
 
-  it('defaults session to first session when no defaultSessionId', () => {
+  it('defaults session to No Session when no defaultSessionId', () => {
     renderModal()
     const sessionSelect = screen.getByRole('combobox')
-    expect(sessionSelect).toHaveValue('session-1')
+    expect(sessionSelect).toHaveValue('')
   })
 
   it('defaults visibility to private for new notes', () => {
@@ -174,7 +174,7 @@ describe('NoteModal', () => {
     expect(privateRadio).toBeChecked()
   })
 
-  it('submits a new note on valid create', async () => {
+  it('submits a new note on valid create (no session by default)', async () => {
     const user = userEvent.setup()
     const { props } = renderModal()
 
@@ -190,12 +190,17 @@ describe('NoteModal', () => {
       expect(mockCreate).toHaveBeenCalledWith(
         expect.objectContaining({
           campaignId: 'campaign-123',
-          sessionId: 'session-1',
           title: 'My Note',
           note: 'Some markdown content',
           isPublic: false,
         }),
       )
+    })
+
+    // sessionId should NOT be included when "No Session" is selected
+    await waitFor(() => {
+      const callArg = mockCreate.mock.calls[0][0]
+      expect(callArg).not.toHaveProperty('sessionId')
     })
 
     expect(props.onClose).toHaveBeenCalled()
@@ -288,10 +293,13 @@ describe('NoteModal', () => {
     expect(mockCreate).not.toHaveBeenCalled()
   })
 
-  it('shows validation error when session is missing', () => {
+  it('allows creating a note with no sessions available', () => {
     renderModal({ sessions: [] })
 
-    expect(screen.getByText('Session Required')).toBeInTheDocument()
+    // No "Session Required" warning — notes can be created without sessions
+    expect(screen.queryByText('Session Required')).not.toBeInTheDocument()
+    // The submit button should still be enabled
+    expect(screen.getByRole('button', { name: 'Create Note' })).not.toBeDisabled()
   })
 
   it('shows multiple validation errors simultaneously', async () => {

--- a/tests/components/mainview/notes/NoteModal.test.tsx
+++ b/tests/components/mainview/notes/NoteModal.test.tsx
@@ -168,6 +168,12 @@ describe('NoteModal', () => {
     expect(sessionSelect).toHaveValue('')
   })
 
+  it('treats "__none__" defaultSessionId as No Session', () => {
+    renderModal({ defaultSessionId: '__none__' })
+    const sessionSelect = screen.getByRole('combobox')
+    expect(sessionSelect).toHaveValue('')
+  })
+
   it('defaults visibility to private for new notes', () => {
     renderModal()
     const privateRadio = screen.getByRole('radio', { name: /private/i })

--- a/tests/server/functions/notes.test.ts
+++ b/tests/server/functions/notes.test.ts
@@ -596,7 +596,7 @@ describe('createNoteSchema', () => {
     expect(result.success).toBe(false)
   })
 
-  it('rejects whitespace-only sessionId', () => {
+  it('rejects whitespace-only sessionId when provided', () => {
     const result = createNoteSchema.safeParse({
       campaignId: 'camp-1',
       sessionId: '   ',
@@ -606,19 +606,22 @@ describe('createNoteSchema', () => {
     expect(result.success).toBe(false)
   })
 
+  it('accepts when sessionId is omitted', () => {
+    const result = createNoteSchema.safeParse({
+      campaignId: 'camp-1',
+      title: 'Title',
+      note: 'body',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.sessionId).toBeUndefined()
+    }
+  })
+
   it('rejects whitespace-only campaignId', () => {
     const result = createNoteSchema.safeParse({
       campaignId: '   ',
       sessionId: 'sess-1',
-      title: 'Title',
-      note: 'body',
-    })
-    expect(result.success).toBe(false)
-  })
-
-  it('rejects when sessionId is missing', () => {
-    const result = createNoteSchema.safeParse({
-      campaignId: 'camp-1',
       title: 'Title',
       note: 'body',
     })
@@ -682,6 +685,30 @@ describe('updateNoteSchema', () => {
       note: '   ',
     })
     expect(result.success).toBe(false)
+  })
+
+  it('rejects whitespace-only sessionId when provided', () => {
+    const result = updateNoteSchema.safeParse({
+      id: 'note-1',
+      campaignId: 'camp-1',
+      sessionId: '   ',
+      title: 'Title',
+      note: 'body',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts when sessionId is omitted', () => {
+    const result = updateNoteSchema.safeParse({
+      id: 'note-1',
+      campaignId: 'camp-1',
+      title: 'Title',
+      note: 'body',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.sessionId).toBeUndefined()
+    }
   })
 })
 

--- a/tests/server/functions/notes.test.ts
+++ b/tests/server/functions/notes.test.ts
@@ -443,6 +443,17 @@ describe('listNotes', () => {
     expect(vi.mocked(Note.find).mock.calls[0][0]).not.toHaveProperty('$text')
   })
 
+  it('filters for notes with no session when sessionId is "__none__"', async () => {
+    vi.mocked(Note.find).mockReturnValue({
+      select: vi.fn().mockReturnValue({ sort: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue([]) }) }),
+    } as never)
+
+    await _listNotes({ data: { campaignId: 'camp-1', sessionId: '__none__' } })
+
+    const filter = vi.mocked(Note.find).mock.calls[0][0] as Record<string, unknown>
+    expect(filter.sessionId).toEqual({ $exists: false })
+  })
+
   it('throws when not authenticated', async () => {
     vi.mocked(getSession).mockResolvedValue(null)
 

--- a/tests/server/functions/notes.test.ts
+++ b/tests/server/functions/notes.test.ts
@@ -196,6 +196,25 @@ describe('createNote', () => {
     expect(createArg).not.toHaveProperty('sessionId')
   })
 
+  it('does not persist the "__none__" sessionId sentinel', async () => {
+    const created = makeNote({ sessionId: undefined })
+    vi.mocked(Note.create).mockResolvedValue(created as never)
+
+    const result = await _createNote({
+      data: {
+        campaignId: 'camp-1',
+        sessionId: '__none__',
+        title: 'Sentinel Session Note',
+        note: 'body',
+      },
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.note.sessionId).toBeUndefined()
+    const createArg = vi.mocked(Note.create).mock.calls[0][0] as Record<string, unknown>
+    expect(createArg).not.toHaveProperty('sessionId')
+  })
+
   it('fires note_created analytics event', async () => {
     vi.mocked(Note.create).mockResolvedValue(makeNote() as never)
 
@@ -253,6 +272,26 @@ describe('updateNote', () => {
 
     expect(result.success).toBe(true)
     expect(existing.sessionId).toBeUndefined()
+    expect(existing.save).toHaveBeenCalled()
+  })
+
+  it('clears sessionId when update receives the __none__ sentinel', async () => {
+    const existing = makeNote({ sessionId: 'sess-1' })
+    vi.mocked(Note.findById).mockResolvedValue(existing as never)
+
+    const result = await _updateNote({
+      data: {
+        id: 'note-1',
+        campaignId: 'camp-1',
+        sessionId: '__none__',
+        title: 'Updated Title',
+        note: 'Updated body',
+      },
+    })
+
+    expect(result.success).toBe(true)
+    expect(existing.sessionId).toBeUndefined()
+    expect(existing.sessionId).not.toBe('__none__')
     expect(existing.save).toHaveBeenCalled()
   })
 

--- a/tests/server/functions/notes.test.ts
+++ b/tests/server/functions/notes.test.ts
@@ -178,6 +178,24 @@ describe('createNote', () => {
     ).rejects.toThrow('Forbidden')
   })
 
+  it('creates a note without sessionId when omitted', async () => {
+    const created = makeNote({ sessionId: undefined })
+    vi.mocked(Note.create).mockResolvedValue(created as never)
+
+    const result = await _createNote({
+      data: {
+        campaignId: 'camp-1',
+        title: 'No Session Note',
+        note: 'body',
+      },
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.note.sessionId).toBeUndefined()
+    const createArg = vi.mocked(Note.create).mock.calls[0][0] as Record<string, unknown>
+    expect(createArg).not.toHaveProperty('sessionId')
+  })
+
   it('fires note_created analytics event', async () => {
     vi.mocked(Note.create).mockResolvedValue(makeNote() as never)
 
@@ -218,6 +236,24 @@ describe('updateNote', () => {
     expect(existing.note).toBe('Updated body')
     expect(existing.tags).toEqual(['new-tag'])
     expect(existing.sessionId).toBe('sess-2')
+  })
+
+  it('clears sessionId when omitted from update', async () => {
+    const existing = makeNote()
+    vi.mocked(Note.findById).mockResolvedValue(existing as never)
+
+    const result = await _updateNote({
+      data: {
+        id: 'note-1',
+        campaignId: 'camp-1',
+        title: 'Updated Title',
+        note: 'Updated body',
+      },
+    })
+
+    expect(result.success).toBe(true)
+    expect(existing.sessionId).toBeUndefined()
+    expect(existing.save).toHaveBeenCalled()
   })
 
   it('throws when note is not found', async () => {

--- a/tests/server/functions/notes.test.ts
+++ b/tests/server/functions/notes.test.ts
@@ -450,7 +450,7 @@ describe('listNotes', () => {
 
     await _listNotes({ data: { campaignId: 'camp-1', sessionId: '__none__' } })
 
-    const filter = vi.mocked(Note.find).mock.calls[0][0] as Record<string, unknown>
+    const filter = vi.mocked(Note.find).mock.calls[0][0] as unknown as Record<string, unknown>
     expect(filter.sessionId).toEqual({ $exists: false })
   })
 


### PR DESCRIPTION
## Summary

- Makes the session field optional when creating and editing notes — notes can now exist independently of any session
- Adds a "No Session" default option in the session dropdown on the note modal
- Removes the "Session Required" gate that blocked note creation when no sessions existed
- Adds a "No Session" filter option in the notes list so users can find unassigned notes
- Updates MongoDB schema, Zod validation, TypeScript types, server functions, and UI components across the full stack

## Test plan

- [x] All 53 server-side notes tests pass (including new tests for sessionless create/update/filter)
- [x] All 36 NoteModal component tests pass (updated for new default behavior)
- [x] TypeScript type checking passes with zero errors
- [x] 989/990 total tests pass (1 pre-existing PostHog test failure, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)