### PR TITLE
[Feature]: Add Rules feature to Wiki

### DIFF
--- a/app/components/mainview/gmscreens/GMScreensView.tsx
+++ b/app/components/mainview/gmscreens/GMScreensView.tsx
@@ -3,7 +3,6 @@ import { Plus, Layers, Loader2, AlertTriangle } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useGMScreenList, useGMScreenDetail, useGMScreenMutations } from '~/hooks/useGMScreens';
-import { useCampaign } from '~/hooks/useCampaigns';
 import {
   FloatingWindowManager,
   type ManagedWindow,
@@ -19,6 +18,7 @@ import { StackCard } from './StackCard';
 
 export interface GMScreensViewProps {
   campaignId: string;
+  isGM?: boolean;
 }
 
 const DEBOUNCE_MS = 500;
@@ -36,10 +36,8 @@ function toFloatingState(state: string): FloatingWindowState {
   return 'normal';
 }
 
-export function GMScreensView({ campaignId }: GMScreensViewProps) {
+export function GMScreensView({ campaignId, isGM = true }: GMScreensViewProps) {
   const { screens, isLoading: listLoading, error: listError } = useGMScreenList(campaignId);
-  const { campaign } = useCampaign(campaignId);
-  const isGM = campaign?.isGM ?? false;
   const [activeScreenId, setActiveScreenId] = useState<string | null>(null);
   const [dialog, setDialog] = useState<DialogState>({ type: 'none' });
   const mutations = useGMScreenMutations(campaignId);

--- a/app/components/mainview/gmscreens/GMScreensView.tsx
+++ b/app/components/mainview/gmscreens/GMScreensView.tsx
@@ -3,6 +3,7 @@ import { Plus, Layers, Loader2, AlertTriangle } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useGMScreenList, useGMScreenDetail, useGMScreenMutations } from '~/hooks/useGMScreens';
+import { useCampaign } from '~/hooks/useCampaigns';
 import {
   FloatingWindowManager,
   type ManagedWindow,
@@ -11,6 +12,7 @@ import type { FloatingWindowState } from '~/components/mainview/FloatingWindow';
 import type { WindowState } from '~/types/gmscreen';
 import { MARKDOWN_PROSE_CLASSES } from '~/utils/markdownProseClasses';
 import { CharacterWindowWrapper, EditCharacterModalWrapper } from './CharacterWindowWrapper';
+import { RuleWindowWrapper, EditRuleModalWrapper } from './RuleWindowWrapper';
 import { GMScreenDialogs, type DialogState } from './GMScreenDialogs';
 import { ScreenBar } from './ScreenBar';
 import { StackCard } from './StackCard';
@@ -36,10 +38,12 @@ function toFloatingState(state: string): FloatingWindowState {
 
 export function GMScreensView({ campaignId }: GMScreensViewProps) {
   const { screens, isLoading: listLoading, error: listError } = useGMScreenList(campaignId);
+  const { campaign } = useCampaign(campaignId);
   const [activeScreenId, setActiveScreenId] = useState<string | null>(null);
   const [dialog, setDialog] = useState<DialogState>({ type: 'none' });
   const mutations = useGMScreenMutations(campaignId);
   const [editingCharacterId, setEditingCharacterId] = useState<string | null>(null);
+  const [editingRuleId, setEditingRuleId] = useState<string | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
   const [flashWindowId, setFlashWindowId] = useState<string | null>(null);
   const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -397,6 +401,15 @@ export function GMScreensView({ campaignId }: GMScreensViewProps) {
               onEdit={() => setEditingCharacterId(w.documentId)}
             />
           );
+        } else if (w.collection === 'rule') {
+          windowContent = (
+            <RuleWindowWrapper
+              ruleId={w.documentId}
+              campaignId={campaignId}
+              isGM={campaign?.isGM ?? false}
+              onEdit={() => setEditingRuleId(w.documentId)}
+            />
+          );
         } else {
           windowContent = (
             <div className="p-4 overflow-auto h-full">
@@ -451,7 +464,7 @@ export function GMScreensView({ campaignId }: GMScreensViewProps) {
 
       return merged;
     });
-  }, [activeScreen, activeScreenId, flashWindowId, campaignId]);
+  }, [activeScreen, activeScreenId, flashWindowId, campaignId, campaign]);
 
   // --- Render ---
 
@@ -615,6 +628,13 @@ export function GMScreensView({ campaignId }: GMScreensViewProps) {
           campaignId={campaignId}
           characterId={editingCharacterId}
           onClose={() => setEditingCharacterId(null)}
+        />
+      )}
+      {editingRuleId !== null && (
+        <EditRuleModalWrapper
+          campaignId={campaignId}
+          ruleId={editingRuleId}
+          onClose={() => setEditingRuleId(null)}
         />
       )}
     </div>

--- a/app/components/mainview/gmscreens/GMScreensView.tsx
+++ b/app/components/mainview/gmscreens/GMScreensView.tsx
@@ -39,6 +39,7 @@ function toFloatingState(state: string): FloatingWindowState {
 export function GMScreensView({ campaignId }: GMScreensViewProps) {
   const { screens, isLoading: listLoading, error: listError } = useGMScreenList(campaignId);
   const { campaign } = useCampaign(campaignId);
+  const isGM = campaign?.isGM ?? false;
   const [activeScreenId, setActiveScreenId] = useState<string | null>(null);
   const [dialog, setDialog] = useState<DialogState>({ type: 'none' });
   const mutations = useGMScreenMutations(campaignId);
@@ -406,7 +407,7 @@ export function GMScreensView({ campaignId }: GMScreensViewProps) {
             <RuleWindowWrapper
               ruleId={w.documentId}
               campaignId={campaignId}
-              isGM={campaign?.isGM ?? false}
+              isGM={isGM}
               onEdit={() => setEditingRuleId(w.documentId)}
             />
           );
@@ -464,7 +465,7 @@ export function GMScreensView({ campaignId }: GMScreensViewProps) {
 
       return merged;
     });
-  }, [activeScreen, activeScreenId, flashWindowId, campaignId, campaign]);
+  }, [activeScreen, activeScreenId, flashWindowId, campaignId, isGM]);
 
   // --- Render ---
 

--- a/app/components/mainview/gmscreens/RuleWindowWrapper.tsx
+++ b/app/components/mainview/gmscreens/RuleWindowWrapper.tsx
@@ -1,0 +1,62 @@
+import { Pencil } from 'lucide-react';
+import { RuleWindow } from '~/components/wiki/rules/RuleWindow';
+import { RuleModal } from '~/components/wiki/rules/RuleModal';
+import { useRule } from '~/hooks/useRules';
+
+export function EditRuleModalWrapper({
+  campaignId,
+  ruleId,
+  onClose,
+}: {
+  campaignId: string;
+  ruleId: string;
+  onClose: () => void;
+}) {
+  return <RuleModal isOpen onClose={onClose} campaignId={campaignId} ruleId={ruleId} />;
+}
+
+export function RuleWindowWrapper({
+  ruleId,
+  campaignId,
+  isGM,
+  onEdit,
+}: {
+  ruleId: string;
+  campaignId: string;
+  isGM: boolean;
+  onEdit: () => void;
+}) {
+  const { rule, isLoading } = useRule(ruleId, campaignId);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-xs text-slate-500 animate-pulse">Loading rule...</p>
+      </div>
+    );
+  }
+
+  if (!rule) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-xs text-slate-500">Rule not found</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative h-full">
+      {isGM && (
+        <button
+          type="button"
+          onClick={onEdit}
+          className="absolute top-2 right-2 z-10 p-1.5 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors"
+          aria-label="Edit rule"
+        >
+          <Pencil className="h-3.5 w-3.5" />
+        </button>
+      )}
+      <RuleWindow rule={rule} />
+    </div>
+  );
+}

--- a/app/components/wiki/WikiPanel.tsx
+++ b/app/components/wiki/WikiPanel.tsx
@@ -1,28 +1,30 @@
-import React, { useState } from 'react'
-import { Users } from 'lucide-react'
-import { CharactersPanel } from './characters/CharactersPanel'
+import React, { useState } from 'react';
+import { Users, ScrollText } from 'lucide-react';
+import { CharactersPanel } from './characters/CharactersPanel';
+import { RulesPanel } from './rules/RulesPanel';
 
-type WikiCategoryId = 'characters'
+type WikiCategoryId = 'characters' | 'rules';
 
 interface WikiCategory {
-  id: WikiCategoryId
-  label: string
-  icon: React.ComponentType<{ className?: string }>
+  id: WikiCategoryId;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
 }
 
 const WIKI_CATEGORIES: WikiCategory[] = [
   { id: 'characters', label: 'Characters', icon: Users },
-]
+  { id: 'rules', label: 'Rules', icon: ScrollText },
+];
 
 export function WikiPanel() {
-  const [selectedCategory, setSelectedCategory] = useState<WikiCategoryId | null>(null)
+  const [selectedCategory, setSelectedCategory] = useState<WikiCategoryId | null>(null);
 
   return (
     <div className="h-full flex flex-col bg-[#080A12] w-full">
       {selectedCategory === null ? (
         <div className="flex-1 overflow-y-auto">
           {WIKI_CATEGORIES.map((category, index) => {
-            const Icon = category.icon
+            const Icon = category.icon;
             return (
               <button
                 key={category.id}
@@ -38,12 +40,14 @@ export function WikiPanel() {
                   {category.label}
                 </span>
               </button>
-            )
+            );
           })}
         </div>
       ) : selectedCategory === 'characters' ? (
         <CharactersPanel onBack={() => setSelectedCategory(null)} />
+      ) : selectedCategory === 'rules' ? (
+        <RulesPanel onBack={() => setSelectedCategory(null)} />
       ) : null}
     </div>
-  )
+  );
 }

--- a/app/components/wiki/rules/RuleCard.tsx
+++ b/app/components/wiki/rules/RuleCard.tsx
@@ -1,0 +1,66 @@
+import { Globe, Lock } from 'lucide-react';
+import type { RuleListItem } from '~/types/rule';
+
+interface RuleCardProps {
+  rule: RuleListItem;
+  onClick: (rule: RuleListItem) => void;
+}
+
+export function RuleCard({ rule, onClick }: RuleCardProps) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      draggable="true"
+      onDragStart={(e) => {
+        e.dataTransfer.setData(
+          'application/x-cartyx-document',
+          JSON.stringify({
+            collection: 'rule',
+            documentId: rule.id,
+            title: rule.title,
+          })
+        );
+        e.dataTransfer.effectAllowed = 'copy';
+        e.currentTarget.style.opacity = '0.4';
+      }}
+      onDragEnd={(e) => {
+        e.currentTarget.style.opacity = '';
+      }}
+      onClick={() => onClick(rule)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick(rule);
+        }
+      }}
+      className="flex items-start gap-3 px-4 py-3 border-b border-white/[0.05] hover:bg-white/[0.03] transition-colors group cursor-grab active:cursor-grabbing"
+    >
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-0.5">
+          <span className="text-sm font-semibold text-slate-200 group-hover:text-blue-400 transition-colors truncate">
+            {rule.title}
+          </span>
+          {rule.isPublic ? (
+            <Globe className="h-3.5 w-3.5 text-emerald-500 shrink-0" aria-label="Public" />
+          ) : (
+            <Lock className="h-3.5 w-3.5 text-amber-500 shrink-0" aria-label="Private" />
+          )}
+        </div>
+
+        {rule.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1 mt-1">
+            {rule.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[9px] tracking-tight"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/wiki/rules/RuleModal.tsx
+++ b/app/components/wiki/rules/RuleModal.tsx
@@ -19,12 +19,7 @@ interface FieldErrors {
   content?: string;
 }
 
-export function RuleModal({
-  isOpen,
-  onClose,
-  campaignId,
-  ruleId,
-}: RuleModalProps) {
+export function RuleModal({ isOpen, onClose, campaignId, ruleId }: RuleModalProps) {
   const { rule: fetchedRule, isLoading: isFetchingRule } = useRule(ruleId ?? '', campaignId);
   const { create, isLoading: isCreating } = useCreateRule();
   const { update, isLoading: isUpdating } = useUpdateRule();

--- a/app/components/wiki/rules/RuleModal.tsx
+++ b/app/components/wiki/rules/RuleModal.tsx
@@ -1,0 +1,325 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { X, Globe, Lock } from 'lucide-react';
+import { FormInput } from '~/components/FormInput';
+import { PixelButton } from '~/components/PixelButton';
+import { MarkdownEditor } from '~/components/shared/MarkdownEditor';
+import { useCreateRule, useUpdateRule, useDeleteRule, useRule } from '~/hooks/useRules';
+import { TagAutocompleteInput } from '~/components/shared/TagAutocompleteInput';
+
+interface RuleModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  campaignId: string;
+  ruleId?: string;
+}
+
+interface FieldErrors {
+  title?: string;
+  content?: string;
+}
+
+export function RuleModal({
+  isOpen,
+  onClose,
+  campaignId,
+  ruleId,
+}: RuleModalProps) {
+  const { rule: fetchedRule, isLoading: isFetchingRule } = useRule(ruleId ?? '', campaignId);
+  const { create, isLoading: isCreating } = useCreateRule();
+  const { update, isLoading: isUpdating } = useUpdateRule();
+  const { remove, isLoading: isDeleting } = useDeleteRule();
+
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [tags, setTags] = useState<string[]>([]);
+  const [isPublic, setIsPublic] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [hasSubmitted, setHasSubmitted] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [onClose]);
+
+  // Reset form when switching ruleId or opening the modal
+  useEffect(() => {
+    setTitle('');
+    setContent('');
+    setTags([]);
+    setIsPublic(false);
+    setError(null);
+    setFieldErrors({});
+    setHasSubmitted(false);
+    setShowDeleteConfirm(false);
+  }, [ruleId, isOpen]);
+
+  // Populate form once the fetched rule resolves in edit mode
+  useEffect(() => {
+    if (ruleId && fetchedRule) {
+      setTitle(fetchedRule.title);
+      setContent(fetchedRule.content);
+      setTags(fetchedRule.tags);
+      setIsPublic(fetchedRule.isPublic);
+    }
+  }, [ruleId, fetchedRule]);
+
+  const validate = useCallback((): FieldErrors => {
+    const errors: FieldErrors = {};
+    if (!title.trim()) errors.title = 'Title is required';
+    if (!content.trim()) errors.content = 'Rule content is required';
+    return errors;
+  }, [title, content]);
+
+  useEffect(() => {
+    if (hasSubmitted) {
+      setFieldErrors(validate());
+    }
+  }, [hasSubmitted, validate]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setHasSubmitted(true);
+    setError(null);
+
+    const errors = validate();
+    setFieldErrors(errors);
+    if (Object.keys(errors).length > 0) return;
+
+    const input = {
+      campaignId,
+      title: title.trim(),
+      content: content.trim(),
+      tags,
+      isPublic,
+    };
+
+    let success = false;
+    if (ruleId) {
+      const result = await update({ ...input, id: ruleId });
+      success = !!result;
+    } else {
+      const result = await create(input);
+      success = !!result;
+    }
+
+    if (success) {
+      onClose();
+    } else {
+      setError('Failed to save rule. Please try again.');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!ruleId) return;
+    setError(null);
+    const result = await remove({ id: ruleId, campaignId });
+    if (result) {
+      onClose();
+    } else {
+      setError('Failed to delete rule. Please try again.');
+      setShowDeleteConfirm(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const isLoadingRule = !!(ruleId && isFetchingRule);
+  const isSaving = isCreating || isUpdating;
+  const isDisabled = isLoadingRule || isSaving || isDeleting;
+
+  return createPortal(
+    <div
+      role="presentation"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-2 sm:p-4 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="rule-modal-title"
+        className="w-full h-full max-w-[90vw] max-h-[90vh] sm:max-w-[90vw] sm:max-h-[90vh] bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col"
+      >
+        <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
+          <h2
+            id="rule-modal-title"
+            className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest"
+          >
+            {ruleId ? 'Edit Rule' : 'Create Rule'}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-slate-500 hover:text-white transition-colors"
+            aria-label="Close modal"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto p-4 sm:p-6 space-y-5 min-h-0">
+          {error && (
+            <div className="p-3 bg-rose-500/10 border border-rose-500/20 rounded-lg text-rose-400 text-xs font-semibold">
+              {error}
+            </div>
+          )}
+
+          <FormInput
+            label="Title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="e.g. Critical Hit Rules"
+            disabled={isDisabled}
+            error={fieldErrors.title}
+          />
+
+          <MarkdownEditor
+            label="Rule Content"
+            value={content}
+            onChange={setContent}
+            placeholder="Write the rule details in markdown..."
+            disabled={isDisabled}
+            error={fieldErrors.content}
+            minHeight="16rem"
+            id="rule-modal-editor"
+          />
+
+          {/* Tags */}
+          <div>
+            <label
+              htmlFor="rule-tags-input"
+              className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide"
+            >
+              Tags
+            </label>
+            <TagAutocompleteInput
+              campaignId={campaignId}
+              selectedTags={tags}
+              onTagsChange={setTags}
+              placeholder="Type a tag and press Enter"
+              disabled={isDisabled}
+              id="rule-tags-input"
+            />
+            <p className="text-xs text-slate-700 mt-1.5">
+              Press Enter or comma to add. Suggestions appear as you type.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-6 pt-2">
+            <label className="flex items-center gap-3 cursor-pointer group">
+              <input
+                type="radio"
+                name="rule-visibility"
+                checked={!isPublic}
+                onChange={() => setIsPublic(false)}
+                className="sr-only"
+                disabled={isDisabled}
+              />
+              <div
+                className={`h-10 px-4 rounded-xl border flex items-center gap-2.5 transition-all ${
+                  !isPublic
+                    ? 'bg-blue-600/10 border-blue-500/50 text-blue-300 shadow-sm shadow-blue-500/10'
+                    : 'bg-white/[0.03] border-white/[0.07] text-slate-500 hover:border-white/20'
+                }`}
+              >
+                <Lock className="h-3.5 w-3.5" />
+                <span className="font-sans font-bold text-xs">Private</span>
+              </div>
+            </label>
+
+            <label className="flex items-center gap-3 cursor-pointer group">
+              <input
+                type="radio"
+                name="rule-visibility"
+                checked={isPublic}
+                onChange={() => setIsPublic(true)}
+                className="sr-only"
+                disabled={isDisabled}
+              />
+              <div
+                className={`h-10 px-4 rounded-xl border flex items-center gap-2.5 transition-all ${
+                  isPublic
+                    ? 'bg-emerald-600/10 border-emerald-500/50 text-emerald-300 shadow-sm shadow-emerald-500/10'
+                    : 'bg-white/[0.03] border-white/[0.07] text-slate-500 hover:border-white/20'
+                }`}
+              >
+                <Globe className="h-3.5 w-3.5" />
+                <span className="font-sans font-bold text-xs">Public</span>
+              </div>
+            </label>
+          </div>
+        </div>
+
+        <footer className="flex items-center justify-between px-4 sm:px-6 py-4 border-t border-white/[0.07] bg-white/[0.01] shrink-0">
+          <div>
+            {ruleId && !showDeleteConfirm && (
+              <PixelButton
+                variant="secondary"
+                size="sm"
+                onClick={() => setShowDeleteConfirm(true)}
+                disabled={isDisabled}
+                type="button"
+              >
+                <span className="text-rose-400">Delete</span>
+              </PixelButton>
+            )}
+            {ruleId && showDeleteConfirm && (
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-rose-400 font-semibold">Delete this rule?</span>
+                <PixelButton
+                  variant="secondary"
+                  size="sm"
+                  onClick={handleDelete}
+                  disabled={isDeleting}
+                  type="button"
+                >
+                  <span className="text-rose-400">
+                    {isDeleting ? 'Deleting...' : 'Yes, delete'}
+                  </span>
+                </PixelButton>
+                <PixelButton
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => setShowDeleteConfirm(false)}
+                  disabled={isDeleting}
+                  type="button"
+                >
+                  Cancel
+                </PixelButton>
+              </div>
+            )}
+          </div>
+          <div className="flex items-center gap-3">
+            <PixelButton
+              variant="secondary"
+              size="sm"
+              onClick={onClose}
+              disabled={isSaving || isDeleting}
+              type="button"
+            >
+              Cancel
+            </PixelButton>
+            <PixelButton variant="primary" size="sm" disabled={isDisabled} type="submit">
+              {isSaving
+                ? 'Saving...'
+                : isLoadingRule
+                  ? 'Loading...'
+                  : ruleId
+                    ? 'Update Rule'
+                    : 'Create Rule'}
+            </PixelButton>
+          </div>
+        </footer>
+      </form>
+    </div>,
+    document.body
+  );
+}

--- a/app/components/wiki/rules/RuleViewModal.tsx
+++ b/app/components/wiki/rules/RuleViewModal.tsx
@@ -1,0 +1,77 @@
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { X } from 'lucide-react';
+import { RuleWindow } from './RuleWindow';
+import { useRule } from '~/hooks/useRules';
+
+interface RuleViewModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  ruleId: string;
+  campaignId: string;
+}
+
+export function RuleViewModal({ isOpen, onClose, ruleId, campaignId }: RuleViewModalProps) {
+  const { rule, isLoading } = useRule(ruleId, campaignId);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div
+      role="presentation"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-2 sm:p-4 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="rule-view-modal-title"
+        className="w-full max-w-lg max-h-[90vh] bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col"
+      >
+        <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
+          <h2
+            id="rule-view-modal-title"
+            className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest"
+          >
+            Rule
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-slate-500 hover:text-white transition-colors"
+            aria-label="Close modal"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto min-h-0">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <p className="text-xs text-slate-500 animate-pulse">Loading rule...</p>
+            </div>
+          ) : rule ? (
+            <RuleWindow rule={rule} />
+          ) : (
+            <div className="flex items-center justify-center py-12">
+              <p className="text-xs text-slate-500">Rule not found</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/app/components/wiki/rules/RuleWindow.tsx
+++ b/app/components/wiki/rules/RuleWindow.tsx
@@ -1,0 +1,52 @@
+import { Globe, Lock } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { RuleData } from '~/types/rule';
+import { MARKDOWN_PROSE_CLASSES } from '~/utils/markdownProseClasses';
+
+interface RuleWindowProps {
+  rule: RuleData;
+}
+
+export function RuleWindow({ rule }: RuleWindowProps) {
+  return (
+    <div className="flex flex-col gap-4 p-4 overflow-auto h-full">
+      {/* Title */}
+      <h2 className="text-sm font-bold text-slate-200">{rule.title}</h2>
+
+      {/* Visibility badge */}
+      <div className="flex">
+        {rule.isPublic ? (
+          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 text-[10px] font-semibold">
+            <Globe className="h-3 w-3" />
+            Public
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-amber-500/10 border border-amber-500/20 text-amber-400 text-[10px] font-semibold">
+            <Lock className="h-3 w-3" />
+            Private
+          </span>
+        )}
+      </div>
+
+      {/* Tags */}
+      {rule.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {rule.tags.map((tag) => (
+            <span
+              key={tag}
+              className="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[9px] tracking-tight"
+            >
+              #{tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Rendered markdown content */}
+      <div className={MARKDOWN_PROSE_CLASSES}>
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{rule.content}</ReactMarkdown>
+      </div>
+    </div>
+  );
+}

--- a/app/components/wiki/rules/RulesPanel.tsx
+++ b/app/components/wiki/rules/RulesPanel.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { useParams } from '@tanstack/react-router';
+import { ScrollText } from 'lucide-react';
+import { WikiCategoryHeader } from '~/components/wiki/shared/WikiCategoryHeader';
+import { WikiFilterBar } from '~/components/wiki/shared/WikiFilterBar';
+import { RuleCard } from './RuleCard';
+import { RuleModal } from './RuleModal';
+import { RuleViewModal } from './RuleViewModal';
+import { useRules } from '~/hooks/useRules';
+import { useCampaign } from '~/hooks/useCampaigns';
+import type { RuleListItem } from '~/types/rule';
+
+interface RulesPanelProps {
+  onBack: () => void;
+}
+
+export function RulesPanel({ onBack }: RulesPanelProps) {
+  const { campaignId } = useParams({ from: '/campaigns/$campaignId/play' });
+  const { campaign } = useCampaign(campaignId);
+  const isGM = campaign?.isGM ?? false;
+
+  const [search, setSearch] = useState('');
+  const [visibility, setVisibility] = useState<'all' | 'public' | 'private'>('all');
+  const [filterTags, setFilterTags] = useState<string[]>([]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedRuleId, setSelectedRuleId] = useState<string | undefined>();
+  const [viewRuleId, setViewRuleId] = useState<string | undefined>();
+
+  const { rules, isLoading, error } = useRules(campaignId, {
+    search: search || undefined,
+    visibility,
+    tags: filterTags.length > 0 ? filterTags : undefined,
+  });
+
+  const handleCreateClick = () => {
+    setSelectedRuleId(undefined);
+    setIsModalOpen(true);
+  };
+
+  const handleRuleClick = (rule: RuleListItem) => {
+    if (isGM) {
+      setSelectedRuleId(rule.id);
+      setIsModalOpen(true);
+    } else {
+      setViewRuleId(rule.id);
+    }
+  };
+
+  const handleModalClose = () => {
+    setIsModalOpen(false);
+    setSelectedRuleId(undefined);
+  };
+
+  const handleViewModalClose = () => {
+    setViewRuleId(undefined);
+  };
+
+  return (
+    <div className="flex flex-col h-full w-full bg-[#080A12]">
+      <WikiCategoryHeader title="Rules" onBack={onBack} />
+      <WikiFilterBar
+        search={search}
+        onSearchChange={setSearch}
+        visibility={visibility}
+        onVisibilityChange={setVisibility}
+        onCreateClick={handleCreateClick}
+        campaignId={campaignId}
+        filterTags={filterTags}
+        onFilterTagsChange={setFilterTags}
+        searchPlaceholder="Search rules..."
+        showSessionFilter={false}
+      />
+
+      {isLoading ? (
+        <div className="flex flex-1 items-center justify-center p-8">
+          <p className="font-sans font-semibold text-xs text-slate-500 animate-pulse">
+            Loading rules...
+          </p>
+        </div>
+      ) : error ? (
+        <div className="flex flex-1 items-center justify-center p-8 text-center">
+          <p className="font-sans font-semibold text-xs text-rose-400">{error}</p>
+        </div>
+      ) : rules.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center p-8 text-center">
+          <div className="h-12 w-12 rounded-full bg-white/[0.03] flex items-center justify-center mb-3">
+            <ScrollText className="h-6 w-6 text-slate-600" />
+          </div>
+          <p className="font-sans font-semibold text-xs text-slate-500">
+            No rules found matching your filters.
+          </p>
+        </div>
+      ) : (
+        <div className="flex-1 overflow-y-auto min-h-0">
+          <div className="flex flex-col">
+            {rules.map((rule) => (
+              <RuleCard key={rule.id} rule={rule} onClick={handleRuleClick} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {isGM && (
+        <RuleModal
+          isOpen={isModalOpen}
+          onClose={handleModalClose}
+          campaignId={campaignId}
+          ruleId={selectedRuleId}
+        />
+      )}
+      {viewRuleId && (
+        <RuleViewModal
+          isOpen={!!viewRuleId}
+          onClose={handleViewModalClose}
+          ruleId={viewRuleId}
+          campaignId={campaignId}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/components/wiki/rules/RulesPanel.tsx
+++ b/app/components/wiki/rules/RulesPanel.tsx
@@ -63,12 +63,13 @@ export function RulesPanel({ onBack }: RulesPanelProps) {
         onSearchChange={setSearch}
         visibility={visibility}
         onVisibilityChange={setVisibility}
-        onCreateClick={handleCreateClick}
+        onCreateClick={isGM ? handleCreateClick : undefined}
         campaignId={campaignId}
         filterTags={filterTags}
         onFilterTagsChange={setFilterTags}
         searchPlaceholder="Search rules..."
         showSessionFilter={false}
+        showVisibilityFilter={isGM}
       />
 
       {isLoading ? (

--- a/app/components/wiki/shared/WikiFilterBar.tsx
+++ b/app/components/wiki/shared/WikiFilterBar.tsx
@@ -10,12 +10,13 @@ interface WikiFilterBarProps {
   visibility: 'all' | 'public' | 'private';
   onVisibilityChange: (value: 'all' | 'public' | 'private') => void;
   sessions?: CampaignData['sessions'];
-  onCreateClick: () => void;
+  onCreateClick?: () => void;
   campaignId: string;
   filterTags: string[];
   onFilterTagsChange: (tags: string[]) => void;
   searchPlaceholder?: string;
   showSessionFilter?: boolean;
+  showVisibilityFilter?: boolean;
 }
 
 export function WikiFilterBar({
@@ -32,6 +33,7 @@ export function WikiFilterBar({
   onFilterTagsChange,
   searchPlaceholder = 'Search...',
   showSessionFilter = true,
+  showVisibilityFilter = true,
 }: WikiFilterBarProps) {
   return (
     <div className="flex flex-col gap-3 p-3 border-b border-white/[0.07] bg-[#0D1117]">
@@ -47,14 +49,16 @@ export function WikiFilterBar({
             className="w-full bg-[#080A12] border border-white/[0.07] rounded px-9 py-2 font-sans font-semibold text-xs text-white outline-none focus:border-blue-500/50 transition-colors placeholder:text-slate-600"
           />
         </div>
-        <button
-          type="button"
-          onClick={onCreateClick}
-          className="flex items-center justify-center h-8 w-8 rounded bg-blue-600 hover:bg-blue-500 text-white transition-colors"
-          aria-label="Create new item"
-        >
-          <Plus className="h-4 w-4" />
-        </button>
+        {onCreateClick && (
+          <button
+            type="button"
+            onClick={onCreateClick}
+            className="flex items-center justify-center h-8 w-8 rounded bg-blue-600 hover:bg-blue-500 text-white transition-colors"
+            aria-label="Create new item"
+          >
+            <Plus className="h-4 w-4" />
+          </button>
+        )}
       </div>
 
       <TagAutocompleteInput
@@ -64,45 +68,49 @@ export function WikiFilterBar({
         placeholder="Filter by tags..."
       />
 
-      <div className="flex gap-2">
-        {showSessionFilter && sessions && onSessionChange && (
-          <div className="flex-1">
-            <label htmlFor="wiki-session-filter" className="sr-only">
-              Filter by session
-            </label>
-            <select
-              id="wiki-session-filter"
-              value={sessionId ?? ''}
-              onChange={(e) => onSessionChange(e.target.value)}
-              className="w-full bg-[#080A12] border border-white/[0.07] rounded px-2 py-1.5 font-sans font-semibold text-[11px] text-slate-300 outline-none focus:border-blue-500/50 transition-colors"
-            >
-              <option value="">All Sessions</option>
-              <option value="__none__">No Session</option>
-              {sessions.map((session) => (
-                <option key={session.id} value={session.id}>
-                  Session {session.number}: {session.name}
-                </option>
-              ))}
-            </select>
-          </div>
-        )}
+      {(showSessionFilter || showVisibilityFilter) && (
+        <div className="flex gap-2">
+          {showSessionFilter && sessions && onSessionChange && (
+            <div className="flex-1">
+              <label htmlFor="wiki-session-filter" className="sr-only">
+                Filter by session
+              </label>
+              <select
+                id="wiki-session-filter"
+                value={sessionId ?? ''}
+                onChange={(e) => onSessionChange(e.target.value)}
+                className="w-full bg-[#080A12] border border-white/[0.07] rounded px-2 py-1.5 font-sans font-semibold text-[11px] text-slate-300 outline-none focus:border-blue-500/50 transition-colors"
+              >
+                <option value="">All Sessions</option>
+                <option value="__none__">No Session</option>
+                {sessions.map((session) => (
+                  <option key={session.id} value={session.id}>
+                    Session {session.number}: {session.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
 
-        <div className={showSessionFilter && sessions && onSessionChange ? 'w-32' : 'flex-1'}>
-          <label htmlFor="wiki-visibility-filter" className="sr-only">
-            Filter by visibility
-          </label>
-          <select
-            id="wiki-visibility-filter"
-            value={visibility}
-            onChange={(e) => onVisibilityChange(e.target.value as 'all' | 'public' | 'private')}
-            className="w-full bg-[#080A12] border border-white/[0.07] rounded px-2 py-1.5 font-sans font-semibold text-[11px] text-slate-300 outline-none focus:border-blue-500/50 transition-colors"
-          >
-            <option value="all">All</option>
-            <option value="public">Public Only</option>
-            <option value="private">Private Only</option>
-          </select>
+          {showVisibilityFilter && (
+            <div className={showSessionFilter && sessions && onSessionChange ? 'w-32' : 'flex-1'}>
+              <label htmlFor="wiki-visibility-filter" className="sr-only">
+                Filter by visibility
+              </label>
+              <select
+                id="wiki-visibility-filter"
+                value={visibility}
+                onChange={(e) => onVisibilityChange(e.target.value as 'all' | 'public' | 'private')}
+                className="w-full bg-[#080A12] border border-white/[0.07] rounded px-2 py-1.5 font-sans font-semibold text-[11px] text-slate-300 outline-none focus:border-blue-500/50 transition-colors"
+              >
+                <option value="all">All</option>
+                <option value="public">Public Only</option>
+                <option value="private">Private Only</option>
+              </select>
+            </div>
+          )}
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/app/components/wiki/shared/WikiFilterBar.tsx
+++ b/app/components/wiki/shared/WikiFilterBar.tsx
@@ -1,20 +1,21 @@
-import { Plus, Search } from 'lucide-react'
-import type { CampaignData } from '~/types/campaign'
-import { TagAutocompleteInput } from '~/components/shared/TagAutocompleteInput'
+import { Plus, Search } from 'lucide-react';
+import type { CampaignData } from '~/types/campaign';
+import { TagAutocompleteInput } from '~/components/shared/TagAutocompleteInput';
 
 interface WikiFilterBarProps {
-  search: string
-  onSearchChange: (value: string) => void
-  sessionId: string
-  onSessionChange: (value: string) => void
-  visibility: 'all' | 'public' | 'private'
-  onVisibilityChange: (value: 'all' | 'public' | 'private') => void
-  sessions: CampaignData['sessions']
-  onCreateClick: () => void
-  campaignId: string
-  filterTags: string[]
-  onFilterTagsChange: (tags: string[]) => void
-  searchPlaceholder?: string
+  search: string;
+  onSearchChange: (value: string) => void;
+  sessionId?: string;
+  onSessionChange?: (value: string) => void;
+  visibility: 'all' | 'public' | 'private';
+  onVisibilityChange: (value: 'all' | 'public' | 'private') => void;
+  sessions?: CampaignData['sessions'];
+  onCreateClick: () => void;
+  campaignId: string;
+  filterTags: string[];
+  onFilterTagsChange: (tags: string[]) => void;
+  searchPlaceholder?: string;
+  showSessionFilter?: boolean;
 }
 
 export function WikiFilterBar({
@@ -30,6 +31,7 @@ export function WikiFilterBar({
   filterTags,
   onFilterTagsChange,
   searchPlaceholder = 'Search...',
+  showSessionFilter = true,
 }: WikiFilterBarProps) {
   return (
     <div className="flex flex-col gap-3 p-3 border-b border-white/[0.07] bg-[#0D1117]">
@@ -63,26 +65,32 @@ export function WikiFilterBar({
       />
 
       <div className="flex gap-2">
-        <div className="flex-1">
-          <label htmlFor="wiki-session-filter" className="sr-only">Filter by session</label>
-          <select
-            id="wiki-session-filter"
-            value={sessionId}
-            onChange={(e) => onSessionChange(e.target.value)}
-            className="w-full bg-[#080A12] border border-white/[0.07] rounded px-2 py-1.5 font-sans font-semibold text-[11px] text-slate-300 outline-none focus:border-blue-500/50 transition-colors"
-          >
-            <option value="">All Sessions</option>
-            <option value="__none__">No Session</option>
-            {sessions.map((session) => (
-              <option key={session.id} value={session.id}>
-                Session {session.number}: {session.name}
-              </option>
-            ))}
-          </select>
-        </div>
+        {showSessionFilter && sessions && onSessionChange && (
+          <div className="flex-1">
+            <label htmlFor="wiki-session-filter" className="sr-only">
+              Filter by session
+            </label>
+            <select
+              id="wiki-session-filter"
+              value={sessionId ?? ''}
+              onChange={(e) => onSessionChange(e.target.value)}
+              className="w-full bg-[#080A12] border border-white/[0.07] rounded px-2 py-1.5 font-sans font-semibold text-[11px] text-slate-300 outline-none focus:border-blue-500/50 transition-colors"
+            >
+              <option value="">All Sessions</option>
+              <option value="__none__">No Session</option>
+              {sessions.map((session) => (
+                <option key={session.id} value={session.id}>
+                  Session {session.number}: {session.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
 
-        <div className="w-32">
-          <label htmlFor="wiki-visibility-filter" className="sr-only">Filter by visibility</label>
+        <div className={showSessionFilter && sessions && onSessionChange ? 'w-32' : 'flex-1'}>
+          <label htmlFor="wiki-visibility-filter" className="sr-only">
+            Filter by visibility
+          </label>
           <select
             id="wiki-visibility-filter"
             value={visibility}
@@ -96,5 +104,5 @@ export function WikiFilterBar({
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/app/hooks/useRules.ts
+++ b/app/hooks/useRules.ts
@@ -1,0 +1,243 @@
+import { createServerFn } from '@tanstack/react-start';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { RuleData, RuleListItem } from '~/types/rule';
+import { captureException } from '~/providers/PostHogProvider';
+import { queryKeys } from '~/utils/queryKeys';
+import {
+  listRulesSchema,
+  getRuleSchema,
+  createRuleSchema,
+  updateRuleSchema,
+  deleteRuleSchema,
+} from '~/types/schemas/rules';
+
+// ---------------------------------------------------------------------------
+// Server function wrappers — dynamic imports keep Mongoose server-only.
+// ---------------------------------------------------------------------------
+
+const listRulesFn = createServerFn({ method: 'GET' })
+  .inputValidator(listRulesSchema)
+  .handler(async ({ data }) => {
+    const { listRules } = await import('~/server/functions/rules');
+    return listRules({ data });
+  });
+
+const getRuleFn = createServerFn({ method: 'GET' })
+  .inputValidator(getRuleSchema)
+  .handler(async ({ data }) => {
+    const { getRule } = await import('~/server/functions/rules');
+    return getRule({ data });
+  });
+
+const createRuleFn = createServerFn({ method: 'POST' })
+  .inputValidator(createRuleSchema)
+  .handler(async ({ data }) => {
+    const { createRule } = await import('~/server/functions/rules');
+    return createRule({ data });
+  });
+
+const updateRuleFn = createServerFn({ method: 'POST' })
+  .inputValidator(updateRuleSchema)
+  .handler(async ({ data }) => {
+    const { updateRule } = await import('~/server/functions/rules');
+    return updateRule({ data });
+  });
+
+const deleteRuleFn = createServerFn({ method: 'POST' })
+  .inputValidator(deleteRuleSchema)
+  .handler(async ({ data }) => {
+    const { deleteRule } = await import('~/server/functions/rules');
+    return deleteRule({ data });
+  });
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+interface ListRulesFilters {
+  search?: string;
+  visibility?: 'all' | 'public' | 'private';
+  tags?: string[];
+}
+
+export function useRules(campaignId: string, filters?: ListRulesFilters) {
+  const search = filters?.search;
+  const visibility = filters?.visibility;
+  const tags = filters?.tags;
+
+  const {
+    data: rules = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.rules.list(campaignId, search, visibility, tags),
+    queryFn: () =>
+      listRulesFn({
+        data: {
+          campaignId,
+          search,
+          visibility,
+          tags,
+        },
+      }),
+    enabled: !!campaignId,
+  });
+
+  return {
+    rules: rules as RuleListItem[],
+    isLoading,
+    error: error instanceof Error ? error.message : error ? String(error) : null,
+  };
+}
+
+export function useRule(id: string, campaignId: string) {
+  const {
+    data: rule = null,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.rules.detail(id, campaignId),
+    queryFn: () => getRuleFn({ data: { id, campaignId } }),
+    enabled: !!id && !!campaignId,
+  });
+
+  return {
+    rule: rule as RuleData | null,
+    isLoading,
+    error: error instanceof Error ? error.message : error ? String(error) : null,
+  };
+}
+
+interface CreateRuleInput {
+  campaignId: string;
+  title: string;
+  content: string;
+  tags?: string[];
+  isPublic?: boolean;
+}
+
+export function useCreateRule() {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (input: CreateRuleInput) => createRuleFn({ data: input }),
+    onSuccess: (_data, { campaignId }) => {
+      queryClient.invalidateQueries({ queryKey: ['rules', 'list', campaignId], exact: false });
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags.list(campaignId) });
+    },
+    onError: (e) => {
+      captureException(e, { action: 'createRule' });
+    },
+  });
+
+  const create = async (input: CreateRuleInput) => {
+    try {
+      return await mutation.mutateAsync(input);
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    create,
+    isLoading: mutation.isPending,
+    error:
+      mutation.error instanceof Error
+        ? mutation.error.message
+        : mutation.error
+          ? String(mutation.error)
+          : null,
+  };
+}
+
+interface UpdateRuleInput {
+  id: string;
+  campaignId: string;
+  title: string;
+  content: string;
+  tags?: string[];
+  isPublic?: boolean;
+}
+
+export function useUpdateRule() {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (input: UpdateRuleInput) => updateRuleFn({ data: input }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['rules', 'list', variables.campaignId],
+        exact: false,
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.rules.detail(variables.id, variables.campaignId),
+      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags.list(variables.campaignId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+    },
+    onError: (e, variables) => {
+      captureException(e, { action: 'updateRule', ruleId: variables.id });
+    },
+  });
+
+  const update = async (input: UpdateRuleInput) => {
+    try {
+      return await mutation.mutateAsync(input);
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    update,
+    isLoading: mutation.isPending,
+    error:
+      mutation.error instanceof Error
+        ? mutation.error.message
+        : mutation.error
+          ? String(mutation.error)
+          : null,
+  };
+}
+
+interface DeleteRuleInput {
+  id: string;
+  campaignId: string;
+}
+
+export function useDeleteRule() {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (input: DeleteRuleInput) => deleteRuleFn({ data: input }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['rules', 'list', variables.campaignId],
+        exact: false,
+      });
+      queryClient.removeQueries({
+        queryKey: queryKeys.rules.detail(variables.id, variables.campaignId),
+      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+    },
+    onError: (e, variables) => {
+      captureException(e, { action: 'deleteRule', ruleId: variables.id });
+    },
+  });
+
+  const remove = async (input: DeleteRuleInput) => {
+    try {
+      return await mutation.mutateAsync(input);
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    remove,
+    isLoading: mutation.isPending,
+    error:
+      mutation.error instanceof Error
+        ? mutation.error.message
+        : mutation.error
+          ? String(mutation.error)
+          : null,
+  };
+}

--- a/app/hooks/useRules.ts
+++ b/app/hooks/useRules.ts
@@ -171,6 +171,7 @@ export function useUpdateRule() {
         queryKey: queryKeys.rules.detail(variables.id, variables.campaignId),
       });
       queryClient.invalidateQueries({ queryKey: queryKeys.tags.list(variables.campaignId) });
+      // Refresh GM screen windows that may display this rule's content
       queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
     },
     onError: (e, variables) => {
@@ -215,6 +216,7 @@ export function useDeleteRule() {
       queryClient.removeQueries({
         queryKey: queryKeys.rules.detail(variables.id, variables.campaignId),
       });
+      // Refresh GM screen windows — server removes refs for deleted rules
       queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
     },
     onError: (e, variables) => {

--- a/app/routes/campaigns/$campaignId/play.tsx
+++ b/app/routes/campaigns/$campaignId/play.tsx
@@ -1,46 +1,47 @@
-import { z } from 'zod'
-import { createFileRoute, redirect } from '@tanstack/react-router'
-import { getMe } from '~/server/functions/auth'
-import { useCampaign } from '~/hooks/useCampaigns'
-import { CampaignHeader } from '~/components/mainview/CampaignHeader'
-import { DashboardView } from '~/components/mainview/DashboardView'
-import { MainView } from '~/components/mainview/MainView'
-import { TabletopView } from '~/components/mainview/TabletopView'
-import { GMScreensView } from '~/components/mainview/gmscreens'
-import type { TabId } from '~/components/mainview/TabNavigation'
-import { CatchUpWidget } from '~/components/mainview/widgets/CatchUpWidget'
-import { CampaignTimelineWidget } from '~/components/mainview/widgets/CampaignTimelineWidget'
-import { KeyAlliesWidget } from '~/components/mainview/widgets/KeyAlliesWidget'
-import { PartyMembersWidget } from '~/components/mainview/widgets/PartyMembersWidget'
-import { SessionsListWidget } from '~/components/mainview/widgets/SessionsListWidget'
+import { z } from 'zod';
+import { createFileRoute, redirect } from '@tanstack/react-router';
+import { getMe } from '~/server/functions/auth';
+import { useCampaign } from '~/hooks/useCampaigns';
+import { CampaignHeader } from '~/components/mainview/CampaignHeader';
+import { DashboardView } from '~/components/mainview/DashboardView';
+import { MainView } from '~/components/mainview/MainView';
+import { TabletopView } from '~/components/mainview/TabletopView';
+import { GMScreensView } from '~/components/mainview/gmscreens';
+import type { TabId } from '~/components/mainview/TabNavigation';
+import { CatchUpWidget } from '~/components/mainview/widgets/CatchUpWidget';
+import { CampaignTimelineWidget } from '~/components/mainview/widgets/CampaignTimelineWidget';
+import { KeyAlliesWidget } from '~/components/mainview/widgets/KeyAlliesWidget';
+import { PartyMembersWidget } from '~/components/mainview/widgets/PartyMembersWidget';
+import { SessionsListWidget } from '~/components/mainview/widgets/SessionsListWidget';
 
 export const playSearchSchema = z.object({
   tab: z.enum(['dashboard', 'tabletop', 'gmscreens']).catch('dashboard'),
-})
+});
 
 export const Route = createFileRoute('/campaigns/$campaignId/play')({
   validateSearch: (search: Record<string, unknown>) => playSearchSchema.parse(search),
   beforeLoad: async () => {
-    const user = await getMe()
-    if (!user) throw redirect({ to: '/', search: { reason: 'session_expired' } })
-    return { user }
+    const user = await getMe();
+    if (!user) throw redirect({ to: '/', search: { reason: 'session_expired' } });
+    return { user };
   },
   component: PlayPage,
-})
+});
 
 function PlayPage() {
-  const { tab: activeTab } = Route.useSearch()
-  const { campaignId } = Route.useParams()
-  const navigate = Route.useNavigate()
-  const { campaign } = useCampaign(campaignId)
+  const { tab: activeTab } = Route.useSearch();
+  const { campaignId } = Route.useParams();
+  const navigate = Route.useNavigate();
+  const { campaign } = useCampaign(campaignId);
 
-  const activeSession = campaign?.sessions.find(s => s.status === 'active')
+  const activeSession = campaign?.sessions.find((s) => s.status === 'active');
 
   // Coerce non-GMs away from the GM-only tab
-  const effectiveTab = (activeTab === 'gmscreens' && !campaign?.isGM) ? 'dashboard' as const : activeTab
+  const effectiveTab =
+    activeTab === 'gmscreens' && !campaign?.isGM ? ('dashboard' as const) : activeTab;
 
   function handleTabChange(tab: TabId) {
-    navigate({ search: (prev: Record<string, unknown>) => ({ ...prev, tab }) })
+    navigate({ search: (prev: Record<string, unknown>) => ({ ...prev, tab }) });
   }
 
   return (
@@ -87,11 +88,11 @@ function PlayPage() {
               aria-labelledby="tab-gmscreens"
               hidden={effectiveTab !== 'gmscreens'}
             >
-              <GMScreensView campaignId={campaignId} />
+              <GMScreensView campaignId={campaignId} isGM={campaign?.isGM} />
             </div>
           )}
         </MainView>
       </div>
     </div>
-  )
+  );
 }

--- a/app/server/db/models/Rule.ts
+++ b/app/server/db/models/Rule.ts
@@ -24,12 +24,15 @@ ruleSchema.pre('findOneAndUpdate', function () {
   if (!update) return;
 
   if (Array.isArray(update)) {
+    // Aggregation pipeline: only patch existing $set stages, never mutate others
     let hasSetStage = false;
     update.forEach((stage) => {
       if (!stage || typeof stage !== 'object') return;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Mongoose pipeline stage
       const stageObj = stage as Record<string, any>;
       if (!('$set' in stageObj)) return;
       hasSetStage = true;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Mongoose $set object
       const set = stageObj.$set as Record<string, any>;
       if (Array.isArray(set.tags)) {
         set.tags = normalizeTags(set.tags as string[]);
@@ -43,6 +46,7 @@ ruleSchema.pre('findOneAndUpdate', function () {
     return;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Mongoose update object
   const updateObj = update as Record<string, any>;
   if ('$set' in updateObj) {
     const set = (updateObj.$set ??= {});
@@ -58,6 +62,7 @@ ruleSchema.pre('findOneAndUpdate', function () {
   }
 });
 
+// istanbul ignore next
 if (typeof (ruleSchema as { index?: unknown }).index === 'function') {
   ruleSchema.index({ campaignId: 1 });
   ruleSchema.index({ campaignId: 1, updatedAt: -1 });

--- a/app/server/db/models/Rule.ts
+++ b/app/server/db/models/Rule.ts
@@ -1,0 +1,70 @@
+import mongoose from 'mongoose';
+import { normalizeTags } from '~/server/utils/helpers';
+
+const ruleSchema = new mongoose.Schema({
+  title: { type: String, required: true },
+  content: { type: String, required: true },
+  tags: { type: [String], default: [] },
+  isPublic: { type: Boolean, default: false },
+  createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+  campaignId: { type: mongoose.Schema.Types.ObjectId, ref: 'Campaign', required: true },
+});
+
+ruleSchema.pre('save', function () {
+  if (this.isModified('tags')) {
+    this.tags = normalizeTags(this.tags);
+  }
+  this.updatedAt = new Date();
+});
+
+ruleSchema.pre('findOneAndUpdate', function () {
+  const update = this.getUpdate() as unknown;
+  if (!update) return;
+
+  if (Array.isArray(update)) {
+    let hasSetStage = false;
+    update.forEach((stage) => {
+      if (!stage || typeof stage !== 'object') return;
+      const stageObj = stage as Record<string, any>;
+      if (!('$set' in stageObj)) return;
+      hasSetStage = true;
+      const set = stageObj.$set as Record<string, any>;
+      if (Array.isArray(set.tags)) {
+        set.tags = normalizeTags(set.tags as string[]);
+      }
+      set.updatedAt = new Date();
+    });
+    if (!hasSetStage) {
+      update.push({ $set: { updatedAt: new Date() } });
+    }
+    this.setUpdate(update);
+    return;
+  }
+
+  const updateObj = update as Record<string, any>;
+  if ('$set' in updateObj) {
+    const set = (updateObj.$set ??= {});
+    if (Array.isArray(set.tags)) {
+      set.tags = normalizeTags(set.tags as string[]);
+    }
+    set.updatedAt = new Date();
+  } else {
+    if (Array.isArray(updateObj.tags)) {
+      updateObj.tags = normalizeTags(updateObj.tags as string[]);
+    }
+    updateObj.updatedAt = new Date();
+  }
+});
+
+if (typeof (ruleSchema as { index?: unknown }).index === 'function') {
+  ruleSchema.index({ campaignId: 1 });
+  ruleSchema.index({ campaignId: 1, updatedAt: -1 });
+  ruleSchema.index({ createdBy: 1 });
+  ruleSchema.index({ tags: 1 });
+  ruleSchema.index({ isPublic: 1 });
+  ruleSchema.index({ title: 'text', content: 'text' });
+}
+
+export const Rule = mongoose.models.Rule || mongoose.model('Rule', ruleSchema);

--- a/app/server/functions/gmscreens.ts
+++ b/app/server/functions/gmscreens.ts
@@ -7,6 +7,7 @@ import { Campaign } from '../db/models/Campaign';
 import { GMScreen, GMSCREEN_LIMITS } from '../db/models/GMScreen';
 import { Note } from '../db/models/Note';
 import { Character } from '../db/models/Character';
+import { Rule } from '../db/models/Rule';
 import { serverCaptureException, serverCaptureEvent } from '../utils/posthog';
 import type {
   GMScreenData,
@@ -148,6 +149,19 @@ const COLLECTION_REGISTRY: Record<string, CollectionFetcher> = {
               content: ch.notes,
             };
           })
+        ) as Promise<Array<{ _id: unknown; title?: string; content?: string }>>;
+    },
+  },
+  rule: {
+    async fetch(ids: string[], campaignId: string) {
+      return Rule.find({ _id: { $in: ids }, campaignId }, '_id title content')
+        .lean()
+        .then((docs) =>
+          docs.map((d) => ({
+            _id: d._id,
+            title: (d as { title?: string }).title,
+            content: (d as { content?: string }).content,
+          }))
         ) as Promise<Array<{ _id: unknown; title?: string; content?: string }>>;
     },
   },

--- a/app/server/functions/rules.ts
+++ b/app/server/functions/rules.ts
@@ -63,6 +63,10 @@ function serializeRuleListItem(r: {
   };
 }
 
+/**
+ * Verify the authenticated user is a member of the given campaign.
+ * Returns the DB user ID string, session user ID, and whether the user is the GM.
+ */
 async function requireCampaignMember(
   campaignId: string
 ): Promise<{ userId: string; sessionUserId: string; isGM: boolean }> {
@@ -90,6 +94,10 @@ async function requireCampaignMember(
   return { userId, sessionUserId: user.id, isGM };
 }
 
+/**
+ * Verify the authenticated user is a GM for the given campaign.
+ * Any GM can create, edit, or delete rules — no per-creator ownership.
+ */
 async function requireCampaignGM(
   campaignId: string
 ): Promise<{ userId: string; sessionUserId: string }> {
@@ -228,6 +236,9 @@ export const deleteRule = createServerFn({ method: 'POST' })
 
       await existing.deleteOne();
 
+      // Clean up GM Screen references to this rule.
+      // Best-effort: the rule is already deleted, so cleanup failure must not
+      // surface as a user-facing error — report it and move on.
       try {
         await removeDocumentRefsFromScreens(data.campaignId, 'rule', data.id);
       } catch (cleanupError) {

--- a/app/server/functions/rules.ts
+++ b/app/server/functions/rules.ts
@@ -1,0 +1,341 @@
+import { createServerFn } from '@tanstack/react-start';
+import { getSession } from '../session';
+import { connectDB, isDBConnected } from '../db/connection';
+import { User } from '../db/models/User';
+import { Campaign } from '../db/models/Campaign';
+import { Rule } from '../db/models/Rule';
+import { serverCaptureException, serverCaptureEvent } from '../utils/posthog';
+import { normalizeTags } from '../utils/helpers';
+import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
+import { ensureTags as ensureTagsFn } from './tags';
+import type { RuleData, RuleListItem } from '~/types/rule';
+import {
+  createRuleSchema,
+  updateRuleSchema,
+  deleteRuleSchema,
+  listRulesSchema,
+  getRuleSchema,
+} from '~/types/schemas/rules';
+
+function serializeRule(r: {
+  _id: unknown;
+  campaignId: unknown;
+  createdBy: unknown;
+  title?: string;
+  content?: string;
+  tags?: string[];
+  isPublic?: boolean;
+  createdAt?: Date;
+  updatedAt?: Date;
+}): RuleData {
+  return {
+    id: String(r._id),
+    campaignId: String(r.campaignId),
+    createdBy: String(r.createdBy),
+    title: r.title ?? '',
+    content: r.content ?? '',
+    tags: r.tags ?? [],
+    isPublic: r.isPublic ?? false,
+    createdAt: r.createdAt instanceof Date ? r.createdAt.toISOString() : '',
+    updatedAt: r.updatedAt instanceof Date ? r.updatedAt.toISOString() : '',
+  };
+}
+
+function serializeRuleListItem(r: {
+  _id: unknown;
+  campaignId: unknown;
+  createdBy: unknown;
+  title?: string;
+  tags?: string[];
+  isPublic?: boolean;
+  createdAt?: Date;
+  updatedAt?: Date;
+}): RuleListItem {
+  return {
+    id: String(r._id),
+    campaignId: String(r.campaignId),
+    createdBy: String(r.createdBy),
+    title: r.title ?? '',
+    tags: r.tags ?? [],
+    isPublic: r.isPublic ?? false,
+    createdAt: r.createdAt instanceof Date ? r.createdAt.toISOString() : '',
+    updatedAt: r.updatedAt instanceof Date ? r.updatedAt.toISOString() : '',
+  };
+}
+
+async function requireCampaignMember(
+  campaignId: string
+): Promise<{ userId: string; sessionUserId: string; isGM: boolean }> {
+  const user = await getSession();
+  if (!user) throw new Error('Not authenticated');
+
+  await connectDB();
+  if (!isDBConnected()) throw new Error('Database not available');
+
+  const dbUser = await User.findOne({ providerId: user.id });
+  if (!dbUser) throw new Error('User not found');
+
+  const campaign = await Campaign.findById(campaignId);
+  if (!campaign) throw new Error('Campaign not found');
+
+  const userId = String(dbUser._id);
+  const members = campaign.members ?? [];
+  const member = members.find(
+    (m: { userId: unknown; role?: string }) => String(m.userId) === userId
+  );
+  const isGM = String(campaign.gameMasterId) === userId || member?.role === 'gm';
+  const isMember = !!member || isGM;
+  if (!isMember) throw new Error('Forbidden');
+
+  return { userId, sessionUserId: user.id, isGM };
+}
+
+async function requireCampaignGM(
+  campaignId: string
+): Promise<{ userId: string; sessionUserId: string }> {
+  const user = await getSession();
+  if (!user) throw new Error('Not authenticated');
+
+  await connectDB();
+  if (!isDBConnected()) throw new Error('Database not available');
+
+  const dbUser = await User.findOne({ providerId: user.id });
+  if (!dbUser) throw new Error('User not found');
+
+  const campaign = await Campaign.findById(campaignId);
+  if (!campaign) throw new Error('Campaign not found');
+
+  const userId = String(dbUser._id);
+  const members = campaign.members ?? [];
+  const isGM =
+    String(campaign.gameMasterId) === userId ||
+    members.some(
+      (m: { userId: unknown; role?: string }) => String(m.userId) === userId && m.role === 'gm'
+    );
+  if (!isGM) throw new Error('Forbidden');
+
+  return { userId, sessionUserId: user.id };
+}
+
+// ---------------------------------------------------------------------------
+// createRule
+// ---------------------------------------------------------------------------
+
+export { createRuleSchema };
+
+export const createRule = createServerFn({ method: 'POST' })
+  .inputValidator(createRuleSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const gm = await requireCampaignGM(data.campaignId);
+      sessionUserId = gm.sessionUserId;
+      const userId = gm.userId;
+
+      const now = new Date();
+      const finalTags = normalizeTags(data.tags ?? []);
+      const ruleData: Record<string, unknown> = {
+        campaignId: data.campaignId,
+        createdBy: userId,
+        title: data.title.trim(),
+        content: data.content.trim(),
+        tags: finalTags,
+        isPublic: data.isPublic ?? false,
+        createdAt: now,
+        updatedAt: now,
+      };
+      const doc = await Rule.create(ruleData);
+
+      await ensureTagsFn({ data: { campaignId: data.campaignId, tags: finalTags } });
+
+      serverCaptureEvent(sessionUserId, 'rule_created', {
+        campaign_id: data.campaignId,
+        rule_id: String(doc._id),
+      });
+
+      return { success: true, rule: serializeRule(doc) };
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, {
+        action: 'createRule',
+        campaignId: data.campaignId,
+      });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// updateRule
+// ---------------------------------------------------------------------------
+
+export { updateRuleSchema };
+
+export const updateRule = createServerFn({ method: 'POST' })
+  .inputValidator(updateRuleSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const gm = await requireCampaignGM(data.campaignId);
+      sessionUserId = gm.sessionUserId;
+      const userId = gm.userId;
+
+      const existing = await Rule.findById(data.id);
+      if (!existing) throw new Error('Rule not found');
+      if (String(existing.campaignId) !== data.campaignId) throw new Error('Forbidden');
+
+      const finalTags = normalizeTags(data.tags ?? []);
+      existing.title = data.title.trim();
+      existing.content = data.content.trim();
+      existing.tags = finalTags;
+      if (data.isPublic !== undefined) {
+        existing.isPublic = data.isPublic;
+      }
+      existing.updatedAt = new Date();
+      await existing.save();
+
+      await ensureTagsFn({ data: { campaignId: data.campaignId, tags: finalTags } });
+
+      serverCaptureEvent(sessionUserId, 'rule_updated', {
+        campaign_id: data.campaignId,
+        rule_id: data.id,
+        updated_by: userId,
+      });
+
+      return { success: true, rule: serializeRule(existing) };
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, { action: 'updateRule', ruleId: data.id });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// deleteRule
+// ---------------------------------------------------------------------------
+
+export { deleteRuleSchema };
+
+export const deleteRule = createServerFn({ method: 'POST' })
+  .inputValidator(deleteRuleSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const gm = await requireCampaignGM(data.campaignId);
+      sessionUserId = gm.sessionUserId;
+      const userId = gm.userId;
+
+      const existing = await Rule.findById(data.id);
+      if (!existing) throw new Error('Rule not found');
+      if (String(existing.campaignId) !== data.campaignId) throw new Error('Forbidden');
+
+      await existing.deleteOne();
+
+      try {
+        await removeDocumentRefsFromScreens(data.campaignId, 'rule', data.id);
+      } catch (cleanupError) {
+        serverCaptureException(cleanupError, sessionUserId, {
+          action: 'deleteRule.cleanup',
+          campaignId: data.campaignId,
+          ruleId: data.id,
+        });
+      }
+
+      serverCaptureEvent(sessionUserId, 'rule_deleted', {
+        campaign_id: data.campaignId,
+        rule_id: data.id,
+        deleted_by: userId,
+      });
+
+      return { success: true };
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, { action: 'deleteRule', ruleId: data.id });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// listRules
+// ---------------------------------------------------------------------------
+
+export { listRulesSchema };
+
+export const listRules = createServerFn({ method: 'GET' })
+  .inputValidator(listRulesSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      sessionUserId = member.sessionUserId;
+
+      const filter: Record<string, unknown> = { campaignId: data.campaignId };
+
+      if (member.isGM) {
+        if (data.visibility === 'public') {
+          filter.isPublic = true;
+        } else if (data.visibility === 'private') {
+          filter.isPublic = false;
+        }
+      } else {
+        filter.isPublic = true;
+      }
+
+      if (data.search && data.search.trim()) {
+        filter.$text = { $search: data.search.trim() };
+      }
+
+      if (data.tags && data.tags.length > 0) {
+        const normalizedTags = [...new Set(normalizeTags(data.tags))];
+        if (normalizedTags.length > 0) {
+          filter.tags = { $all: normalizedTags };
+        }
+      }
+
+      const docs = await Rule.find(filter).select('-content').sort({ updatedAt: -1 }).lean();
+
+      return (
+        docs as Array<{
+          _id: unknown;
+          campaignId: unknown;
+          createdBy: unknown;
+          title?: string;
+          tags?: string[];
+          isPublic?: boolean;
+          createdAt?: Date;
+          updatedAt?: Date;
+        }>
+      ).map(serializeRuleListItem);
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, {
+        action: 'listRules',
+        campaignId: data.campaignId,
+      });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// getRule
+// ---------------------------------------------------------------------------
+
+export { getRuleSchema };
+
+export const getRule = createServerFn({ method: 'GET' })
+  .inputValidator(getRuleSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      sessionUserId = member.sessionUserId;
+
+      const doc = await Rule.findById(data.id);
+      if (!doc) return null;
+      if (String(doc.campaignId) !== data.campaignId) return null;
+
+      if (!doc.isPublic && !member.isGM) {
+        return null;
+      }
+
+      return serializeRule(doc);
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, { action: 'getRule', ruleId: data.id });
+      throw e;
+    }
+  });

--- a/app/types/rule.ts
+++ b/app/types/rule.ts
@@ -1,0 +1,22 @@
+export interface RuleData {
+  id: string;
+  campaignId: string;
+  createdBy: string;
+  title: string;
+  content: string;
+  tags: string[];
+  isPublic: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RuleListItem {
+  id: string;
+  campaignId: string;
+  createdBy: string;
+  title: string;
+  tags: string[];
+  isPublic: boolean;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/app/types/schemas/gmscreens.ts
+++ b/app/types/schemas/gmscreens.ts
@@ -1,11 +1,11 @@
-import { z } from 'zod'
-import { WINDOW_STATES } from '~/types/gmscreen'
+import { z } from 'zod';
+import { WINDOW_STATES } from '~/types/gmscreen';
 
 /**
  * Collection names that can be opened as windows or referenced in stacks.
  * Must stay in sync with COLLECTION_REGISTRY in the server implementation.
  */
-export const SUPPORTED_COLLECTIONS: [string, ...string[]] = ['note', 'character']
+export const SUPPORTED_COLLECTIONS: [string, ...string[]] = ['note', 'character', 'rule'];
 
 // ---------------------------------------------------------------------------
 // Screen CRUD
@@ -13,33 +13,33 @@ export const SUPPORTED_COLLECTIONS: [string, ...string[]] = ['note', 'character'
 
 export const listGMScreensSchema = z.object({
   campaignId: z.string().trim().min(1),
-})
+});
 
 export const createGMScreenSchema = z.object({
   campaignId: z.string().trim().min(1),
   name: z.string().trim().min(1, 'Screen name is required'),
-})
+});
 
 export const renameGMScreenSchema = z.object({
   id: z.string().trim().min(1),
   campaignId: z.string().trim().min(1),
   name: z.string().trim().min(1, 'Screen name is required'),
-})
+});
 
 export const deleteGMScreenSchema = z.object({
   id: z.string().trim().min(1),
   campaignId: z.string().trim().min(1),
-})
+});
 
 export const reorderGMScreensSchema = z.object({
   campaignId: z.string().trim().min(1),
   screenIds: z.array(z.string().trim().min(1)).min(1, 'At least one screen ID is required'),
-})
+});
 
 export const getGMScreenSchema = z.object({
   id: z.string().trim().min(1),
   campaignId: z.string().trim().min(1),
-})
+});
 
 // ---------------------------------------------------------------------------
 // Windows
@@ -56,28 +56,36 @@ export const openWindowSchema = z.object({
   documentId: z.string().trim().min(1),
   x: z.number().nullable().optional(),
   y: z.number().nullable().optional(),
-})
+});
 
-export const updateWindowSchema = z.object({
-  screenId: z.string().trim().min(1),
-  campaignId: z.string().trim().min(1),
-  windowId: z.string().trim().min(1),
-  x: z.number().nullable().optional(),
-  y: z.number().nullable().optional(),
-  width: z.number().nullable().optional(),
-  height: z.number().nullable().optional(),
-  zIndex: z.number().optional(),
-  state: z.enum(WINDOW_STATES).optional(),
-}).refine(
-  (d) => d.x !== undefined || d.y !== undefined || d.width !== undefined || d.height !== undefined || d.zIndex !== undefined || d.state !== undefined,
-  { message: 'At least one updatable field (x, y, width, height, zIndex, state) is required' },
-)
+export const updateWindowSchema = z
+  .object({
+    screenId: z.string().trim().min(1),
+    campaignId: z.string().trim().min(1),
+    windowId: z.string().trim().min(1),
+    x: z.number().nullable().optional(),
+    y: z.number().nullable().optional(),
+    width: z.number().nullable().optional(),
+    height: z.number().nullable().optional(),
+    zIndex: z.number().optional(),
+    state: z.enum(WINDOW_STATES).optional(),
+  })
+  .refine(
+    (d) =>
+      d.x !== undefined ||
+      d.y !== undefined ||
+      d.width !== undefined ||
+      d.height !== undefined ||
+      d.zIndex !== undefined ||
+      d.state !== undefined,
+    { message: 'At least one updatable field (x, y, width, height, zIndex, state) is required' }
+  );
 
 export const closeWindowSchema = z.object({
   screenId: z.string().trim().min(1),
   campaignId: z.string().trim().min(1),
   windowId: z.string().trim().min(1),
-})
+});
 
 // ---------------------------------------------------------------------------
 // Stacks
@@ -87,14 +95,14 @@ export const createStackSchema = z.object({
   screenId: z.string().trim().min(1),
   campaignId: z.string().trim().min(1),
   name: z.string().trim().min(1, 'Stack name is required'),
-})
+});
 
 export const renameStackSchema = z.object({
   screenId: z.string().trim().min(1),
   campaignId: z.string().trim().min(1),
   stackId: z.string().trim().min(1),
   name: z.string().trim().min(1, 'Stack name is required'),
-})
+});
 
 export const moveStackSchema = z.object({
   screenId: z.string().trim().min(1),
@@ -102,13 +110,13 @@ export const moveStackSchema = z.object({
   stackId: z.string().trim().min(1),
   x: z.number().nullable(),
   y: z.number().nullable(),
-})
+});
 
 export const deleteStackSchema = z.object({
   screenId: z.string().trim().min(1),
   campaignId: z.string().trim().min(1),
   stackId: z.string().trim().min(1),
-})
+});
 
 export const addStackItemSchema = z.object({
   screenId: z.string().trim().min(1),
@@ -121,11 +129,11 @@ export const addStackItemSchema = z.object({
   }),
   documentId: z.string().trim().min(1),
   label: z.string().trim().default(''),
-})
+});
 
 export const removeStackItemSchema = z.object({
   screenId: z.string().trim().min(1),
   campaignId: z.string().trim().min(1),
   stackId: z.string().trim().min(1),
   itemId: z.string().trim().min(1),
-})
+});

--- a/app/types/schemas/rules.ts
+++ b/app/types/schemas/rules.ts
@@ -23,7 +23,7 @@ export const deleteRuleSchema = z.object({
 });
 
 export const listRulesSchema = z.object({
-  campaignId: z.string().min(1),
+  campaignId: z.string().trim().min(1),
   search: z.string().optional(),
   visibility: z.enum(['all', 'public', 'private']).optional().default('all'),
   tags: z.array(z.string()).optional(),

--- a/app/types/schemas/rules.ts
+++ b/app/types/schemas/rules.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+export const createRuleSchema = z.object({
+  campaignId: z.string().trim().min(1),
+  title: z.string().trim().min(1, 'Title is required'),
+  content: z.string().trim().min(1, 'Rule content is required'),
+  tags: z.array(z.string()).optional().default([]),
+  isPublic: z.boolean().optional().default(false),
+});
+
+export const updateRuleSchema = z.object({
+  id: z.string().trim().min(1),
+  campaignId: z.string().trim().min(1),
+  title: z.string().trim().min(1, 'Title is required'),
+  content: z.string().trim().min(1, 'Rule content is required'),
+  tags: z.array(z.string()).optional().default([]),
+  isPublic: z.boolean().optional(),
+});
+
+export const deleteRuleSchema = z.object({
+  id: z.string().trim().min(1),
+  campaignId: z.string().trim().min(1),
+});
+
+export const listRulesSchema = z.object({
+  campaignId: z.string().min(1),
+  search: z.string().optional(),
+  visibility: z.enum(['all', 'public', 'private']).optional().default('all'),
+  tags: z.array(z.string()).optional(),
+});
+
+export const getRuleSchema = z.object({
+  id: z.string().trim().min(1),
+  campaignId: z.string().trim().min(1),
+});

--- a/app/utils/queryKeys.ts
+++ b/app/utils/queryKeys.ts
@@ -59,6 +59,12 @@ export const queryKeys = {
     detail: (id: string, campaignId?: string) =>
       ['characters', 'detail', campaignId ?? '', id] as const,
   },
+  rules: {
+    all: ['rules'] as const,
+    list: (campaignId: string, search?: string, visibility?: string, tags?: string[]) =>
+      ['rules', 'list', campaignId, search ?? '', visibility ?? 'all', tags ?? []] as const,
+    detail: (id: string, campaignId?: string) => ['rules', 'detail', campaignId ?? '', id] as const,
+  },
   tags: {
     all: ['tags'] as const,
     list: (campaignId: string) => ['tags', 'list', campaignId] as const,

--- a/docs/superpowers/plans/2026-04-05-wiki-rules.md
+++ b/docs/superpowers/plans/2026-04-05-wiki-rules.md
@@ -1,0 +1,1988 @@
+# Wiki Rules Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Rules feature to the Wiki system — GM-only CRUD, public/private visibility, drag-to-GM-screen with scrollable rendered markdown.
+
+**Architecture:** Mirrors the existing Notes feature. Dedicated Mongoose model, TanStack Start server functions, React Query hooks, and Wiki panel integration. Rules use GM-only permissions (any GM can create/edit/delete any rule) with no session association.
+
+**Tech Stack:** MongoDB/Mongoose, TanStack Start (createServerFn), React 19, TanStack Query, Zod, Tailwind CSS, ReactMarkdown, lucide-react
+
+**Spec:** `docs/superpowers/specs/2026-04-05-wiki-rules-design.md`
+
+---
+
+## File Structure
+
+### New Files
+
+- `app/types/rule.ts` — TypeScript interfaces (RuleData, RuleListItem)
+- `app/types/schemas/rules.ts` — Zod validation schemas
+- `app/server/db/models/Rule.ts` — Mongoose model
+- `app/server/functions/rules.ts` — Server functions (CRUD + list)
+- `app/hooks/useRules.ts` — React Query hooks
+- `app/components/wiki/rules/RulesPanel.tsx` — Wiki list panel with filtering
+- `app/components/wiki/rules/RuleCard.tsx` — Draggable list item card
+- `app/components/wiki/rules/RuleModal.tsx` — Editor modal (GM-only)
+- `app/components/wiki/rules/RuleViewModal.tsx` — Read-only view modal (players)
+- `app/components/wiki/rules/RuleWindow.tsx` — GM screen rendered content
+- `app/components/mainview/gmscreens/RuleWindowWrapper.tsx` — GM screen wrapper with edit button
+
+### Modified Files
+
+- `app/utils/queryKeys.ts` — Add rules query keys
+- `app/components/wiki/shared/WikiFilterBar.tsx` — Add `showSessionFilter` prop
+- `app/components/wiki/WikiPanel.tsx` — Add "Rules" category
+- `app/server/functions/gmscreens.ts` — Add `rule` to `COLLECTION_REGISTRY`, import Rule model
+- `app/components/mainview/gmscreens/GMScreensView.tsx` — Handle `rule` collection windows with edit support
+
+---
+
+### Task 1: Types & Validation Schemas
+
+**Files:**
+
+- Create: `app/types/rule.ts`
+- Create: `app/types/schemas/rules.ts`
+
+- [ ] **Step 1: Create TypeScript interfaces**
+
+Create `app/types/rule.ts`:
+
+```typescript
+export interface RuleData {
+  id: string;
+  campaignId: string;
+  createdBy: string;
+  title: string;
+  content: string;
+  tags: string[];
+  isPublic: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RuleListItem {
+  id: string;
+  campaignId: string;
+  createdBy: string;
+  title: string;
+  tags: string[];
+  isPublic: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+- [ ] **Step 2: Create Zod validation schemas**
+
+Create `app/types/schemas/rules.ts`:
+
+```typescript
+import { z } from 'zod';
+
+export const createRuleSchema = z.object({
+  campaignId: z.string().trim().min(1),
+  title: z.string().trim().min(1, 'Title is required'),
+  content: z.string().trim().min(1, 'Rule content is required'),
+  tags: z.array(z.string()).optional().default([]),
+  isPublic: z.boolean().optional().default(false),
+});
+
+export const updateRuleSchema = z.object({
+  id: z.string().trim().min(1),
+  campaignId: z.string().trim().min(1),
+  title: z.string().trim().min(1, 'Title is required'),
+  content: z.string().trim().min(1, 'Rule content is required'),
+  tags: z.array(z.string()).optional().default([]),
+  isPublic: z.boolean().optional(),
+});
+
+export const deleteRuleSchema = z.object({
+  id: z.string().trim().min(1),
+  campaignId: z.string().trim().min(1),
+});
+
+export const listRulesSchema = z.object({
+  campaignId: z.string().min(1),
+  search: z.string().optional(),
+  visibility: z.enum(['all', 'public', 'private']).optional().default('all'),
+  tags: z.array(z.string()).optional(),
+});
+
+export const getRuleSchema = z.object({
+  id: z.string().trim().min(1),
+  campaignId: z.string().trim().min(1),
+});
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/types/rule.ts app/types/schemas/rules.ts
+git commit -m "feat(rules): add TypeScript types and Zod validation schemas"
+```
+
+---
+
+### Task 2: Mongoose Model
+
+**Files:**
+
+- Create: `app/server/db/models/Rule.ts`
+
+- [ ] **Step 1: Create Rule Mongoose model**
+
+Create `app/server/db/models/Rule.ts`:
+
+```typescript
+import mongoose from 'mongoose';
+import { normalizeTags } from '~/server/utils/helpers';
+
+const ruleSchema = new mongoose.Schema({
+  title: { type: String, required: true },
+  content: { type: String, required: true },
+  tags: { type: [String], default: [] },
+  isPublic: { type: Boolean, default: false },
+  createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+  campaignId: { type: mongoose.Schema.Types.ObjectId, ref: 'Campaign', required: true },
+});
+
+ruleSchema.pre('save', function () {
+  if (this.isModified('tags')) {
+    this.tags = normalizeTags(this.tags);
+  }
+  this.updatedAt = new Date();
+});
+
+ruleSchema.pre('findOneAndUpdate', function () {
+  const update = this.getUpdate() as unknown;
+  if (!update) return;
+
+  if (Array.isArray(update)) {
+    let hasSetStage = false;
+    update.forEach((stage) => {
+      if (!stage || typeof stage !== 'object') return;
+      const stageObj = stage as Record<string, any>;
+      if (!('$set' in stageObj)) return;
+      hasSetStage = true;
+      const set = stageObj.$set as Record<string, any>;
+      if (Array.isArray(set.tags)) {
+        set.tags = normalizeTags(set.tags as string[]);
+      }
+      set.updatedAt = new Date();
+    });
+    if (!hasSetStage) {
+      update.push({ $set: { updatedAt: new Date() } });
+    }
+    this.setUpdate(update);
+    return;
+  }
+
+  const updateObj = update as Record<string, any>;
+  if ('$set' in updateObj) {
+    const set = (updateObj.$set ??= {});
+    if (Array.isArray(set.tags)) {
+      set.tags = normalizeTags(set.tags as string[]);
+    }
+    set.updatedAt = new Date();
+  } else {
+    if (Array.isArray(updateObj.tags)) {
+      updateObj.tags = normalizeTags(updateObj.tags as string[]);
+    }
+    updateObj.updatedAt = new Date();
+  }
+});
+
+if (typeof (ruleSchema as { index?: unknown }).index === 'function') {
+  ruleSchema.index({ campaignId: 1 });
+  ruleSchema.index({ campaignId: 1, updatedAt: -1 });
+  ruleSchema.index({ createdBy: 1 });
+  ruleSchema.index({ tags: 1 });
+  ruleSchema.index({ isPublic: 1 });
+  ruleSchema.index({ title: 'text', content: 'text' });
+}
+
+export const Rule = mongoose.models.Rule || mongoose.model('Rule', ruleSchema);
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/server/db/models/Rule.ts
+git commit -m "feat(rules): add Rule Mongoose model"
+```
+
+---
+
+### Task 3: Server Functions
+
+**Files:**
+
+- Create: `app/server/functions/rules.ts`
+
+- [ ] **Step 1: Create server functions file**
+
+Create `app/server/functions/rules.ts`. This file contains two auth helpers (`requireCampaignMember` and `requireCampaignGM`) and five server functions.
+
+Key differences from Notes:
+
+- `createRule`, `updateRule`, `deleteRule` use `requireCampaignGM` (not `requireCampaignMember`)
+- `updateRule` and `deleteRule` do NOT check `createdBy` — any GM can edit/delete any rule
+- No `sessionId` anywhere
+- No `isReadOnly` check
+- `listRules` constrains non-GMs to public rules only (they can't see private rules at all)
+
+```typescript
+import { createServerFn } from '@tanstack/react-start';
+import { getSession } from '../session';
+import { connectDB, isDBConnected } from '../db/connection';
+import { User } from '../db/models/User';
+import { Campaign } from '../db/models/Campaign';
+import { Rule } from '../db/models/Rule';
+import { serverCaptureException, serverCaptureEvent } from '../utils/posthog';
+import { normalizeTags } from '../utils/helpers';
+import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
+import { ensureTags as ensureTagsFn } from './tags';
+import type { RuleData, RuleListItem } from '~/types/rule';
+import {
+  createRuleSchema,
+  updateRuleSchema,
+  deleteRuleSchema,
+  listRulesSchema,
+  getRuleSchema,
+} from '~/types/schemas/rules';
+
+function serializeRule(r: {
+  _id: unknown;
+  campaignId: unknown;
+  createdBy: unknown;
+  title?: string;
+  content?: string;
+  tags?: string[];
+  isPublic?: boolean;
+  createdAt?: Date;
+  updatedAt?: Date;
+}): RuleData {
+  return {
+    id: String(r._id),
+    campaignId: String(r.campaignId),
+    createdBy: String(r.createdBy),
+    title: r.title ?? '',
+    content: r.content ?? '',
+    tags: r.tags ?? [],
+    isPublic: r.isPublic ?? false,
+    createdAt: r.createdAt instanceof Date ? r.createdAt.toISOString() : '',
+    updatedAt: r.updatedAt instanceof Date ? r.updatedAt.toISOString() : '',
+  };
+}
+
+function serializeRuleListItem(r: {
+  _id: unknown;
+  campaignId: unknown;
+  createdBy: unknown;
+  title?: string;
+  tags?: string[];
+  isPublic?: boolean;
+  createdAt?: Date;
+  updatedAt?: Date;
+}): RuleListItem {
+  return {
+    id: String(r._id),
+    campaignId: String(r.campaignId),
+    createdBy: String(r.createdBy),
+    title: r.title ?? '',
+    tags: r.tags ?? [],
+    isPublic: r.isPublic ?? false,
+    createdAt: r.createdAt instanceof Date ? r.createdAt.toISOString() : '',
+    updatedAt: r.updatedAt instanceof Date ? r.updatedAt.toISOString() : '',
+  };
+}
+
+async function requireCampaignMember(
+  campaignId: string
+): Promise<{ userId: string; sessionUserId: string; isGM: boolean }> {
+  const user = await getSession();
+  if (!user) throw new Error('Not authenticated');
+
+  await connectDB();
+  if (!isDBConnected()) throw new Error('Database not available');
+
+  const dbUser = await User.findOne({ providerId: user.id });
+  if (!dbUser) throw new Error('User not found');
+
+  const campaign = await Campaign.findById(campaignId);
+  if (!campaign) throw new Error('Campaign not found');
+
+  const userId = String(dbUser._id);
+  const members = campaign.members ?? [];
+  const member = members.find(
+    (m: { userId: unknown; role?: string }) => String(m.userId) === userId
+  );
+  const isGM = String(campaign.gameMasterId) === userId || member?.role === 'gm';
+  const isMember = !!member || isGM;
+  if (!isMember) throw new Error('Forbidden');
+
+  return { userId, sessionUserId: user.id, isGM };
+}
+
+async function requireCampaignGM(
+  campaignId: string
+): Promise<{ userId: string; sessionUserId: string }> {
+  const user = await getSession();
+  if (!user) throw new Error('Not authenticated');
+
+  await connectDB();
+  if (!isDBConnected()) throw new Error('Database not available');
+
+  const dbUser = await User.findOne({ providerId: user.id });
+  if (!dbUser) throw new Error('User not found');
+
+  const campaign = await Campaign.findById(campaignId);
+  if (!campaign) throw new Error('Campaign not found');
+
+  const userId = String(dbUser._id);
+  const members = campaign.members ?? [];
+  const isGM =
+    String(campaign.gameMasterId) === userId ||
+    members.some(
+      (m: { userId: unknown; role?: string }) => String(m.userId) === userId && m.role === 'gm'
+    );
+  if (!isGM) throw new Error('Forbidden');
+
+  return { userId, sessionUserId: user.id };
+}
+
+// ---------------------------------------------------------------------------
+// createRule
+// ---------------------------------------------------------------------------
+
+export { createRuleSchema };
+
+export const createRule = createServerFn({ method: 'POST' })
+  .inputValidator(createRuleSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const gm = await requireCampaignGM(data.campaignId);
+      sessionUserId = gm.sessionUserId;
+      const userId = gm.userId;
+
+      const now = new Date();
+      const finalTags = normalizeTags(data.tags ?? []);
+      const ruleData: Record<string, unknown> = {
+        campaignId: data.campaignId,
+        createdBy: userId,
+        title: data.title.trim(),
+        content: data.content.trim(),
+        tags: finalTags,
+        isPublic: data.isPublic ?? false,
+        createdAt: now,
+        updatedAt: now,
+      };
+      const doc = await Rule.create(ruleData);
+
+      await ensureTagsFn({ data: { campaignId: data.campaignId, tags: finalTags } });
+
+      serverCaptureEvent(sessionUserId, 'rule_created', {
+        campaign_id: data.campaignId,
+        rule_id: String(doc._id),
+      });
+
+      return { success: true, rule: serializeRule(doc) };
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, {
+        action: 'createRule',
+        campaignId: data.campaignId,
+      });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// updateRule
+// ---------------------------------------------------------------------------
+
+export { updateRuleSchema };
+
+export const updateRule = createServerFn({ method: 'POST' })
+  .inputValidator(updateRuleSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const gm = await requireCampaignGM(data.campaignId);
+      sessionUserId = gm.sessionUserId;
+      const userId = gm.userId;
+
+      const existing = await Rule.findById(data.id);
+      if (!existing) throw new Error('Rule not found');
+      if (String(existing.campaignId) !== data.campaignId) throw new Error('Forbidden');
+
+      const finalTags = normalizeTags(data.tags ?? []);
+      existing.title = data.title.trim();
+      existing.content = data.content.trim();
+      existing.tags = finalTags;
+      if (data.isPublic !== undefined) {
+        existing.isPublic = data.isPublic;
+      }
+      existing.updatedAt = new Date();
+      await existing.save();
+
+      await ensureTagsFn({ data: { campaignId: data.campaignId, tags: finalTags } });
+
+      serverCaptureEvent(sessionUserId, 'rule_updated', {
+        campaign_id: data.campaignId,
+        rule_id: data.id,
+        updated_by: userId,
+      });
+
+      return { success: true, rule: serializeRule(existing) };
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, { action: 'updateRule', ruleId: data.id });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// deleteRule
+// ---------------------------------------------------------------------------
+
+export { deleteRuleSchema };
+
+export const deleteRule = createServerFn({ method: 'POST' })
+  .inputValidator(deleteRuleSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const gm = await requireCampaignGM(data.campaignId);
+      sessionUserId = gm.sessionUserId;
+      const userId = gm.userId;
+
+      const existing = await Rule.findById(data.id);
+      if (!existing) throw new Error('Rule not found');
+      if (String(existing.campaignId) !== data.campaignId) throw new Error('Forbidden');
+
+      await existing.deleteOne();
+
+      try {
+        await removeDocumentRefsFromScreens(data.campaignId, 'rule', data.id);
+      } catch (cleanupError) {
+        serverCaptureException(cleanupError, sessionUserId, {
+          action: 'deleteRule.cleanup',
+          campaignId: data.campaignId,
+          ruleId: data.id,
+        });
+      }
+
+      serverCaptureEvent(sessionUserId, 'rule_deleted', {
+        campaign_id: data.campaignId,
+        rule_id: data.id,
+        deleted_by: userId,
+      });
+
+      return { success: true };
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, { action: 'deleteRule', ruleId: data.id });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// listRules
+// ---------------------------------------------------------------------------
+
+export { listRulesSchema };
+
+export const listRules = createServerFn({ method: 'GET' })
+  .inputValidator(listRulesSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      sessionUserId = member.sessionUserId;
+
+      const filter: Record<string, unknown> = { campaignId: data.campaignId };
+
+      if (member.isGM) {
+        // GMs see all rules; apply visibility filter only when explicitly requested
+        if (data.visibility === 'public') {
+          filter.isPublic = true;
+        } else if (data.visibility === 'private') {
+          filter.isPublic = false;
+        }
+      } else {
+        // Non-GMs can only see public rules
+        filter.isPublic = true;
+      }
+
+      if (data.search && data.search.trim()) {
+        filter.$text = { $search: data.search.trim() };
+      }
+
+      if (data.tags && data.tags.length > 0) {
+        const normalizedTags = [...new Set(normalizeTags(data.tags))];
+        if (normalizedTags.length > 0) {
+          filter.tags = { $all: normalizedTags };
+        }
+      }
+
+      const docs = await Rule.find(filter).select('-content').sort({ updatedAt: -1 }).lean();
+
+      return (
+        docs as Array<{
+          _id: unknown;
+          campaignId: unknown;
+          createdBy: unknown;
+          title?: string;
+          tags?: string[];
+          isPublic?: boolean;
+          createdAt?: Date;
+          updatedAt?: Date;
+        }>
+      ).map(serializeRuleListItem);
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, {
+        action: 'listRules',
+        campaignId: data.campaignId,
+      });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// getRule
+// ---------------------------------------------------------------------------
+
+export { getRuleSchema };
+
+export const getRule = createServerFn({ method: 'GET' })
+  .inputValidator(getRuleSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      sessionUserId = member.sessionUserId;
+
+      const doc = await Rule.findById(data.id);
+      if (!doc) return null;
+      if (String(doc.campaignId) !== data.campaignId) return null;
+
+      // Non-GMs can only see public rules
+      if (!doc.isPublic && !member.isGM) {
+        return null;
+      }
+
+      return serializeRule(doc);
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, { action: 'getRule', ruleId: data.id });
+      throw e;
+    }
+  });
+```
+
+- [ ] **Step 2: Verify the app compiles**
+
+Run: `npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors related to the new files
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/server/functions/rules.ts
+git commit -m "feat(rules): add server functions for CRUD and listing"
+```
+
+---
+
+### Task 4: Query Keys & React Query Hooks
+
+**Files:**
+
+- Modify: `app/utils/queryKeys.ts`
+- Create: `app/hooks/useRules.ts`
+
+- [ ] **Step 1: Add rules query keys**
+
+In `app/utils/queryKeys.ts`, add a `rules` entry to the `queryKeys` object, after the `characters` entry and before the `tags` entry:
+
+```typescript
+  rules: {
+    all: ['rules'] as const,
+    list: (
+      campaignId: string,
+      search?: string,
+      visibility?: string,
+      tags?: string[]
+    ) =>
+      [
+        'rules',
+        'list',
+        campaignId,
+        search ?? '',
+        visibility ?? 'all',
+        tags ?? [],
+      ] as const,
+    detail: (id: string, campaignId?: string) => ['rules', 'detail', campaignId ?? '', id] as const,
+  },
+```
+
+- [ ] **Step 2: Create React Query hooks**
+
+Create `app/hooks/useRules.ts`:
+
+```typescript
+import { createServerFn } from '@tanstack/react-start';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { RuleData, RuleListItem } from '~/types/rule';
+import { captureException } from '~/providers/PostHogProvider';
+import { queryKeys } from '~/utils/queryKeys';
+import {
+  listRulesSchema,
+  getRuleSchema,
+  createRuleSchema,
+  updateRuleSchema,
+  deleteRuleSchema,
+} from '~/types/schemas/rules';
+
+// ---------------------------------------------------------------------------
+// Server function wrappers — dynamic imports keep Mongoose server-only.
+// ---------------------------------------------------------------------------
+
+const listRulesFn = createServerFn({ method: 'GET' })
+  .inputValidator(listRulesSchema)
+  .handler(async ({ data }) => {
+    const { listRules } = await import('~/server/functions/rules');
+    return listRules({ data });
+  });
+
+const getRuleFn = createServerFn({ method: 'GET' })
+  .inputValidator(getRuleSchema)
+  .handler(async ({ data }) => {
+    const { getRule } = await import('~/server/functions/rules');
+    return getRule({ data });
+  });
+
+const createRuleFn = createServerFn({ method: 'POST' })
+  .inputValidator(createRuleSchema)
+  .handler(async ({ data }) => {
+    const { createRule } = await import('~/server/functions/rules');
+    return createRule({ data });
+  });
+
+const updateRuleFn = createServerFn({ method: 'POST' })
+  .inputValidator(updateRuleSchema)
+  .handler(async ({ data }) => {
+    const { updateRule } = await import('~/server/functions/rules');
+    return updateRule({ data });
+  });
+
+const deleteRuleFn = createServerFn({ method: 'POST' })
+  .inputValidator(deleteRuleSchema)
+  .handler(async ({ data }) => {
+    const { deleteRule } = await import('~/server/functions/rules');
+    return deleteRule({ data });
+  });
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+interface ListRulesFilters {
+  search?: string;
+  visibility?: 'all' | 'public' | 'private';
+  tags?: string[];
+}
+
+export function useRules(campaignId: string, filters?: ListRulesFilters) {
+  const search = filters?.search;
+  const visibility = filters?.visibility;
+  const tags = filters?.tags;
+
+  const {
+    data: rules = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.rules.list(campaignId, search, visibility, tags),
+    queryFn: () =>
+      listRulesFn({
+        data: {
+          campaignId,
+          search,
+          visibility,
+          tags,
+        },
+      }),
+    enabled: !!campaignId,
+  });
+
+  return {
+    rules: rules as RuleListItem[],
+    isLoading,
+    error: error instanceof Error ? error.message : error ? String(error) : null,
+  };
+}
+
+export function useRule(id: string, campaignId: string) {
+  const {
+    data: rule = null,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.rules.detail(id, campaignId),
+    queryFn: () => getRuleFn({ data: { id, campaignId } }),
+    enabled: !!id && !!campaignId,
+  });
+
+  return {
+    rule: rule as RuleData | null,
+    isLoading,
+    error: error instanceof Error ? error.message : error ? String(error) : null,
+  };
+}
+
+interface CreateRuleInput {
+  campaignId: string;
+  title: string;
+  content: string;
+  tags?: string[];
+  isPublic?: boolean;
+}
+
+export function useCreateRule() {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (input: CreateRuleInput) => createRuleFn({ data: input }),
+    onSuccess: (_data, { campaignId }) => {
+      queryClient.invalidateQueries({ queryKey: ['rules', 'list', campaignId], exact: false });
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags.list(campaignId) });
+    },
+    onError: (e) => {
+      captureException(e, { action: 'createRule' });
+    },
+  });
+
+  const create = async (input: CreateRuleInput) => {
+    try {
+      return await mutation.mutateAsync(input);
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    create,
+    isLoading: mutation.isPending,
+    error:
+      mutation.error instanceof Error
+        ? mutation.error.message
+        : mutation.error
+          ? String(mutation.error)
+          : null,
+  };
+}
+
+interface UpdateRuleInput {
+  id: string;
+  campaignId: string;
+  title: string;
+  content: string;
+  tags?: string[];
+  isPublic?: boolean;
+}
+
+export function useUpdateRule() {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (input: UpdateRuleInput) => updateRuleFn({ data: input }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['rules', 'list', variables.campaignId],
+        exact: false,
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.rules.detail(variables.id, variables.campaignId),
+      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags.list(variables.campaignId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+    },
+    onError: (e, variables) => {
+      captureException(e, { action: 'updateRule', ruleId: variables.id });
+    },
+  });
+
+  const update = async (input: UpdateRuleInput) => {
+    try {
+      return await mutation.mutateAsync(input);
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    update,
+    isLoading: mutation.isPending,
+    error:
+      mutation.error instanceof Error
+        ? mutation.error.message
+        : mutation.error
+          ? String(mutation.error)
+          : null,
+  };
+}
+
+interface DeleteRuleInput {
+  id: string;
+  campaignId: string;
+}
+
+export function useDeleteRule() {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (input: DeleteRuleInput) => deleteRuleFn({ data: input }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['rules', 'list', variables.campaignId],
+        exact: false,
+      });
+      queryClient.removeQueries({
+        queryKey: queryKeys.rules.detail(variables.id, variables.campaignId),
+      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+    },
+    onError: (e, variables) => {
+      captureException(e, { action: 'deleteRule', ruleId: variables.id });
+    },
+  });
+
+  const remove = async (input: DeleteRuleInput) => {
+    try {
+      return await mutation.mutateAsync(input);
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    remove,
+    isLoading: mutation.isPending,
+    error:
+      mutation.error instanceof Error
+        ? mutation.error.message
+        : mutation.error
+          ? String(mutation.error)
+          : null,
+  };
+}
+```
+
+- [ ] **Step 3: Verify the app compiles**
+
+Run: `npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors related to the new files
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/utils/queryKeys.ts app/hooks/useRules.ts
+git commit -m "feat(rules): add query keys and React Query hooks"
+```
+
+---
+
+### Task 5: WikiFilterBar — Optional Session Filter
+
+**Files:**
+
+- Modify: `app/components/wiki/shared/WikiFilterBar.tsx`
+
+- [ ] **Step 1: Add showSessionFilter prop**
+
+In `app/components/wiki/shared/WikiFilterBar.tsx`, make the session-related props optional and add a `showSessionFilter` prop:
+
+Update the `WikiFilterBarProps` interface — make `sessionId`, `onSessionChange`, and `sessions` optional, and add `showSessionFilter`:
+
+```typescript
+interface WikiFilterBarProps {
+  search: string;
+  onSearchChange: (value: string) => void;
+  sessionId?: string;
+  onSessionChange?: (value: string) => void;
+  visibility: 'all' | 'public' | 'private';
+  onVisibilityChange: (value: 'all' | 'public' | 'private') => void;
+  sessions?: CampaignData['sessions'];
+  onCreateClick: () => void;
+  campaignId: string;
+  filterTags: string[];
+  onFilterTagsChange: (tags: string[]) => void;
+  searchPlaceholder?: string;
+  showSessionFilter?: boolean;
+}
+```
+
+Update the function signature to destructure `showSessionFilter` with default `true`:
+
+```typescript
+export function WikiFilterBar({
+  search,
+  onSearchChange,
+  sessionId,
+  onSessionChange,
+  visibility,
+  onVisibilityChange,
+  sessions,
+  onCreateClick,
+  campaignId,
+  filterTags,
+  onFilterTagsChange,
+  searchPlaceholder = 'Search...',
+  showSessionFilter = true,
+}: WikiFilterBarProps) {
+```
+
+Wrap the session select in a conditional — replace the existing `<div className="flex gap-2">` block with:
+
+```tsx
+<div className="flex gap-2">
+  {showSessionFilter && sessions && onSessionChange && (
+    <div className="flex-1">
+      <label htmlFor="wiki-session-filter" className="sr-only">
+        Filter by session
+      </label>
+      <select
+        id="wiki-session-filter"
+        value={sessionId ?? ''}
+        onChange={(e) => onSessionChange(e.target.value)}
+        className="w-full bg-[#080A12] border border-white/[0.07] rounded px-2 py-1.5 font-sans font-semibold text-[11px] text-slate-300 outline-none focus:border-blue-500/50 transition-colors"
+      >
+        <option value="">All Sessions</option>
+        <option value="__none__">No Session</option>
+        {sessions.map((session) => (
+          <option key={session.id} value={session.id}>
+            Session {session.number}: {session.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  )}
+
+  <div className={showSessionFilter && sessions && onSessionChange ? 'w-32' : 'flex-1'}>
+    <label htmlFor="wiki-visibility-filter" className="sr-only">
+      Filter by visibility
+    </label>
+    <select
+      id="wiki-visibility-filter"
+      value={visibility}
+      onChange={(e) => onVisibilityChange(e.target.value as 'all' | 'public' | 'private')}
+      className="w-full bg-[#080A12] border border-white/[0.07] rounded px-2 py-1.5 font-sans font-semibold text-[11px] text-slate-300 outline-none focus:border-blue-500/50 transition-colors"
+    >
+      <option value="all">All</option>
+      <option value="public">Public Only</option>
+      <option value="private">Private Only</option>
+    </select>
+  </div>
+</div>
+```
+
+- [ ] **Step 2: Verify CharactersPanel still works**
+
+Run: `npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors — CharactersPanel still passes all required props and the defaults make it backward-compatible.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/components/wiki/shared/WikiFilterBar.tsx
+git commit -m "feat(wiki): make session filter optional in WikiFilterBar"
+```
+
+---
+
+### Task 6: RuleCard Component
+
+**Files:**
+
+- Create: `app/components/wiki/rules/RuleCard.tsx`
+
+- [ ] **Step 1: Create RuleCard component**
+
+Create `app/components/wiki/rules/RuleCard.tsx`:
+
+```tsx
+import { Globe, Lock } from 'lucide-react';
+import type { RuleListItem } from '~/types/rule';
+
+interface RuleCardProps {
+  rule: RuleListItem;
+  onClick: (rule: RuleListItem) => void;
+}
+
+export function RuleCard({ rule, onClick }: RuleCardProps) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      draggable="true"
+      onDragStart={(e) => {
+        e.dataTransfer.setData(
+          'application/x-cartyx-document',
+          JSON.stringify({
+            collection: 'rule',
+            documentId: rule.id,
+            title: rule.title,
+          })
+        );
+        e.dataTransfer.effectAllowed = 'copy';
+        e.currentTarget.style.opacity = '0.4';
+      }}
+      onDragEnd={(e) => {
+        e.currentTarget.style.opacity = '';
+      }}
+      onClick={() => onClick(rule)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick(rule);
+        }
+      }}
+      className="flex items-start gap-3 px-4 py-3 border-b border-white/[0.05] hover:bg-white/[0.03] transition-colors group cursor-grab active:cursor-grabbing"
+    >
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-0.5">
+          <span className="text-sm font-semibold text-slate-200 group-hover:text-blue-400 transition-colors truncate">
+            {rule.title}
+          </span>
+          {rule.isPublic ? (
+            <Globe className="h-3.5 w-3.5 text-emerald-500 shrink-0" aria-label="Public" />
+          ) : (
+            <Lock className="h-3.5 w-3.5 text-amber-500 shrink-0" aria-label="Private" />
+          )}
+        </div>
+
+        {rule.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1 mt-1">
+            {rule.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[9px] tracking-tight"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/components/wiki/rules/RuleCard.tsx
+git commit -m "feat(rules): add RuleCard component with drag support"
+```
+
+---
+
+### Task 7: RuleModal (Editor)
+
+**Files:**
+
+- Create: `app/components/wiki/rules/RuleModal.tsx`
+
+- [ ] **Step 1: Create RuleModal component**
+
+Create `app/components/wiki/rules/RuleModal.tsx`:
+
+```tsx
+import React, { useState, useEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { X, Globe, Lock } from 'lucide-react';
+import { FormInput } from '~/components/FormInput';
+import { PixelButton } from '~/components/PixelButton';
+import { MarkdownEditor } from '~/components/shared/MarkdownEditor';
+import { useCreateRule, useUpdateRule, useDeleteRule, useRule } from '~/hooks/useRules';
+import { TagAutocompleteInput } from '~/components/shared/TagAutocompleteInput';
+
+interface RuleModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  campaignId: string;
+  ruleId?: string;
+}
+
+interface FieldErrors {
+  title?: string;
+  content?: string;
+}
+
+export function RuleModal({ isOpen, onClose, campaignId, ruleId }: RuleModalProps) {
+  const { rule: fetchedRule, isLoading: isFetchingRule } = useRule(ruleId ?? '', campaignId);
+  const { create, isLoading: isCreating } = useCreateRule();
+  const { update, isLoading: isUpdating } = useUpdateRule();
+  const { remove, isLoading: isDeleting } = useDeleteRule();
+
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [tags, setTags] = useState<string[]>([]);
+  const [isPublic, setIsPublic] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [hasSubmitted, setHasSubmitted] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [onClose]);
+
+  // Reset form when switching ruleId or opening the modal
+  useEffect(() => {
+    setTitle('');
+    setContent('');
+    setTags([]);
+    setIsPublic(false);
+    setError(null);
+    setFieldErrors({});
+    setHasSubmitted(false);
+    setShowDeleteConfirm(false);
+  }, [ruleId, isOpen]);
+
+  // Populate form once the fetched rule resolves in edit mode
+  useEffect(() => {
+    if (ruleId && fetchedRule) {
+      setTitle(fetchedRule.title);
+      setContent(fetchedRule.content);
+      setTags(fetchedRule.tags);
+      setIsPublic(fetchedRule.isPublic);
+    }
+  }, [ruleId, fetchedRule]);
+
+  const validate = useCallback((): FieldErrors => {
+    const errors: FieldErrors = {};
+    if (!title.trim()) errors.title = 'Title is required';
+    if (!content.trim()) errors.content = 'Rule content is required';
+    return errors;
+  }, [title, content]);
+
+  useEffect(() => {
+    if (hasSubmitted) {
+      setFieldErrors(validate());
+    }
+  }, [hasSubmitted, validate]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setHasSubmitted(true);
+    setError(null);
+
+    const errors = validate();
+    setFieldErrors(errors);
+    if (Object.keys(errors).length > 0) return;
+
+    const input = {
+      campaignId,
+      title: title.trim(),
+      content: content.trim(),
+      tags,
+      isPublic,
+    };
+
+    let success = false;
+    if (ruleId) {
+      const result = await update({ ...input, id: ruleId });
+      success = !!result;
+    } else {
+      const result = await create(input);
+      success = !!result;
+    }
+
+    if (success) {
+      onClose();
+    } else {
+      setError('Failed to save rule. Please try again.');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!ruleId) return;
+    setError(null);
+    const result = await remove({ id: ruleId, campaignId });
+    if (result) {
+      onClose();
+    } else {
+      setError('Failed to delete rule. Please try again.');
+      setShowDeleteConfirm(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const isLoadingRule = !!(ruleId && isFetchingRule);
+  const isSaving = isCreating || isUpdating;
+  const isDisabled = isLoadingRule || isSaving || isDeleting;
+
+  return createPortal(
+    <div
+      role="presentation"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-2 sm:p-4 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="rule-modal-title"
+        className="w-full h-full max-w-[90vw] max-h-[90vh] sm:max-w-[90vw] sm:max-h-[90vh] bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col"
+      >
+        <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
+          <h2
+            id="rule-modal-title"
+            className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest"
+          >
+            {ruleId ? 'Edit Rule' : 'Create Rule'}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-slate-500 hover:text-white transition-colors"
+            aria-label="Close modal"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto p-4 sm:p-6 space-y-5 min-h-0">
+          {error && (
+            <div className="p-3 bg-rose-500/10 border border-rose-500/20 rounded-lg text-rose-400 text-xs font-semibold">
+              {error}
+            </div>
+          )}
+
+          <FormInput
+            label="Title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="e.g. Critical Hit Rules"
+            disabled={isDisabled}
+            error={fieldErrors.title}
+          />
+
+          <MarkdownEditor
+            label="Rule Content"
+            value={content}
+            onChange={setContent}
+            placeholder="Write the rule details in markdown..."
+            disabled={isDisabled}
+            error={fieldErrors.content}
+            minHeight="16rem"
+            id="rule-modal-editor"
+          />
+
+          {/* Tags */}
+          <div>
+            <label
+              htmlFor="rule-tags-input"
+              className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide"
+            >
+              Tags
+            </label>
+            <TagAutocompleteInput
+              campaignId={campaignId}
+              selectedTags={tags}
+              onTagsChange={setTags}
+              placeholder="Type a tag and press Enter"
+              disabled={isDisabled}
+              id="rule-tags-input"
+            />
+            <p className="text-xs text-slate-700 mt-1.5">
+              Press Enter or comma to add. Suggestions appear as you type.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-6 pt-2">
+            <label className="flex items-center gap-3 cursor-pointer group">
+              <input
+                type="radio"
+                name="rule-visibility"
+                checked={!isPublic}
+                onChange={() => setIsPublic(false)}
+                className="sr-only"
+                disabled={isDisabled}
+              />
+              <div
+                className={`h-10 px-4 rounded-xl border flex items-center gap-2.5 transition-all ${
+                  !isPublic
+                    ? 'bg-blue-600/10 border-blue-500/50 text-blue-300 shadow-sm shadow-blue-500/10'
+                    : 'bg-white/[0.03] border-white/[0.07] text-slate-500 hover:border-white/20'
+                }`}
+              >
+                <Lock className="h-3.5 w-3.5" />
+                <span className="font-sans font-bold text-xs">Private</span>
+              </div>
+            </label>
+
+            <label className="flex items-center gap-3 cursor-pointer group">
+              <input
+                type="radio"
+                name="rule-visibility"
+                checked={isPublic}
+                onChange={() => setIsPublic(true)}
+                className="sr-only"
+                disabled={isDisabled}
+              />
+              <div
+                className={`h-10 px-4 rounded-xl border flex items-center gap-2.5 transition-all ${
+                  isPublic
+                    ? 'bg-emerald-600/10 border-emerald-500/50 text-emerald-300 shadow-sm shadow-emerald-500/10'
+                    : 'bg-white/[0.03] border-white/[0.07] text-slate-500 hover:border-white/20'
+                }`}
+              >
+                <Globe className="h-3.5 w-3.5" />
+                <span className="font-sans font-bold text-xs">Public</span>
+              </div>
+            </label>
+          </div>
+        </div>
+
+        <footer className="flex items-center justify-between px-4 sm:px-6 py-4 border-t border-white/[0.07] bg-white/[0.01] shrink-0">
+          <div>
+            {ruleId && !showDeleteConfirm && (
+              <PixelButton
+                variant="secondary"
+                size="sm"
+                onClick={() => setShowDeleteConfirm(true)}
+                disabled={isDisabled}
+                type="button"
+              >
+                <span className="text-rose-400">Delete</span>
+              </PixelButton>
+            )}
+            {ruleId && showDeleteConfirm && (
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-rose-400 font-semibold">Delete this rule?</span>
+                <PixelButton
+                  variant="secondary"
+                  size="sm"
+                  onClick={handleDelete}
+                  disabled={isDeleting}
+                  type="button"
+                >
+                  <span className="text-rose-400">
+                    {isDeleting ? 'Deleting...' : 'Yes, delete'}
+                  </span>
+                </PixelButton>
+                <PixelButton
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => setShowDeleteConfirm(false)}
+                  disabled={isDeleting}
+                  type="button"
+                >
+                  Cancel
+                </PixelButton>
+              </div>
+            )}
+          </div>
+          <div className="flex items-center gap-3">
+            <PixelButton
+              variant="secondary"
+              size="sm"
+              onClick={onClose}
+              disabled={isSaving || isDeleting}
+              type="button"
+            >
+              Cancel
+            </PixelButton>
+            <PixelButton variant="primary" size="sm" disabled={isDisabled} type="submit">
+              {isSaving
+                ? 'Saving...'
+                : isLoadingRule
+                  ? 'Loading...'
+                  : ruleId
+                    ? 'Update Rule'
+                    : 'Create Rule'}
+            </PixelButton>
+          </div>
+        </footer>
+      </form>
+    </div>,
+    document.body
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/components/wiki/rules/RuleModal.tsx
+git commit -m "feat(rules): add RuleModal editor component"
+```
+
+---
+
+### Task 8: RuleViewModal & RuleWindow
+
+**Files:**
+
+- Create: `app/components/wiki/rules/RuleWindow.tsx`
+- Create: `app/components/wiki/rules/RuleViewModal.tsx`
+
+- [ ] **Step 1: Create RuleWindow component**
+
+Create `app/components/wiki/rules/RuleWindow.tsx`:
+
+```tsx
+import { Globe, Lock } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { RuleData } from '~/types/rule';
+import { MARKDOWN_PROSE_CLASSES } from '~/utils/markdownProseClasses';
+
+interface RuleWindowProps {
+  rule: RuleData;
+}
+
+export function RuleWindow({ rule }: RuleWindowProps) {
+  return (
+    <div className="flex flex-col gap-4 p-4 overflow-auto h-full">
+      {/* Title */}
+      <h2 className="text-sm font-bold text-slate-200">{rule.title}</h2>
+
+      {/* Visibility badge */}
+      <div className="flex">
+        {rule.isPublic ? (
+          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 text-[10px] font-semibold">
+            <Globe className="h-3 w-3" />
+            Public
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-amber-500/10 border border-amber-500/20 text-amber-400 text-[10px] font-semibold">
+            <Lock className="h-3 w-3" />
+            Private
+          </span>
+        )}
+      </div>
+
+      {/* Tags */}
+      {rule.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {rule.tags.map((tag) => (
+            <span
+              key={tag}
+              className="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[9px] tracking-tight"
+            >
+              #{tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Rendered markdown content */}
+      <div className={MARKDOWN_PROSE_CLASSES}>
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{rule.content}</ReactMarkdown>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create RuleViewModal component**
+
+Create `app/components/wiki/rules/RuleViewModal.tsx`:
+
+```tsx
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { X } from 'lucide-react';
+import { RuleWindow } from './RuleWindow';
+import { useRule } from '~/hooks/useRules';
+
+interface RuleViewModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  ruleId: string;
+  campaignId: string;
+}
+
+export function RuleViewModal({ isOpen, onClose, ruleId, campaignId }: RuleViewModalProps) {
+  const { rule, isLoading } = useRule(ruleId, campaignId);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div
+      role="presentation"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-2 sm:p-4 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="rule-view-modal-title"
+        className="w-full max-w-lg max-h-[90vh] bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col"
+      >
+        <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
+          <h2
+            id="rule-view-modal-title"
+            className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest"
+          >
+            Rule
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-slate-500 hover:text-white transition-colors"
+            aria-label="Close modal"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto min-h-0">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <p className="text-xs text-slate-500 animate-pulse">Loading rule...</p>
+            </div>
+          ) : rule ? (
+            <RuleWindow rule={rule} />
+          ) : (
+            <div className="flex items-center justify-center py-12">
+              <p className="text-xs text-slate-500">Rule not found</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/components/wiki/rules/RuleWindow.tsx app/components/wiki/rules/RuleViewModal.tsx
+git commit -m "feat(rules): add RuleWindow and RuleViewModal components"
+```
+
+---
+
+### Task 9: RulesPanel & Wiki Integration
+
+**Files:**
+
+- Create: `app/components/wiki/rules/RulesPanel.tsx`
+- Modify: `app/components/wiki/WikiPanel.tsx`
+
+- [ ] **Step 1: Create RulesPanel component**
+
+Create `app/components/wiki/rules/RulesPanel.tsx`:
+
+```tsx
+import { useState } from 'react';
+import { useParams } from '@tanstack/react-router';
+import { ScrollText } from 'lucide-react';
+import { WikiCategoryHeader } from '~/components/wiki/shared/WikiCategoryHeader';
+import { WikiFilterBar } from '~/components/wiki/shared/WikiFilterBar';
+import { RuleCard } from './RuleCard';
+import { RuleModal } from './RuleModal';
+import { RuleViewModal } from './RuleViewModal';
+import { useRules } from '~/hooks/useRules';
+import { useCampaign } from '~/hooks/useCampaigns';
+import type { RuleListItem } from '~/types/rule';
+
+interface RulesPanelProps {
+  onBack: () => void;
+}
+
+export function RulesPanel({ onBack }: RulesPanelProps) {
+  const { campaignId } = useParams({ from: '/campaigns/$campaignId/play' });
+  const { campaign } = useCampaign(campaignId);
+  const isGM = campaign?.isGM ?? false;
+
+  const [search, setSearch] = useState('');
+  const [visibility, setVisibility] = useState<'all' | 'public' | 'private'>('all');
+  const [filterTags, setFilterTags] = useState<string[]>([]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedRuleId, setSelectedRuleId] = useState<string | undefined>();
+  const [viewRuleId, setViewRuleId] = useState<string | undefined>();
+
+  const { rules, isLoading, error } = useRules(campaignId, {
+    search: search || undefined,
+    visibility,
+    tags: filterTags.length > 0 ? filterTags : undefined,
+  });
+
+  const handleCreateClick = () => {
+    setSelectedRuleId(undefined);
+    setIsModalOpen(true);
+  };
+
+  const handleRuleClick = (rule: RuleListItem) => {
+    if (isGM) {
+      setSelectedRuleId(rule.id);
+      setIsModalOpen(true);
+    } else {
+      setViewRuleId(rule.id);
+    }
+  };
+
+  const handleModalClose = () => {
+    setIsModalOpen(false);
+    setSelectedRuleId(undefined);
+  };
+
+  const handleViewModalClose = () => {
+    setViewRuleId(undefined);
+  };
+
+  return (
+    <div className="flex flex-col h-full w-full bg-[#080A12]">
+      <WikiCategoryHeader title="Rules" onBack={onBack} />
+      <WikiFilterBar
+        search={search}
+        onSearchChange={setSearch}
+        visibility={visibility}
+        onVisibilityChange={setVisibility}
+        onCreateClick={handleCreateClick}
+        campaignId={campaignId}
+        filterTags={filterTags}
+        onFilterTagsChange={setFilterTags}
+        searchPlaceholder="Search rules..."
+        showSessionFilter={false}
+      />
+
+      {isLoading ? (
+        <div className="flex flex-1 items-center justify-center p-8">
+          <p className="font-sans font-semibold text-xs text-slate-500 animate-pulse">
+            Loading rules...
+          </p>
+        </div>
+      ) : error ? (
+        <div className="flex flex-1 items-center justify-center p-8 text-center">
+          <p className="font-sans font-semibold text-xs text-rose-400">{error}</p>
+        </div>
+      ) : rules.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center p-8 text-center">
+          <div className="h-12 w-12 rounded-full bg-white/[0.03] flex items-center justify-center mb-3">
+            <ScrollText className="h-6 w-6 text-slate-600" />
+          </div>
+          <p className="font-sans font-semibold text-xs text-slate-500">
+            No rules found matching your filters.
+          </p>
+        </div>
+      ) : (
+        <div className="flex-1 overflow-y-auto min-h-0">
+          <div className="flex flex-col">
+            {rules.map((rule) => (
+              <RuleCard key={rule.id} rule={rule} onClick={handleRuleClick} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {isGM && (
+        <RuleModal
+          isOpen={isModalOpen}
+          onClose={handleModalClose}
+          campaignId={campaignId}
+          ruleId={selectedRuleId}
+        />
+      )}
+      {viewRuleId && (
+        <RuleViewModal
+          isOpen={!!viewRuleId}
+          onClose={handleViewModalClose}
+          ruleId={viewRuleId}
+          campaignId={campaignId}
+        />
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Add Rules category to WikiPanel**
+
+In `app/components/wiki/WikiPanel.tsx`:
+
+1. Add imports at the top:
+
+```typescript
+import { Users, ScrollText } from 'lucide-react';
+import { CharactersPanel } from './characters/CharactersPanel';
+import { RulesPanel } from './rules/RulesPanel';
+```
+
+2. Update the type and categories array:
+
+```typescript
+type WikiCategoryId = 'characters' | 'rules';
+
+const WIKI_CATEGORIES: WikiCategory[] = [
+  { id: 'characters', label: 'Characters', icon: Users },
+  { id: 'rules', label: 'Rules', icon: ScrollText },
+];
+```
+
+3. Add the rules panel rendering in the conditional block. After the `selectedCategory === 'characters'` branch, add:
+
+```typescript
+      ) : selectedCategory === 'rules' ? (
+        <RulesPanel onBack={() => setSelectedCategory(null)} />
+```
+
+- [ ] **Step 3: Verify the app compiles**
+
+Run: `npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/components/wiki/rules/RulesPanel.tsx app/components/wiki/WikiPanel.tsx
+git commit -m "feat(rules): add RulesPanel and integrate into WikiPanel"
+```
+
+---
+
+### Task 10: GM Screen Integration
+
+**Files:**
+
+- Create: `app/components/mainview/gmscreens/RuleWindowWrapper.tsx`
+- Modify: `app/server/functions/gmscreens.ts`
+- Modify: `app/components/mainview/gmscreens/GMScreensView.tsx`
+
+- [ ] **Step 1: Add rule to COLLECTION_REGISTRY**
+
+In `app/server/functions/gmscreens.ts`:
+
+1. Add import at the top (after the Character import on line 8):
+
+```typescript
+import { Rule } from '../db/models/Rule';
+```
+
+2. Add `rule` entry to `COLLECTION_REGISTRY` (after the `character` entry, before the closing `};` on line 154):
+
+```typescript
+  rule: {
+    async fetch(ids: string[], campaignId: string) {
+      return Rule.find({ _id: { $in: ids }, campaignId }, '_id title content')
+        .lean()
+        .then((docs) =>
+          docs.map((d) => ({
+            _id: d._id,
+            title: (d as { title?: string }).title,
+            content: (d as { content?: string }).content,
+          }))
+        ) as Promise<Array<{ _id: unknown; title?: string; content?: string }>>;
+    },
+  },
+```
+
+- [ ] **Step 2: Create RuleWindowWrapper**
+
+Create `app/components/mainview/gmscreens/RuleWindowWrapper.tsx`:
+
+```tsx
+import { Pencil } from 'lucide-react';
+import { RuleWindow } from '~/components/wiki/rules/RuleWindow';
+import { RuleModal } from '~/components/wiki/rules/RuleModal';
+import { useRule } from '~/hooks/useRules';
+
+export function EditRuleModalWrapper({
+  campaignId,
+  ruleId,
+  onClose,
+}: {
+  campaignId: string;
+  ruleId: string;
+  onClose: () => void;
+}) {
+  return <RuleModal isOpen onClose={onClose} campaignId={campaignId} ruleId={ruleId} />;
+}
+
+export function RuleWindowWrapper({
+  ruleId,
+  campaignId,
+  isGM,
+  onEdit,
+}: {
+  ruleId: string;
+  campaignId: string;
+  isGM: boolean;
+  onEdit: () => void;
+}) {
+  const { rule, isLoading } = useRule(ruleId, campaignId);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-xs text-slate-500 animate-pulse">Loading rule...</p>
+      </div>
+    );
+  }
+
+  if (!rule) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-xs text-slate-500">Rule not found</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative h-full">
+      {isGM && (
+        <button
+          type="button"
+          onClick={onEdit}
+          className="absolute top-2 right-2 z-10 p-1.5 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors"
+          aria-label="Edit rule"
+        >
+          <Pencil className="h-3.5 w-3.5" />
+        </button>
+      )}
+      <RuleWindow rule={rule} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Update GMScreensView to handle rule windows**
+
+In `app/components/mainview/gmscreens/GMScreensView.tsx`:
+
+1. Add import for RuleWindowWrapper (near the CharacterWindowWrapper import on line 13):
+
+```typescript
+import { RuleWindowWrapper, EditRuleModalWrapper } from './RuleWindowWrapper';
+```
+
+2. Add state for editing rule ID (near `editingCharacterId` state on line 42):
+
+```typescript
+const [editingRuleId, setEditingRuleId] = useState<string | null>(null);
+```
+
+3. In the window content rendering block (around line 390-408), update the conditional to handle rules. Replace the `if (w.collection === 'character') { ... } else { ... }` block with:
+
+```typescript
+        if (w.collection === 'character') {
+          windowContent = (
+            <CharacterWindowWrapper
+              characterId={w.documentId}
+              campaignId={campaignId}
+              onEdit={() => setEditingCharacterId(w.documentId)}
+            />
+          );
+        } else if (w.collection === 'rule') {
+          windowContent = (
+            <RuleWindowWrapper
+              ruleId={w.documentId}
+              campaignId={campaignId}
+              isGM={campaign?.isGM ?? false}
+              onEdit={() => setEditingRuleId(w.documentId)}
+            />
+          );
+        } else {
+          windowContent = (
+            <div className="p-4 overflow-auto h-full">
+              <div className={MARKDOWN_PROSE_CLASSES}>
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{markdownContent}</ReactMarkdown>
+              </div>
+            </div>
+          );
+        }
+```
+
+4. Add the edit rule modal at the bottom of the return JSX (after the `editingCharacterId` block around line 613-619):
+
+```tsx
+{
+  editingRuleId !== null && (
+    <EditRuleModalWrapper
+      campaignId={campaignId}
+      ruleId={editingRuleId}
+      onClose={() => setEditingRuleId(null)}
+    />
+  );
+}
+```
+
+- [ ] **Step 4: Verify `campaign` is accessible in the window rendering scope**
+
+The GMScreensView component already has access to `campaign` via its props or hooks. Verify by checking the existing code. If `campaign` is not available in scope, use `useCampaign(campaignId)` to get it. The `isGM` flag is needed for the `RuleWindowWrapper`.
+
+Check: Look at the component's existing imports and props for `campaign` — it's passed as a prop or available via hook. The code at line 40 references `campaign?.isGM` check in play.tsx so the value flows through.
+
+Run: `npx tsc --noEmit 2>&1 | head -30`
+
+If `campaign` is not in scope, add:
+
+```typescript
+import { useCampaign } from '~/hooks/useCampaigns';
+```
+
+And in the component body:
+
+```typescript
+const { campaign } = useCampaign(campaignId);
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/server/functions/gmscreens.ts app/components/mainview/gmscreens/RuleWindowWrapper.tsx app/components/mainview/gmscreens/GMScreensView.tsx
+git commit -m "feat(rules): integrate rules into GM screen with edit support"
+```
+
+---
+
+### Task 11: Final Verification
+
+- [ ] **Step 1: Type check**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 2: Lint check**
+
+Run: `npx eslint app/types/rule.ts app/types/schemas/rules.ts app/server/db/models/Rule.ts app/server/functions/rules.ts app/hooks/useRules.ts app/components/wiki/rules/ app/components/mainview/gmscreens/RuleWindowWrapper.tsx --fix`
+Expected: No errors (or auto-fixed)
+
+- [ ] **Step 3: Dev server smoke test**
+
+Run: `npm run dev`
+Expected: App starts without errors. Navigate to a campaign, open the Wiki panel, and verify "Rules" appears as a category.
+
+- [ ] **Step 4: Commit any lint fixes**
+
+```bash
+git add -A
+git commit -m "chore(rules): lint fixes"
+```

--- a/docs/superpowers/specs/2026-04-05-wiki-rules-design.md
+++ b/docs/superpowers/specs/2026-04-05-wiki-rules-design.md
@@ -1,0 +1,215 @@
+# Wiki Rules Feature — Design Spec
+
+**Date:** 2026-04-05
+**Status:** Approved
+
+## Overview
+
+Add a "Rules" feature to the Wiki system. Rules are custom text entries (stored as markdown) that Game Masters can create, edit, and delete. Rules can be public (visible to all campaign members) or private (GM-only). Players see rendered HTML for public rules — never raw markdown.
+
+Rules have no session association and never will.
+
+## Data Model
+
+### Rule Schema (Mongoose)
+
+```
+Rule {
+  _id: ObjectId
+  title: String (required)
+  content: String (markdown, required)
+  tags: [String] (normalized lowercase, deduplicated, trimmed)
+  isPublic: Boolean (default: false)
+  campaignId: ObjectId (required)
+  createdBy: ObjectId (User reference, required)
+  createdAt: Date (default: Date.now)
+  updatedAt: Date (auto-updated on save/update)
+}
+```
+
+### Indexes
+
+- `{ campaignId: 1, updatedAt: -1 }` — list queries sorted by recent
+- `{ campaignId: 1 }` — base campaign filter
+- `{ tags: 1 }` — tag filtering
+- `{ isPublic: 1 }` — visibility filtering
+- `{ createdBy: 1 }` — creator lookup
+- Full-text index on `title`, `content` — search
+
+### Pre-save Hooks
+
+- Normalize tags (lowercase, deduplicate, trim) — same pattern as Character/Note models
+- Auto-update `updatedAt` timestamp
+
+## API Layer
+
+Five TanStack Start server functions mirroring the Notes pattern.
+
+### Permission Model
+
+- **Create/Edit/Delete:** Any campaign GM (`requireCampaignGM`). No per-creator restrictions — any GM can edit or delete any rule.
+- **List:** GMs see all rules. Players see public rules only.
+- **Detail:** GMs see any rule. Players see public rules only. Non-public rules return null for non-GMs.
+
+### Server Functions
+
+#### `listRules`
+
+- **Method:** GET
+- **Input:** `campaignId`, `search?`, `visibility: 'all' | 'public' | 'private'`, `tags?: string[]`
+- **Returns:** `RuleListItem[]` (id, title, tags, isPublic, createdAt, updatedAt — no content)
+- **Permission:** Campaign members. GMs see all rules; players see only public rules (visibility filter constrained to 'public' for non-GMs).
+
+#### `getRule`
+
+- **Method:** GET
+- **Input:** `id`, `campaignId`
+- **Returns:** `RuleData | null`
+- **Permission:** Campaign members. GMs see any rule. Players see public rules only; non-public returns null.
+
+#### `createRule`
+
+- **Method:** POST
+- **Input:** `campaignId`, `title`, `content`, `tags?: string[]`, `isPublic?: boolean`
+- **Returns:** `{ success: true, rule: RuleData }`
+- **Permission:** GM-only (`requireCampaignGM`)
+- **Side effects:** Auto-registers tags via `ensureTags`. PostHog event: `rule_created`.
+
+#### `updateRule`
+
+- **Method:** POST
+- **Input:** `id`, `campaignId`, `title`, `content`, `tags?: string[]`, `isPublic?: boolean`
+- **Returns:** `{ success: true, rule: RuleData }`
+- **Permission:** GM-only. Any GM can edit any rule.
+- **Side effects:** Invalidates GM screen windows displaying this rule. PostHog event: `rule_updated`.
+
+#### `deleteRule`
+
+- **Method:** POST
+- **Input:** `id`, `campaignId`
+- **Returns:** `{ success: true }`
+- **Permission:** GM-only. Any GM can delete any rule.
+- **Side effects:** Removes rule references from all GM screens. PostHog event: `rule_deleted`.
+
+### Response Serialization
+
+- `serializeRule(doc)` — Full rule with content
+- `serializeRuleListItem(doc)` — Rule without content (for list views)
+
+## Types & Validation
+
+### Type File: `types/rule.ts`
+
+- `RuleData` — full rule including content
+- `RuleListItem` — list item without content
+
+### Schema File: `types/schemas/rules.ts`
+
+Zod schemas for all five server function inputs, mirroring `types/schemas/notes.ts`.
+
+## Frontend — Wiki Integration
+
+### Wiki Panel
+
+Add "Rules" as a new category in `WikiPanel.tsx` alongside Characters. Clicking "Rules" renders a `RulesPanel` component.
+
+### RulesPanel (`components/wiki/rules/RulesPanel.tsx`)
+
+- Uses `WikiFilterBar` for search, visibility toggle, and tag filtering
+- **No session filter** — Rules are session-independent
+- `WikiFilterBar` needs a `showSessionFilter?: boolean` prop (default `true`) to hide the session dropdown for Rules. RulesPanel passes `showSessionFilter={false}`.
+- Lists `RuleCard` components
+- Loading, error, and empty states
+
+### RuleCard (`components/wiki/rules/RuleCard.tsx`)
+
+- Displays: title, tags, public/private icon
+- Draggable using `application/x-cartyx-document` MIME type: `{ collection: 'rule', documentId, title }`
+- Click behavior:
+  - GM → opens `RuleModal` (editor)
+  - Player → opens `RuleViewModal` (read-only rendered markdown)
+
+### RuleModal (`components/wiki/rules/RuleModal.tsx`)
+
+Editor modal for GMs:
+
+- Title text input (required)
+- `MarkdownEditor` component for content (existing CodeMirror component)
+- `TagAutocompleteInput` for tags (existing component)
+- Public/Private toggle with icons
+- Save and Delete buttons
+- Delete confirmation dialog
+
+### RuleViewModal (`components/wiki/rules/RuleViewModal.tsx`)
+
+Read-only modal for players:
+
+- Title display
+- Fully rendered markdown content as HTML
+- Tags display
+- Close button
+
+## GM Screen Integration
+
+### GMScreen Model Update
+
+The `windows[].collection` field accepts `'rule'` in addition to `'character'` and `'note'`.
+
+### RuleWindowWrapper (`components/mainview/gmscreens/RuleWindowWrapper.tsx`)
+
+- Loads rule via `useRule` hook
+- Renders inside `FloatingWindow` — gets minimize, maximize, close, drag, resize, and position/size persistence for free
+- Shows edit button if user is a GM (opens `RuleModal`)
+- Window state (`x`, `y`, `width`, `height`, `zIndex`, `state`) persisted via GMScreen model
+
+### RuleWindow (`components/wiki/rules/RuleWindow.tsx`)
+
+- Renders rule title and fully rendered markdown content
+- Scrollable container for variable-length content
+- Same styling approach as `CharacterWindow`
+
+### Drop Handling
+
+The existing drop handler in `GMScreensView.tsx` parses `application/x-cartyx-document` payload. It needs to accept `collection: 'rule'` as a valid type and render `RuleWindowWrapper` for rule windows.
+
+### Live Updates
+
+When a rule is edited via `updateRule`, React Query invalidation on `rules.detail` and `gmscreens` query keys causes the GM screen window to re-render with updated content — same mechanism as Characters/Notes.
+
+## React Query Hooks & Cache Keys
+
+### Query Keys (`utils/queryKeys.ts`)
+
+- `rules.list(campaignId, search?, visibility?, tags?)` — list cache key
+- `rules.detail(id, campaignId)` — single rule cache key
+
+### Hook File: `hooks/useRules.ts`
+
+- `useRules()` — list query with filter params
+- `useRule(id)` — single rule detail query
+- `useCreateRule()` — mutation, invalidates list + tags
+- `useUpdateRule()` — mutation, invalidates list + detail + gmscreens
+- `useDeleteRule()` — mutation, invalidates list + gmscreens
+
+## Files to Create
+
+1. `app/server/db/models/Rule.ts` — Mongoose model
+2. `app/server/functions/rules.ts` — Server functions
+3. `app/types/rule.ts` — TypeScript types
+4. `app/types/schemas/rules.ts` — Zod validation schemas
+5. `app/hooks/useRules.ts` — React Query hooks
+6. `app/components/wiki/rules/RulesPanel.tsx` — Wiki list panel
+7. `app/components/wiki/rules/RuleCard.tsx` — List item card
+8. `app/components/wiki/rules/RuleModal.tsx` — Editor modal
+9. `app/components/wiki/rules/RuleViewModal.tsx` — Read-only modal
+10. `app/components/wiki/rules/RuleWindow.tsx` — GM screen display
+11. `app/components/mainview/gmscreens/RuleWindowWrapper.tsx` — GM screen wrapper
+
+## Files to Modify
+
+1. `app/components/wiki/WikiPanel.tsx` — Add "Rules" category
+2. `app/components/wiki/shared/WikiFilterBar.tsx` — Add `showSessionFilter` prop to optionally hide session dropdown
+3. `app/components/mainview/gmscreens/GMScreensView.tsx` — Handle 'rule' collection in drop handler and window rendering
+4. `app/server/db/models/GMScreen.ts` — Accept 'rule' in collection enum
+5. `app/utils/queryKeys.ts` — Add rules query keys
+6. `app/types/gmscreen.ts` — Update collection type to include 'rule'

--- a/tests/components/mainview/WikiPanel.test.tsx
+++ b/tests/components/mainview/WikiPanel.test.tsx
@@ -1,48 +1,67 @@
-import React from 'react'
-import { describe, expect, it, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { WikiPanel } from '~/components/wiki/WikiPanel'
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { WikiPanel } from '~/components/wiki/WikiPanel';
 
-// Mock CharactersPanel since it requires routing/campaign context
+// Mock CharactersPanel and RulesPanel since they require routing/campaign context
 vi.mock('~/components/wiki/characters/CharactersPanel', () => ({
   CharactersPanel: ({ onBack }: { onBack: () => void }) => (
     <div data-testid="characters-panel">
       <button onClick={onBack}>Back</button>
     </div>
   ),
-}))
+}));
+
+vi.mock('~/components/wiki/rules/RulesPanel', () => ({
+  RulesPanel: ({ onBack }: { onBack: () => void }) => (
+    <div data-testid="rules-panel">
+      <button onClick={onBack}>Back</button>
+    </div>
+  ),
+}));
 
 describe('WikiPanel', () => {
   it('renders the Characters category button', () => {
-    render(<WikiPanel />)
+    render(<WikiPanel />);
 
-    expect(screen.getByRole('button', { name: 'Characters' })).toBeInTheDocument()
-  })
+    expect(screen.getByRole('button', { name: 'Characters' })).toBeInTheDocument();
+  });
 
-  it('only shows Characters category (no other categories)', () => {
-    render(<WikiPanel />)
+  it('shows Characters and Rules categories', () => {
+    render(<WikiPanel />);
 
-    expect(screen.getAllByRole('button')).toHaveLength(1)
-  })
+    expect(screen.getAllByRole('button')).toHaveLength(2);
+    expect(screen.getByRole('button', { name: 'Characters' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Rules' })).toBeInTheDocument();
+  });
 
   it('clicking Characters shows CharactersPanel', async () => {
-    const user = userEvent.setup()
-    render(<WikiPanel />)
+    const user = userEvent.setup();
+    render(<WikiPanel />);
 
-    await user.click(screen.getByRole('button', { name: 'Characters' }))
+    await user.click(screen.getByRole('button', { name: 'Characters' }));
 
-    expect(screen.getByTestId('characters-panel')).toBeInTheDocument()
-  })
+    expect(screen.getByTestId('characters-panel')).toBeInTheDocument();
+  });
+
+  it('clicking Rules shows RulesPanel', async () => {
+    const user = userEvent.setup();
+    render(<WikiPanel />);
+
+    await user.click(screen.getByRole('button', { name: 'Rules' }));
+
+    expect(screen.getByTestId('rules-panel')).toBeInTheDocument();
+  });
 
   it('CharactersPanel onBack returns to category list', async () => {
-    const user = userEvent.setup()
-    render(<WikiPanel />)
+    const user = userEvent.setup();
+    render(<WikiPanel />);
 
-    await user.click(screen.getByRole('button', { name: 'Characters' }))
-    await user.click(screen.getByRole('button', { name: 'Back' }))
+    await user.click(screen.getByRole('button', { name: 'Characters' }));
+    await user.click(screen.getByRole('button', { name: 'Back' }));
 
-    expect(screen.queryByTestId('characters-panel')).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Characters' })).toBeInTheDocument()
-  })
-})
+    expect(screen.queryByTestId('characters-panel')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Characters' })).toBeInTheDocument();
+  });
+});

--- a/tests/components/wiki/rules/RulesPanel.test.tsx
+++ b/tests/components/wiki/rules/RulesPanel.test.tsx
@@ -1,0 +1,226 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RulesPanel } from '~/components/wiki/rules/RulesPanel';
+import { useRules, useRule, useCreateRule, useUpdateRule, useDeleteRule } from '~/hooks/useRules';
+import { useCampaign } from '~/hooks/useCampaigns';
+
+vi.mock('~/hooks/useRules');
+vi.mock('~/hooks/useCampaigns');
+vi.mock('~/hooks/useTags', () => ({
+  useTags: () => ({ tags: [], isLoading: false, error: null }),
+}));
+vi.mock('@tanstack/react-router', () => ({
+  useParams: () => ({ campaignId: 'campaign-123' }),
+}));
+
+const mockRules = [
+  {
+    id: 'rule-1',
+    campaignId: 'campaign-123',
+    title: 'Critical Hit Rule',
+    tags: ['combat', 'damage'],
+    isPublic: true,
+    updatedAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    createdBy: 'user-1',
+  },
+];
+
+function setupMocks(overrides: { isGM?: boolean; rules?: typeof mockRules } = {}) {
+  const { isGM = true, rules = mockRules } = overrides;
+  (useCampaign as any).mockReturnValue({
+    campaign: { isGM, sessions: [] },
+    isLoading: false,
+    error: null,
+  });
+  (useRules as any).mockReturnValue({
+    rules,
+    isLoading: false,
+    error: null,
+  });
+  (useRule as any).mockReturnValue({
+    rule: null,
+    isLoading: false,
+    error: null,
+  });
+  (useCreateRule as any).mockReturnValue({
+    create: vi.fn(),
+    isLoading: false,
+    error: null,
+  });
+  (useUpdateRule as any).mockReturnValue({
+    update: vi.fn(),
+    isLoading: false,
+    error: null,
+  });
+  (useDeleteRule as any).mockReturnValue({
+    remove: vi.fn(),
+    isLoading: false,
+    error: null,
+  });
+}
+
+describe('RulesPanel', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('renders search, create button, and rules list for GM', async () => {
+    setupMocks();
+    render(<RulesPanel onBack={vi.fn()} />);
+
+    expect(screen.getByPlaceholderText('Search rules...')).toBeInTheDocument();
+    expect(screen.getByLabelText('Create new item')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText('Critical Hit Rule')).toBeInTheDocument();
+      expect(screen.getByText('#combat')).toBeInTheDocument();
+      expect(screen.getByText('#damage')).toBeInTheDocument();
+    });
+  });
+
+  it('hides create button for non-GM players', () => {
+    setupMocks({ isGM: false });
+    render(<RulesPanel onBack={vi.fn()} />);
+
+    expect(screen.queryByLabelText('Create new item')).not.toBeInTheDocument();
+  });
+
+  it('hides visibility filter for non-GM players', () => {
+    setupMocks({ isGM: false });
+    render(<RulesPanel onBack={vi.fn()} />);
+
+    expect(screen.queryByLabelText('Filter by visibility')).not.toBeInTheDocument();
+  });
+
+  it('shows visibility filter for GMs', () => {
+    setupMocks({ isGM: true });
+    render(<RulesPanel onBack={vi.fn()} />);
+
+    expect(screen.getByLabelText('Filter by visibility')).toBeInTheDocument();
+  });
+
+  it('does not show session filter (rules are session-independent)', () => {
+    setupMocks();
+    render(<RulesPanel onBack={vi.fn()} />);
+
+    expect(screen.queryByLabelText('Filter by session')).not.toBeInTheDocument();
+  });
+
+  it('GM clicking a rule opens edit modal', async () => {
+    setupMocks({ isGM: true });
+    const user = userEvent.setup();
+    render(<RulesPanel onBack={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Critical Hit Rule')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText('Critical Hit Rule'));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Edit Rule' })).toBeInTheDocument();
+  });
+
+  it('player clicking a rule opens read-only view modal', async () => {
+    setupMocks({ isGM: false });
+    const user = userEvent.setup();
+    render(<RulesPanel onBack={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Critical Hit Rule')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText('Critical Hit Rule'));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Rule' })).toBeInTheDocument();
+  });
+
+  it('GM clicking create button opens create modal', async () => {
+    setupMocks({ isGM: true });
+    const user = userEvent.setup();
+    render(<RulesPanel onBack={vi.fn()} />);
+
+    await user.click(screen.getByLabelText('Create new item'));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Create Rule' })).toBeInTheDocument();
+  });
+
+  it('updates filters when search input changes', async () => {
+    setupMocks();
+    const user = userEvent.setup();
+    render(<RulesPanel onBack={vi.fn()} />);
+
+    const searchInput = screen.getByPlaceholderText('Search rules...');
+    await user.type(searchInput, 'critical');
+
+    expect(useRules).toHaveBeenLastCalledWith(
+      'campaign-123',
+      expect.objectContaining({
+        search: 'critical',
+      })
+    );
+  });
+
+  it('updates filters when visibility select changes', async () => {
+    setupMocks({ isGM: true });
+    const user = userEvent.setup();
+    render(<RulesPanel onBack={vi.fn()} />);
+
+    const visibilitySelect = screen.getByLabelText('Filter by visibility');
+    await user.selectOptions(visibilitySelect, 'public');
+
+    expect(useRules).toHaveBeenLastCalledWith(
+      'campaign-123',
+      expect.objectContaining({
+        visibility: 'public',
+      })
+    );
+  });
+
+  it('shows loading state', () => {
+    setupMocks();
+    (useRules as any).mockReturnValue({
+      rules: [],
+      isLoading: true,
+      error: null,
+    });
+
+    render(<RulesPanel onBack={vi.fn()} />);
+    expect(screen.getByText('Loading rules...')).toBeInTheDocument();
+  });
+
+  it('shows empty state', () => {
+    setupMocks({ rules: [] });
+
+    render(<RulesPanel onBack={vi.fn()} />);
+    expect(screen.getByText('No rules found matching your filters.')).toBeInTheDocument();
+  });
+
+  it('shows error state', () => {
+    setupMocks();
+    (useRules as any).mockReturnValue({
+      rules: [],
+      isLoading: false,
+      error: 'Failed to fetch',
+    });
+
+    render(<RulesPanel onBack={vi.fn()} />);
+    expect(screen.getByText('Failed to fetch')).toBeInTheDocument();
+  });
+
+  it('calls onBack when header back button is clicked', async () => {
+    setupMocks();
+    const onBack = vi.fn();
+    const user = userEvent.setup();
+    render(<RulesPanel onBack={onBack} />);
+
+    await user.click(screen.getByLabelText('Back'));
+
+    expect(onBack).toHaveBeenCalled();
+  });
+});

--- a/tests/server/functions/gmscreens.test.ts
+++ b/tests/server/functions/gmscreens.test.ts
@@ -49,6 +49,11 @@ vi.mock('~/server/db/models/Character', () => ({
     find: vi.fn(),
   },
 }));
+vi.mock('~/server/db/models/Rule', () => ({
+  Rule: {
+    find: vi.fn(),
+  },
+}));
 vi.mock('~/server/utils/posthog', () => ({
   serverCaptureException: vi.fn(),
   serverCaptureEvent: vi.fn(),

--- a/tests/server/functions/gmscreens.test.ts
+++ b/tests/server/functions/gmscreens.test.ts
@@ -1765,8 +1765,10 @@ describe('openWindowSchema', () => {
 });
 
 describe('SUPPORTED_COLLECTIONS', () => {
-  it('contains only collections registered for hydration', () => {
+  it('contains all collections registered for hydration', () => {
     expect(SUPPORTED_COLLECTIONS).toContain('note');
+    expect(SUPPORTED_COLLECTIONS).toContain('character');
+    expect(SUPPORTED_COLLECTIONS).toContain('rule');
     expect(SUPPORTED_COLLECTIONS.length).toBeGreaterThan(0);
   });
 });

--- a/tests/server/functions/rules.test.ts
+++ b/tests/server/functions/rules.test.ts
@@ -1,0 +1,662 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tanstack/react-start', () => ({
+  createServerFn: () => ({
+    inputValidator: () => ({
+      handler: (fn: unknown) => fn,
+    }),
+    handler: (fn: unknown) => fn,
+  }),
+}));
+
+vi.mock('~/server/session', () => ({ getSession: vi.fn() }));
+vi.mock('~/server/db/connection', () => ({
+  connectDB: vi.fn(),
+  isDBConnected: vi.fn(() => true),
+}));
+vi.mock('~/server/db/models/User', () => ({
+  User: { findOne: vi.fn() },
+}));
+vi.mock('~/server/db/models/Campaign', () => ({
+  Campaign: { findById: vi.fn() },
+}));
+vi.mock('~/server/db/models/Rule', () => ({
+  Rule: {
+    create: vi.fn(),
+    findById: vi.fn(),
+    find: vi.fn(),
+  },
+}));
+vi.mock('~/server/db/models/Tag', () => ({
+  Tag: {
+    bulkWrite: vi.fn().mockResolvedValue({}),
+    find: vi.fn(),
+  },
+}));
+vi.mock('~/server/utils/posthog', () => ({
+  serverCaptureException: vi.fn(),
+  serverCaptureEvent: vi.fn(),
+}));
+vi.mock('~/server/functions/gmscreens-helpers', () => ({
+  removeDocumentRefsFromScreens: vi.fn().mockResolvedValue(0),
+}));
+
+import { getSession } from '~/server/session';
+import { User } from '~/server/db/models/User';
+import { Campaign } from '~/server/db/models/Campaign';
+import { Rule } from '~/server/db/models/Rule';
+import {
+  createRule,
+  updateRule,
+  deleteRule,
+  listRules,
+  getRule,
+  createRuleSchema,
+  updateRuleSchema,
+  listRulesSchema,
+} from '~/server/functions/rules';
+import type { RuleListItem } from '~/types/rule';
+import { serverCaptureEvent, serverCaptureException } from '~/server/utils/posthog';
+import { removeDocumentRefsFromScreens } from '~/server/functions/gmscreens-helpers';
+
+const mockSession = {
+  id: 'session-user-1',
+  provider: 'google',
+  name: 'Test User',
+  email: 'test@example.com',
+  avatar: null,
+  role: 'gm',
+  accessToken: null,
+  refreshToken: null,
+  tokenIssuedAt: 0,
+};
+const mockDbUser = { _id: 'dbuser-1', firstName: 'Test', lastName: 'User' };
+const mockGMCampaign = {
+  _id: 'camp-1',
+  gameMasterId: 'dbuser-1',
+  members: [{ userId: 'dbuser-1', role: 'gm' }],
+};
+const mockPlayerCampaign = {
+  _id: 'camp-1',
+  gameMasterId: 'someone-else',
+  members: [
+    { userId: 'someone-else', role: 'gm' },
+    { userId: 'dbuser-1', role: 'player' },
+  ],
+};
+
+function makeRule(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: 'rule-1',
+    campaignId: 'camp-1',
+    createdBy: 'dbuser-1',
+    title: 'Test Rule',
+    content: '# Critical Hit\n\nDouble damage on nat 20.',
+    tags: ['combat', 'damage'],
+    isPublic: false,
+    createdAt: new Date('2026-03-01'),
+    updatedAt: new Date('2026-03-01'),
+    save: vi.fn(),
+    deleteOne: vi.fn(),
+    ...overrides,
+  };
+}
+
+// Cast server functions to callable handler signatures
+const _createRule = createRule as unknown as (args: {
+  data: Record<string, unknown>;
+}) => Promise<{ success: boolean; rule: Record<string, unknown> }>;
+const _updateRule = updateRule as unknown as (args: {
+  data: Record<string, unknown>;
+}) => Promise<{ success: boolean; rule: Record<string, unknown> }>;
+const _listRules = listRules as unknown as (args: {
+  data: Record<string, unknown>;
+}) => Promise<RuleListItem[]>;
+const _deleteRule = deleteRule as unknown as (args: {
+  data: Record<string, unknown>;
+}) => Promise<{ success: boolean }>;
+const _getRule = getRule as unknown as (args: {
+  data: Record<string, unknown>;
+}) => Promise<Record<string, unknown> | null>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getSession).mockResolvedValue(mockSession);
+  vi.mocked(User.findOne).mockResolvedValue(mockDbUser);
+  vi.mocked(Campaign.findById).mockResolvedValue(mockGMCampaign);
+});
+
+// ---------------------------------------------------------------------------
+// createRule
+// ---------------------------------------------------------------------------
+
+describe('createRule', () => {
+  it('creates a rule with required fields and normalized tags', async () => {
+    const created = makeRule();
+    vi.mocked(Rule.create).mockResolvedValue(created as never);
+
+    const result = await _createRule({
+      data: {
+        campaignId: 'camp-1',
+        title: '  Critical Hit  ',
+        content: '# Content',
+        tags: [' Combat ', 'DAMAGE', ' combat '],
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.rule.id).toBe('rule-1');
+    expect(vi.mocked(Rule.create).mock.calls[0][0]).toMatchObject({
+      title: 'Critical Hit',
+      content: '# Content',
+      tags: ['combat', 'damage'],
+    });
+  });
+
+  it('defaults isPublic to false when omitted', async () => {
+    vi.mocked(Rule.create).mockResolvedValue(makeRule() as never);
+
+    await _createRule({
+      data: { campaignId: 'camp-1', title: 'Rule', content: 'body' },
+    });
+
+    expect(vi.mocked(Rule.create).mock.calls[0][0]).toMatchObject({
+      isPublic: false,
+    });
+  });
+
+  it('allows explicitly setting isPublic to true', async () => {
+    vi.mocked(Rule.create).mockResolvedValue(makeRule({ isPublic: true }) as never);
+
+    await _createRule({
+      data: { campaignId: 'camp-1', title: 'Public Rule', content: 'body', isPublic: true },
+    });
+
+    expect(vi.mocked(Rule.create).mock.calls[0][0]).toMatchObject({
+      isPublic: true,
+    });
+  });
+
+  it('throws when not authenticated', async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+
+    await expect(
+      _createRule({ data: { campaignId: 'camp-1', title: 'T', content: 'B' } })
+    ).rejects.toThrow('Not authenticated');
+  });
+
+  it('throws when user is not a GM', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(mockPlayerCampaign);
+
+    await expect(
+      _createRule({ data: { campaignId: 'camp-1', title: 'T', content: 'B' } })
+    ).rejects.toThrow('Forbidden');
+  });
+
+  it('fires rule_created analytics event', async () => {
+    vi.mocked(Rule.create).mockResolvedValue(makeRule() as never);
+
+    await _createRule({
+      data: { campaignId: 'camp-1', title: 'T', content: 'B' },
+    });
+
+    expect(serverCaptureEvent).toHaveBeenCalledWith('session-user-1', 'rule_created', {
+      campaign_id: 'camp-1',
+      rule_id: 'rule-1',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateRule
+// ---------------------------------------------------------------------------
+
+describe('updateRule', () => {
+  it('updates an existing rule', async () => {
+    const existing = makeRule();
+    vi.mocked(Rule.findById).mockResolvedValue(existing as never);
+
+    const result = await _updateRule({
+      data: {
+        id: 'rule-1',
+        campaignId: 'camp-1',
+        title: 'Updated Title',
+        content: 'Updated body',
+        tags: ['new-tag'],
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(existing.save).toHaveBeenCalled();
+    expect(existing.title).toBe('Updated Title');
+    expect(existing.content).toBe('Updated body');
+    expect(existing.tags).toEqual(['new-tag']);
+  });
+
+  it('allows any GM to edit any rule (no ownership check)', async () => {
+    // Rule created by a different user, but current user is still a GM
+    const existing = makeRule({ createdBy: 'other-gm-user' });
+    vi.mocked(Rule.findById).mockResolvedValue(existing as never);
+
+    const result = await _updateRule({
+      data: {
+        id: 'rule-1',
+        campaignId: 'camp-1',
+        title: 'Updated',
+        content: 'Updated body',
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(existing.save).toHaveBeenCalled();
+  });
+
+  it('throws when rule is not found', async () => {
+    vi.mocked(Rule.findById).mockResolvedValue(null);
+
+    await expect(
+      _updateRule({
+        data: { id: 'nonexistent', campaignId: 'camp-1', title: 'T', content: 'B' },
+      })
+    ).rejects.toThrow('Rule not found');
+  });
+
+  it('throws when rule belongs to a different campaign', async () => {
+    const existing = makeRule({ campaignId: 'camp-other' });
+    vi.mocked(Rule.findById).mockResolvedValue(existing as never);
+
+    await expect(
+      _updateRule({
+        data: { id: 'rule-1', campaignId: 'camp-1', title: 'T', content: 'B' },
+      })
+    ).rejects.toThrow('Forbidden');
+  });
+
+  it('throws when user is not a GM', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(mockPlayerCampaign);
+
+    await expect(
+      _updateRule({
+        data: { id: 'rule-1', campaignId: 'camp-1', title: 'T', content: 'B' },
+      })
+    ).rejects.toThrow('Forbidden');
+  });
+
+  it('fires rule_updated analytics event', async () => {
+    const existing = makeRule();
+    vi.mocked(Rule.findById).mockResolvedValue(existing as never);
+
+    await _updateRule({
+      data: { id: 'rule-1', campaignId: 'camp-1', title: 'T', content: 'B' },
+    });
+
+    expect(serverCaptureEvent).toHaveBeenCalledWith('session-user-1', 'rule_updated', {
+      campaign_id: 'camp-1',
+      rule_id: 'rule-1',
+      updated_by: 'dbuser-1',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listRules
+// ---------------------------------------------------------------------------
+
+describe('listRules', () => {
+  function mockFind(docs: unknown[] = []) {
+    vi.mocked(Rule.find).mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        sort: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue(docs) }),
+      }),
+    } as never);
+  }
+
+  it('returns rules for a GM (default visibility shows all)', async () => {
+    const rules = [makeRule(), makeRule({ _id: 'rule-2', title: 'Second Rule' })];
+    mockFind(rules);
+
+    const result = await _listRules({ data: { campaignId: 'camp-1' } });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('rule-1');
+    expect(result[1].title).toBe('Second Rule');
+    // GM with default visibility should NOT have isPublic filter
+    const filter = vi.mocked(Rule.find).mock.calls[0][0] as unknown as Record<string, unknown>;
+    expect(filter).not.toHaveProperty('isPublic');
+  });
+
+  it('constrains non-GM users to public rules only', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(mockPlayerCampaign);
+    mockFind([]);
+
+    await _listRules({ data: { campaignId: 'camp-1' } });
+
+    expect(vi.mocked(Rule.find).mock.calls[0][0]).toMatchObject({
+      isPublic: true,
+    });
+  });
+
+  it('GM can filter by visibility=public', async () => {
+    mockFind([]);
+
+    await _listRules({ data: { campaignId: 'camp-1', visibility: 'public' } });
+
+    expect(vi.mocked(Rule.find).mock.calls[0][0]).toMatchObject({
+      isPublic: true,
+    });
+  });
+
+  it('GM can filter by visibility=private', async () => {
+    mockFind([]);
+
+    await _listRules({ data: { campaignId: 'camp-1', visibility: 'private' } });
+
+    expect(vi.mocked(Rule.find).mock.calls[0][0]).toMatchObject({
+      isPublic: false,
+    });
+  });
+
+  it('list responses omit content field', async () => {
+    mockFind([makeRule()]);
+
+    const result = await _listRules({ data: { campaignId: 'camp-1' } });
+
+    expect(result[0]).not.toHaveProperty('content');
+  });
+
+  it('applies text search filter', async () => {
+    mockFind([]);
+
+    await _listRules({ data: { campaignId: 'camp-1', search: 'critical' } });
+
+    expect(vi.mocked(Rule.find).mock.calls[0][0]).toMatchObject({
+      $text: { $search: 'critical' },
+    });
+  });
+
+  it('ignores empty search string', async () => {
+    mockFind([]);
+
+    await _listRules({ data: { campaignId: 'camp-1', search: '   ' } });
+
+    expect(vi.mocked(Rule.find).mock.calls[0][0]).not.toHaveProperty('$text');
+  });
+
+  it('filters by tags', async () => {
+    mockFind([]);
+
+    await _listRules({ data: { campaignId: 'camp-1', tags: ['combat'] } });
+
+    expect(vi.mocked(Rule.find).mock.calls[0][0]).toMatchObject({
+      tags: { $all: ['combat'] },
+    });
+  });
+
+  it('throws when not authenticated', async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+
+    await expect(_listRules({ data: { campaignId: 'camp-1' } })).rejects.toThrow(
+      'Not authenticated'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getRule
+// ---------------------------------------------------------------------------
+
+describe('getRule', () => {
+  it('returns a rule for a GM', async () => {
+    const rule = makeRule();
+    vi.mocked(Rule.findById).mockResolvedValue(rule as never);
+
+    const result = await _getRule({ data: { id: 'rule-1', campaignId: 'camp-1' } });
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe('rule-1');
+  });
+
+  it('returns null when rule does not exist', async () => {
+    vi.mocked(Rule.findById).mockResolvedValue(null);
+
+    const result = await _getRule({ data: { id: 'nonexistent', campaignId: 'camp-1' } });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null for private rules when user is not a GM', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(mockPlayerCampaign);
+    const rule = makeRule({ isPublic: false });
+    vi.mocked(Rule.findById).mockResolvedValue(rule as never);
+
+    const result = await _getRule({ data: { id: 'rule-1', campaignId: 'camp-1' } });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns public rules for non-GM users', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(mockPlayerCampaign);
+    const rule = makeRule({ isPublic: true });
+    vi.mocked(Rule.findById).mockResolvedValue(rule as never);
+
+    const result = await _getRule({ data: { id: 'rule-1', campaignId: 'camp-1' } });
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe('rule-1');
+  });
+
+  it('returns null when rule belongs to a different campaign', async () => {
+    const rule = makeRule({ campaignId: 'camp-other' });
+    vi.mocked(Rule.findById).mockResolvedValue(rule as never);
+
+    const result = await _getRule({ data: { id: 'rule-1', campaignId: 'camp-1' } });
+
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteRule
+// ---------------------------------------------------------------------------
+
+describe('deleteRule', () => {
+  it('deletes a rule and cleans up GM Screen refs', async () => {
+    const existing = makeRule({ deleteOne: vi.fn() });
+    vi.mocked(Rule.findById).mockResolvedValue(existing as never);
+
+    const result = await _deleteRule({ data: { id: 'rule-1', campaignId: 'camp-1' } });
+
+    expect(result.success).toBe(true);
+    expect(existing.deleteOne).toHaveBeenCalled();
+    expect(removeDocumentRefsFromScreens).toHaveBeenCalledWith('camp-1', 'rule', 'rule-1');
+  });
+
+  it('allows any GM to delete any rule (no ownership check)', async () => {
+    const existing = makeRule({ createdBy: 'other-gm-user', deleteOne: vi.fn() });
+    vi.mocked(Rule.findById).mockResolvedValue(existing as never);
+
+    const result = await _deleteRule({ data: { id: 'rule-1', campaignId: 'camp-1' } });
+
+    expect(result.success).toBe(true);
+    expect(existing.deleteOne).toHaveBeenCalled();
+  });
+
+  it('throws when rule is not found', async () => {
+    vi.mocked(Rule.findById).mockResolvedValue(null);
+
+    await expect(
+      _deleteRule({ data: { id: 'nonexistent', campaignId: 'camp-1' } })
+    ).rejects.toThrow('Rule not found');
+  });
+
+  it('throws when rule belongs to a different campaign', async () => {
+    const existing = makeRule({ campaignId: 'camp-other' });
+    vi.mocked(Rule.findById).mockResolvedValue(existing as never);
+
+    await expect(_deleteRule({ data: { id: 'rule-1', campaignId: 'camp-1' } })).rejects.toThrow(
+      'Forbidden'
+    );
+  });
+
+  it('throws when user is not a GM', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(mockPlayerCampaign);
+
+    await expect(_deleteRule({ data: { id: 'rule-1', campaignId: 'camp-1' } })).rejects.toThrow(
+      'Forbidden'
+    );
+  });
+
+  it('succeeds even when cleanup fails, reporting the cleanup error', async () => {
+    const existing = makeRule({ deleteOne: vi.fn() });
+    vi.mocked(Rule.findById).mockResolvedValue(existing as never);
+    const cleanupError = new Error('MongoDB timeout during cleanup');
+    vi.mocked(removeDocumentRefsFromScreens).mockRejectedValueOnce(cleanupError);
+
+    const result = await _deleteRule({ data: { id: 'rule-1', campaignId: 'camp-1' } });
+
+    expect(result.success).toBe(true);
+    expect(existing.deleteOne).toHaveBeenCalled();
+    expect(serverCaptureException).toHaveBeenCalledWith(
+      cleanupError,
+      'session-user-1',
+      expect.objectContaining({
+        action: 'deleteRule.cleanup',
+        campaignId: 'camp-1',
+        ruleId: 'rule-1',
+      })
+    );
+  });
+
+  it('fires rule_deleted analytics event', async () => {
+    const existing = makeRule({ deleteOne: vi.fn() });
+    vi.mocked(Rule.findById).mockResolvedValue(existing as never);
+
+    await _deleteRule({ data: { id: 'rule-1', campaignId: 'camp-1' } });
+
+    expect(serverCaptureEvent).toHaveBeenCalledWith('session-user-1', 'rule_deleted', {
+      campaign_id: 'camp-1',
+      rule_id: 'rule-1',
+      deleted_by: 'dbuser-1',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Zod schemas — validation
+// ---------------------------------------------------------------------------
+
+describe('createRuleSchema', () => {
+  it('rejects when title is empty', () => {
+    const result = createRuleSchema.safeParse({
+      campaignId: 'camp-1',
+      title: '',
+      content: 'body',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects when content is empty', () => {
+    const result = createRuleSchema.safeParse({
+      campaignId: 'camp-1',
+      title: 'Title',
+      content: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects whitespace-only title', () => {
+    const result = createRuleSchema.safeParse({
+      campaignId: 'camp-1',
+      title: '   ',
+      content: 'body',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects whitespace-only content', () => {
+    const result = createRuleSchema.safeParse({
+      campaignId: 'camp-1',
+      title: 'Title',
+      content: '   ',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects whitespace-only campaignId', () => {
+    const result = createRuleSchema.safeParse({
+      campaignId: '   ',
+      title: 'Title',
+      content: 'body',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts valid input with defaults', () => {
+    const result = createRuleSchema.safeParse({
+      campaignId: 'camp-1',
+      title: 'Title',
+      content: 'body',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.isPublic).toBe(false);
+      expect(result.data.tags).toEqual([]);
+    }
+  });
+});
+
+describe('updateRuleSchema', () => {
+  it('rejects when id is missing', () => {
+    const result = updateRuleSchema.safeParse({
+      campaignId: 'camp-1',
+      title: 'Title',
+      content: 'body',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects when title is empty', () => {
+    const result = updateRuleSchema.safeParse({
+      id: 'rule-1',
+      campaignId: 'camp-1',
+      title: '',
+      content: 'body',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects whitespace-only title', () => {
+    const result = updateRuleSchema.safeParse({
+      id: 'rule-1',
+      campaignId: 'camp-1',
+      title: '   ',
+      content: 'body',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects whitespace-only content', () => {
+    const result = updateRuleSchema.safeParse({
+      id: 'rule-1',
+      campaignId: 'camp-1',
+      title: 'Title',
+      content: '   ',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('listRulesSchema', () => {
+  it('defaults visibility to all', () => {
+    const result = listRulesSchema.safeParse({ campaignId: 'camp-1' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.visibility).toBe('all');
+    }
+  });
+
+  it('rejects invalid visibility value', () => {
+    const result = listRulesSchema.safeParse({ campaignId: 'camp-1', visibility: 'secret' });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a complete Rules feature to the Wiki system — Game Masters can create, edit, and delete rules with markdown content, tags, and public/private visibility
- Players can browse and read public rules with fully rendered markdown (never see raw markdown)
- Rules integrate with the GM Screen: drag from wiki list, render in scrollable floating windows with edit button for GMs, live updates on edit via React Query invalidation
- WikiFilterBar updated to support optional session and visibility filters for reuse across wiki categories

## New Files
- `app/types/rule.ts`, `app/types/schemas/rules.ts` — Types and validation
- `app/server/db/models/Rule.ts` — Mongoose model
- `app/server/functions/rules.ts` — Server functions (CRUD + list)
- `app/hooks/useRules.ts` — React Query hooks
- `app/components/wiki/rules/` — RulesPanel, RuleCard, RuleModal, RuleViewModal, RuleWindow
- `app/components/mainview/gmscreens/RuleWindowWrapper.tsx` — GM screen wrapper

## Modified Files
- `app/utils/queryKeys.ts` — Added rules query keys
- `app/components/wiki/shared/WikiFilterBar.tsx` — Optional session/visibility/create filters
- `app/components/wiki/WikiPanel.tsx` — Added Rules category
- `app/server/functions/gmscreens.ts` — Added rule to COLLECTION_REGISTRY
- `app/components/mainview/gmscreens/GMScreensView.tsx` — Rule window rendering + edit support

## Test plan
- [ ] Verify Rules category appears in Wiki panel
- [ ] GM can create a rule with title, markdown content, tags, and public/private toggle
- [ ] GM can edit and delete any rule (not just their own)
- [ ] Players can only see public rules in the list
- [ ] Players see rendered markdown in read-only view (no raw markdown visible)
- [ ] Rules can be dragged to GM Screen and render in floating windows
- [ ] GM Screen rule windows support minimize, maximize, close, resize, and persist position
- [ ] Edit button appears on GM Screen rule windows for GMs only
- [ ] Editing a rule from GM Screen updates the window content automatically
- [ ] Create button and visibility filter hidden from non-GM players
- [ ] All existing tests pass (994 tests, 78 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)