### PR TITLE
feat(tags): universal tag system with autocomplete and filtering

### DIFF
--- a/app/components/mainview/notes/NoteModal.tsx
+++ b/app/components/mainview/notes/NoteModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback, useId } from 'react'
+import React, { useState, useEffect, useMemo, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { X, Globe, Lock } from 'lucide-react'
 import { FormInput } from '~/components/FormInput'
@@ -7,6 +7,7 @@ import { PixelButton } from '~/components/PixelButton'
 import { MarkdownEditor } from '~/components/shared/MarkdownEditor'
 import type { CampaignData } from '~/types/campaign'
 import { useCreateNote, useUpdateNote, useDeleteNote, useNote } from '~/hooks/useNotes'
+import { TagAutocompleteInput } from '~/components/shared/TagAutocompleteInput'
 
 interface NoteModalProps {
   isOpen: boolean
@@ -39,14 +40,11 @@ export function NoteModal({
   const [sessionId, setSessionId] = useState('')
   const [content, setContent] = useState('')
   const [tags, setTags] = useState<string[]>([])
-  const [tagInput, setTagInput] = useState('')
   const [isPublic, setIsPublic] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({})
   const [hasSubmitted, setHasSubmitted] = useState(false)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
-
-  const tagInputId = useId()
 
   // Reset form to blank when switching noteId or opening the modal,
   // so stale values from a previous note never flash.
@@ -57,7 +55,6 @@ export function NoteModal({
     setContent('')
     setTags([])
     setIsPublic(false)
-    setTagInput('')
     setError(null)
     setFieldErrors({})
     setHasSubmitted(false)
@@ -96,27 +93,6 @@ export function NoteModal({
     }
   }, [hasSubmitted, validate])
 
-  const addTag = useCallback((raw: string) => {
-    const cleaned = raw.replace(/^#/, '').trim().toLowerCase()
-    if (cleaned) {
-      setTags((prev) => (prev.includes(cleaned) ? prev : [...prev, cleaned]))
-    }
-    setTagInput('')
-  }, [])
-
-  const handleTagKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' || e.key === ',') {
-      e.preventDefault()
-      addTag(tagInput)
-    } else if (e.key === 'Backspace' && tagInput === '') {
-      setTags((prev) => (prev.length > 0 ? prev.slice(0, -1) : prev))
-    }
-  }, [tagInput, addTag])
-
-  const removeTag = useCallback((tagToRemove: string) => {
-    setTags((prev) => prev.filter((t) => t !== tagToRemove))
-  }, [])
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setHasSubmitted(true)
@@ -126,21 +102,11 @@ export function NoteModal({
     setFieldErrors(errors)
     if (Object.keys(errors).length > 0) return
 
-    // Flush any pending tag input into state so it's visible and not reprocessed
-    const pendingTag = tagInput.replace(/^#/, '').trim().toLowerCase()
-    let finalTags = tags
-    if (pendingTag) {
-      const merged = tags.includes(pendingTag) ? tags : [...tags, pendingTag]
-      setTags(merged)
-      setTagInput('')
-      finalTags = merged
-    }
-
     const input = {
       campaignId,
       title: title.trim(),
       note: content.trim(),
-      tags: finalTags,
+      tags,
       isPublic,
       ...(sessionId ? { sessionId } : {}),
     }
@@ -243,56 +209,20 @@ export function NoteModal({
             id="note-modal-editor"
           />
 
-          {/* Tag chips input */}
+          {/* Tags */}
           <div>
-            <label htmlFor={tagInputId} className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide">
+            <label className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide">
               Tags
             </label>
-            <div
-              className={[
-                'flex flex-wrap items-center gap-1.5 bg-white/[0.04] border rounded-xl px-3 py-2 min-h-[44px] transition-all',
-                'focus-within:border-blue-500/50 border-white/10',
-                isDisabled ? 'opacity-50 cursor-not-allowed' : '',
-              ].filter(Boolean).join(' ')}
-              onClick={() => document.getElementById(tagInputId)?.focus()}
-            >
-              {tags.map((tag) => (
-                <span
-                  key={tag}
-                  className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[11px] tracking-tight"
-                >
-                  #{tag}
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      removeTag(tag)
-                    }}
-                    className="ml-0.5 text-blue-400/60 hover:text-blue-300 transition-colors"
-                    aria-label={`Remove tag ${tag}`}
-                    disabled={isDisabled}
-                  >
-                    <X className="h-3 w-3" />
-                  </button>
-                </span>
-              ))}
-              <input
-                id={tagInputId}
-                type="text"
-                value={tagInput}
-                onChange={(e) => setTagInput(e.target.value)}
-                onKeyDown={handleTagKeyDown}
-                onBlur={() => {
-                  if (tagInput.trim()) addTag(tagInput)
-                }}
-                placeholder={tags.length === 0 ? 'Type a tag and press Enter' : ''}
-                disabled={isDisabled}
-                className="flex-1 min-w-[120px] bg-transparent border-none outline-none text-slate-200 text-sm placeholder-slate-700"
-                aria-label="Add tag"
-              />
-            </div>
+            <TagAutocompleteInput
+              campaignId={campaignId}
+              selectedTags={tags}
+              onTagsChange={setTags}
+              placeholder="Type a tag and press Enter"
+              disabled={isDisabled}
+            />
             <p className="text-xs text-slate-700 mt-1.5">
-              Tags are displayed with # prefix. Press Enter or comma to add.
+              Press Enter or comma to add. Suggestions appear as you type.
             </p>
           </div>
 

--- a/app/components/mainview/notes/NotesFilterWidget.tsx
+++ b/app/components/mainview/notes/NotesFilterWidget.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Plus, Search } from 'lucide-react'
 import type { CampaignData } from '~/types/campaign'
+import { TagAutocompleteInput } from '~/components/shared/TagAutocompleteInput'
 
 interface NotesFilterWidgetProps {
   search: string
@@ -11,6 +12,9 @@ interface NotesFilterWidgetProps {
   onVisibilityChange: (value: 'all' | 'public' | 'private') => void
   sessions: CampaignData['sessions']
   onCreateClick: () => void
+  campaignId: string
+  filterTags: string[]
+  onFilterTagsChange: (tags: string[]) => void
 }
 
 export function NotesFilterWidget({
@@ -22,6 +26,9 @@ export function NotesFilterWidget({
   onVisibilityChange,
   sessions,
   onCreateClick,
+  campaignId,
+  filterTags,
+  onFilterTagsChange,
 }: NotesFilterWidgetProps) {
   return (
     <div className="flex flex-col gap-3 p-3 border-b border-white/[0.07] bg-[#0D1117]">
@@ -80,6 +87,13 @@ export function NotesFilterWidget({
           </select>
         </div>
       </div>
+
+      <TagAutocompleteInput
+        campaignId={campaignId}
+        selectedTags={filterTags}
+        onTagsChange={onFilterTagsChange}
+        placeholder="Filter by tags..."
+      />
     </div>
   )
 }

--- a/app/components/mainview/notes/NotesFilterWidget.tsx
+++ b/app/components/mainview/notes/NotesFilterWidget.tsx
@@ -54,6 +54,13 @@ export function NotesFilterWidget({
         </button>
       </div>
 
+      <TagAutocompleteInput
+        campaignId={campaignId}
+        selectedTags={filterTags}
+        onTagsChange={onFilterTagsChange}
+        placeholder="Filter by tags..."
+      />
+
       <div className="flex gap-2">
         <div className="flex-1">
           <label htmlFor="session-filter" className="sr-only">Filter by session</label>
@@ -87,13 +94,6 @@ export function NotesFilterWidget({
           </select>
         </div>
       </div>
-
-      <TagAutocompleteInput
-        campaignId={campaignId}
-        selectedTags={filterTags}
-        onTagsChange={onFilterTagsChange}
-        placeholder="Filter by tags..."
-      />
     </div>
   )
 }

--- a/app/components/mainview/notes/NotesPanel.tsx
+++ b/app/components/mainview/notes/NotesPanel.tsx
@@ -14,6 +14,7 @@ export function NotesPanel() {
   const [search, setSearch] = useState('')
   const [sessionId, setSessionId] = useState('')
   const [visibility, setVisibility] = useState<'all' | 'public' | 'private'>('all')
+  const [filterTags, setFilterTags] = useState<string[]>([])
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [selectedNoteId, setSelectedNoteId] = useState<string | undefined>()
 
@@ -23,6 +24,7 @@ export function NotesPanel() {
     search: search || undefined,
     sessionId: sessionId || undefined,
     visibility,
+    tags: filterTags.length > 0 ? filterTags : undefined,
   })
 
   const handleCreateClick = () => {
@@ -51,6 +53,9 @@ export function NotesPanel() {
         onVisibilityChange={setVisibility}
         sessions={sessions}
         onCreateClick={handleCreateClick}
+        campaignId={campaignId}
+        filterTags={filterTags}
+        onFilterTagsChange={setFilterTags}
       />
       <NotesListWidget
         notes={notes}

--- a/app/components/shared/TagAutocompleteInput.tsx
+++ b/app/components/shared/TagAutocompleteInput.tsx
@@ -24,7 +24,14 @@ export function TagAutocompleteInput({
   const [highlightIndex, setHighlightIndex] = useState(-1)
   const inputRef = useRef<HTMLInputElement>(null)
   const dropdownRef = useRef<HTMLDivElement>(null)
+  const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const inputId = useId()
+
+  useEffect(() => {
+    return () => {
+      if (blurTimeoutRef.current) clearTimeout(blurTimeoutRef.current)
+    }
+  }, [])
 
   const suggestions = allTags
     .filter((t) => !selectedTags.includes(t.name))
@@ -84,7 +91,8 @@ export function TagAutocompleteInput({
 
   const handleBlur = useCallback(() => {
     // Delay to allow click on dropdown item to fire first
-    setTimeout(() => {
+    if (blurTimeoutRef.current) clearTimeout(blurTimeoutRef.current)
+    blurTimeoutRef.current = setTimeout(() => {
       if (input.trim()) {
         addTag(input)
       }

--- a/app/components/shared/TagAutocompleteInput.tsx
+++ b/app/components/shared/TagAutocompleteInput.tsx
@@ -97,8 +97,8 @@ export function TagAutocompleteInput({
     <div className="relative">
       <div
         className={[
-          'flex flex-wrap items-center gap-1.5 bg-white/[0.04] border rounded-xl px-3 py-2 min-h-[44px] transition-all',
-          'focus-within:border-blue-500/50 border-white/10',
+          'flex flex-wrap items-center gap-1.5 bg-[#080A12] border rounded px-3 py-2 transition-all',
+          'focus-within:border-blue-500/50 border-white/[0.07]',
           disabled ? 'opacity-50 cursor-not-allowed' : '',
         ].filter(Boolean).join(' ')}
         onClick={() => inputRef.current?.focus()}

--- a/app/components/shared/TagAutocompleteInput.tsx
+++ b/app/components/shared/TagAutocompleteInput.tsx
@@ -1,0 +1,174 @@
+// app/components/shared/TagAutocompleteInput.tsx
+import React, { useState, useRef, useCallback, useId, useEffect } from 'react'
+import { X } from 'lucide-react'
+import { useTags } from '~/hooks/useTags'
+
+interface TagAutocompleteInputProps {
+  campaignId: string
+  selectedTags: string[]
+  onTagsChange: (tags: string[]) => void
+  placeholder?: string
+  disabled?: boolean
+}
+
+export function TagAutocompleteInput({
+  campaignId,
+  selectedTags,
+  onTagsChange,
+  placeholder = 'Type a tag and press Enter',
+  disabled = false,
+}: TagAutocompleteInputProps) {
+  const { tags: allTags } = useTags(campaignId)
+  const [input, setInput] = useState('')
+  const [isOpen, setIsOpen] = useState(false)
+  const [highlightIndex, setHighlightIndex] = useState(-1)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  const inputId = useId()
+
+  const suggestions = allTags
+    .filter((t) => !selectedTags.includes(t.name))
+    .filter((t) => input.trim() === '' ? false : t.name.startsWith(input.trim().toLowerCase().replace(/^#/, '')))
+
+  // Reset highlight when suggestions change
+  useEffect(() => {
+    setHighlightIndex(-1)
+  }, [suggestions.length, input])
+
+  const addTag = useCallback((raw: string) => {
+    const cleaned = raw.replace(/^#/, '').trim().toLowerCase()
+    if (cleaned && !selectedTags.includes(cleaned)) {
+      onTagsChange([...selectedTags, cleaned])
+    }
+    setInput('')
+    setIsOpen(false)
+  }, [selectedTags, onTagsChange])
+
+  const removeTag = useCallback((tag: string) => {
+    onTagsChange(selectedTags.filter((t) => t !== tag))
+  }, [selectedTags, onTagsChange])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      if (suggestions.length > 0) {
+        setIsOpen(true)
+        setHighlightIndex((prev) => (prev < suggestions.length - 1 ? prev + 1 : 0))
+      }
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      if (suggestions.length > 0) {
+        setHighlightIndex((prev) => (prev > 0 ? prev - 1 : suggestions.length - 1))
+      }
+    } else if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault()
+      if (highlightIndex >= 0 && highlightIndex < suggestions.length) {
+        addTag(suggestions[highlightIndex].name)
+      } else if (input.trim()) {
+        addTag(input)
+      }
+    } else if (e.key === 'Escape') {
+      setIsOpen(false)
+      setHighlightIndex(-1)
+    } else if (e.key === 'Backspace' && input === '') {
+      if (selectedTags.length > 0) {
+        onTagsChange(selectedTags.slice(0, -1))
+      }
+    }
+  }, [input, highlightIndex, suggestions, addTag, selectedTags, onTagsChange])
+
+  const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setInput(e.target.value)
+    setIsOpen(true)
+  }, [])
+
+  const handleBlur = useCallback(() => {
+    // Delay to allow click on dropdown item to fire first
+    setTimeout(() => {
+      if (input.trim()) {
+        addTag(input)
+      }
+      setIsOpen(false)
+      setHighlightIndex(-1)
+    }, 150)
+  }, [input, addTag])
+
+  return (
+    <div className="relative">
+      <div
+        className={[
+          'flex flex-wrap items-center gap-1.5 bg-white/[0.04] border rounded-xl px-3 py-2 min-h-[44px] transition-all',
+          'focus-within:border-blue-500/50 border-white/10',
+          disabled ? 'opacity-50 cursor-not-allowed' : '',
+        ].filter(Boolean).join(' ')}
+        onClick={() => inputRef.current?.focus()}
+      >
+        {selectedTags.map((tag) => (
+          <span
+            key={tag}
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[11px] tracking-tight"
+          >
+            #{tag}
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation()
+                removeTag(tag)
+              }}
+              className="ml-0.5 text-blue-400/60 hover:text-blue-300 transition-colors"
+              aria-label={`Remove tag ${tag}`}
+              disabled={disabled}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </span>
+        ))}
+        <input
+          ref={inputRef}
+          id={inputId}
+          type="text"
+          value={input}
+          onChange={handleInputChange}
+          onKeyDown={handleKeyDown}
+          onBlur={handleBlur}
+          onFocus={() => { if (input.trim()) setIsOpen(true) }}
+          placeholder={selectedTags.length === 0 ? placeholder : ''}
+          disabled={disabled}
+          className="flex-1 min-w-[120px] bg-transparent border-none outline-none text-slate-200 text-sm placeholder-slate-700"
+          aria-label="Add tag"
+          autoComplete="off"
+        />
+      </div>
+
+      {isOpen && suggestions.length > 0 && (
+        <div
+          ref={dropdownRef}
+          className="absolute z-50 left-0 right-0 mt-1 bg-[#0f1520] border border-white/10 rounded-lg py-1 shadow-2xl max-h-48 overflow-y-auto"
+        >
+          <div className="px-3 py-1.5 text-[10px] font-semibold text-slate-500 uppercase tracking-wider">
+            Suggestions
+          </div>
+          {suggestions.map((tag, index) => (
+            <button
+              key={tag.id}
+              type="button"
+              className={[
+                'w-full text-left px-3 py-1.5 text-xs font-semibold transition-colors',
+                index === highlightIndex
+                  ? 'bg-blue-500/10 text-slate-200'
+                  : 'text-slate-400 hover:bg-white/5 hover:text-slate-200',
+              ].join(' ')}
+              onMouseDown={(e) => {
+                e.preventDefault()
+                addTag(tag.name)
+              }}
+              onMouseEnter={() => setHighlightIndex(index)}
+            >
+              #{tag.name}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/hooks/useNotes.ts
+++ b/app/hooks/useNotes.ts
@@ -59,15 +59,17 @@ interface ListNotesFilters {
   sessionId?: string
   search?: string
   visibility?: 'all' | 'public' | 'private'
+  tags?: string[]
 }
 
 export function useNotes(campaignId: string, filters?: ListNotesFilters) {
   const sessionId = filters?.sessionId
   const search = filters?.search
   const visibility = filters?.visibility
+  const tags = filters?.tags
 
   const { data: notes = [], isLoading, error } = useQuery({
-    queryKey: queryKeys.notes.list(campaignId, sessionId, search, visibility),
+    queryKey: queryKeys.notes.list(campaignId, sessionId, search, visibility, tags),
     queryFn: () =>
       listNotesFn({
         data: {
@@ -75,6 +77,7 @@ export function useNotes(campaignId: string, filters?: ListNotesFilters) {
           sessionId,
           search,
           visibility,
+          tags,
         },
       }),
     enabled: !!campaignId,
@@ -117,6 +120,7 @@ export function useCreateNote() {
       createNoteFn({ data: input }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.notes.all })
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags.all })
     },
     onError: (e) => {
       captureException(e, { action: 'createNote' })
@@ -156,6 +160,7 @@ export function useUpdateNote() {
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.notes.all })
       queryClient.invalidateQueries({ queryKey: queryKeys.notes.detail(variables.id) })
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags.all })
       // Refresh GM screen windows that may display this note's content
       queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all })
     },

--- a/app/hooks/useTags.ts
+++ b/app/hooks/useTags.ts
@@ -1,0 +1,26 @@
+import { createServerFn } from '@tanstack/react-start'
+import { useQuery } from '@tanstack/react-query'
+import type { TagListItem } from '~/types/tag'
+import { listTagsSchema } from '~/types/tag'
+import { queryKeys } from '~/utils/queryKeys'
+
+const listTagsFn = createServerFn({ method: 'GET' })
+  .inputValidator(listTagsSchema)
+  .handler(async ({ data }) => {
+    const { listTags } = await import('~/server/functions/tags')
+    return listTags({ data })
+  })
+
+export function useTags(campaignId: string) {
+  const { data: tags = [], isLoading, error } = useQuery({
+    queryKey: queryKeys.tags.list(campaignId),
+    queryFn: () => listTagsFn({ data: { campaignId } }),
+    enabled: !!campaignId,
+  })
+
+  return {
+    tags: tags as TagListItem[],
+    isLoading,
+    error: error instanceof Error ? error.message : error ? String(error) : null,
+  }
+}

--- a/app/server/db/models/Tag.ts
+++ b/app/server/db/models/Tag.ts
@@ -1,0 +1,14 @@
+import mongoose from 'mongoose'
+
+const tagSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  campaignId: { type: mongoose.Schema.Types.ObjectId, ref: 'Campaign', required: true },
+  createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+})
+
+tagSchema.index({ campaignId: 1, name: 1 }, { unique: true })
+tagSchema.index({ campaignId: 1 })
+
+export const Tag = mongoose.models.Tag || mongoose.model('Tag', tagSchema)

--- a/app/server/db/models/Tag.ts
+++ b/app/server/db/models/Tag.ts
@@ -8,7 +8,10 @@ const tagSchema = new mongoose.Schema({
   updatedAt: { type: Date, default: Date.now },
 })
 
-tagSchema.index({ campaignId: 1, name: 1 }, { unique: true })
-tagSchema.index({ campaignId: 1 })
+// istanbul ignore next
+if (typeof (tagSchema as { index?: unknown }).index === 'function') {
+  tagSchema.index({ campaignId: 1, name: 1 }, { unique: true })
+  tagSchema.index({ campaignId: 1 })
+}
 
 export const Tag = mongoose.models.Tag || mongoose.model('Tag', tagSchema)

--- a/app/server/functions/notes.ts
+++ b/app/server/functions/notes.ts
@@ -163,10 +163,11 @@ export const updateNote = createServerFn({ method: 'POST' })
       if (String(existing.createdBy) !== userId) throw new Error('Forbidden')
       if (existing.isReadOnly) throw new Error('Note is read-only')
 
+      const finalTags = normalizeTags(data.tags ?? [])
       existing.sessionId = data.sessionId && data.sessionId !== '__none__' ? data.sessionId : undefined
       existing.title = data.title.trim()
       existing.note = data.note.trim()
-      existing.tags = normalizeTags(data.tags ?? [])
+      existing.tags = finalTags
       if (data.isPublic !== undefined) {
         existing.isPublic = data.isPublic
       }
@@ -174,7 +175,7 @@ export const updateNote = createServerFn({ method: 'POST' })
       await existing.save()
 
       // Register any new tags in the campaign tag registry
-      await ensureTagsFn({ data: { campaignId: data.campaignId, tags: normalizeTags(data.tags ?? []) } })
+      await ensureTagsFn({ data: { campaignId: data.campaignId, tags: finalTags } })
 
       serverCaptureEvent(sessionUserId, 'note_updated', {
         campaign_id: data.campaignId,

--- a/app/server/functions/notes.ts
+++ b/app/server/functions/notes.ts
@@ -7,6 +7,7 @@ import { Note } from '../db/models/Note'
 import { serverCaptureException, serverCaptureEvent } from '../utils/posthog'
 import { normalizeTags } from '../utils/helpers'
 import { removeDocumentRefsFromScreens } from './gmscreens-helpers'
+import { ensureTags as ensureTagsFn } from './tags'
 import type { NoteData, NoteListItem } from '~/types/note'
 import {
   createNoteSchema,
@@ -110,12 +111,13 @@ export const createNote = createServerFn({ method: 'POST' })
       const userId = member.userId
 
       const now = new Date()
+      const finalTags = normalizeTags(data.tags ?? [])
       const noteData: Record<string, unknown> = {
         campaignId: data.campaignId,
         createdBy: userId,
         title: data.title.trim(),
         note: data.note.trim(),
-        tags: normalizeTags(data.tags ?? []),
+        tags: finalTags,
         isPublic: data.isPublic ?? false,
         createdAt: now,
         updatedAt: now,
@@ -124,6 +126,9 @@ export const createNote = createServerFn({ method: 'POST' })
         noteData.sessionId = data.sessionId
       }
       const doc = await Note.create(noteData)
+
+      // Register any new tags in the campaign tag registry
+      await ensureTagsFn({ data: { campaignId: data.campaignId, tags: finalTags } })
 
       serverCaptureEvent(sessionUserId, 'note_created', {
         campaign_id: data.campaignId,
@@ -167,6 +172,9 @@ export const updateNote = createServerFn({ method: 'POST' })
       }
       existing.updatedAt = new Date()
       await existing.save()
+
+      // Register any new tags in the campaign tag registry
+      await ensureTagsFn({ data: { campaignId: data.campaignId, tags: normalizeTags(data.tags ?? []) } })
 
       serverCaptureEvent(sessionUserId, 'note_updated', {
         campaign_id: data.campaignId,
@@ -266,6 +274,10 @@ export const listNotes = createServerFn({ method: 'GET' })
 
       if (data.search && data.search.trim()) {
         filter.$text = { $search: data.search.trim() }
+      }
+
+      if (data.tags && data.tags.length > 0) {
+        filter.tags = { $all: data.tags }
       }
 
       const docs = await Note.find(filter)

--- a/app/server/functions/notes.ts
+++ b/app/server/functions/notes.ts
@@ -278,7 +278,10 @@ export const listNotes = createServerFn({ method: 'GET' })
       }
 
       if (data.tags && data.tags.length > 0) {
-        filter.tags = { $all: data.tags }
+        const normalizedTags = [...new Set(normalizeTags(data.tags))]
+        if (normalizedTags.length > 0) {
+          filter.tags = { $all: normalizedTags }
+        }
       }
 
       const docs = await Note.find(filter)

--- a/app/server/functions/tags.ts
+++ b/app/server/functions/tags.ts
@@ -1,0 +1,104 @@
+import { createServerFn } from '@tanstack/react-start'
+import { getSession } from '../session'
+import { connectDB, isDBConnected } from '../db/connection'
+import { User } from '../db/models/User'
+import { Campaign } from '../db/models/Campaign'
+import { Tag } from '../db/models/Tag'
+import { serverCaptureException } from '../utils/posthog'
+import { normalizeTags } from '../utils/helpers'
+import type { TagListItem } from '~/types/tag'
+import { listTagsSchema, ensureTagsSchema } from '~/types/tag'
+
+async function requireCampaignMember(campaignId: string): Promise<{ userId: string; sessionUserId: string }> {
+  const user = await getSession()
+  if (!user) throw new Error('Not authenticated')
+
+  await connectDB()
+  if (!isDBConnected()) throw new Error('Database not available')
+
+  const dbUser = await User.findOne({ providerId: user.id })
+  if (!dbUser) throw new Error('User not found')
+
+  const campaign = await Campaign.findById(campaignId)
+  if (!campaign) throw new Error('Campaign not found')
+
+  const userId = String(dbUser._id)
+  const members = campaign.members ?? []
+  const isMember =
+    members.some((m: { userId: unknown }) => String(m.userId) === userId) ||
+    String(campaign.gameMasterId) === userId
+  if (!isMember) throw new Error('Forbidden')
+
+  return { userId, sessionUserId: user.id }
+}
+
+// ---------------------------------------------------------------------------
+// listTags
+// ---------------------------------------------------------------------------
+
+export { listTagsSchema }
+
+export const listTags = createServerFn({ method: 'GET' })
+  .inputValidator(listTagsSchema)
+  .handler(async ({ data }): Promise<TagListItem[]> => {
+    let sessionUserId: string | undefined
+    try {
+      const member = await requireCampaignMember(data.campaignId)
+      sessionUserId = member.sessionUserId
+
+      const docs = await Tag.find({ campaignId: data.campaignId })
+        .select('name')
+        .sort({ name: 1 })
+        .lean()
+
+      return docs.map((d: { _id: unknown; name?: string }) => ({
+        id: String(d._id),
+        name: d.name ?? '',
+      }))
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, { action: 'listTags', campaignId: data.campaignId })
+      throw e
+    }
+  })
+
+// ---------------------------------------------------------------------------
+// ensureTags
+// ---------------------------------------------------------------------------
+
+export { ensureTagsSchema }
+
+export const ensureTags = createServerFn({ method: 'POST' })
+  .inputValidator(ensureTagsSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined
+    try {
+      const member = await requireCampaignMember(data.campaignId)
+      sessionUserId = member.sessionUserId
+      const userId = member.userId
+
+      const normalized = normalizeTags(data.tags)
+      if (normalized.length === 0) return { success: true }
+
+      const ops = normalized.map((name) => ({
+        updateOne: {
+          filter: { campaignId: data.campaignId, name },
+          update: {
+            $setOnInsert: {
+              name,
+              campaignId: data.campaignId,
+              createdBy: userId,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          },
+          upsert: true,
+        },
+      }))
+
+      await Tag.bulkWrite(ops, { ordered: false })
+      return { success: true }
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, { action: 'ensureTags', campaignId: data.campaignId })
+      throw e
+    }
+  })

--- a/app/types/schemas/notes.ts
+++ b/app/types/schemas/notes.ts
@@ -29,6 +29,7 @@ export const listNotesSchema = z.object({
   sessionId: z.string().optional(),
   search: z.string().optional(),
   visibility: z.enum(['all', 'public', 'private']).optional().default('all'),
+  tags: z.array(z.string()).optional(),
 })
 
 export const getNoteSchema = z.object({

--- a/app/types/tag.ts
+++ b/app/types/tag.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod'
+
+export interface TagData {
+  id: string
+  name: string
+  campaignId: string
+  createdBy: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface TagListItem {
+  id: string
+  name: string
+}
+
+export const listTagsSchema = z.object({
+  campaignId: z.string().min(1),
+})
+
+export const ensureTagsSchema = z.object({
+  campaignId: z.string().min(1),
+  tags: z.array(z.string()),
+})

--- a/app/utils/queryKeys.ts
+++ b/app/utils/queryKeys.ts
@@ -19,8 +19,12 @@ export const queryKeys = {
   },
   notes: {
     all: ['notes'] as const,
-    list: (campaignId: string, sessionId?: string, search?: string, visibility?: string) =>
-      ['notes', 'list', campaignId, sessionId ?? '', search ?? '', visibility ?? 'all'] as const,
+    list: (campaignId: string, sessionId?: string, search?: string, visibility?: string, tags?: string[]) =>
+      ['notes', 'list', campaignId, sessionId ?? '', search ?? '', visibility ?? 'all', ...(tags ?? [])] as const,
     detail: (id: string) => ['notes', 'detail', id] as const,
+  },
+  tags: {
+    all: ['tags'] as const,
+    list: (campaignId: string) => ['tags', 'list', campaignId] as const,
   },
 }

--- a/app/utils/queryKeys.ts
+++ b/app/utils/queryKeys.ts
@@ -20,7 +20,7 @@ export const queryKeys = {
   notes: {
     all: ['notes'] as const,
     list: (campaignId: string, sessionId?: string, search?: string, visibility?: string, tags?: string[]) =>
-      ['notes', 'list', campaignId, sessionId ?? '', search ?? '', visibility ?? 'all', ...(tags ?? [])] as const,
+      ['notes', 'list', campaignId, sessionId ?? '', search ?? '', visibility ?? 'all', tags ?? []] as const,
     detail: (id: string) => ['notes', 'detail', id] as const,
   },
   tags: {

--- a/docs/superpowers/plans/2026-04-04-universal-tags.md
+++ b/docs/superpowers/plans/2026-04-04-universal-tags.md
@@ -1,0 +1,913 @@
+# Universal Tag System Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a per-campaign Tag collection with autocomplete support across all entity forms, and a tag filter in the NotesPanel.
+
+**Architecture:** A new `Tag` Mongoose model stores canonical tag names per campaign. A `useTags` hook provides autocomplete data. A shared `TagAutocompleteInput` component handles chip display + autocomplete and is used by both the NotesFilterWidget and NoteModal. Server functions `listTags` and `ensureTags` provide the API layer.
+
+**Tech Stack:** MongoDB/Mongoose, TanStack Start (server functions), TanStack React Query, React 19, TypeScript, Tailwind CSS, Zod
+
+---
+
+### Task 1: Tag Mongoose Model
+
+**Files:**
+- Create: `app/server/db/models/Tag.ts`
+
+- [ ] **Step 1: Create the Tag model**
+
+```typescript
+// app/server/db/models/Tag.ts
+import mongoose from 'mongoose'
+
+const tagSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  campaignId: { type: mongoose.Schema.Types.ObjectId, ref: 'Campaign', required: true },
+  createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+})
+
+tagSchema.index({ campaignId: 1, name: 1 }, { unique: true })
+tagSchema.index({ campaignId: 1 })
+
+export const Tag = mongoose.models.Tag || mongoose.model('Tag', tagSchema)
+```
+
+- [ ] **Step 2: Verify the file compiles**
+
+Run: `npx tsc --noEmit --pretty 2>&1 | head -20`
+Expected: No errors related to `Tag.ts`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/server/db/models/Tag.ts
+git commit -m "feat(tags): add Tag mongoose model with campaign-scoped unique index"
+```
+
+---
+
+### Task 2: Tag Types and Zod Schemas
+
+**Files:**
+- Create: `app/types/tag.ts`
+
+- [ ] **Step 1: Create tag types and schemas**
+
+```typescript
+// app/types/tag.ts
+import { z } from 'zod'
+
+export interface TagData {
+  id: string
+  name: string
+  campaignId: string
+  createdBy: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface TagListItem {
+  id: string
+  name: string
+}
+
+export const listTagsSchema = z.object({
+  campaignId: z.string().min(1),
+})
+
+export const ensureTagsSchema = z.object({
+  campaignId: z.string().min(1),
+  tags: z.array(z.string()),
+})
+```
+
+- [ ] **Step 2: Verify the file compiles**
+
+Run: `npx tsc --noEmit --pretty 2>&1 | head -20`
+Expected: No errors related to `tag.ts`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/types/tag.ts
+git commit -m "feat(tags): add tag TypeScript types and Zod schemas"
+```
+
+---
+
+### Task 3: Tag Server Functions
+
+**Files:**
+- Create: `app/server/functions/tags.ts`
+
+- [ ] **Step 1: Create the tags server functions**
+
+This file provides `listTags` and `ensureTags`. The `ensureTags` function uses `bulkWrite` with upsert to efficiently create missing tags in a single round trip.
+
+```typescript
+// app/server/functions/tags.ts
+import { createServerFn } from '@tanstack/react-start'
+import { getSession } from '../session'
+import { connectDB, isDBConnected } from '../db/connection'
+import { User } from '../db/models/User'
+import { Campaign } from '../db/models/Campaign'
+import { Tag } from '../db/models/Tag'
+import { serverCaptureException } from '../utils/posthog'
+import { normalizeTags } from '../utils/helpers'
+import type { TagListItem } from '~/types/tag'
+import { listTagsSchema, ensureTagsSchema } from '~/types/tag'
+
+async function requireCampaignMember(campaignId: string): Promise<{ userId: string; sessionUserId: string }> {
+  const user = await getSession()
+  if (!user) throw new Error('Not authenticated')
+
+  await connectDB()
+  if (!isDBConnected()) throw new Error('Database not available')
+
+  const dbUser = await User.findOne({ providerId: user.id })
+  if (!dbUser) throw new Error('User not found')
+
+  const campaign = await Campaign.findById(campaignId)
+  if (!campaign) throw new Error('Campaign not found')
+
+  const userId = String(dbUser._id)
+  const members = campaign.members ?? []
+  const isMember =
+    members.some((m: { userId: unknown }) => String(m.userId) === userId) ||
+    String(campaign.gameMasterId) === userId
+  if (!isMember) throw new Error('Forbidden')
+
+  return { userId, sessionUserId: user.id }
+}
+
+// ---------------------------------------------------------------------------
+// listTags
+// ---------------------------------------------------------------------------
+
+export { listTagsSchema }
+
+export const listTags = createServerFn({ method: 'GET' })
+  .inputValidator(listTagsSchema)
+  .handler(async ({ data }): Promise<TagListItem[]> => {
+    let sessionUserId: string | undefined
+    try {
+      const member = await requireCampaignMember(data.campaignId)
+      sessionUserId = member.sessionUserId
+
+      const docs = await Tag.find({ campaignId: data.campaignId })
+        .select('name')
+        .sort({ name: 1 })
+        .lean()
+
+      return docs.map((d: { _id: unknown; name?: string }) => ({
+        id: String(d._id),
+        name: d.name ?? '',
+      }))
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, { action: 'listTags', campaignId: data.campaignId })
+      throw e
+    }
+  })
+
+// ---------------------------------------------------------------------------
+// ensureTags
+// ---------------------------------------------------------------------------
+
+export { ensureTagsSchema }
+
+export const ensureTags = createServerFn({ method: 'POST' })
+  .inputValidator(ensureTagsSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined
+    try {
+      const member = await requireCampaignMember(data.campaignId)
+      sessionUserId = member.sessionUserId
+      const userId = member.userId
+
+      const normalized = normalizeTags(data.tags)
+      if (normalized.length === 0) return { success: true }
+
+      const ops = normalized.map((name) => ({
+        updateOne: {
+          filter: { campaignId: data.campaignId, name },
+          update: {
+            $setOnInsert: {
+              name,
+              campaignId: data.campaignId,
+              createdBy: userId,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          },
+          upsert: true,
+        },
+      }))
+
+      await Tag.bulkWrite(ops, { ordered: false })
+      return { success: true }
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, { action: 'ensureTags', campaignId: data.campaignId })
+      throw e
+    }
+  })
+```
+
+- [ ] **Step 2: Verify the file compiles**
+
+Run: `npx tsc --noEmit --pretty 2>&1 | head -20`
+Expected: No errors related to `tags.ts`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/server/functions/tags.ts
+git commit -m "feat(tags): add listTags and ensureTags server functions"
+```
+
+---
+
+### Task 4: Integrate ensureTags into Note Create/Update
+
+**Files:**
+- Modify: `app/server/functions/notes.ts:103-138` (createNote handler)
+- Modify: `app/server/functions/notes.ts:146-182` (updateNote handler)
+
+- [ ] **Step 1: Add ensureTags import**
+
+At the top of `app/server/functions/notes.ts`, add the import for `ensureTagsFn` (a local caller that bypasses the RPC layer). Since `ensureTags` is in the same server context, we call it directly:
+
+Add after the existing imports (after line 17):
+
+```typescript
+import { ensureTags as ensureTagsFn } from './tags'
+```
+
+- [ ] **Step 2: Call ensureTags in createNote handler**
+
+In the `createNote` handler, after `const doc = await Note.create(noteData)` (line 126) and before the `serverCaptureEvent` call (line 128), add:
+
+```typescript
+      // Register any new tags in the campaign tag registry
+      await ensureTagsFn({ data: { campaignId: data.campaignId, tags: finalTags } })
+```
+
+Where `finalTags` refers to the normalized tags. Since `normalizeTags` is already called on line 118, capture the result. Change line 118 from:
+
+```typescript
+        tags: normalizeTags(data.tags ?? []),
+```
+
+to:
+
+```typescript
+        tags: finalTags,
+```
+
+And add before `const noteData` (before line 113):
+
+```typescript
+      const finalTags = normalizeTags(data.tags ?? [])
+```
+
+- [ ] **Step 3: Call ensureTags in updateNote handler**
+
+In the `updateNote` handler, after `await existing.save()` (line 169) and before the `serverCaptureEvent` call (line 171), add:
+
+```typescript
+      // Register any new tags in the campaign tag registry
+      await ensureTagsFn({ data: { campaignId: data.campaignId, tags: normalizeTags(data.tags ?? []) } })
+```
+
+- [ ] **Step 4: Verify the file compiles**
+
+Run: `npx tsc --noEmit --pretty 2>&1 | head -20`
+Expected: No errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/server/functions/notes.ts
+git commit -m "feat(tags): call ensureTags on note create and update"
+```
+
+---
+
+### Task 5: Add Tags Filter to listNotes
+
+**Files:**
+- Modify: `app/types/schemas/notes.ts:27-32` (listNotesSchema)
+- Modify: `app/server/functions/notes.ts:239-291` (listNotes handler)
+
+- [ ] **Step 1: Add tags field to listNotesSchema**
+
+In `app/types/schemas/notes.ts`, update the `listNotesSchema` to include an optional `tags` array:
+
+```typescript
+export const listNotesSchema = z.object({
+  campaignId: z.string().min(1),
+  sessionId: z.string().optional(),
+  search: z.string().optional(),
+  visibility: z.enum(['all', 'public', 'private']).optional().default('all'),
+  tags: z.array(z.string()).optional(),
+})
+```
+
+- [ ] **Step 2: Add tags filter to listNotes query**
+
+In `app/server/functions/notes.ts`, in the `listNotes` handler, after the search filter block (after line 269 `filter.$text = { $search: data.search.trim() }`) and before the `const docs = await Note.find(filter)` line, add:
+
+```typescript
+      if (data.tags && data.tags.length > 0) {
+        filter.tags = { $all: data.tags }
+      }
+```
+
+- [ ] **Step 3: Verify the file compiles**
+
+Run: `npx tsc --noEmit --pretty 2>&1 | head -20`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/types/schemas/notes.ts app/server/functions/notes.ts
+git commit -m "feat(tags): add tags filter to listNotes query with AND logic"
+```
+
+---
+
+### Task 6: Query Keys and useTags Hook
+
+**Files:**
+- Modify: `app/utils/queryKeys.ts`
+- Create: `app/hooks/useTags.ts`
+- Modify: `app/hooks/useNotes.ts`
+
+- [ ] **Step 1: Add tags query keys**
+
+In `app/utils/queryKeys.ts`, add a `tags` group after the `notes` group:
+
+```typescript
+  tags: {
+    all: ['tags'] as const,
+    list: (campaignId: string) => ['tags', 'list', campaignId] as const,
+  },
+```
+
+- [ ] **Step 2: Update notes.list query key to include tags**
+
+In `app/utils/queryKeys.ts`, update the `notes.list` function to include a tags parameter:
+
+```typescript
+    list: (campaignId: string, sessionId?: string, search?: string, visibility?: string, tags?: string[]) =>
+      ['notes', 'list', campaignId, sessionId ?? '', search ?? '', visibility ?? 'all', ...(tags ?? [])] as const,
+```
+
+- [ ] **Step 3: Create useTags hook**
+
+```typescript
+// app/hooks/useTags.ts
+import { createServerFn } from '@tanstack/react-start'
+import { useQuery } from '@tanstack/react-query'
+import type { TagListItem } from '~/types/tag'
+import { listTagsSchema } from '~/types/tag'
+import { queryKeys } from '~/utils/queryKeys'
+
+const listTagsFn = createServerFn({ method: 'GET' })
+  .inputValidator(listTagsSchema)
+  .handler(async ({ data }) => {
+    const { listTags } = await import('~/server/functions/tags')
+    return listTags({ data })
+  })
+
+export function useTags(campaignId: string) {
+  const { data: tags = [], isLoading, error } = useQuery({
+    queryKey: queryKeys.tags.list(campaignId),
+    queryFn: () => listTagsFn({ data: { campaignId } }),
+    enabled: !!campaignId,
+  })
+
+  return {
+    tags: tags as TagListItem[],
+    isLoading,
+    error: error instanceof Error ? error.message : error ? String(error) : null,
+  }
+}
+```
+
+- [ ] **Step 4: Update useNotes to accept tags filter and invalidate tags**
+
+In `app/hooks/useNotes.ts`:
+
+Update the `ListNotesFilters` interface (line 58-62) to add `tags`:
+
+```typescript
+interface ListNotesFilters {
+  sessionId?: string
+  search?: string
+  visibility?: 'all' | 'public' | 'private'
+  tags?: string[]
+}
+```
+
+In the `useNotes` function, extract the tags filter (after line 67):
+
+```typescript
+  const tags = filters?.tags
+```
+
+Update the query key call (line 70) to include tags:
+
+```typescript
+    queryKey: queryKeys.notes.list(campaignId, sessionId, search, visibility, tags),
+```
+
+Update the `queryFn` call (line 71-78) to pass tags:
+
+```typescript
+    queryFn: () =>
+      listNotesFn({
+        data: {
+          campaignId,
+          sessionId,
+          search,
+          visibility,
+          tags,
+        },
+      }),
+```
+
+In `useCreateNote`, update the `onSuccess` callback (lines 118-120) to also invalidate tags:
+
+```typescript
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.notes.all })
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags.all })
+    },
+```
+
+In `useUpdateNote`, update the `onSuccess` callback (lines 156-161) to also invalidate tags:
+
+```typescript
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.notes.all })
+      queryClient.invalidateQueries({ queryKey: queryKeys.notes.detail(variables.id) })
+      queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all })
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags.all })
+    },
+```
+
+- [ ] **Step 5: Verify all files compile**
+
+Run: `npx tsc --noEmit --pretty 2>&1 | head -20`
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/utils/queryKeys.ts app/hooks/useTags.ts app/hooks/useNotes.ts
+git commit -m "feat(tags): add useTags hook, tags query keys, and tags filter to useNotes"
+```
+
+---
+
+### Task 7: TagAutocompleteInput Component
+
+**Files:**
+- Create: `app/components/shared/TagAutocompleteInput.tsx`
+
+- [ ] **Step 1: Create the shared component**
+
+```typescript
+// app/components/shared/TagAutocompleteInput.tsx
+import React, { useState, useRef, useCallback, useId, useEffect } from 'react'
+import { X } from 'lucide-react'
+import { useTags } from '~/hooks/useTags'
+
+interface TagAutocompleteInputProps {
+  campaignId: string
+  selectedTags: string[]
+  onTagsChange: (tags: string[]) => void
+  placeholder?: string
+  disabled?: boolean
+}
+
+export function TagAutocompleteInput({
+  campaignId,
+  selectedTags,
+  onTagsChange,
+  placeholder = 'Type a tag and press Enter',
+  disabled = false,
+}: TagAutocompleteInputProps) {
+  const { tags: allTags } = useTags(campaignId)
+  const [input, setInput] = useState('')
+  const [isOpen, setIsOpen] = useState(false)
+  const [highlightIndex, setHighlightIndex] = useState(-1)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  const inputId = useId()
+
+  const suggestions = allTags
+    .filter((t) => !selectedTags.includes(t.name))
+    .filter((t) => input.trim() === '' ? false : t.name.startsWith(input.trim().toLowerCase().replace(/^#/, '')))
+
+  // Reset highlight when suggestions change
+  useEffect(() => {
+    setHighlightIndex(-1)
+  }, [suggestions.length, input])
+
+  const addTag = useCallback((raw: string) => {
+    const cleaned = raw.replace(/^#/, '').trim().toLowerCase()
+    if (cleaned && !selectedTags.includes(cleaned)) {
+      onTagsChange([...selectedTags, cleaned])
+    }
+    setInput('')
+    setIsOpen(false)
+  }, [selectedTags, onTagsChange])
+
+  const removeTag = useCallback((tag: string) => {
+    onTagsChange(selectedTags.filter((t) => t !== tag))
+  }, [selectedTags, onTagsChange])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      if (suggestions.length > 0) {
+        setIsOpen(true)
+        setHighlightIndex((prev) => (prev < suggestions.length - 1 ? prev + 1 : 0))
+      }
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      if (suggestions.length > 0) {
+        setHighlightIndex((prev) => (prev > 0 ? prev - 1 : suggestions.length - 1))
+      }
+    } else if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault()
+      if (highlightIndex >= 0 && highlightIndex < suggestions.length) {
+        addTag(suggestions[highlightIndex].name)
+      } else if (input.trim()) {
+        addTag(input)
+      }
+    } else if (e.key === 'Escape') {
+      setIsOpen(false)
+      setHighlightIndex(-1)
+    } else if (e.key === 'Backspace' && input === '') {
+      if (selectedTags.length > 0) {
+        onTagsChange(selectedTags.slice(0, -1))
+      }
+    }
+  }, [input, highlightIndex, suggestions, addTag, selectedTags, onTagsChange])
+
+  const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setInput(e.target.value)
+    setIsOpen(true)
+  }, [])
+
+  const handleBlur = useCallback(() => {
+    // Delay to allow click on dropdown item to fire first
+    setTimeout(() => {
+      if (input.trim()) {
+        addTag(input)
+      }
+      setIsOpen(false)
+      setHighlightIndex(-1)
+    }, 150)
+  }, [input, addTag])
+
+  return (
+    <div className="relative">
+      <div
+        className={[
+          'flex flex-wrap items-center gap-1.5 bg-white/[0.04] border rounded-xl px-3 py-2 min-h-[44px] transition-all',
+          'focus-within:border-blue-500/50 border-white/10',
+          disabled ? 'opacity-50 cursor-not-allowed' : '',
+        ].filter(Boolean).join(' ')}
+        onClick={() => inputRef.current?.focus()}
+      >
+        {selectedTags.map((tag) => (
+          <span
+            key={tag}
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[11px] tracking-tight"
+          >
+            #{tag}
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation()
+                removeTag(tag)
+              }}
+              className="ml-0.5 text-blue-400/60 hover:text-blue-300 transition-colors"
+              aria-label={`Remove tag ${tag}`}
+              disabled={disabled}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </span>
+        ))}
+        <input
+          ref={inputRef}
+          id={inputId}
+          type="text"
+          value={input}
+          onChange={handleInputChange}
+          onKeyDown={handleKeyDown}
+          onBlur={handleBlur}
+          onFocus={() => { if (input.trim()) setIsOpen(true) }}
+          placeholder={selectedTags.length === 0 ? placeholder : ''}
+          disabled={disabled}
+          className="flex-1 min-w-[120px] bg-transparent border-none outline-none text-slate-200 text-sm placeholder-slate-700"
+          aria-label="Add tag"
+          autoComplete="off"
+        />
+      </div>
+
+      {isOpen && suggestions.length > 0 && (
+        <div
+          ref={dropdownRef}
+          className="absolute z-50 left-0 right-0 mt-1 bg-[#0f1520] border border-white/10 rounded-lg py-1 shadow-2xl max-h-48 overflow-y-auto"
+        >
+          <div className="px-3 py-1.5 text-[10px] font-semibold text-slate-500 uppercase tracking-wider">
+            Suggestions
+          </div>
+          {suggestions.map((tag, index) => (
+            <button
+              key={tag.id}
+              type="button"
+              className={[
+                'w-full text-left px-3 py-1.5 text-xs font-semibold transition-colors',
+                index === highlightIndex
+                  ? 'bg-blue-500/10 text-slate-200'
+                  : 'text-slate-400 hover:bg-white/5 hover:text-slate-200',
+              ].join(' ')}
+              onMouseDown={(e) => {
+                e.preventDefault()
+                addTag(tag.name)
+              }}
+              onMouseEnter={() => setHighlightIndex(index)}
+            >
+              #{tag.name}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Verify the file compiles**
+
+Run: `npx tsc --noEmit --pretty 2>&1 | head -20`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/components/shared/TagAutocompleteInput.tsx
+git commit -m "feat(tags): add shared TagAutocompleteInput component with autocomplete"
+```
+
+---
+
+### Task 8: Integrate TagAutocompleteInput into NoteModal
+
+**Files:**
+- Modify: `app/components/mainview/notes/NoteModal.tsx`
+
+- [ ] **Step 1: Replace inline tag logic with TagAutocompleteInput**
+
+In `app/components/mainview/notes/NoteModal.tsx`:
+
+Add the import (after line 7):
+
+```typescript
+import { TagAutocompleteInput } from '~/components/shared/TagAutocompleteInput'
+```
+
+Remove the `tagInput` state declaration (line 42):
+```typescript
+  const [tagInput, setTagInput] = useState('')
+```
+
+Remove `tagInputId` (line 49):
+```typescript
+  const tagInputId = useId()
+```
+
+Remove `useId` from the React import on line 1 (keep the other imports).
+
+In the reset effect (lines 53-65), remove the `setTagInput('')` line.
+
+Remove the `addTag` callback (lines 99-105).
+
+Remove the `handleTagKeyDown` callback (lines 107-114).
+
+Remove the `removeTag` callback (lines 116-118).
+
+In `handleSubmit` (lines 120-162), simplify the tag flushing. Remove lines 130-137 (the `pendingTag` block) and change `finalTags` to just `tags`:
+
+```typescript
+    const input = {
+      campaignId,
+      title: title.trim(),
+      note: content.trim(),
+      tags,
+      isPublic,
+      ...(sessionId ? { sessionId } : {}),
+    }
+```
+
+Replace the entire tag chips JSX section (lines 246-297, from `{/* Tag chips input */}` through the closing `</div>` and hint paragraph) with:
+
+```tsx
+          {/* Tags */}
+          <div>
+            <label className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide">
+              Tags
+            </label>
+            <TagAutocompleteInput
+              campaignId={campaignId}
+              selectedTags={tags}
+              onTagsChange={setTags}
+              placeholder="Type a tag and press Enter"
+              disabled={isDisabled}
+            />
+            <p className="text-xs text-slate-700 mt-1.5">
+              Press Enter or comma to add. Suggestions appear as you type.
+            </p>
+          </div>
+```
+
+- [ ] **Step 2: Verify the file compiles**
+
+Run: `npx tsc --noEmit --pretty 2>&1 | head -20`
+Expected: No errors
+
+- [ ] **Step 3: Manually test in browser**
+
+1. Open the app, navigate to a campaign
+2. Open the Notes panel, click the + button to create a note
+3. Verify the tag input shows autocomplete suggestions as you type
+4. Verify Enter/comma adds tags, backspace removes them
+5. Verify clicking a suggestion adds it
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/components/mainview/notes/NoteModal.tsx
+git commit -m "feat(tags): replace NoteModal inline tag input with TagAutocompleteInput"
+```
+
+---
+
+### Task 9: Add Tag Filter to NotesFilterWidget and NotesPanel
+
+**Files:**
+- Modify: `app/components/mainview/notes/NotesFilterWidget.tsx`
+- Modify: `app/components/mainview/notes/NotesPanel.tsx`
+
+- [ ] **Step 1: Update NotesFilterWidget**
+
+In `app/components/mainview/notes/NotesFilterWidget.tsx`:
+
+Add the import at the top:
+
+```typescript
+import { TagAutocompleteInput } from '~/components/shared/TagAutocompleteInput'
+```
+
+Update the props interface to add tag filter props and campaignId:
+
+```typescript
+interface NotesFilterWidgetProps {
+  search: string
+  onSearchChange: (value: string) => void
+  sessionId: string
+  onSessionChange: (value: string) => void
+  visibility: 'all' | 'public' | 'private'
+  onVisibilityChange: (value: 'all' | 'public' | 'private') => void
+  sessions: CampaignData['sessions']
+  onCreateClick: () => void
+  campaignId: string
+  filterTags: string[]
+  onFilterTagsChange: (tags: string[]) => void
+}
+```
+
+Add the new props to the destructured parameters:
+
+```typescript
+export function NotesFilterWidget({
+  search,
+  onSearchChange,
+  sessionId,
+  onSessionChange,
+  visibility,
+  onVisibilityChange,
+  sessions,
+  onCreateClick,
+  campaignId,
+  filterTags,
+  onFilterTagsChange,
+}: NotesFilterWidgetProps) {
+```
+
+Add a third row inside the outer `<div>`, after the session/visibility `<div>` (after line 81, before the closing `</div>`):
+
+```tsx
+      <TagAutocompleteInput
+        campaignId={campaignId}
+        selectedTags={filterTags}
+        onTagsChange={onFilterTagsChange}
+        placeholder="Filter by tags..."
+      />
+```
+
+- [ ] **Step 2: Update NotesPanel to wire tag filter state**
+
+In `app/components/mainview/notes/NotesPanel.tsx`:
+
+Add a new state variable after the `visibility` state (after line 16):
+
+```typescript
+  const [filterTags, setFilterTags] = useState<string[]>([])
+```
+
+Update the `useNotes` call (lines 22-26) to pass the tags filter:
+
+```typescript
+  const { notes, isLoading, error } = useNotes(campaignId, {
+    search: search || undefined,
+    sessionId: sessionId || undefined,
+    visibility,
+    tags: filterTags.length > 0 ? filterTags : undefined,
+  })
+```
+
+Update the `<NotesFilterWidget>` JSX (lines 45-54) to pass the new props:
+
+```tsx
+      <NotesFilterWidget
+        search={search}
+        onSearchChange={setSearch}
+        sessionId={sessionId}
+        onSessionChange={setSessionId}
+        visibility={visibility}
+        onVisibilityChange={setVisibility}
+        sessions={sessions}
+        onCreateClick={handleCreateClick}
+        campaignId={campaignId}
+        filterTags={filterTags}
+        onFilterTagsChange={setFilterTags}
+      />
+```
+
+- [ ] **Step 3: Verify all files compile**
+
+Run: `npx tsc --noEmit --pretty 2>&1 | head -20`
+Expected: No errors
+
+- [ ] **Step 4: Manually test in browser**
+
+1. Open the app, navigate to a campaign with notes that have tags
+2. In the Notes panel, the tag filter row should appear below session/visibility
+3. Type a tag name — autocomplete suggestions should appear
+4. Select a tag — the notes list should filter to only notes with that tag
+5. Add a second tag — notes list should show only notes with BOTH tags (AND logic)
+6. Remove a tag chip — list should update accordingly
+7. Verify text search still works alongside tag filtering
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/mainview/notes/NotesFilterWidget.tsx app/components/mainview/notes/NotesPanel.tsx
+git commit -m "feat(tags): add tag filter to NotesPanel with AND logic"
+```
+
+---
+
+### Task 10: Final Verification
+
+- [ ] **Step 1: Run TypeScript compilation check**
+
+Run: `npx tsc --noEmit --pretty`
+Expected: No errors
+
+- [ ] **Step 2: Run the dev server and test end-to-end**
+
+Run: `npm run dev`
+
+Test the full flow:
+1. Create a note with tags "combat", "boss", "session-1"
+2. Create another note with tags "combat", "lore"
+3. In the tag filter, type "com" — should see "combat" in autocomplete
+4. Select "combat" — both notes should appear
+5. Add "boss" to filter — only the first note should appear
+6. Remove "boss" — both notes appear again
+7. Edit a note and add a new tag "treasure" — it should appear in autocomplete for the next note
+8. Verify text search + tag filter work together
+
+- [ ] **Step 3: Commit any fixes if needed**

--- a/docs/superpowers/specs/2026-04-04-universal-tags-design.md
+++ b/docs/superpowers/specs/2026-04-04-universal-tags-design.md
@@ -1,0 +1,183 @@
+# Universal Tag System Design
+
+## Overview
+
+Add a dedicated Tag collection scoped per-campaign that serves as the canonical registry for all tags in the system. Tags are flat labels (lowercase, trimmed strings) shared across notes and future wiki entities (characters, locations, creatures, quests, etc.). The system provides autocomplete when adding tags to any entity, and a new tag filter in the NotesPanel for filtering notes by selected tags using AND logic.
+
+## Goals
+
+- Universal tag registry per campaign with autocomplete across all entity types
+- Tag filter in NotesPanel (separate from text search) with AND logic
+- Shared `TagAutocompleteInput` component reusable by all current and future entity forms
+- Frictionless tag creation — new tags auto-created silently on entity save
+- No migration needed — existing data can be discarded
+
+## Data Model
+
+### New: Tag Collection
+
+```
+Tag {
+  name: String        // normalized (lowercase, trimmed, no '#' prefix)
+  campaignId: ObjectId // ref: Campaign
+  createdBy: ObjectId  // ref: User
+  createdAt: Date
+  updatedAt: Date
+}
+
+Indexes:
+  { campaignId: 1, name: 1 }  // unique compound — one tag per name per campaign
+  { campaignId: 1 }            // list all tags for a campaign
+```
+
+### Unchanged: Note Schema
+
+Notes continue to store `tags: [String]` as normalized name strings. No foreign key references to the Tag collection. The Tag collection is a registry for autocomplete and discovery, not a relational join target.
+
+### Tag Normalization
+
+Existing `normalizeTag()` and `normalizeTags()` helpers in `app/server/utils/helpers.ts` are reused as-is. They handle trimming, lowercasing, removing `#` prefix, and deduplication.
+
+## Server Functions
+
+### New: `app/server/functions/tags.ts`
+
+#### `listTags(campaignId: string)`
+- Returns all tags for a campaign, sorted alphabetically by name
+- Requires campaign membership (via `requireCampaignMember`)
+- Used by `useTags` hook for autocomplete data
+
+#### `ensureTags(campaignId: string, tags: string[], userId: string)`
+- Upserts an array of tag names into the Tag collection
+- Uses `bulkWrite` with `updateOne` + `upsert: true` for each tag — single round trip
+- Called internally during note create/update (and future entity saves)
+- No-ops for tags that already exist
+
+### Modified: `app/server/functions/notes.ts`
+
+#### `createNote`
+- After saving the note, calls `ensureTags(campaignId, note.tags, userId)`
+
+#### `updateNote`
+- After updating the note, calls `ensureTags(campaignId, note.tags, userId)`
+
+#### `listNotes`
+- New optional parameter: `tags: string[]`
+- When provided and non-empty, adds `{ tags: { $all: data.tags } }` to the MongoDB query
+- Composes with existing text search, session, and visibility filters
+
+## Types & Schemas
+
+### New: `app/types/tag.ts`
+
+```typescript
+export interface TagData {
+  id: string
+  name: string
+  campaignId: string
+  createdBy: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface TagListItem {
+  id: string
+  name: string
+}
+```
+
+### Modified: `app/types/schemas/noteSchemas.ts`
+
+- Add optional `tags: z.array(z.string()).optional()` to the list notes input schema
+
+## Hooks
+
+### New: `app/hooks/useTags.ts`
+
+```typescript
+useTags(campaignId: string) → { tags: TagListItem[], isLoading: boolean }
+```
+
+- `useQuery` calling `listTags` server function
+- Query key: `['tags', 'list', campaignId]`
+
+### Modified: `app/hooks/useNotes.ts`
+
+- Accept optional `tags: string[]` in filter options, pass through to `listNotes`
+- Note create/update mutations invalidate `['tags', 'list', campaignId]` in addition to notes queries
+
+### Modified: `app/utils/queryKeys.ts`
+
+```typescript
+tags: {
+  all: ['tags'] as const,
+  list: (campaignId: string) => ['tags', 'list', campaignId] as const,
+}
+```
+
+## UI Components
+
+### New: `app/components/shared/TagAutocompleteInput.tsx`
+
+Shared chip-based tag input with autocomplete dropdown. Used by both the filter widget and the note modal (and future entity forms).
+
+**Props:**
+- `campaignId: string` — drives the `useTags` query
+- `selectedTags: string[]` — currently selected tags (controlled)
+- `onTagsChange: (tags: string[]) => void` — callback when tags change
+- `placeholder?: string` — customizable placeholder text
+- `disabled?: boolean`
+
+**Behavior:**
+- Fetches all campaign tags via `useTags(campaignId)`
+- Client-side prefix filtering of suggestions, excluding already-selected tags
+- Dropdown appears when input has text and there are matching suggestions
+- Keyboard navigation: Up/Down arrows to highlight, Enter to select highlighted suggestion or add raw input, Escape to close dropdown
+- Click on suggestion to select it
+- Backspace on empty input removes the last chip
+- Comma and Enter keys add current input as a tag
+- On blur, adds any pending input text as a tag and closes dropdown
+- Chips display with `#` prefix and an `✕` remove button
+
+**Styling:** Matches existing NoteModal tag chip styling — blue pill chips on dark background with the same border, font, and spacing patterns.
+
+### Modified: `app/components/mainview/notes/NotesFilterWidget.tsx`
+
+- New prop: `filterTags: string[]` and `onFilterTagsChange: (tags: string[]) => void`
+- New prop: `campaignId: string`
+- Renders `<TagAutocompleteInput>` as a third row below the session/visibility filter row
+- Placeholder text: "Filter by tags..."
+
+### Modified: `app/components/mainview/notes/NotesPanel.tsx`
+
+- New state: `filterTags: string[]` (default `[]`)
+- Passes `filterTags` and setter to `NotesFilterWidget`
+- Passes `filterTags` to `useNotes` filter options
+
+### Modified: `app/components/mainview/notes/NoteModal.tsx`
+
+- Replaces inline tag state management (`tagInput`, `addTag`, `handleTagKeyDown`, `removeTag`, `onBlur` logic) with `<TagAutocompleteInput>`
+- The modal still owns `tags` state and passes it as `selectedTags` / `onTagsChange`
+- Tag flushing on submit simplified — `TagAutocompleteInput` handles pending input on blur
+
+## New Files
+
+| File | Purpose |
+|------|---------|
+| `app/server/db/models/Tag.ts` | Mongoose schema and model |
+| `app/server/functions/tags.ts` | `listTags` and `ensureTags` server functions |
+| `app/hooks/useTags.ts` | React Query hook for tag autocomplete |
+| `app/components/shared/TagAutocompleteInput.tsx` | Shared chip + autocomplete component |
+| `app/types/tag.ts` | TypeScript types and Zod schemas |
+
+## Modified Files
+
+| File | Change |
+|------|--------|
+| `app/server/functions/notes.ts` | Call `ensureTags` on create/update; add `tags` filter to `listNotes` |
+| `app/types/schemas/noteSchemas.ts` | Add optional `tags` to list notes input schema |
+| `app/hooks/useNotes.ts` | Accept `tags` filter; invalidate tags query on mutations |
+| `app/utils/queryKeys.ts` | Add `tags` query key group |
+| `app/components/mainview/notes/NotesFilterWidget.tsx` | Add tag filter row with `TagAutocompleteInput` |
+| `app/components/mainview/notes/NotesPanel.tsx` | Add `filterTags` state, wire to filter widget and hook |
+| `app/components/mainview/notes/NoteModal.tsx` | Replace inline tag logic with `TagAutocompleteInput` |

--- a/tests/components/mainview/notes/NoteModal.test.tsx
+++ b/tests/components/mainview/notes/NoteModal.test.tsx
@@ -7,6 +7,9 @@ import { useCreateNote, useUpdateNote, useDeleteNote, useNote } from '~/hooks/us
 
 // Mock hooks
 vi.mock('~/hooks/useNotes')
+vi.mock('~/hooks/useTags', () => ({
+  useTags: () => ({ tags: [], isLoading: false, error: null }),
+}))
 
 // Mock CodeMirror (same approach as MarkdownEditor tests)
 let lastCmOnChange: ((value: string) => void) | undefined

--- a/tests/components/mainview/notes/NotesPanel.test.tsx
+++ b/tests/components/mainview/notes/NotesPanel.test.tsx
@@ -9,6 +9,9 @@ import { useCampaign } from '~/hooks/useCampaigns'
 // Mock the hooks
 vi.mock('~/hooks/useNotes')
 vi.mock('~/hooks/useCampaigns')
+vi.mock('~/hooks/useTags', () => ({
+  useTags: () => ({ tags: [], isLoading: false, error: null }),
+}))
 vi.mock('@tanstack/react-router', () => ({
   useParams: () => ({ campaignId: 'campaign-123' }),
 }))

--- a/tests/server/functions/notes.test.ts
+++ b/tests/server/functions/notes.test.ts
@@ -27,6 +27,12 @@ vi.mock('~/server/db/models/Note', () => ({
     find: vi.fn(),
   },
 }))
+vi.mock('~/server/db/models/Tag', () => ({
+  Tag: {
+    bulkWrite: vi.fn().mockResolvedValue({}),
+    find: vi.fn(),
+  },
+}))
 vi.mock('~/server/utils/posthog', () => ({
   serverCaptureException: vi.fn(),
   serverCaptureEvent: vi.fn(),


### PR DESCRIPTION
## Summary

- Adds a per-campaign `Tag` MongoDB collection as a canonical tag registry
- `listTags` / `ensureTags` server functions with bulkWrite upsert for efficient tag creation
- New tags auto-created silently when notes are saved
- Shared `TagAutocompleteInput` component with keyboard navigation, chip display, and dropdown suggestions from existing campaign tags
- Tag filter in NotesPanel (above session/visibility dropdowns) with AND logic (`$all` query)
- NoteModal tag input replaced with `TagAutocompleteInput` for autocomplete support
- `useTags` React Query hook with cache invalidation on note create/update
- Designed to be reusable across future wiki entity types (characters, locations, creatures, etc.)

## Test plan

- [ ] Create a note with new tags — verify tags appear as chips and are saved
- [ ] Edit a note — verify existing tags load and autocomplete suggests campaign tags
- [ ] Type partial tag name in NoteModal — verify dropdown shows matching suggestions
- [ ] Use tag filter in NotesPanel — verify notes filter by AND logic (all selected tags must match)
- [ ] Add multiple tags to filter — verify list narrows correctly
- [ ] Remove a tag chip from filter — verify list updates
- [ ] Verify text search + tag filter work together
- [ ] TypeScript compiles clean (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)