### PR TITLE
fix(gmscreens): preserve note window state across tab switches

### DIFF
--- a/app/routes/campaigns/$campaignId/play.tsx
+++ b/app/routes/campaigns/$campaignId/play.tsx
@@ -87,9 +87,7 @@ function PlayPage() {
               aria-labelledby="tab-gmscreens"
               hidden={effectiveTab !== 'gmscreens'}
             >
-              {effectiveTab === 'gmscreens' && (
-                <GMScreensView campaignId={campaignId} />
-              )}
+              <GMScreensView campaignId={campaignId} />
             </div>
           )}
         </MainView>


### PR DESCRIPTION
## Summary
- **Bug:** Notes on the GM Screen were minimized when switching to the Tabletop tab and back
- **Cause:** `GMScreensView` was conditionally rendered (`effectiveTab === 'gmscreens' && ...`), which unmounted the entire component on tab switch, destroying all local window state
- **Fix:** Keep `GMScreensView` mounted and rely on the parent div's `hidden` attribute to hide it — matching how `TabletopView` already works

## Test plan
- [ ] Open the GM Screen with two or more notes positioned and open
- [ ] Switch to the Tabletop tab
- [ ] Switch back to the GM Screen tab
- [ ] Verify the notes are still open (not minimized) and in the same position

🤖 Generated with [Claude Code](https://claude.com/claude-code)