### PR TITLE
[Feature]: UI space optimization

### DIFF
--- a/app/components/mainview/FloatingWindow.tsx
+++ b/app/components/mainview/FloatingWindow.tsx
@@ -34,6 +34,8 @@ export interface FloatingWindowProps {
   onStateChange?: (state: FloatingWindowState) => void;
   onLayoutChange?: (layout: { position: FloatingWindowPosition; size: FloatingWindowSize }) => void;
   className?: string;
+  titleIcon?: ReactNode;
+  titleSuffix?: ReactNode;
 }
 
 const DEFAULT_POSITION: FloatingWindowPosition = { x: 100, y: 100 };
@@ -88,6 +90,8 @@ export function FloatingWindow({
   onStateChange,
   onLayoutChange,
   className = '',
+  titleIcon,
+  titleSuffix,
 }: FloatingWindowProps) {
   const [position, setPosition] = useState<FloatingWindowPosition>(initialPosition);
   const [size, setSize] = useState<FloatingWindowSize>(initialSize);
@@ -332,8 +336,13 @@ export function FloatingWindow({
         ].join(' ')}
         onMouseDown={handleTitleBarMouseDown}
       >
-        <div id={titleId} className="truncate font-sans font-semibold text-xs text-slate-300">
-          {title}
+        <div
+          id={titleId}
+          className="flex items-center gap-1.5 min-w-0 font-sans font-semibold text-xs text-slate-300"
+        >
+          {titleIcon && <span className="shrink-0 flex items-center">{titleIcon}</span>}
+          <span className="truncate">{title}</span>
+          {titleSuffix && <span className="shrink-0 flex items-center">{titleSuffix}</span>}
         </div>
 
         <div className="flex shrink-0 items-center gap-1.5">

--- a/app/components/mainview/FloatingWindow.tsx
+++ b/app/components/mainview/FloatingWindow.tsx
@@ -336,12 +336,11 @@ export function FloatingWindow({
         ].join(' ')}
         onMouseDown={handleTitleBarMouseDown}
       >
-        <div
-          id={titleId}
-          className="flex items-center gap-1.5 min-w-0 font-sans font-semibold text-xs text-slate-300"
-        >
+        <div className="flex items-center gap-1.5 min-w-0 font-sans font-semibold text-xs text-slate-300">
           {titleIcon && <span className="shrink-0 flex items-center">{titleIcon}</span>}
-          <span className="truncate">{title}</span>
+          <span id={titleId} className="truncate">
+            {title}
+          </span>
           {titleSuffix && <span className="shrink-0 flex items-center">{titleSuffix}</span>}
         </div>
 

--- a/app/components/mainview/FloatingWindowManager.tsx
+++ b/app/components/mainview/FloatingWindowManager.tsx
@@ -1,33 +1,35 @@
-import type { ReactNode } from 'react'
+import type { ReactNode } from 'react';
 import {
   FloatingWindow,
   type FloatingWindowPosition,
   type FloatingWindowSize,
   type FloatingWindowState,
-} from './FloatingWindow'
-import { FloatingWindowTray } from './FloatingWindowTray'
+} from './FloatingWindow';
+import { FloatingWindowTray } from './FloatingWindowTray';
 
 export interface ManagedWindow {
-  id: string
-  title: string
-  content: ReactNode
+  id: string;
+  title: string;
+  content: ReactNode;
   /** Opaque key that changes when content changes — used by staleness checks */
-  contentKey?: string
-  position?: FloatingWindowPosition
-  size?: FloatingWindowSize
-  state: FloatingWindowState
-  zIndex: number
-  className?: string
+  contentKey?: string;
+  titleIcon?: ReactNode;
+  titleSuffix?: ReactNode;
+  position?: FloatingWindowPosition;
+  size?: FloatingWindowSize;
+  state: FloatingWindowState;
+  zIndex: number;
+  className?: string;
 }
 
 export interface FloatingWindowManagerProps {
-  windows: ManagedWindow[]
-  onWindowsChange: (windows: ManagedWindow[]) => void
-  className?: string
+  windows: ManagedWindow[];
+  onWindowsChange: (windows: ManagedWindow[]) => void;
+  className?: string;
 }
 
 function getHighestZIndex(windows: ManagedWindow[]) {
-  return windows.reduce((max, window) => Math.max(max, window.zIndex), 0)
+  return windows.reduce((max, window) => Math.max(max, window.zIndex), 0);
 }
 
 export function FloatingWindowManager({
@@ -35,65 +37,62 @@ export function FloatingWindowManager({
   onWindowsChange,
   className = '',
 }: FloatingWindowManagerProps) {
-  const activeWindows = windows.filter(window => window.state !== 'minimized')
-  const minimizedWindows = windows.filter(window => window.state === 'minimized')
+  const activeWindows = windows.filter((window) => window.state !== 'minimized');
+  const minimizedWindows = windows.filter((window) => window.state === 'minimized');
 
   const handleFocus = (id: string) => {
-    const highestZIndex = getHighestZIndex(windows)
-    const focused = windows.find(w => w.id === id)
+    const highestZIndex = getHighestZIndex(windows);
+    const focused = windows.find((w) => w.id === id);
 
     // Short-circuit if already at the top
-    if (focused?.zIndex === highestZIndex) return
+    if (focused?.zIndex === highestZIndex) return;
 
     // Normalize all z-indexes to keep values small (re-rank from 1)
-    const sorted = [...windows].sort((a, b) => a.zIndex - b.zIndex)
-    const normalized = sorted.map((w, i) => ({ ...w, zIndex: i + 1 }))
-    const focusedRank = normalized.length // highest rank = top
+    const sorted = [...windows].sort((a, b) => a.zIndex - b.zIndex);
+    const normalized = sorted.map((w, i) => ({ ...w, zIndex: i + 1 }));
+    const focusedRank = normalized.length; // highest rank = top
 
-    onWindowsChange(
-      normalized.map(w => w.id === id ? { ...w, zIndex: focusedRank } : w)
-    )
-  }
+    onWindowsChange(normalized.map((w) => (w.id === id ? { ...w, zIndex: focusedRank } : w)));
+  };
 
   const handleClose = (id: string) => {
-    onWindowsChange(windows.filter(window => window.id !== id))
-  }
+    onWindowsChange(windows.filter((window) => window.id !== id));
+  };
 
   const handleStateChange = (id: string, state: FloatingWindowState) => {
-    const highestZIndex = getHighestZIndex(windows)
+    const highestZIndex = getHighestZIndex(windows);
 
     onWindowsChange(
-      windows.map(window => {
+      windows.map((window) => {
         if (window.id !== id) {
-          return window
+          return window;
         }
 
         return {
           ...window,
           state,
           zIndex: state === 'normal' ? highestZIndex + 1 : window.zIndex,
-        }
-      }),
-    )
-  }
+        };
+      })
+    );
+  };
 
-  const handleLayoutChange = (id: string, layout: { position: FloatingWindowPosition; size: FloatingWindowSize }) => {
+  const handleLayoutChange = (
+    id: string,
+    layout: { position: FloatingWindowPosition; size: FloatingWindowSize }
+  ) => {
     onWindowsChange(
-      windows.map(w =>
-        w.id === id
-          ? { ...w, position: layout.position, size: layout.size }
-          : w
-      )
-    )
-  }
+      windows.map((w) => (w.id === id ? { ...w, position: layout.position, size: layout.size } : w))
+    );
+  };
 
   const handleRestore = (id: string) => {
-    handleStateChange(id, 'normal')
-  }
+    handleStateChange(id, 'normal');
+  };
 
   return (
     <div className={`relative h-full w-full overflow-hidden ${className}`}>
-      {activeWindows.map(window => (
+      {activeWindows.map((window) => (
         <FloatingWindow
           key={window.id}
           id={window.id}
@@ -103,6 +102,8 @@ export function FloatingWindowManager({
           initialSize={window.size}
           initialState={window.state}
           zIndex={window.zIndex}
+          titleIcon={window.titleIcon}
+          titleSuffix={window.titleSuffix}
           onFocus={() => handleFocus(window.id)}
           onClose={() => handleClose(window.id)}
           onStateChange={(state) => handleStateChange(window.id, state)}
@@ -113,9 +114,9 @@ export function FloatingWindowManager({
       ))}
 
       <FloatingWindowTray
-        windows={minimizedWindows.map(window => ({ id: window.id, title: window.title }))}
+        windows={minimizedWindows.map((window) => ({ id: window.id, title: window.title }))}
         onRestore={handleRestore}
       />
     </div>
-  )
+  );
 }

--- a/app/components/mainview/FloatingWindowManager.tsx
+++ b/app/components/mainview/FloatingWindowManager.tsx
@@ -13,6 +13,8 @@ export interface ManagedWindow {
   content: ReactNode;
   /** Opaque key that changes when content changes — used by staleness checks */
   contentKey?: string;
+  /** Opaque key that changes when title bar icons change — used by staleness checks */
+  iconKey?: string;
   titleIcon?: ReactNode;
   titleSuffix?: ReactNode;
   position?: FloatingWindowPosition;

--- a/app/components/mainview/gmscreens/CharacterWindowWrapper.tsx
+++ b/app/components/mainview/gmscreens/CharacterWindowWrapper.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { CharacterWindow } from '~/components/wiki/characters/CharacterWindow';
 import { CharacterModal } from '~/components/wiki/characters/CharacterModal';
 import { useCharacter } from '~/hooks/useCharacters';

--- a/app/components/mainview/gmscreens/CharacterWindowWrapper.tsx
+++ b/app/components/mainview/gmscreens/CharacterWindowWrapper.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Pencil } from 'lucide-react';
 import { CharacterWindow } from '~/components/wiki/characters/CharacterWindow';
 import { CharacterModal } from '~/components/wiki/characters/CharacterModal';
 import { useCharacter } from '~/hooks/useCharacters';
@@ -54,19 +53,5 @@ export function CharacterWindowWrapper({
     );
   }
 
-  return (
-    <div className="relative h-full">
-      {character.canEdit && (
-        <button
-          type="button"
-          onClick={onEdit}
-          className="absolute top-2 right-2 z-10 p-1.5 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors"
-          aria-label="Edit character"
-        >
-          <Pencil className="h-3.5 w-3.5" />
-        </button>
-      )}
-      <CharacterWindow character={character} />
-    </div>
-  );
+  return <CharacterWindow character={character} onEdit={onEdit} />;
 }

--- a/app/components/mainview/gmscreens/GMScreensView.tsx
+++ b/app/components/mainview/gmscreens/GMScreensView.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useRef, useEffect, useMemo, type DragEvent } from 'react';
-import { Plus, Layers, Loader2, AlertTriangle } from 'lucide-react';
+import { Plus, Layers, Loader2, AlertTriangle, Globe, Lock, ExternalLink } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useGMScreenList, useGMScreenDetail, useGMScreenMutations } from '~/hooks/useGMScreens';
@@ -429,12 +429,41 @@ export function GMScreensView({ campaignId, isGM = true }: GMScreensViewProps) {
           );
         }
 
+        let titleIcon: React.ReactNode;
+        let titleSuffix: React.ReactNode;
+
+        if (w.collection === 'rule' || w.collection === 'character') {
+          if (doc?.isPublic === true) {
+            titleIcon = <Globe className="h-3 w-3 text-emerald-400" />;
+          } else if (doc?.isPublic === false) {
+            titleIcon = <Lock className="h-3 w-3 text-amber-400" />;
+          }
+        }
+
+        if (w.collection === 'character' && doc?.link) {
+          titleSuffix = (
+            <a
+              href={doc.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              onMouseDown={(e) => e.stopPropagation()}
+              onClick={(e) => e.stopPropagation()}
+              className="flex items-center"
+              aria-label="External link"
+            >
+              <ExternalLink className="h-3 w-3 text-slate-500 hover:text-blue-400 transition-colors" />
+            </a>
+          );
+        }
+
         const existing = prevById.get(w.id);
         if (existing) {
           // Preserve local layout, update title/content from server
           return {
             ...existing,
             title,
+            titleIcon,
+            titleSuffix,
             contentKey: markdownContent,
             className: flashWindowId === existing.id ? 'animate-flash-border' : '',
             content: windowContent,
@@ -445,6 +474,8 @@ export function GMScreensView({ campaignId, isGM = true }: GMScreensViewProps) {
         return {
           id: w.id,
           title,
+          titleIcon,
+          titleSuffix,
           contentKey: markdownContent,
           position: w.x != null && w.y != null ? { x: w.x, y: w.y } : undefined,
           size:

--- a/app/components/mainview/gmscreens/GMScreensView.tsx
+++ b/app/components/mainview/gmscreens/GMScreensView.tsx
@@ -435,9 +435,17 @@ export function GMScreensView({ campaignId, isGM = true }: GMScreensViewProps) {
 
         if (w.collection === 'rule' || w.collection === 'character') {
           if (doc?.isPublic === true) {
-            titleIcon = <Globe className="h-3 w-3 text-emerald-400" />;
+            titleIcon = (
+              <span aria-label="Public">
+                <Globe className="h-3 w-3 text-emerald-400" aria-hidden="true" />
+              </span>
+            );
           } else if (doc?.isPublic === false) {
-            titleIcon = <Lock className="h-3 w-3 text-amber-400" />;
+            titleIcon = (
+              <span aria-label="Private">
+                <Lock className="h-3 w-3 text-amber-400" aria-hidden="true" />
+              </span>
+            );
           }
         }
 

--- a/app/components/mainview/gmscreens/GMScreensView.tsx
+++ b/app/components/mainview/gmscreens/GMScreensView.tsx
@@ -431,6 +431,7 @@ export function GMScreensView({ campaignId, isGM = true }: GMScreensViewProps) {
 
         let titleIcon: React.ReactNode;
         let titleSuffix: React.ReactNode;
+        const iconKey = `${doc?.isPublic ?? 'none'}:${doc?.link ?? ''}`;
 
         if (w.collection === 'rule' || w.collection === 'character') {
           if (doc?.isPublic === true) {
@@ -464,6 +465,7 @@ export function GMScreensView({ campaignId, isGM = true }: GMScreensViewProps) {
             title,
             titleIcon,
             titleSuffix,
+            iconKey,
             contentKey: markdownContent,
             className: flashWindowId === existing.id ? 'animate-flash-border' : '',
             content: windowContent,
@@ -476,6 +478,7 @@ export function GMScreensView({ campaignId, isGM = true }: GMScreensViewProps) {
           title,
           titleIcon,
           titleSuffix,
+          iconKey,
           contentKey: markdownContent,
           position: w.x != null && w.y != null ? { x: w.x, y: w.y } : undefined,
           size:
@@ -495,6 +498,7 @@ export function GMScreensView({ campaignId, isGM = true }: GMScreensViewProps) {
             p.id === merged[i]!.id &&
             p.title === merged[i]!.title &&
             p.contentKey === merged[i]!.contentKey &&
+            p.iconKey === merged[i]!.iconKey &&
             p.className === merged[i]!.className
         ) &&
         serverIds.size === prev.length

--- a/app/components/mainview/gmscreens/RuleWindowWrapper.tsx
+++ b/app/components/mainview/gmscreens/RuleWindowWrapper.tsx
@@ -1,4 +1,3 @@
-import { Pencil } from 'lucide-react';
 import { RuleWindow } from '~/components/wiki/rules/RuleWindow';
 import { RuleModal } from '~/components/wiki/rules/RuleModal';
 import { useRule } from '~/hooks/useRules';
@@ -44,19 +43,5 @@ export function RuleWindowWrapper({
     );
   }
 
-  return (
-    <div className="relative h-full">
-      {isGM && (
-        <button
-          type="button"
-          onClick={onEdit}
-          className="absolute top-2 right-2 z-10 p-1.5 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors"
-          aria-label="Edit rule"
-        >
-          <Pencil className="h-3.5 w-3.5" />
-        </button>
-      )}
-      <RuleWindow rule={rule} />
-    </div>
-  );
+  return <RuleWindow rule={rule} isGM={isGM} onEdit={onEdit} />;
 }

--- a/app/components/mainview/notes/NoteModal.tsx
+++ b/app/components/mainview/notes/NoteModal.tsx
@@ -174,12 +174,19 @@ export function NoteModal({
         className="w-full h-full max-w-[90vw] max-h-[90vh] sm:max-w-[90vw] sm:max-h-[90vh] bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col"
       >
         <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
-          <h2
-            id="note-modal-title"
-            className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest"
-          >
-            {noteId ? 'Edit Note' : 'Create Note'}
-          </h2>
+          <div className="flex items-center gap-2">
+            {isPublic ? (
+              <Globe className="h-3.5 w-3.5 text-emerald-400 shrink-0" aria-label="Public" />
+            ) : (
+              <Lock className="h-3.5 w-3.5 text-amber-400 shrink-0" aria-label="Private" />
+            )}
+            <h2
+              id="note-modal-title"
+              className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest"
+            >
+              {noteId ? 'Edit Note' : 'Create Note'}
+            </h2>
+          </div>
           <button
             type="button"
             onClick={onClose}

--- a/app/components/wiki/characters/CharacterViewModal.tsx
+++ b/app/components/wiki/characters/CharacterViewModal.tsx
@@ -58,6 +58,9 @@ export function CharacterViewModal({
               className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest truncate"
             >
               {character ? `${character.firstName} ${character.lastName}`.trim() : 'Character'}
+              {character && (
+                <span className="sr-only">{character.isPublic ? ' (Public)' : ' (Private)'}</span>
+              )}
             </h2>
             {character?.link && (
               <a

--- a/app/components/wiki/characters/CharacterViewModal.tsx
+++ b/app/components/wiki/characters/CharacterViewModal.tsx
@@ -49,9 +49,9 @@ export function CharacterViewModal({
           <div className="flex items-center gap-2 min-w-0">
             {character &&
               (character.isPublic ? (
-                <Globe className="h-3.5 w-3.5 text-emerald-400 shrink-0" />
+                <Globe className="h-3.5 w-3.5 text-emerald-400 shrink-0" aria-hidden="true" />
               ) : (
-                <Lock className="h-3.5 w-3.5 text-amber-400 shrink-0" />
+                <Lock className="h-3.5 w-3.5 text-amber-400 shrink-0" aria-hidden="true" />
               ))}
             <h2
               id="character-view-modal-title"

--- a/app/components/wiki/characters/CharacterViewModal.tsx
+++ b/app/components/wiki/characters/CharacterViewModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { X } from 'lucide-react';
+import { ExternalLink, Globe, Lock, X } from 'lucide-react';
 import { CharacterWindow } from './CharacterWindow';
 import { useCharacter } from '~/hooks/useCharacters';
 
@@ -46,16 +46,35 @@ export function CharacterViewModal({
         className="w-full max-w-lg max-h-[90vh] bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col"
       >
         <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
-          <h2
-            id="character-view-modal-title"
-            className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest"
-          >
-            Character
-          </h2>
+          <div className="flex items-center gap-2 min-w-0">
+            {character &&
+              (character.isPublic ? (
+                <Globe className="h-3.5 w-3.5 text-emerald-400 shrink-0" />
+              ) : (
+                <Lock className="h-3.5 w-3.5 text-amber-400 shrink-0" />
+              ))}
+            <h2
+              id="character-view-modal-title"
+              className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest truncate"
+            >
+              {character ? `${character.firstName} ${character.lastName}`.trim() : 'Character'}
+            </h2>
+            {character?.link && (
+              <a
+                href={character.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="shrink-0"
+                aria-label="External link"
+              >
+                <ExternalLink className="h-3.5 w-3.5 text-slate-500 hover:text-blue-400 transition-colors" />
+              </a>
+            )}
+          </div>
           <button
             type="button"
             onClick={onClose}
-            className="text-slate-500 hover:text-white transition-colors"
+            className="text-slate-500 hover:text-white transition-colors shrink-0"
             aria-label="Close modal"
           >
             <X className="h-5 w-5" />

--- a/app/components/wiki/characters/CharacterWindow.tsx
+++ b/app/components/wiki/characters/CharacterWindow.tsx
@@ -135,7 +135,7 @@ export function CharacterWindow({ character, onEdit }: CharacterWindowProps) {
             <button
               type="button"
               onClick={onEdit}
-              className="p-1 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors"
+              className="shrink-0 p-1 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors"
               aria-label="Edit character"
             >
               <Pencil className="h-3.5 w-3.5" />

--- a/app/components/wiki/characters/CharacterWindow.tsx
+++ b/app/components/wiki/characters/CharacterWindow.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { ExternalLink, ChevronDown, Globe, Lock } from 'lucide-react';
+import { ChevronDown, Pencil } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { CharacterData, PictureCrop } from '~/types/character';
@@ -17,6 +17,7 @@ function getCropStyle(crop: PictureCrop): React.CSSProperties {
 
 interface CharacterWindowProps {
   character: CharacterData;
+  onEdit?: () => void;
 }
 
 const GRADIENT_PAIRS = [
@@ -80,7 +81,7 @@ function Accordion({
   );
 }
 
-export function CharacterWindow({ character }: CharacterWindowProps) {
+export function CharacterWindow({ character, onEdit }: CharacterWindowProps) {
   const fullName = `${character.firstName} ${character.lastName}`.trim();
   const initials = getInitials(character.firstName, character.lastName);
   const gradientIndex = hashName(fullName) % GRADIENT_PAIRS.length;
@@ -92,8 +93,10 @@ export function CharacterWindow({ character }: CharacterWindowProps) {
   if (character.age != null) stats.push({ label: 'Age', value: String(character.age) });
   if (character.location) stats.push({ label: 'Location', value: character.location });
 
+  const showMeta = character.tags.length > 0 || (character.canEdit && !!onEdit);
+
   return (
-    <div className="flex flex-col gap-4 p-4">
+    <div className="flex flex-col gap-3 p-4 overflow-y-auto h-full">
       {/* Portrait */}
       <div className="flex justify-center">
         <div
@@ -117,49 +120,9 @@ export function CharacterWindow({ character }: CharacterWindowProps) {
         </div>
       </div>
 
-      {/* Name + link */}
-      <div className="flex items-center justify-center gap-2">
-        <h2 className="text-sm font-bold text-slate-200 text-center">{fullName}</h2>
-        {character.link && (
-          <a
-            href={character.link}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="shrink-0"
-            aria-label="External link"
-          >
-            <ExternalLink className="h-3.5 w-3.5 text-slate-500 hover:text-blue-400 transition-colors" />
-          </a>
-        )}
-      </div>
-
-      {/* Visibility badge */}
-      <div className="flex justify-center">
-        {character.isPublic ? (
-          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 text-[10px] font-semibold">
-            <Globe className="h-3 w-3" />
-            Public
-          </span>
-        ) : (
-          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-amber-500/10 border border-amber-500/20 text-amber-400 text-[10px] font-semibold">
-            <Lock className="h-3 w-3" />
-            Private
-          </span>
-        )}
-      </div>
-
-      {/* Stats grid */}
-      {stats.length > 0 && (
-        <div className="grid grid-cols-2 gap-2">
-          {stats.map((s) => (
-            <StatBlock key={s.label} label={s.label} value={s.value} />
-          ))}
-        </div>
-      )}
-
-      {/* Tags */}
-      {character.tags.length > 0 && (
-        <div className="flex flex-wrap gap-1">
+      {/* Tags + edit button below portrait */}
+      {showMeta && (
+        <div className="flex items-center justify-center gap-1.5 flex-wrap">
           {character.tags.map((tag) => (
             <span
               key={tag}
@@ -167,6 +130,25 @@ export function CharacterWindow({ character }: CharacterWindowProps) {
             >
               #{tag}
             </span>
+          ))}
+          {character.canEdit && onEdit && (
+            <button
+              type="button"
+              onClick={onEdit}
+              className="p-1 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors"
+              aria-label="Edit character"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Stats grid */}
+      {stats.length > 0 && (
+        <div className="grid grid-cols-2 gap-2">
+          {stats.map((s) => (
+            <StatBlock key={s.label} label={s.label} value={s.value} />
           ))}
         </div>
       )}

--- a/app/components/wiki/races/RaceViewModal.tsx
+++ b/app/components/wiki/races/RaceViewModal.tsx
@@ -43,9 +43,9 @@ export function RaceViewModal({ isOpen, onClose, raceId, campaignId }: RaceViewM
         <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
           <h2
             id="race-view-modal-title"
-            className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest"
+            className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest truncate"
           >
-            Race
+            {race?.title ?? 'Race'}
           </h2>
           <button
             type="button"

--- a/app/components/wiki/races/RaceWindow.tsx
+++ b/app/components/wiki/races/RaceWindow.tsx
@@ -38,7 +38,7 @@ export function RaceWindow({ race, onEdit }: RaceWindowProps) {
           )}
         </div>
       )}
-      <div className="flex-1 overflow-y-auto p-4 min-h-0">
+      <div className="flex-1 overflow-y-auto p-3 min-h-0">
         <div className={MARKDOWN_PROSE_CLASSES}>
           <ReactMarkdown remarkPlugins={[remarkGfm]}>{race.content}</ReactMarkdown>
         </div>

--- a/app/components/wiki/races/RaceWindow.tsx
+++ b/app/components/wiki/races/RaceWindow.tsx
@@ -1,3 +1,4 @@
+import { Pencil } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { RaceData } from '~/types/race';
@@ -5,16 +6,17 @@ import { MARKDOWN_PROSE_CLASSES } from '~/utils/markdownProseClasses';
 
 interface RaceWindowProps {
   race: RaceData;
+  onEdit?: () => void;
 }
 
-export function RaceWindow({ race }: RaceWindowProps) {
+export function RaceWindow({ race, onEdit }: RaceWindowProps) {
+  const showMeta = race.tags.length > 0 || (race.canEdit && !!onEdit);
+
   return (
     <div className="flex flex-col h-full">
-      {/* Header */}
-      <div className="px-4 pt-4 pb-3 border-b border-white/[0.07] shrink-0">
-        <h2 className="text-sm font-bold text-slate-100 tracking-wide">{race.title}</h2>
-        {race.tags.length > 0 && (
-          <div className="flex flex-wrap gap-1 mt-2">
+      {showMeta && (
+        <div className="flex items-center gap-2 px-3 py-1.5 border-b border-white/[0.05] shrink-0">
+          <div className="flex flex-wrap gap-1 flex-1 min-w-0">
             {race.tags.map((tag) => (
               <span
                 key={tag}
@@ -24,10 +26,18 @@ export function RaceWindow({ race }: RaceWindowProps) {
               </span>
             ))}
           </div>
-        )}
-      </div>
-
-      {/* Scrollable markdown content */}
+          {race.canEdit && onEdit && (
+            <button
+              type="button"
+              onClick={onEdit}
+              className="shrink-0 p-1 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors"
+              aria-label="Edit race"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+      )}
       <div className="flex-1 overflow-y-auto p-4 min-h-0">
         <div className={MARKDOWN_PROSE_CLASSES}>
           <ReactMarkdown remarkPlugins={[remarkGfm]}>{race.content}</ReactMarkdown>

--- a/app/components/wiki/races/RaceWindowWrapper.tsx
+++ b/app/components/wiki/races/RaceWindowWrapper.tsx
@@ -1,4 +1,3 @@
-import { Pencil } from 'lucide-react';
 import { RaceWindow } from './RaceWindow';
 import { RaceModal } from './RaceModal';
 import { useRace } from '~/hooks/useRaces';
@@ -12,14 +11,7 @@ export function EditRaceModalWrapper({
   raceId: string;
   onClose: () => void;
 }) {
-  return (
-    <RaceModal
-      isOpen
-      onClose={onClose}
-      campaignId={campaignId}
-      raceId={raceId}
-    />
-  );
+  return <RaceModal isOpen onClose={onClose} campaignId={campaignId} raceId={raceId} />;
 }
 
 export function RaceWindowWrapper({
@@ -49,19 +41,5 @@ export function RaceWindowWrapper({
     );
   }
 
-  return (
-    <div className="relative h-full">
-      {race.canEdit && (
-        <button
-          type="button"
-          onClick={onEdit}
-          className="absolute top-2 right-2 z-10 p-1.5 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors"
-          aria-label="Edit race"
-        >
-          <Pencil className="h-3.5 w-3.5" />
-        </button>
-      )}
-      <RaceWindow race={race} />
-    </div>
-  );
+  return <RaceWindow race={race} onEdit={onEdit} />;
 }

--- a/app/components/wiki/rules/RuleViewModal.tsx
+++ b/app/components/wiki/rules/RuleViewModal.tsx
@@ -53,6 +53,9 @@ export function RuleViewModal({ isOpen, onClose, ruleId, campaignId }: RuleViewM
               className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest truncate"
             >
               {rule?.title ?? 'Rule'}
+              {rule && (
+                <span className="sr-only">{rule.isPublic ? ' (Public)' : ' (Private)'}</span>
+              )}
             </h2>
           </div>
           <button

--- a/app/components/wiki/rules/RuleViewModal.tsx
+++ b/app/components/wiki/rules/RuleViewModal.tsx
@@ -44,9 +44,9 @@ export function RuleViewModal({ isOpen, onClose, ruleId, campaignId }: RuleViewM
           <div className="flex items-center gap-2 min-w-0">
             {rule &&
               (rule.isPublic ? (
-                <Globe className="h-3.5 w-3.5 text-emerald-400 shrink-0" />
+                <Globe className="h-3.5 w-3.5 text-emerald-400 shrink-0" aria-hidden="true" />
               ) : (
-                <Lock className="h-3.5 w-3.5 text-amber-400 shrink-0" />
+                <Lock className="h-3.5 w-3.5 text-amber-400 shrink-0" aria-hidden="true" />
               ))}
             <h2
               id="rule-view-modal-title"

--- a/app/components/wiki/rules/RuleViewModal.tsx
+++ b/app/components/wiki/rules/RuleViewModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { X } from 'lucide-react';
+import { Globe, Lock, X } from 'lucide-react';
 import { RuleWindow } from './RuleWindow';
 import { useRule } from '~/hooks/useRules';
 
@@ -41,16 +41,24 @@ export function RuleViewModal({ isOpen, onClose, ruleId, campaignId }: RuleViewM
         className="w-full max-w-lg max-h-[90vh] bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col"
       >
         <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
-          <h2
-            id="rule-view-modal-title"
-            className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest"
-          >
-            Rule
-          </h2>
+          <div className="flex items-center gap-2 min-w-0">
+            {rule &&
+              (rule.isPublic ? (
+                <Globe className="h-3.5 w-3.5 text-emerald-400 shrink-0" />
+              ) : (
+                <Lock className="h-3.5 w-3.5 text-amber-400 shrink-0" />
+              ))}
+            <h2
+              id="rule-view-modal-title"
+              className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest truncate"
+            >
+              {rule?.title ?? 'Rule'}
+            </h2>
+          </div>
           <button
             type="button"
             onClick={onClose}
-            className="text-slate-500 hover:text-white transition-colors"
+            className="text-slate-500 hover:text-white transition-colors shrink-0"
             aria-label="Close modal"
           >
             <X className="h-5 w-5" />

--- a/app/components/wiki/rules/RuleWindow.tsx
+++ b/app/components/wiki/rules/RuleWindow.tsx
@@ -1,4 +1,4 @@
-import { Globe, Lock } from 'lucide-react';
+import { Pencil } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { RuleData } from '~/types/rule';
@@ -6,46 +6,43 @@ import { MARKDOWN_PROSE_CLASSES } from '~/utils/markdownProseClasses';
 
 interface RuleWindowProps {
   rule: RuleData;
+  isGM?: boolean;
+  onEdit?: () => void;
 }
 
-export function RuleWindow({ rule }: RuleWindowProps) {
+export function RuleWindow({ rule, isGM, onEdit }: RuleWindowProps) {
+  const showMeta = rule.tags.length > 0 || (isGM && !!onEdit);
+
   return (
-    <div className="flex flex-col gap-4 p-4 overflow-auto h-full">
-      {/* Title */}
-      <h2 className="text-sm font-bold text-slate-200">{rule.title}</h2>
-
-      {/* Visibility badge */}
-      <div className="flex">
-        {rule.isPublic ? (
-          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 text-[10px] font-semibold">
-            <Globe className="h-3 w-3" />
-            Public
-          </span>
-        ) : (
-          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-amber-500/10 border border-amber-500/20 text-amber-400 text-[10px] font-semibold">
-            <Lock className="h-3 w-3" />
-            Private
-          </span>
-        )}
-      </div>
-
-      {/* Tags */}
-      {rule.tags.length > 0 && (
-        <div className="flex flex-wrap gap-1">
-          {rule.tags.map((tag) => (
-            <span
-              key={tag}
-              className="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[9px] tracking-tight"
+    <div className="flex flex-col h-full">
+      {showMeta && (
+        <div className="flex items-center gap-2 px-3 py-1.5 border-b border-white/[0.05] shrink-0">
+          <div className="flex flex-wrap gap-1 flex-1 min-w-0">
+            {rule.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[9px] tracking-tight"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+          {isGM && onEdit && (
+            <button
+              type="button"
+              onClick={onEdit}
+              className="shrink-0 p-1 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors"
+              aria-label="Edit rule"
             >
-              #{tag}
-            </span>
-          ))}
+              <Pencil className="h-3.5 w-3.5" />
+            </button>
+          )}
         </div>
       )}
-
-      {/* Rendered markdown content */}
-      <div className={MARKDOWN_PROSE_CLASSES}>
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>{rule.content}</ReactMarkdown>
+      <div className="flex-1 overflow-y-auto p-3 min-h-0">
+        <div className={MARKDOWN_PROSE_CLASSES}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{rule.content}</ReactMarkdown>
+        </div>
       </div>
     </div>
   );

--- a/app/server/functions/gmscreens.ts
+++ b/app/server/functions/gmscreens.ts
@@ -120,7 +120,9 @@ interface CollectionFetcher {
   fetch(
     ids: string[],
     campaignId: string
-  ): Promise<Array<{ _id: unknown; title?: string; content?: string }>>;
+  ): Promise<
+    Array<{ _id: unknown; title?: string; content?: string; isPublic?: boolean; link?: string }>
+  >;
 }
 
 const COLLECTION_REGISTRY: Record<string, CollectionFetcher> = {
@@ -139,18 +141,32 @@ const COLLECTION_REGISTRY: Record<string, CollectionFetcher> = {
   },
   character: {
     async fetch(ids: string[], campaignId: string) {
-      return Character.find({ _id: { $in: ids }, campaignId }, '_id firstName lastName notes')
+      return Character.find(
+        { _id: { $in: ids }, campaignId },
+        '_id firstName lastName notes isPublic link'
+      )
         .lean()
         .then((docs) =>
           docs.map((d) => {
-            const ch = d as { _id: unknown; firstName?: string; lastName?: string; notes?: string };
+            const ch = d as {
+              _id: unknown;
+              firstName?: string;
+              lastName?: string;
+              notes?: string;
+              isPublic?: boolean;
+              link?: string;
+            };
             return {
               _id: ch._id,
               title: `${ch.firstName ?? ''} ${ch.lastName ?? ''}`.trim(),
               content: ch.notes,
+              isPublic: ch.isPublic,
+              link: ch.link,
             };
           })
-        ) as Promise<Array<{ _id: unknown; title?: string; content?: string }>>;
+        ) as Promise<
+        Array<{ _id: unknown; title?: string; content?: string; isPublic?: boolean; link?: string }>
+      >;
     },
   },
   race: {
@@ -168,15 +184,18 @@ const COLLECTION_REGISTRY: Record<string, CollectionFetcher> = {
   },
   rule: {
     async fetch(ids: string[], campaignId: string) {
-      return Rule.find({ _id: { $in: ids }, campaignId }, '_id title content')
+      return Rule.find({ _id: { $in: ids }, campaignId }, '_id title content isPublic')
         .lean()
         .then((docs) =>
           docs.map((d) => ({
             _id: d._id,
             title: (d as { title?: string }).title,
             content: (d as { content?: string }).content,
+            isPublic: (d as { isPublic?: boolean }).isPublic,
           }))
-        ) as Promise<Array<{ _id: unknown; title?: string; content?: string }>>;
+        ) as Promise<
+        Array<{ _id: unknown; title?: string; content?: string; isPublic?: boolean; link?: string }>
+      >;
     },
   },
 };
@@ -216,6 +235,8 @@ async function hydrateRefs(
           collection: collectionName,
           title: doc.title ?? '',
           content: doc.content ?? '',
+          ...(doc.isPublic !== undefined && { isPublic: doc.isPublic }),
+          ...(doc.link && { link: doc.link }),
         };
       }
     })

--- a/app/types/gmscreen.ts
+++ b/app/types/gmscreen.ts
@@ -1,52 +1,54 @@
-export const WINDOW_STATES = ['open', 'minimized', 'hidden'] as const
-export type WindowState = (typeof WINDOW_STATES)[number]
+export const WINDOW_STATES = ['open', 'minimized', 'hidden'] as const;
+export type WindowState = (typeof WINDOW_STATES)[number];
 
 export interface GMScreenData {
-  id: string
-  campaignId: string
-  name: string
-  tabOrder: number
-  createdBy: string
-  createdAt: string
-  updatedAt: string
+  id: string;
+  campaignId: string;
+  name: string;
+  tabOrder: number;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface WindowData {
-  id: string
-  collection: string
-  documentId: string
-  state: WindowState
-  x: number | null
-  y: number | null
-  width: number | null
-  height: number | null
-  zIndex: number
+  id: string;
+  collection: string;
+  documentId: string;
+  state: WindowState;
+  x: number | null;
+  y: number | null;
+  width: number | null;
+  height: number | null;
+  zIndex: number;
 }
 
 export interface StackItemData {
-  id: string
-  collection: string
-  documentId: string
-  label: string
+  id: string;
+  collection: string;
+  documentId: string;
+  label: string;
 }
 
 export interface StackData {
-  id: string
-  name: string
-  x: number | null
-  y: number | null
-  items: StackItemData[]
+  id: string;
+  name: string;
+  x: number | null;
+  y: number | null;
+  items: StackItemData[];
 }
 
 export interface HydratedDocument {
-  id: string
-  collection: string
-  title: string
-  content: string
+  id: string;
+  collection: string;
+  title: string;
+  content: string;
+  isPublic?: boolean;
+  link?: string;
 }
 
 export interface GMScreenDetailData extends GMScreenData {
-  windows: WindowData[]
-  stacks: StackData[]
-  hydrated: Record<string, HydratedDocument>
+  windows: WindowData[];
+  stacks: StackData[];
+  hydrated: Record<string, HydratedDocument>;
 }

--- a/docs/superpowers/plans/2026-04-05-ui-space-optimization.md
+++ b/docs/superpowers/plans/2026-04-05-ui-space-optimization.md
@@ -1,0 +1,1685 @@
+# UI Space Optimization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate duplicate titles, consolidate visibility badges and tags into compact rows, and move Globe/Lock/ExternalLink icons into title bars across Rules, Races, Characters, and Notes windows and modals.
+
+**Architecture:** Add `isPublic` and `link` to the backend's `HydratedDocument` hydration response; add `titleIcon`/`titleSuffix` props to `FloatingWindow` and thread them through `FloatingWindowManager` → `GMScreensView`; refactor all three Window content components to accept `onEdit` and render a single compact meta row; update view modals to show actual titles and icons in their headers.
+
+**Tech Stack:** React, TypeScript, Tailwind CSS, Lucide React, Vitest + React Testing Library, Mongoose (backend)
+
+---
+
+## File Map
+
+| File                                                           | Change                                                              |
+| -------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `app/types/gmscreen.ts`                                        | Add `isPublic?`, `link?` to `HydratedDocument`                      |
+| `app/server/functions/gmscreens.ts`                            | Update `CollectionFetcher`, character/rule fetchers, `hydrateRefs`  |
+| `tests/server/functions/gmscreens.test.ts`                     | Add hydration tests for character and rule `isPublic`/`link`        |
+| `app/components/mainview/FloatingWindow.tsx`                   | Add `titleIcon?`, `titleSuffix?` props                              |
+| `app/components/mainview/FloatingWindowManager.tsx`            | Add same fields to `ManagedWindow`, thread to `FloatingWindow`      |
+| `tests/components/mainview/FloatingWindow.test.tsx`            | Add tests for `titleIcon` and `titleSuffix` rendering               |
+| `app/components/mainview/gmscreens/GMScreensView.tsx`          | Build icons from hydrated data, set on `ManagedWindow`              |
+| `app/components/wiki/rules/RuleWindow.tsx`                     | Remove title/badge, add compact meta row, add `onEdit`/`isGM` props |
+| `app/components/mainview/gmscreens/RuleWindowWrapper.tsx`      | Pass `onEdit`/`isGM` to `RuleWindow`, remove absolute edit button   |
+| `app/components/wiki/races/RaceWindow.tsx`                     | Remove title, add compact meta row, add `onEdit` prop               |
+| `app/components/wiki/races/RaceWindowWrapper.tsx`              | Pass `onEdit` to `RaceWindow`, remove absolute edit button          |
+| `app/components/wiki/characters/CharacterWindow.tsx`           | Remove name/badge/link, move tags below portrait, add `onEdit`      |
+| `app/components/mainview/gmscreens/CharacterWindowWrapper.tsx` | Pass `onEdit` to `CharacterWindow`, remove absolute edit button     |
+| `app/components/wiki/rules/RuleViewModal.tsx`                  | Show `rule.title` + Globe/Lock icon in header                       |
+| `app/components/wiki/races/RaceViewModal.tsx`                  | Show `race.title` in header                                         |
+| `app/components/wiki/characters/CharacterViewModal.tsx`        | Show character name + Globe/Lock + ExternalLink in header           |
+| `app/components/mainview/notes/NoteModal.tsx`                  | Show live Globe/Lock icon in header                                 |
+| `tests/components/mainview/notes/NoteModal.test.tsx`           | Add visibility icon tests                                           |
+
+---
+
+## Task 1: Backend — Extend HydratedDocument with isPublic and link
+
+**Files:**
+
+- Modify: `app/types/gmscreen.ts`
+- Modify: `app/server/functions/gmscreens.ts`
+- Test: `tests/server/functions/gmscreens.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test block near the end of the `getGMScreen` describe block in `tests/server/functions/gmscreens.test.ts` (after the existing tests around line 1025):
+
+```typescript
+it('includes isPublic and link in hydrated character and isPublic in hydrated rule', async () => {
+  const screenDoc = {
+    _id: 'screen-x',
+    campaignId: 'camp-1',
+    name: 'Test',
+    tabOrder: 0,
+    createdBy: 'dbuser-1',
+    createdAt: new Date('2026-04-01'),
+    updatedAt: new Date('2026-04-01'),
+    windows: [
+      {
+        _id: 'win-c',
+        collection: 'character',
+        documentId: 'char-1',
+        state: 'open',
+        x: 0,
+        y: 0,
+        width: 300,
+        height: 400,
+        zIndex: 1,
+      },
+      {
+        _id: 'win-r',
+        collection: 'rule',
+        documentId: 'rule-1',
+        state: 'open',
+        x: 320,
+        y: 0,
+        width: 300,
+        height: 400,
+        zIndex: 2,
+      },
+    ],
+    stacks: [],
+  };
+
+  vi.mocked(GMScreen.findOne).mockReturnValue({
+    lean: vi.fn().mockResolvedValue(screenDoc),
+  } as never);
+
+  vi.mocked(Character.find).mockReturnValue({
+    lean: vi.fn().mockResolvedValue([
+      {
+        _id: 'char-1',
+        firstName: 'Thorin',
+        lastName: 'Grudgebearer',
+        notes: 'A dwarf warrior.',
+        isPublic: true,
+        link: 'https://example.com/thorin',
+      },
+    ]),
+  } as never);
+
+  vi.mocked(Rule.find).mockReturnValue({
+    lean: vi.fn().mockResolvedValue([
+      {
+        _id: 'rule-1',
+        title: 'Difficulty',
+        content: 'Setting a DC',
+        isPublic: false,
+      },
+    ]),
+  } as never);
+
+  const result = await _getGMScreen({ data: { id: 'screen-x', campaignId: 'camp-1' } });
+
+  expect(result.hydrated['character:char-1']).toEqual({
+    id: 'char-1',
+    collection: 'character',
+    title: 'Thorin Grudgebearer',
+    content: 'A dwarf warrior.',
+    isPublic: true,
+    link: 'https://example.com/thorin',
+  });
+
+  expect(result.hydrated['rule:rule-1']).toEqual({
+    id: 'rule-1',
+    collection: 'rule',
+    title: 'Difficulty',
+    content: 'Setting a DC',
+    isPublic: false,
+  });
+
+  expect(Character.find).toHaveBeenCalledWith(
+    { _id: { $in: ['char-1'] }, campaignId: 'camp-1' },
+    '_id firstName lastName notes isPublic link'
+  );
+
+  expect(Rule.find).toHaveBeenCalledWith(
+    { _id: { $in: ['rule-1'] }, campaignId: 'camp-1' },
+    '_id title content isPublic'
+  );
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npx vitest run --project unit tests/server/functions/gmscreens.test.ts -t "includes isPublic and link"
+```
+
+Expected: FAIL — the hydrated objects won't have `isPublic` or `link` yet.
+
+- [ ] **Step 3: Update `HydratedDocument` type in `app/types/gmscreen.ts`**
+
+Replace the `HydratedDocument` interface:
+
+```typescript
+export interface HydratedDocument {
+  id: string;
+  collection: string;
+  title: string;
+  content: string;
+  isPublic?: boolean;
+  link?: string;
+}
+```
+
+- [ ] **Step 4: Update `CollectionFetcher` interface in `app/server/functions/gmscreens.ts`**
+
+At line 119, replace the `CollectionFetcher` interface:
+
+```typescript
+interface CollectionFetcher {
+  fetch(
+    ids: string[],
+    campaignId: string
+  ): Promise<
+    Array<{ _id: unknown; title?: string; content?: string; isPublic?: boolean; link?: string }>
+  >;
+}
+```
+
+- [ ] **Step 5: Update the character fetcher in `COLLECTION_REGISTRY`**
+
+Replace the `character` entry (starting at line 140):
+
+```typescript
+character: {
+  async fetch(ids: string[], campaignId: string) {
+    return Character.find({ _id: { $in: ids }, campaignId }, '_id firstName lastName notes isPublic link')
+      .lean()
+      .then((docs) =>
+        docs.map((d) => {
+          const ch = d as {
+            _id: unknown;
+            firstName?: string;
+            lastName?: string;
+            notes?: string;
+            isPublic?: boolean;
+            link?: string;
+          };
+          return {
+            _id: ch._id,
+            title: `${ch.firstName ?? ''} ${ch.lastName ?? ''}`.trim(),
+            content: ch.notes,
+            isPublic: ch.isPublic,
+            link: ch.link,
+          };
+        })
+      ) as Promise<Array<{ _id: unknown; title?: string; content?: string; isPublic?: boolean; link?: string }>>;
+  },
+},
+```
+
+- [ ] **Step 6: Update the rule fetcher in `COLLECTION_REGISTRY`**
+
+Replace the `rule` entry (starting at line 169):
+
+```typescript
+rule: {
+  async fetch(ids: string[], campaignId: string) {
+    return Rule.find({ _id: { $in: ids }, campaignId }, '_id title content isPublic')
+      .lean()
+      .then((docs) =>
+        docs.map((d) => ({
+          _id: d._id,
+          title: (d as { title?: string }).title,
+          content: (d as { content?: string }).content,
+          isPublic: (d as { isPublic?: boolean }).isPublic,
+        }))
+      ) as Promise<Array<{ _id: unknown; title?: string; content?: string; isPublic?: boolean; link?: string }>>;
+  },
+},
+```
+
+- [ ] **Step 7: Update the `hydrateRefs` loop to include the new fields**
+
+In `hydrateRefs` (around line 214), replace the assignment inside the loop:
+
+```typescript
+hydrated[`${collectionName}:${id}`] = {
+  id,
+  collection: collectionName,
+  title: doc.title ?? '',
+  content: doc.content ?? '',
+  ...(doc.isPublic !== undefined && { isPublic: doc.isPublic }),
+  ...(doc.link && { link: doc.link }),
+};
+```
+
+- [ ] **Step 8: Run the test to verify it passes**
+
+```bash
+npx vitest run --project unit tests/server/functions/gmscreens.test.ts -t "includes isPublic and link"
+```
+
+Expected: PASS
+
+- [ ] **Step 9: Run the full gmscreens test suite to confirm no regressions**
+
+```bash
+npx vitest run --project unit tests/server/functions/gmscreens.test.ts
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add app/types/gmscreen.ts app/server/functions/gmscreens.ts tests/server/functions/gmscreens.test.ts
+git commit -m "feat: include isPublic and link in hydrated GM screen window data"
+```
+
+---
+
+## Task 2: FloatingWindow — Add titleIcon and titleSuffix props
+
+**Files:**
+
+- Modify: `app/components/mainview/FloatingWindow.tsx`
+- Test: `tests/components/mainview/FloatingWindow.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these two tests to `tests/components/mainview/FloatingWindow.test.tsx` inside the existing `describe('FloatingWindow', ...)` block:
+
+```typescript
+it('renders titleIcon before the title text', () => {
+  render(
+    <div className="relative h-[600px] w-[800px]">
+      <FloatingWindow
+        id="rule"
+        title="Difficulty"
+        titleIcon={<span data-testid="lock-icon">🔒</span>}
+      >
+        <div>content</div>
+      </FloatingWindow>
+    </div>,
+  )
+
+  expect(screen.getByTestId('lock-icon')).toBeInTheDocument()
+})
+
+it('renders titleSuffix after the title text', () => {
+  render(
+    <div className="relative h-[600px] w-[800px]">
+      <FloatingWindow
+        id="char"
+        title="Thorin Grudgebearer"
+        titleSuffix={<span data-testid="ext-link">🔗</span>}
+      >
+        <div>content</div>
+      </FloatingWindow>
+    </div>,
+  )
+
+  expect(screen.getByTestId('ext-link')).toBeInTheDocument()
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+npx vitest run --project unit tests/components/mainview/FloatingWindow.test.tsx -t "renders titleIcon|renders titleSuffix"
+```
+
+Expected: FAIL — props don't exist yet.
+
+- [ ] **Step 3: Add the new props to `FloatingWindowProps` in `app/components/mainview/FloatingWindow.tsx`**
+
+In the `FloatingWindowProps` interface (around line 24), add after `className?`:
+
+```typescript
+titleIcon?: ReactNode
+titleSuffix?: ReactNode
+```
+
+Also update the function signature to destructure them:
+
+```typescript
+export function FloatingWindow({
+  id,
+  title,
+  children,
+  initialPosition = DEFAULT_POSITION,
+  initialSize = DEFAULT_SIZE,
+  initialState = 'normal',
+  zIndex = 1,
+  onClose,
+  onFocus,
+  onStateChange,
+  onLayoutChange,
+  className = '',
+  titleIcon,
+  titleSuffix,
+}: FloatingWindowProps) {
+```
+
+- [ ] **Step 4: Update the title bar element to render the new props**
+
+Find the title div around line 335 and replace it:
+
+```tsx
+<div
+  id={titleId}
+  className="flex items-center gap-1.5 min-w-0 font-sans font-semibold text-xs text-slate-300"
+>
+  {titleIcon && <span className="shrink-0 flex items-center">{titleIcon}</span>}
+  <span className="truncate">{title}</span>
+  {titleSuffix && <span className="shrink-0 flex items-center">{titleSuffix}</span>}
+</div>
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+npx vitest run --project unit tests/components/mainview/FloatingWindow.test.tsx
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/components/mainview/FloatingWindow.tsx tests/components/mainview/FloatingWindow.test.tsx
+git commit -m "feat: add titleIcon and titleSuffix props to FloatingWindow"
+```
+
+---
+
+## Task 3: FloatingWindowManager — Thread titleIcon and titleSuffix
+
+**Files:**
+
+- Modify: `app/components/mainview/FloatingWindowManager.tsx`
+- Test: `tests/components/mainview/FloatingWindowManager.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test to `tests/components/mainview/FloatingWindowManager.test.tsx` inside the existing describe block:
+
+```typescript
+it('passes titleIcon to the FloatingWindow', () => {
+  const windows: ManagedWindow[] = [
+    {
+      id: 'rule-1',
+      title: 'Difficulty',
+      titleIcon: <span data-testid="rule-icon">icon</span>,
+      content: <div>Rule content</div>,
+      position: { x: 10, y: 10 },
+      size: { width: 300, height: 200 },
+      state: 'normal',
+      zIndex: 1,
+    },
+  ]
+
+  render(
+    <div className="relative h-[600px] w-[800px]">
+      <FloatingWindowManager windows={windows} onWindowsChange={vi.fn()} />
+    </div>,
+  )
+
+  expect(screen.getByTestId('rule-icon')).toBeInTheDocument()
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npx vitest run --project unit tests/components/mainview/FloatingWindowManager.test.tsx -t "passes titleIcon"
+```
+
+Expected: FAIL — `ManagedWindow` doesn't have `titleIcon` yet.
+
+- [ ] **Step 3: Add `titleIcon` and `titleSuffix` to `ManagedWindow` in `app/components/mainview/FloatingWindowManager.tsx`**
+
+In the `ManagedWindow` interface (around line 11), add after `contentKey?`:
+
+```typescript
+titleIcon?: ReactNode
+titleSuffix?: ReactNode
+```
+
+Make sure `ReactNode` is imported — add it to the existing import:
+
+```typescript
+import type { ReactNode } from 'react';
+```
+
+- [ ] **Step 4: Pass the new props through to `FloatingWindow` in the render**
+
+In the `activeWindows.map(...)` block (around line 96), update the `<FloatingWindow>` usage:
+
+```tsx
+<FloatingWindow
+  key={window.id}
+  id={window.id}
+  title={window.title}
+  titleIcon={window.titleIcon}
+  titleSuffix={window.titleSuffix}
+  className={window.className}
+  initialPosition={window.position}
+  initialSize={window.size}
+  initialState={window.state}
+  zIndex={window.zIndex}
+  onFocus={() => handleFocus(window.id)}
+  onClose={() => handleClose(window.id)}
+  onStateChange={(state) => handleStateChange(window.id, state)}
+  onLayoutChange={(layout) => handleLayoutChange(window.id, layout)}
+>
+  {window.content}
+</FloatingWindow>
+```
+
+- [ ] **Step 5: Run all FloatingWindowManager tests**
+
+```bash
+npx vitest run --project unit tests/components/mainview/FloatingWindowManager.test.tsx
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/components/mainview/FloatingWindowManager.tsx tests/components/mainview/FloatingWindowManager.test.tsx
+git commit -m "feat: thread titleIcon and titleSuffix through FloatingWindowManager"
+```
+
+---
+
+## Task 4: GMScreensView — Build icons from hydrated data
+
+**Files:**
+
+- Modify: `app/components/mainview/gmscreens/GMScreensView.tsx`
+
+No new tests for this task — the icons are built from data already tested in Task 1, and the rendering is covered by Task 2.
+
+- [ ] **Step 1: Add Globe, Lock, ExternalLink to the lucide-react import**
+
+At the top of `app/components/mainview/gmscreens/GMScreensView.tsx`, update the lucide import. Currently it imports `{ Plus, Layers, Loader2, AlertTriangle }`. Add to it:
+
+```typescript
+import { Plus, Layers, Loader2, AlertTriangle, Globe, Lock, ExternalLink } from 'lucide-react';
+```
+
+- [ ] **Step 2: Build `titleIcon` and `titleSuffix` when constructing each `ManagedWindow`**
+
+In the `setLocalWindows` callback (inside the `useEffect` that merges server data), locate where each window is mapped. The `doc` and `key` variables are already computed at the top of the loop. Add icon construction after `markdownContent` is set (around line 393):
+
+```typescript
+const doc = activeScreen.hydrated[key];
+const title = doc?.title || key;
+const markdownContent = doc?.content || '';
+
+let titleIcon: React.ReactNode;
+let titleSuffix: React.ReactNode;
+
+if (w.collection === 'rule' || w.collection === 'character') {
+  if (doc?.isPublic === true) {
+    titleIcon = <Globe className="h-3 w-3 text-emerald-400" />;
+  } else if (doc?.isPublic === false) {
+    titleIcon = <Lock className="h-3 w-3 text-amber-400" />;
+  }
+}
+
+if (w.collection === 'character' && doc?.link) {
+  titleSuffix = (
+    <a
+      href={doc.link}
+      target="_blank"
+      rel="noopener noreferrer"
+      onMouseDown={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+      className="flex items-center"
+      aria-label="External link"
+    >
+      <ExternalLink className="h-3 w-3 text-slate-500 hover:text-blue-400 transition-colors" />
+    </a>
+  );
+}
+```
+
+- [ ] **Step 3: Pass `titleIcon` and `titleSuffix` in the new-window object**
+
+In the `return` statement that builds a new `ManagedWindow` (around line 446):
+
+```typescript
+return {
+  id: w.id,
+  title,
+  titleIcon,
+  titleSuffix,
+  contentKey: markdownContent,
+  position: w.x != null && w.y != null ? { x: w.x, y: w.y } : undefined,
+  size: w.width != null && w.height != null ? { width: w.width, height: w.height } : undefined,
+  state: toFloatingState(w.state),
+  zIndex: w.zIndex,
+  className: flashWindowId === w.id ? 'animate-flash-border' : '',
+  content: windowContent,
+};
+```
+
+- [ ] **Step 4: Pass `titleIcon` and `titleSuffix` in the existing-window merge**
+
+In the `return` statement that merges an existing window (around line 434):
+
+```typescript
+return {
+  ...existing,
+  title,
+  titleIcon,
+  titleSuffix,
+  contentKey: markdownContent,
+  className: flashWindowId === existing.id ? 'animate-flash-border' : '',
+  content: windowContent,
+};
+```
+
+- [ ] **Step 5: Update the staleness check to include `titleIcon` and `titleSuffix`**
+
+The staleness comparison around line 460 currently checks `p.title`, `p.contentKey`, and `p.className`. `titleIcon` and `titleSuffix` are ReactNodes and can't be equality-compared reliably — they will re-create on each render from server data. The check can simply be removed for these fields (they're already excluded); confirm the existing check doesn't reference them and leave it as-is. The current check is:
+
+```typescript
+prev.every(
+  (p, i) =>
+    p.id === merged[i]!.id &&
+    p.title === merged[i]!.title &&
+    p.contentKey === merged[i]!.contentKey &&
+    p.className === merged[i]!.className
+);
+```
+
+This is fine — `titleIcon`/`titleSuffix` aren't compared, so they update whenever the server data updates. No change needed here.
+
+- [ ] **Step 6: Run typecheck to confirm no type errors**
+
+```bash
+npm run typecheck
+```
+
+Expected: no errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/components/mainview/gmscreens/GMScreensView.tsx
+git commit -m "feat: add visibility and external link icons to FloatingWindow title bars"
+```
+
+---
+
+## Task 5: RuleWindow + RuleWindowWrapper — Compact meta row
+
+**Files:**
+
+- Modify: `app/components/wiki/rules/RuleWindow.tsx`
+- Modify: `app/components/mainview/gmscreens/RuleWindowWrapper.tsx`
+
+- [ ] **Step 1: Write a failing test**
+
+Create `tests/components/wiki/rules/RuleWindow.test.tsx`:
+
+```typescript
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RuleWindow } from '~/components/wiki/rules/RuleWindow';
+import type { RuleData } from '~/types/rule';
+
+const baseRule: RuleData = {
+  id: 'rule-1',
+  campaignId: 'camp-1',
+  title: 'Difficulty',
+  content: '# Setting a DC\nVery Easy: 5',
+  tags: ['rules', 'dc'],
+  isPublic: false,
+  createdAt: '2026-01-01',
+  updatedAt: '2026-01-01',
+};
+
+describe('RuleWindow', () => {
+  it('does not render the title as a heading inside the window body', () => {
+    render(<RuleWindow rule={baseRule} />);
+    expect(screen.queryByRole('heading', { name: 'Difficulty' })).not.toBeInTheDocument();
+  });
+
+  it('renders tags in the meta row', () => {
+    render(<RuleWindow rule={baseRule} />);
+    expect(screen.getByText('#rules')).toBeInTheDocument();
+    expect(screen.getByText('#dc')).toBeInTheDocument();
+  });
+
+  it('does not render a visibility badge', () => {
+    render(<RuleWindow rule={baseRule} />);
+    expect(screen.queryByText('Private')).not.toBeInTheDocument();
+    expect(screen.queryByText('Public')).not.toBeInTheDocument();
+  });
+
+  it('shows the edit button when isGM and onEdit are provided', async () => {
+    const onEdit = vi.fn();
+    const user = userEvent.setup();
+    render(<RuleWindow rule={baseRule} isGM onEdit={onEdit} />);
+    await user.click(screen.getByRole('button', { name: 'Edit rule' }));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the edit button when isGM is false', () => {
+    render(<RuleWindow rule={baseRule} isGM={false} onEdit={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: 'Edit rule' })).not.toBeInTheDocument();
+  });
+
+  it('hides the meta row when there are no tags and no edit button', () => {
+    render(<RuleWindow rule={{ ...baseRule, tags: [] }} />);
+    expect(screen.queryByRole('button', { name: 'Edit rule' })).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+npx vitest run --project unit tests/components/wiki/rules/RuleWindow.test.tsx
+```
+
+Expected: multiple FAIL — the current `RuleWindow` still renders the title heading and visibility badge.
+
+- [ ] **Step 3: Rewrite `app/components/wiki/rules/RuleWindow.tsx`**
+
+```typescript
+import { Pencil } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { RuleData } from '~/types/rule';
+import { MARKDOWN_PROSE_CLASSES } from '~/utils/markdownProseClasses';
+
+interface RuleWindowProps {
+  rule: RuleData;
+  isGM?: boolean;
+  onEdit?: () => void;
+}
+
+export function RuleWindow({ rule, isGM, onEdit }: RuleWindowProps) {
+  const showMeta = rule.tags.length > 0 || (isGM && !!onEdit);
+
+  return (
+    <div className="flex flex-col h-full">
+      {showMeta && (
+        <div className="flex items-center gap-2 px-3 py-1.5 border-b border-white/[0.05] shrink-0">
+          <div className="flex flex-wrap gap-1 flex-1 min-w-0">
+            {rule.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[9px] tracking-tight"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+          {isGM && onEdit && (
+            <button
+              type="button"
+              onClick={onEdit}
+              className="shrink-0 p-1 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors"
+              aria-label="Edit rule"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+      )}
+      <div className="flex-1 overflow-y-auto p-3 min-h-0">
+        <div className={MARKDOWN_PROSE_CLASSES}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{rule.content}</ReactMarkdown>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Update `app/components/mainview/gmscreens/RuleWindowWrapper.tsx`**
+
+Replace the `RuleWindowWrapper` function:
+
+```typescript
+import { RuleWindow } from '~/components/wiki/rules/RuleWindow';
+import { RuleModal } from '~/components/wiki/rules/RuleModal';
+import { useRule } from '~/hooks/useRules';
+
+export function EditRuleModalWrapper({
+  campaignId,
+  ruleId,
+  onClose,
+}: {
+  campaignId: string;
+  ruleId: string;
+  onClose: () => void;
+}) {
+  return <RuleModal isOpen onClose={onClose} campaignId={campaignId} ruleId={ruleId} />;
+}
+
+export function RuleWindowWrapper({
+  ruleId,
+  campaignId,
+  isGM,
+  onEdit,
+}: {
+  ruleId: string;
+  campaignId: string;
+  isGM: boolean;
+  onEdit: () => void;
+}) {
+  const { rule, isLoading } = useRule(ruleId, campaignId);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-xs text-slate-500 animate-pulse">Loading rule...</p>
+      </div>
+    );
+  }
+
+  if (!rule) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-xs text-slate-500">Rule not found</p>
+      </div>
+    );
+  }
+
+  return <RuleWindow rule={rule} isGM={isGM} onEdit={onEdit} />;
+}
+```
+
+Note: the `Pencil` import is no longer needed in the wrapper — remove it.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+npx vitest run --project unit tests/components/wiki/rules/RuleWindow.test.tsx
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 6: Run the full test suite**
+
+```bash
+npm test
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/components/wiki/rules/RuleWindow.tsx app/components/mainview/gmscreens/RuleWindowWrapper.tsx tests/components/wiki/rules/RuleWindow.test.tsx
+git commit -m "feat: compact meta row for RuleWindow, move edit button inside component"
+```
+
+---
+
+## Task 6: RaceWindow + RaceWindowWrapper — Compact meta row
+
+**Files:**
+
+- Modify: `app/components/wiki/races/RaceWindow.tsx`
+- Modify: `app/components/wiki/races/RaceWindowWrapper.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/components/wiki/races/RaceWindow.test.tsx`:
+
+```typescript
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RaceWindow } from '~/components/wiki/races/RaceWindow';
+import type { RaceData } from '~/types/race';
+
+const baseRace: RaceData = {
+  id: 'race-1',
+  campaignId: 'camp-1',
+  title: 'Dwarf',
+  content: '## Traits\nDarkvision, Stonecunning',
+  tags: ['playable', 'core'],
+  canEdit: true,
+  createdAt: '2026-01-01',
+  updatedAt: '2026-01-01',
+};
+
+describe('RaceWindow', () => {
+  it('does not render the title as a heading inside the window body', () => {
+    render(<RaceWindow race={baseRace} />);
+    expect(screen.queryByRole('heading', { name: 'Dwarf' })).not.toBeInTheDocument();
+  });
+
+  it('renders tags in the meta row', () => {
+    render(<RaceWindow race={baseRace} />);
+    expect(screen.getByText('#playable')).toBeInTheDocument();
+    expect(screen.getByText('#core')).toBeInTheDocument();
+  });
+
+  it('shows the edit button when race.canEdit and onEdit are provided', async () => {
+    const onEdit = vi.fn();
+    const user = userEvent.setup();
+    render(<RaceWindow race={baseRace} onEdit={onEdit} />);
+    await user.click(screen.getByRole('button', { name: 'Edit race' }));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the edit button when race.canEdit is false', () => {
+    render(<RaceWindow race={{ ...baseRace, canEdit: false }} onEdit={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: 'Edit race' })).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+npx vitest run --project unit tests/components/wiki/races/RaceWindow.test.tsx
+```
+
+Expected: FAIL
+
+- [ ] **Step 3: Rewrite `app/components/wiki/races/RaceWindow.tsx`**
+
+```typescript
+import { Pencil } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { RaceData } from '~/types/race';
+import { MARKDOWN_PROSE_CLASSES } from '~/utils/markdownProseClasses';
+
+interface RaceWindowProps {
+  race: RaceData;
+  onEdit?: () => void;
+}
+
+export function RaceWindow({ race, onEdit }: RaceWindowProps) {
+  const showMeta = race.tags.length > 0 || (race.canEdit && !!onEdit);
+
+  return (
+    <div className="flex flex-col h-full">
+      {showMeta && (
+        <div className="flex items-center gap-2 px-3 py-1.5 border-b border-white/[0.05] shrink-0">
+          <div className="flex flex-wrap gap-1 flex-1 min-w-0">
+            {race.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[9px] tracking-tight"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+          {race.canEdit && onEdit && (
+            <button
+              type="button"
+              onClick={onEdit}
+              className="shrink-0 p-1 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors"
+              aria-label="Edit race"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+      )}
+      <div className="flex-1 overflow-y-auto p-4 min-h-0">
+        <div className={MARKDOWN_PROSE_CLASSES}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{race.content}</ReactMarkdown>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Update `app/components/wiki/races/RaceWindowWrapper.tsx`**
+
+```typescript
+import { RaceWindow } from './RaceWindow';
+import { RaceModal } from './RaceModal';
+import { useRace } from '~/hooks/useRaces';
+
+export function EditRaceModalWrapper({
+  campaignId,
+  raceId,
+  onClose,
+}: {
+  campaignId: string;
+  raceId: string;
+  onClose: () => void;
+}) {
+  return (
+    <RaceModal
+      isOpen
+      onClose={onClose}
+      campaignId={campaignId}
+      raceId={raceId}
+    />
+  );
+}
+
+export function RaceWindowWrapper({
+  raceId,
+  campaignId,
+  onEdit,
+}: {
+  raceId: string;
+  campaignId: string;
+  onEdit: () => void;
+}) {
+  const { race, isLoading } = useRace(raceId, campaignId);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-xs text-slate-500 animate-pulse">Loading race...</p>
+      </div>
+    );
+  }
+
+  if (!race) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-xs text-slate-500">Race not found</p>
+      </div>
+    );
+  }
+
+  return <RaceWindow race={race} onEdit={onEdit} />;
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+npx vitest run --project unit tests/components/wiki/races/RaceWindow.test.tsx
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 6: Run the full test suite**
+
+```bash
+npm test
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/components/wiki/races/RaceWindow.tsx app/components/wiki/races/RaceWindowWrapper.tsx tests/components/wiki/races/RaceWindow.test.tsx
+git commit -m "feat: compact meta row for RaceWindow, move edit button inside component"
+```
+
+---
+
+## Task 7: CharacterWindow + CharacterWindowWrapper — Restructure
+
+**Files:**
+
+- Modify: `app/components/wiki/characters/CharacterWindow.tsx`
+- Modify: `app/components/mainview/gmscreens/CharacterWindowWrapper.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/components/wiki/characters/CharacterWindow.test.tsx`:
+
+```typescript
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CharacterWindow } from '~/components/wiki/characters/CharacterWindow';
+import type { CharacterData } from '~/types/character';
+
+const baseCharacter: CharacterData = {
+  id: 'char-1',
+  campaignId: 'camp-1',
+  firstName: 'Thorin',
+  lastName: 'Grudgebearer',
+  race: 'Dwarf',
+  characterClass: 'Fighter',
+  age: 208,
+  location: 'Stormwind',
+  link: 'https://example.com/thorin',
+  isPublic: true,
+  canEdit: true,
+  tags: ['guard', 'dwarf'],
+  notes: 'A steadfast warrior.',
+  gmNotes: null,
+  picture: null,
+  pictureCrop: null,
+  sessionIntroducedId: null,
+  createdAt: '2026-01-01',
+  updatedAt: '2026-01-01',
+};
+
+describe('CharacterWindow', () => {
+  it('does not render the full name as a heading below the portrait', () => {
+    render(<CharacterWindow character={baseCharacter} />);
+    expect(screen.queryByRole('heading', { name: 'Thorin Grudgebearer' })).not.toBeInTheDocument();
+  });
+
+  it('does not render a visibility badge', () => {
+    render(<CharacterWindow character={baseCharacter} />);
+    expect(screen.queryByText('Public')).not.toBeInTheDocument();
+    expect(screen.queryByText('Private')).not.toBeInTheDocument();
+  });
+
+  it('renders tags below the portrait', () => {
+    render(<CharacterWindow character={baseCharacter} />);
+    expect(screen.getByText('#guard')).toBeInTheDocument();
+    expect(screen.getByText('#dwarf')).toBeInTheDocument();
+  });
+
+  it('shows the edit button when character.canEdit and onEdit are provided', async () => {
+    const onEdit = vi.fn();
+    const user = userEvent.setup();
+    render(<CharacterWindow character={baseCharacter} onEdit={onEdit} />);
+    await user.click(screen.getByRole('button', { name: 'Edit character' }));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the edit button when canEdit is false', () => {
+    render(<CharacterWindow character={{ ...baseCharacter, canEdit: false }} onEdit={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: 'Edit character' })).not.toBeInTheDocument();
+  });
+
+  it('still renders stat blocks', () => {
+    render(<CharacterWindow character={baseCharacter} />);
+    expect(screen.getByText('Dwarf')).toBeInTheDocument();
+    expect(screen.getByText('208')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+npx vitest run --project unit tests/components/wiki/characters/CharacterWindow.test.tsx
+```
+
+Expected: FAIL
+
+- [ ] **Step 3: Rewrite `app/components/wiki/characters/CharacterWindow.tsx`**
+
+```typescript
+import React, { useState } from 'react';
+import { ChevronDown, Pencil } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { CharacterData, PictureCrop } from '~/types/character';
+import { MARKDOWN_PROSE_CLASSES } from '~/utils/markdownProseClasses';
+
+function getCropStyle(crop: PictureCrop): React.CSSProperties {
+  const centerX = (crop.x + crop.width / 2) * 100;
+  const centerY = (crop.y + crop.height / 2) * 100;
+  const scale = 1 / crop.width;
+  return {
+    objectPosition: `${centerX}% ${centerY}%`,
+    transform: `scale(${scale})`,
+  };
+}
+
+interface CharacterWindowProps {
+  character: CharacterData;
+  onEdit?: () => void;
+}
+
+const GRADIENT_PAIRS = [
+  ['#3b82f6', '#8b5cf6'],
+  ['#f59e0b', '#ef4444'],
+  ['#10b981', '#06b6d4'],
+  ['#ec4899', '#8b5cf6'],
+  ['#f97316', '#eab308'],
+  ['#14b8a6', '#3b82f6'],
+];
+
+function hashName(name: string): number {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash << 5) - hash + name.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+
+function getInitials(firstName: string, lastName: string): string {
+  const f = firstName.charAt(0).toUpperCase();
+  const l = lastName.charAt(0).toUpperCase();
+  return l ? `${f}${l}` : f;
+}
+
+function StatBlock({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md bg-white/[0.04] border border-white/[0.06] px-3 py-2">
+      <p className="text-[10px] uppercase tracking-wider text-slate-500 mb-0.5">{label}</p>
+      <p className="text-xs text-slate-300 font-medium truncate">{value}</p>
+    </div>
+  );
+}
+
+function Accordion({
+  title,
+  defaultOpen = false,
+  children,
+}: {
+  title: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <div className="border border-white/[0.06] rounded-md overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between px-3 py-2 text-xs font-semibold text-slate-300 hover:bg-white/[0.03] transition-colors"
+      >
+        {title}
+        <ChevronDown
+          className={`h-3.5 w-3.5 text-slate-500 transition-transform ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+      {open && <div className="px-3 pb-3">{children}</div>}
+    </div>
+  );
+}
+
+export function CharacterWindow({ character, onEdit }: CharacterWindowProps) {
+  const fullName = `${character.firstName} ${character.lastName}`.trim();
+  const initials = getInitials(character.firstName, character.lastName);
+  const gradientIndex = hashName(fullName) % GRADIENT_PAIRS.length;
+  const [gradFrom, gradTo] = GRADIENT_PAIRS[gradientIndex]!;
+
+  const stats: { label: string; value: string }[] = [];
+  if (character.race) stats.push({ label: 'Race', value: character.race });
+  if (character.characterClass) stats.push({ label: 'Class', value: character.characterClass });
+  if (character.age != null) stats.push({ label: 'Age', value: String(character.age) });
+  if (character.location) stats.push({ label: 'Location', value: character.location });
+
+  const showMeta = character.tags.length > 0 || (character.canEdit && !!onEdit);
+
+  return (
+    <div className="flex flex-col gap-3 p-4 overflow-y-auto h-full">
+      {/* Portrait */}
+      <div className="flex justify-center">
+        <div
+          className="w-24 h-24 rounded-full flex-shrink-0 flex items-center justify-center overflow-hidden"
+          style={
+            character.picture
+              ? undefined
+              : { background: `linear-gradient(135deg, ${gradFrom}, ${gradTo})` }
+          }
+        >
+          {character.picture ? (
+            <img
+              src={character.picture}
+              alt={fullName}
+              className="w-full h-full object-cover"
+              style={character.pictureCrop ? getCropStyle(character.pictureCrop) : undefined}
+            />
+          ) : (
+            <span className="text-2xl text-white font-semibold">{initials}</span>
+          )}
+        </div>
+      </div>
+
+      {/* Tags + edit button below portrait */}
+      {showMeta && (
+        <div className="flex items-center justify-center gap-1.5 flex-wrap">
+          {character.tags.map((tag) => (
+            <span
+              key={tag}
+              className="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[9px] tracking-tight"
+            >
+              #{tag}
+            </span>
+          ))}
+          {character.canEdit && onEdit && (
+            <button
+              type="button"
+              onClick={onEdit}
+              className="p-1 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors"
+              aria-label="Edit character"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Stats grid */}
+      {stats.length > 0 && (
+        <div className="grid grid-cols-2 gap-2">
+          {stats.map((s) => (
+            <StatBlock key={s.label} label={s.label} value={s.value} />
+          ))}
+        </div>
+      )}
+
+      {/* Details accordion */}
+      {character.notes && (
+        <Accordion title="Details" defaultOpen>
+          <div className={MARKDOWN_PROSE_CLASSES}>
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{character.notes}</ReactMarkdown>
+          </div>
+        </Accordion>
+      )}
+
+      {/* GM Notes accordion */}
+      {character.gmNotes && (
+        <Accordion title="GM Notes">
+          <div className={MARKDOWN_PROSE_CLASSES}>
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{character.gmNotes}</ReactMarkdown>
+          </div>
+        </Accordion>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Update `app/components/mainview/gmscreens/CharacterWindowWrapper.tsx`**
+
+```typescript
+import React from 'react';
+import { CharacterWindow } from '~/components/wiki/characters/CharacterWindow';
+import { CharacterModal } from '~/components/wiki/characters/CharacterModal';
+import { useCharacter } from '~/hooks/useCharacters';
+import { useCampaign } from '~/hooks/useCampaigns';
+
+export function EditCharacterModalWrapper({
+  campaignId,
+  characterId,
+  onClose,
+}: {
+  campaignId: string;
+  characterId: string;
+  onClose: () => void;
+}) {
+  const { campaign } = useCampaign(campaignId);
+  const sessions = campaign?.sessions ?? [];
+  return (
+    <CharacterModal
+      isOpen
+      onClose={onClose}
+      campaignId={campaignId}
+      characterId={characterId}
+      sessions={sessions}
+    />
+  );
+}
+
+export function CharacterWindowWrapper({
+  characterId,
+  campaignId,
+  onEdit,
+}: {
+  characterId: string;
+  campaignId: string;
+  onEdit: () => void;
+}) {
+  const { character, isLoading } = useCharacter(characterId, campaignId);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-xs text-slate-500 animate-pulse">Loading character...</p>
+      </div>
+    );
+  }
+
+  if (!character) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-xs text-slate-500">Character not found</p>
+      </div>
+    );
+  }
+
+  return <CharacterWindow character={character} onEdit={onEdit} />;
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+npx vitest run --project unit tests/components/wiki/characters/CharacterWindow.test.tsx
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 6: Run the full test suite**
+
+```bash
+npm test
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/components/wiki/characters/CharacterWindow.tsx app/components/mainview/gmscreens/CharacterWindowWrapper.tsx tests/components/wiki/characters/CharacterWindow.test.tsx
+git commit -m "feat: restructure CharacterWindow — remove name/badge, move tags below portrait"
+```
+
+---
+
+## Task 8: RuleViewModal — Show actual title and icon in header
+
+**Files:**
+
+- Modify: `app/components/wiki/rules/RuleViewModal.tsx`
+
+No new test file — the modal's header changes are visual; the data fetching is covered by `useRule` hook tests.
+
+- [ ] **Step 1: Update `app/components/wiki/rules/RuleViewModal.tsx`**
+
+Add `Globe` and `Lock` to the imports:
+
+```typescript
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { Globe, Lock, X } from 'lucide-react';
+import { RuleWindow } from './RuleWindow';
+import { useRule } from '~/hooks/useRules';
+```
+
+Replace the `<header>` element:
+
+```tsx
+<header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
+  <div className="flex items-center gap-2 min-w-0">
+    {rule &&
+      (rule.isPublic ? (
+        <Globe className="h-3.5 w-3.5 text-emerald-400 shrink-0" />
+      ) : (
+        <Lock className="h-3.5 w-3.5 text-amber-400 shrink-0" />
+      ))}
+    <h2
+      id="rule-view-modal-title"
+      className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest truncate"
+    >
+      {rule?.title ?? 'Rule'}
+    </h2>
+  </div>
+  <button
+    type="button"
+    onClick={onClose}
+    className="text-slate-500 hover:text-white transition-colors shrink-0"
+    aria-label="Close modal"
+  >
+    <X className="h-5 w-5" />
+  </button>
+</header>
+```
+
+- [ ] **Step 2: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: no errors
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+npm test
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/components/wiki/rules/RuleViewModal.tsx
+git commit -m "feat: show actual rule title and visibility icon in RuleViewModal header"
+```
+
+---
+
+## Task 9: RaceViewModal — Show actual title in header
+
+**Files:**
+
+- Modify: `app/components/wiki/races/RaceViewModal.tsx`
+
+- [ ] **Step 1: Update `app/components/wiki/races/RaceViewModal.tsx`**
+
+No icon needed for races (no visibility concept). Replace the `<header>` element:
+
+```tsx
+<header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
+  <h2
+    id="race-view-modal-title"
+    className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest truncate"
+  >
+    {race?.title ?? 'Race'}
+  </h2>
+  <button
+    type="button"
+    onClick={onClose}
+    className="text-slate-500 hover:text-white transition-colors"
+    aria-label="Close modal"
+  >
+    <X className="h-5 w-5" />
+  </button>
+</header>
+```
+
+`race` comes from `const { race, isLoading } = useRace(raceId, campaignId)` already in scope. No import changes needed.
+
+- [ ] **Step 2: Run typecheck and full test suite**
+
+```bash
+npm run typecheck && npm test
+```
+
+Expected: no errors, all tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/components/wiki/races/RaceViewModal.tsx
+git commit -m "feat: show actual race title in RaceViewModal header"
+```
+
+---
+
+## Task 10: CharacterViewModal — Show actual title and icons in header
+
+**Files:**
+
+- Modify: `app/components/wiki/characters/CharacterViewModal.tsx`
+
+- [ ] **Step 1: Update `app/components/wiki/characters/CharacterViewModal.tsx`**
+
+Add `Globe`, `Lock`, `ExternalLink` to the imports:
+
+```typescript
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { ExternalLink, Globe, Lock, X } from 'lucide-react';
+import { CharacterWindow } from './CharacterWindow';
+import { useCharacter } from '~/hooks/useCharacters';
+```
+
+Replace the `<header>` element:
+
+```tsx
+<header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
+  <div className="flex items-center gap-2 min-w-0">
+    {character &&
+      (character.isPublic ? (
+        <Globe className="h-3.5 w-3.5 text-emerald-400 shrink-0" />
+      ) : (
+        <Lock className="h-3.5 w-3.5 text-amber-400 shrink-0" />
+      ))}
+    <h2
+      id="character-view-modal-title"
+      className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest truncate"
+    >
+      {character ? `${character.firstName} ${character.lastName}`.trim() : 'Character'}
+    </h2>
+    {character?.link && (
+      <a
+        href={character.link}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="shrink-0"
+        aria-label="External link"
+      >
+        <ExternalLink className="h-3.5 w-3.5 text-slate-500 hover:text-blue-400 transition-colors" />
+      </a>
+    )}
+  </div>
+  <button
+    type="button"
+    onClick={onClose}
+    className="text-slate-500 hover:text-white transition-colors shrink-0"
+    aria-label="Close modal"
+  >
+    <X className="h-5 w-5" />
+  </button>
+</header>
+```
+
+- [ ] **Step 2: Run typecheck and full test suite**
+
+```bash
+npm run typecheck && npm test
+```
+
+Expected: no errors, all tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/components/wiki/characters/CharacterViewModal.tsx
+git commit -m "feat: show character name, visibility icon, and external link in CharacterViewModal header"
+```
+
+---
+
+## Task 11: NoteModal — Live visibility icon in header
+
+**Files:**
+
+- Modify: `app/components/mainview/notes/NoteModal.tsx`
+- Test: `tests/components/mainview/notes/NoteModal.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Add these tests inside the existing `describe` block in `tests/components/mainview/notes/NoteModal.test.tsx`. Place them after the existing tests:
+
+```typescript
+describe('header visibility icon', () => {
+  beforeEach(() => {
+    vi.mocked(useCreateNote).mockReturnValue({ create: vi.fn(), isLoading: false } as never);
+    vi.mocked(useUpdateNote).mockReturnValue({ update: vi.fn(), isLoading: false } as never);
+    vi.mocked(useDeleteNote).mockReturnValue({ remove: vi.fn(), isLoading: false } as never);
+    vi.mocked(useNote).mockReturnValue({ note: null, isLoading: false } as never);
+  });
+
+  it('shows a Lock icon by default when creating a note', () => {
+    render(
+      <NoteModal
+        isOpen
+        onClose={vi.fn()}
+        campaignId="camp-1"
+        sessions={[]}
+      />,
+    );
+    expect(screen.getByLabelText('Private')).toBeInTheDocument();
+  });
+
+  it('shows a Globe icon after the user toggles to Public', async () => {
+    const user = userEvent.setup();
+    render(
+      <NoteModal
+        isOpen
+        onClose={vi.fn()}
+        campaignId="camp-1"
+        sessions={[]}
+      />,
+    );
+    await user.click(screen.getByText('Public'));
+    expect(screen.getByLabelText('Public')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+npx vitest run --project unit tests/components/mainview/notes/NoteModal.test.tsx -t "header visibility icon"
+```
+
+Expected: FAIL
+
+- [ ] **Step 3: Update `app/components/mainview/notes/NoteModal.tsx`**
+
+`Globe` and `Lock` are already imported at line 3. Update the `<header>` element:
+
+```tsx
+<header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
+  <div className="flex items-center gap-2">
+    {isPublic ? (
+      <Globe className="h-3.5 w-3.5 text-emerald-400 shrink-0" aria-label="Public" />
+    ) : (
+      <Lock className="h-3.5 w-3.5 text-amber-400 shrink-0" aria-label="Private" />
+    )}
+    <h2
+      id="note-modal-title"
+      className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest"
+    >
+      {noteId ? 'Edit Note' : 'Create Note'}
+    </h2>
+  </div>
+  <button
+    type="button"
+    onClick={onClose}
+    className="text-slate-500 hover:text-white transition-colors"
+    aria-label="Close modal"
+  >
+    <X className="h-5 w-5" />
+  </button>
+</header>
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+npx vitest run --project unit tests/components/mainview/notes/NoteModal.test.tsx
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 5: Run the full test suite**
+
+```bash
+npm test
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/components/mainview/notes/NoteModal.tsx tests/components/mainview/notes/NoteModal.test.tsx
+git commit -m "feat: add live visibility icon to NoteModal header"
+```

--- a/docs/superpowers/specs/2026-04-05-ui-space-optimization-design.md
+++ b/docs/superpowers/specs/2026-04-05-ui-space-optimization-design.md
@@ -1,0 +1,226 @@
+# UI Space Optimization Design
+
+**Date:** 2026-04-05
+**Scope:** Rules, Races, Characters, Notes windows and modals
+**Goal:** Eliminate duplicated titles, consolidate visibility badges and tags into compact rows, move icons to title bars — reducing scroll in all content windows.
+
+---
+
+## Problem
+
+Every content window (Rule, Race, Character) wastes 3–4 rows of vertical space:
+
+1. The item title appears in the FloatingWindow title bar **and** again as an `h2` inside the window body.
+2. The visibility badge (Public/Private with full text) occupies its own row.
+3. Tags occupy a separate row.
+4. The edit pencil button floats absolutely in the top-right corner.
+
+This forces unnecessary scrolling to reach the actual content.
+
+---
+
+## Solution Overview
+
+- Move the visibility icon (Globe/Lock) into the FloatingWindow title bar, before the title text.
+- Move the character's external link icon into the title bar, after the title text.
+- Remove the duplicate title `h2` from all window bodies.
+- Remove the full-text visibility badge from all window bodies.
+- Consolidate tags and the edit button into a single compact row at the top of the window body.
+- Apply the same header improvements to view modals (RuleViewModal, RaceViewModal, CharacterViewModal) and NoteModal.
+
+---
+
+## Section 1: Data Layer
+
+### `HydratedDocument` type (`app/types/gmscreen.ts`)
+
+Add two optional fields:
+
+```typescript
+export interface HydratedDocument {
+  id: string;
+  collection: string;
+  title: string;
+  content: string;
+  isPublic?: boolean; // rules and characters only
+  link?: string; // characters only (external URL)
+}
+```
+
+### Backend hydration endpoint
+
+The server route that builds the `hydrated` map for `GMScreenDetailData` must populate `isPublic` and `link` when the collection supports them:
+
+- `rule` collection → include `isPublic`
+- `character` collection → include `isPublic` and `link`
+- `race` collection → neither field (races have no visibility concept)
+
+### `FloatingWindow` component (`app/components/mainview/FloatingWindow.tsx`)
+
+Add two optional visual props (the `title: string` prop is unchanged and continues to drive all aria-labels):
+
+```typescript
+titleIcon?: ReactNode    // rendered before the title text (Globe/Lock)
+titleSuffix?: ReactNode  // rendered after the title text (ExternalLink for characters)
+```
+
+Title bar layout becomes:
+
+```
+[titleIcon] [title text] [titleSuffix]     [minimize] [maximize] [close]
+```
+
+### `ManagedWindow` interface + `FloatingWindowManager`
+
+`ManagedWindow` gains matching `titleIcon?: ReactNode` and `titleSuffix?: ReactNode` fields. `FloatingWindowManager` passes them straight through to `FloatingWindow`.
+
+### `GMScreensView` — icon construction
+
+When building each `ManagedWindow` from server data:
+
+- **Rule:** `titleIcon = <Lock/Globe based on doc.isPublic>`
+- **Character:** `titleIcon = <Lock/Globe based on doc.isPublic>`, `titleSuffix = <a href={doc.link}><ExternalLink /></a>` (omitted if `doc.link` is absent)
+- **Race:** no `titleIcon`, no `titleSuffix`
+
+---
+
+## Section 2: Window Content Components
+
+All three window components lose their header elements. Content starts immediately after a single compact meta row.
+
+### Edit button — moved from Wrappers into Window components
+
+Currently the Wrapper components (`RuleWindowWrapper`, `RaceWindowWrapper`, `CharacterWindowWrapper`) each render the edit pencil button as an absolutely-positioned overlay on top of the window body. To place it on the same row as the tags, the button must move inside the Window component itself.
+
+Each Window component gains an optional `onEdit?: () => void` prop. When provided, the button renders inside the meta row. The Wrappers pass their existing `onEdit` callback through, and drop their own absolute-positioned button.
+
+Visibility of the edit button follows existing logic:
+
+- `RuleWindow`: renders when `isGM` is true (also add `isGM?: boolean` prop)
+- `RaceWindow`: renders when `race.canEdit` is true (data already available)
+- `CharacterWindow`: renders when `character.canEdit` is true (data already available)
+
+### `RuleWindow` (`app/components/wiki/rules/RuleWindow.tsx`)
+
+**Remove:**
+
+- Title `h2`
+- Full-width visibility badge div
+
+**Add:**
+
+- `onEdit?: () => void` and `isGM?: boolean` props
+- Single compact row at the top: tags on the left, edit pencil button on the right (only when `isGM`)
+- Reduced top padding so content follows closely
+
+```
+[#rules] [#magic]                              [✏]
+────────────────────────────────────────────────
+### Setting a DC
+...
+```
+
+The row is omitted entirely if there are no tags and no edit button.
+
+### `RaceWindow` (`app/components/wiki/races/RaceWindow.tsx`)
+
+**Remove:**
+
+- Title `h2`
+- Separate tags div (currently in the header section)
+
+**Add:**
+
+- `onEdit?: () => void` prop
+- Same compact tags + edit button row as RuleWindow (button shown when `race.canEdit`)
+- Races have no visibility badge to remove
+
+### `CharacterWindow` (`app/components/wiki/characters/CharacterWindow.tsx`)
+
+**Remove:**
+
+- Name `h2` + external link row (both move to the FloatingWindow/modal title bar)
+- Standalone visibility badge div
+
+**Add:**
+
+- `onEdit?: () => void` prop
+
+**Reorganize:**
+
+- Tags move to directly below the portrait, in a compact centered flex row, with the edit button on the right (shown when `character.canEdit`)
+- Stats grid follows below tags
+- Accordions unchanged
+
+```
+          [portrait]
+    [#guard] [#dwarf]           [✏]
+┌──────────┬──────────┐
+│ Race     │ Age      │
+│ Dwarf    │ 208      │
+└──────────┴──────────┘
+▶ Details
+▶ GM Notes
+```
+
+---
+
+## Section 3: View Modals & NoteModal
+
+### `RuleViewModal` (`app/components/wiki/rules/RuleViewModal.tsx`)
+
+The modal already fetches `rule` via `useRule`. Once loaded:
+
+- Header shows: `[Lock/Globe icon]  {rule.title}` instead of the generic "Rule"
+- During loading: falls back to "Rule"
+- The `RuleWindow` body (compact row + content) renders unchanged
+
+### `RaceViewModal` (`app/components/wiki/races/RaceViewModal.tsx`)
+
+- Header shows: `{race.title}` (no icon — races have no visibility)
+- During loading: falls back to "Race"
+
+### `CharacterViewModal` (`app/components/wiki/characters/CharacterViewModal.tsx`)
+
+The modal fetches `character` via `useCharacter`. Once loaded:
+
+- Header shows: `[Lock/Globe icon]  {character.firstName} {character.lastName}  [ExternalLink icon]`
+- ExternalLink icon is an `<a>` linking to `character.link` (omitted if absent)
+- During loading: falls back to "Character"
+
+### `NoteModal` (`app/components/mainview/notes/NoteModal.tsx`)
+
+`isPublic` is already tracked as local state. The modal header gets a Globe or Lock icon prepended, driven by that state. It updates live as the user toggles the visibility radio buttons.
+
+- Creating: `[Lock icon]  Create Note` (default: private)
+- Editing: `[Globe/Lock icon]  Edit Note` (reflects loaded visibility, updates on toggle)
+
+---
+
+## Files Changed
+
+| File                                                           | Change                                                              |
+| -------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `app/types/gmscreen.ts`                                        | Add `isPublic?`, `link?` to `HydratedDocument`                      |
+| `server/` (hydration route)                                    | Include `isPublic` and `link` in hydrated data                      |
+| `app/components/mainview/FloatingWindow.tsx`                   | Add `titleIcon`, `titleSuffix` props                                |
+| `app/components/mainview/FloatingWindowManager.tsx`            | Thread new props through                                            |
+| `app/components/mainview/gmscreens/GMScreensView.tsx`          | Build and pass icons from hydrated data                             |
+| `app/components/wiki/rules/RuleWindow.tsx`                     | Remove title/badge, add compact meta row, add `onEdit`/`isGM` props |
+| `app/components/mainview/gmscreens/RuleWindowWrapper.tsx`      | Pass `onEdit`/`isGM` to `RuleWindow`, remove absolute edit button   |
+| `app/components/wiki/races/RaceWindow.tsx`                     | Remove title, add compact meta row, add `onEdit` prop               |
+| `app/components/wiki/races/RaceWindowWrapper.tsx`              | Pass `onEdit` to `RaceWindow`, remove absolute edit button          |
+| `app/components/wiki/characters/CharacterWindow.tsx`           | Remove title/badge/link, move tags, add `onEdit` prop               |
+| `app/components/mainview/gmscreens/CharacterWindowWrapper.tsx` | Pass `onEdit` to `CharacterWindow`, remove absolute edit button     |
+| `app/components/wiki/rules/RuleViewModal.tsx`                  | Show actual title + icon in header                                  |
+| `app/components/wiki/races/RaceViewModal.tsx`                  | Show actual title in header                                         |
+| `app/components/wiki/characters/CharacterViewModal.tsx`        | Show actual title + icons in header                                 |
+| `app/components/mainview/notes/NoteModal.tsx`                  | Add live visibility icon to header                                  |
+
+---
+
+## Out of Scope
+
+- Edit modals (RuleModal, RaceModal, CharacterModal) — their headers are form titles ("Edit Rule" etc.) and are fine as-is.
+- The FloatingWindowTray (minimized window list) — uses `title: string` only, unaffected.
+- Card components (RuleCard, RaceCard, CharacterCard) — already compact, not part of this request.

--- a/tests/components/mainview/FloatingWindow.test.tsx
+++ b/tests/components/mainview/FloatingWindow.test.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
-import { describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { FloatingWindow } from '~/components/mainview/FloatingWindow'
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FloatingWindow } from '~/components/mainview/FloatingWindow';
 
 describe('FloatingWindow', () => {
   it('renders title and children', () => {
@@ -11,63 +11,63 @@ describe('FloatingWindow', () => {
         <FloatingWindow id="notes" title="DM Notes">
           <div>Archive key hidden in the altar.</div>
         </FloatingWindow>
-      </div>,
-    )
+      </div>
+    );
 
-    expect(screen.getByText('DM Notes')).toBeInTheDocument()
-    expect(screen.getByText('Archive key hidden in the altar.')).toBeInTheDocument()
-  })
+    expect(screen.getByText('DM Notes')).toBeInTheDocument();
+    expect(screen.getByText('Archive key hidden in the altar.')).toBeInTheDocument();
+  });
 
   it('close button calls onClose', async () => {
-    const user = userEvent.setup()
-    const onClose = vi.fn()
+    const user = userEvent.setup();
+    const onClose = vi.fn();
 
     render(
       <div className="relative h-[600px] w-[800px]">
         <FloatingWindow id="notes" title="DM Notes" onClose={onClose}>
           <div>Content</div>
         </FloatingWindow>
-      </div>,
-    )
+      </div>
+    );
 
-    await user.click(screen.getByRole('button', { name: 'Close DM Notes' }))
+    await user.click(screen.getByRole('button', { name: 'Close DM Notes' }));
 
-    expect(onClose).toHaveBeenCalledTimes(1)
-  })
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
 
   it('minimize button calls onStateChange with minimized', async () => {
-    const user = userEvent.setup()
-    const onStateChange = vi.fn()
+    const user = userEvent.setup();
+    const onStateChange = vi.fn();
 
     render(
       <div className="relative h-[600px] w-[800px]">
         <FloatingWindow id="map" title="Map" onStateChange={onStateChange}>
           <div>Content</div>
         </FloatingWindow>
-      </div>,
-    )
+      </div>
+    );
 
-    await user.click(screen.getByRole('button', { name: 'Minimize Map' }))
+    await user.click(screen.getByRole('button', { name: 'Minimize Map' }));
 
-    expect(onStateChange).toHaveBeenCalledWith('minimized')
-  })
+    expect(onStateChange).toHaveBeenCalledWith('minimized');
+  });
 
   it('maximize button calls onStateChange with maximized', async () => {
-    const user = userEvent.setup()
-    const onStateChange = vi.fn()
+    const user = userEvent.setup();
+    const onStateChange = vi.fn();
 
     render(
       <div className="relative h-[600px] w-[800px]">
         <FloatingWindow id="map" title="Map" onStateChange={onStateChange}>
           <div>Content</div>
         </FloatingWindow>
-      </div>,
-    )
+      </div>
+    );
 
-    await user.click(screen.getByRole('button', { name: 'Maximize Map' }))
+    await user.click(screen.getByRole('button', { name: 'Maximize Map' }));
 
-    expect(onStateChange).toHaveBeenCalledWith('maximized')
-  })
+    expect(onStateChange).toHaveBeenCalledWith('maximized');
+  });
 
   it('maximized window shows restore button', () => {
     render(
@@ -75,15 +75,15 @@ describe('FloatingWindow', () => {
         <FloatingWindow id="sheet" title="Character Sheet" initialState="maximized">
           <div>Content</div>
         </FloatingWindow>
-      </div>,
-    )
+      </div>
+    );
 
-    expect(screen.getByRole('button', { name: 'Restore Character Sheet' })).toBeInTheDocument()
-  })
+    expect(screen.getByRole('button', { name: 'Restore Character Sheet' })).toBeInTheDocument();
+  });
 
   it('clicking restore calls onStateChange with normal', async () => {
-    const user = userEvent.setup()
-    const onStateChange = vi.fn()
+    const user = userEvent.setup();
+    const onStateChange = vi.fn();
 
     render(
       <div className="relative h-[600px] w-[800px]">
@@ -95,13 +95,13 @@ describe('FloatingWindow', () => {
         >
           <div>Content</div>
         </FloatingWindow>
-      </div>,
-    )
+      </div>
+    );
 
-    await user.click(screen.getByRole('button', { name: 'Restore Character Sheet' }))
+    await user.click(screen.getByRole('button', { name: 'Restore Character Sheet' }));
 
-    expect(onStateChange).toHaveBeenCalledWith('normal')
-  })
+    expect(onStateChange).toHaveBeenCalledWith('normal');
+  });
 
   it('has the correct dialog accessibility attributes', () => {
     render(
@@ -109,20 +109,20 @@ describe('FloatingWindow', () => {
         <FloatingWindow id="wiki" title="Wiki Entry">
           <div>Content</div>
         </FloatingWindow>
-      </div>,
-    )
+      </div>
+    );
 
-    const dialog = screen.getByRole('dialog', { name: 'Wiki Entry' })
+    const dialog = screen.getByRole('dialog', { name: 'Wiki Entry' });
 
     // Non-modal dialog — aria-modal removed per a11y guidance (content behind is interactive)
-    expect(dialog).not.toHaveAttribute('aria-modal')
+    expect(dialog).not.toHaveAttribute('aria-modal');
     // aria-label removed — aria-labelledby is sufficient (avoids redundant labeling)
-    expect(dialog).not.toHaveAttribute('aria-label')
-    expect(dialog).toHaveAttribute('aria-labelledby')
-  })
+    expect(dialog).not.toHaveAttribute('aria-label');
+    expect(dialog).toHaveAttribute('aria-labelledby');
+  });
 
   it('calls onLayoutChange after drag ends', () => {
-    const onLayoutChange = vi.fn()
+    const onLayoutChange = vi.fn();
 
     render(
       <div className="relative h-[600px] w-[800px]">
@@ -135,27 +135,27 @@ describe('FloatingWindow', () => {
         >
           <div>Content</div>
         </FloatingWindow>
-      </div>,
-    )
+      </div>
+    );
 
     // The title bar is the drag handle — it has cursor-move class
-    const titleText = screen.getByText('Notes')
-    const titleBar = titleText.closest('div[class*="cursor-move"]')!
+    const titleText = screen.getByText('Notes');
+    const titleBar = titleText.closest('div[class*="cursor-move"]')!;
 
     // Simulate drag: mousedown on title bar, mousemove, mouseup
-    fireEvent.mouseDown(titleBar, { clientX: 100, clientY: 100 })
-    fireEvent.mouseMove(document, { clientX: 150, clientY: 120 })
-    fireEvent.mouseUp(document)
+    fireEvent.mouseDown(titleBar, { clientX: 100, clientY: 100 });
+    fireEvent.mouseMove(document, { clientX: 150, clientY: 120 });
+    fireEvent.mouseUp(document);
 
-    expect(onLayoutChange).toHaveBeenCalledTimes(1)
+    expect(onLayoutChange).toHaveBeenCalledTimes(1);
     expect(onLayoutChange).toHaveBeenCalledWith({
       position: expect.objectContaining({ x: expect.any(Number), y: expect.any(Number) }),
       size: expect.objectContaining({ width: 300, height: 200 }),
-    })
-  })
+    });
+  });
 
   it('calls onLayoutChange after resize ends', () => {
-    const onLayoutChange = vi.fn()
+    const onLayoutChange = vi.fn();
 
     render(
       <div className="relative h-[600px] w-[800px]">
@@ -168,26 +168,26 @@ describe('FloatingWindow', () => {
         >
           <div>Content</div>
         </FloatingWindow>
-      </div>,
-    )
+      </div>
+    );
 
     // The resize handle is the bottom-right corner div with cursor-se-resize
-    const resizeHandle = document.querySelector('[class*="cursor-se-resize"]')!
+    const resizeHandle = document.querySelector('[class*="cursor-se-resize"]')!;
 
-    fireEvent.mouseDown(resizeHandle, { clientX: 350, clientY: 250 })
-    fireEvent.mouseMove(document, { clientX: 400, clientY: 300 })
-    fireEvent.mouseUp(document)
+    fireEvent.mouseDown(resizeHandle, { clientX: 350, clientY: 250 });
+    fireEvent.mouseMove(document, { clientX: 400, clientY: 300 });
+    fireEvent.mouseUp(document);
 
-    expect(onLayoutChange).toHaveBeenCalledTimes(1)
+    expect(onLayoutChange).toHaveBeenCalledTimes(1);
     expect(onLayoutChange).toHaveBeenCalledWith({
       position: expect.objectContaining({ x: expect.any(Number), y: expect.any(Number) }),
       size: expect.objectContaining({ width: expect.any(Number), height: expect.any(Number) }),
-    })
-  })
+    });
+  });
 
   it('maximize then restore preserves original size and position', async () => {
-    const user = userEvent.setup()
-    const stateChanges: string[] = []
+    const user = userEvent.setup();
+    const stateChanges: string[] = [];
 
     render(
       <div className="relative h-[600px] w-[800px]">
@@ -200,54 +200,86 @@ describe('FloatingWindow', () => {
         >
           <div>Content</div>
         </FloatingWindow>
-      </div>,
-    )
+      </div>
+    );
 
-    const dialog = screen.getByRole('dialog', { name: 'Notes' })
+    const dialog = screen.getByRole('dialog', { name: 'Notes' });
 
     // Verify initial geometry
-    expect(dialog.style.transform).toBe('translate(50px, 75px)')
-    expect(dialog.style.width).toBe('300px')
-    expect(dialog.style.height).toBe('250px')
+    expect(dialog.style.transform).toBe('translate(50px, 75px)');
+    expect(dialog.style.width).toBe('300px');
+    expect(dialog.style.height).toBe('250px');
 
     // Maximize
-    await user.click(screen.getByRole('button', { name: 'Maximize Notes' }))
-    expect(stateChanges).toContain('maximized')
+    await user.click(screen.getByRole('button', { name: 'Maximize Notes' }));
+    expect(stateChanges).toContain('maximized');
 
     // Restore
-    await user.click(screen.getByRole('button', { name: 'Restore Notes' }))
-    expect(stateChanges).toContain('normal')
+    await user.click(screen.getByRole('button', { name: 'Restore Notes' }));
+    expect(stateChanges).toContain('normal');
 
     // Geometry should be restored to original values
-    expect(dialog.style.transform).toBe('translate(50px, 75px)')
-    expect(dialog.style.width).toBe('300px')
-    expect(dialog.style.height).toBe('250px')
-  })
+    expect(dialog.style.transform).toBe('translate(50px, 75px)');
+    expect(dialog.style.width).toBe('300px');
+    expect(dialog.style.height).toBe('250px');
+  });
+
+  it('renders titleIcon before the title text', () => {
+    render(
+      <div className="relative h-[600px] w-[800px]">
+        <FloatingWindow
+          id="rule"
+          title="Difficulty"
+          titleIcon={<span data-testid="lock-icon">🔒</span>}
+        >
+          <div>content</div>
+        </FloatingWindow>
+      </div>
+    );
+
+    expect(screen.getByTestId('lock-icon')).toBeInTheDocument();
+  });
+
+  it('renders titleSuffix after the title text', () => {
+    render(
+      <div className="relative h-[600px] w-[800px]">
+        <FloatingWindow
+          id="char"
+          title="Thorin Grudgebearer"
+          titleSuffix={<span data-testid="ext-link">🔗</span>}
+        >
+          <div>content</div>
+        </FloatingWindow>
+      </div>
+    );
+
+    expect(screen.getByTestId('ext-link')).toBeInTheDocument();
+  });
 
   it('cleans up document listeners on unmount during drag', () => {
-    const removeSpy = vi.spyOn(document, 'removeEventListener')
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
 
     const { unmount } = render(
       <div className="relative h-[600px] w-[800px]">
         <FloatingWindow id="notes" title="Notes">
           <div>Content</div>
         </FloatingWindow>
-      </div>,
-    )
+      </div>
+    );
 
-    const titleBar = screen.getByText('Notes').closest('div[class*="cursor-move"]')!
+    const titleBar = screen.getByText('Notes').closest('div[class*="cursor-move"]')!;
 
     // Start a drag but don't finish it
-    fireEvent.mouseDown(titleBar, { clientX: 100, clientY: 100 })
-    fireEvent.mouseMove(document, { clientX: 150, clientY: 120 })
+    fireEvent.mouseDown(titleBar, { clientX: 100, clientY: 100 });
+    fireEvent.mouseMove(document, { clientX: 150, clientY: 120 });
 
     // Unmount while dragging
-    unmount()
+    unmount();
 
     // Verify listeners were cleaned up
-    expect(removeSpy).toHaveBeenCalledWith('mousemove', expect.any(Function))
-    expect(removeSpy).toHaveBeenCalledWith('mouseup', expect.any(Function))
+    expect(removeSpy).toHaveBeenCalledWith('mousemove', expect.any(Function));
+    expect(removeSpy).toHaveBeenCalledWith('mouseup', expect.any(Function));
 
-    removeSpy.mockRestore()
-  })
-})
+    removeSpy.mockRestore();
+  });
+});

--- a/tests/components/mainview/FloatingWindowManager.test.tsx
+++ b/tests/components/mainview/FloatingWindowManager.test.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from 'react'
-import { describe, expect, it, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import React, { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
   FloatingWindowManager,
   type ManagedWindow,
-} from '~/components/mainview/FloatingWindowManager'
+} from '~/components/mainview/FloatingWindowManager';
 
 const baseWindows: ManagedWindow[] = [
   {
@@ -33,84 +33,107 @@ const baseWindows: ManagedWindow[] = [
     state: 'minimized',
     zIndex: 3,
   },
-]
+];
 
 function ControlledManager({
   initialWindows = baseWindows,
   onWindowsChange,
 }: {
-  initialWindows?: ManagedWindow[]
-  onWindowsChange?: (windows: ManagedWindow[]) => void
+  initialWindows?: ManagedWindow[];
+  onWindowsChange?: (windows: ManagedWindow[]) => void;
 }) {
-  const [windows, setWindows] = useState(initialWindows)
+  const [windows, setWindows] = useState(initialWindows);
 
   return (
     <div className="relative h-[600px] w-[800px]">
       <FloatingWindowManager
         windows={windows}
         onWindowsChange={(nextWindows) => {
-          setWindows(nextWindows)
-          onWindowsChange?.(nextWindows)
+          setWindows(nextWindows);
+          onWindowsChange?.(nextWindows);
         }}
       />
     </div>
-  )
+  );
 }
 
 describe('FloatingWindowManager', () => {
   it('renders all non-minimized windows', () => {
-    render(<ControlledManager />)
+    render(<ControlledManager />);
 
-    expect(screen.getByRole('dialog', { name: 'Map' })).toBeInTheDocument()
-    expect(screen.getByRole('dialog', { name: 'Notes' })).toBeInTheDocument()
-    expect(screen.queryByRole('dialog', { name: 'Wiki' })).not.toBeInTheDocument()
-  })
+    expect(screen.getByRole('dialog', { name: 'Map' })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Notes' })).toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: 'Wiki' })).not.toBeInTheDocument();
+  });
 
   it('minimized windows appear in the tray', () => {
-    render(<ControlledManager />)
+    render(<ControlledManager />);
 
-    expect(screen.getByRole('button', { name: 'Restore Wiki' })).toBeInTheDocument()
-  })
+    expect(screen.getByRole('button', { name: 'Restore Wiki' })).toBeInTheDocument();
+  });
 
   it('closing a window calls onWindowsChange without that window', async () => {
-    const user = userEvent.setup()
-    const onWindowsChange = vi.fn()
+    const user = userEvent.setup();
+    const onWindowsChange = vi.fn();
 
-    render(<ControlledManager onWindowsChange={onWindowsChange} />)
+    render(<ControlledManager onWindowsChange={onWindowsChange} />);
 
-    await user.click(screen.getByRole('button', { name: 'Close Notes' }))
+    await user.click(screen.getByRole('button', { name: 'Close Notes' }));
 
-    const latestCall = onWindowsChange.mock.calls.at(-1)?.[0] as ManagedWindow[] | undefined
+    const latestCall = onWindowsChange.mock.calls.at(-1)?.[0] as ManagedWindow[] | undefined;
 
-    expect(latestCall?.map(window => window.id)).toEqual(['map', 'wiki'])
-  })
+    expect(latestCall?.map((window) => window.id)).toEqual(['map', 'wiki']);
+  });
 
   it('renders active (non-minimized) windows as dialogs', async () => {
-    render(<ControlledManager />)
+    render(<ControlledManager />);
 
     // Two non-minimized windows should be in the document
-    expect(screen.getByRole('dialog', { name: 'Map' })).toBeInTheDocument()
-    expect(screen.getByRole('dialog', { name: 'Notes' })).toBeInTheDocument()
-  })
+    expect(screen.getByRole('dialog', { name: 'Map' })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Notes' })).toBeInTheDocument();
+  });
+
+  it('passes titleIcon to the FloatingWindow', () => {
+    const windows: ManagedWindow[] = [
+      {
+        id: 'rule-1',
+        title: 'Difficulty',
+        titleIcon: <span data-testid="rule-icon">icon</span>,
+        content: <div>Rule content</div>,
+        position: { x: 10, y: 10 },
+        size: { width: 300, height: 200 },
+        state: 'normal',
+        zIndex: 1,
+      },
+    ];
+
+    render(
+      <div className="relative h-[600px] w-[800px]">
+        <FloatingWindowManager windows={windows} onWindowsChange={vi.fn()} />
+      </div>
+    );
+
+    expect(screen.getByTestId('rule-icon')).toBeInTheDocument();
+  });
 
   it('focusing a window brings it to the highest zIndex', async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup();
 
-    render(<ControlledManager />)
+    render(<ControlledManager />);
 
-    const mapWindow = screen.getByRole('dialog', { name: 'Map' })
-    const notesWindow = screen.getByRole('dialog', { name: 'Notes' })
+    const mapWindow = screen.getByRole('dialog', { name: 'Map' });
+    const notesWindow = screen.getByRole('dialog', { name: 'Notes' });
 
-    expect(mapWindow).toHaveStyle({ zIndex: '1' })
-    expect(notesWindow).toHaveStyle({ zIndex: '2' })
+    expect(mapWindow).toHaveStyle({ zIndex: '1' });
+    expect(notesWindow).toHaveStyle({ zIndex: '2' });
 
-    await user.click(mapWindow)
+    await user.click(mapWindow);
 
     // After normalization: windows re-ranked 1..n, map brought to top
     // map was lowest (1), notes was middle (2), wiki minimized (3)
     // normalized: map=3 (top), notes=1 or 2, wiki=1 or 2
-    const mapZIndex = Number(mapWindow.style.zIndex)
-    const notesZIndex = Number(notesWindow.style.zIndex)
-    expect(mapZIndex).toBeGreaterThan(notesZIndex)
-  })
-})
+    const mapZIndex = Number(mapWindow.style.zIndex);
+    const notesZIndex = Number(notesWindow.style.zIndex);
+    expect(mapZIndex).toBeGreaterThan(notesZIndex);
+  });
+});

--- a/tests/components/mainview/notes/NoteModal.test.tsx
+++ b/tests/components/mainview/notes/NoteModal.test.tsx
@@ -642,6 +642,24 @@ describe('NoteModal', () => {
     expect(screen.queryByText('Delete this note?')).not.toBeInTheDocument();
   });
 
+  // ── Header visibility icon ───────────────────────────────
+
+  describe('header visibility icon', () => {
+    it('shows a Lock icon by default when creating a note', () => {
+      renderModal();
+      const matches = screen.getAllByLabelText('Private');
+      expect(matches.some((el) => el.tagName.toLowerCase() === 'svg')).toBe(true);
+    });
+
+    it('shows a Globe icon after the user toggles to Public', async () => {
+      const user = userEvent.setup();
+      renderModal();
+      await user.click(screen.getByText('Public'));
+      const matches = screen.getAllByLabelText('Public');
+      expect(matches.some((el) => el.tagName.toLowerCase() === 'svg')).toBe(true);
+    });
+  });
+
   // ── Error handling ──────────────────────────────────────
 
   it('shows error when save fails', async () => {

--- a/tests/components/wiki/characters/CharacterWindow.test.tsx
+++ b/tests/components/wiki/characters/CharacterWindow.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CharacterWindow } from '~/components/wiki/characters/CharacterWindow';
+import type { CharacterData } from '~/types/character';
+
+const baseCharacter: CharacterData = {
+  id: 'char-1',
+  campaignId: 'camp-1',
+  createdBy: 'user-1',
+  firstName: 'Thorin',
+  lastName: 'Grudgebearer',
+  race: 'Dwarf',
+  characterClass: 'Fighter',
+  age: 208,
+  location: 'Stormwind',
+  link: 'https://example.com/thorin',
+  isPublic: true,
+  canEdit: true,
+  tags: ['guard', 'dwarf'],
+  notes: 'A steadfast warrior.',
+  gmNotes: '',
+  picture: '',
+  pictureCrop: null,
+  sessions: [],
+  createdAt: '2026-01-01',
+  updatedAt: '2026-01-01',
+};
+
+describe('CharacterWindow', () => {
+  it('does not render the full name as a heading below the portrait', () => {
+    render(<CharacterWindow character={baseCharacter} />);
+    expect(screen.queryByRole('heading', { name: 'Thorin Grudgebearer' })).not.toBeInTheDocument();
+  });
+
+  it('does not render a visibility badge', () => {
+    render(<CharacterWindow character={baseCharacter} />);
+    expect(screen.queryByText('Public')).not.toBeInTheDocument();
+    expect(screen.queryByText('Private')).not.toBeInTheDocument();
+  });
+
+  it('renders tags below the portrait', () => {
+    render(<CharacterWindow character={baseCharacter} />);
+    expect(screen.getByText('#guard')).toBeInTheDocument();
+    expect(screen.getByText('#dwarf')).toBeInTheDocument();
+  });
+
+  it('shows the edit button when character.canEdit and onEdit are provided', async () => {
+    const onEdit = vi.fn();
+    const user = userEvent.setup();
+    render(<CharacterWindow character={baseCharacter} onEdit={onEdit} />);
+    await user.click(screen.getByRole('button', { name: 'Edit character' }));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the edit button when canEdit is false', () => {
+    render(<CharacterWindow character={{ ...baseCharacter, canEdit: false }} onEdit={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: 'Edit character' })).not.toBeInTheDocument();
+  });
+
+  it('still renders stat blocks', () => {
+    render(<CharacterWindow character={baseCharacter} />);
+    expect(screen.getByText('Dwarf')).toBeInTheDocument();
+    expect(screen.getByText('208')).toBeInTheDocument();
+  });
+});

--- a/tests/components/wiki/characters/CharacterWindow.test.tsx
+++ b/tests/components/wiki/characters/CharacterWindow.test.tsx
@@ -64,4 +64,15 @@ describe('CharacterWindow', () => {
     expect(screen.getByText('Dwarf')).toBeInTheDocument();
     expect(screen.getByText('208')).toBeInTheDocument();
   });
+
+  it('hides the meta row entirely when there are no tags and canEdit is false', () => {
+    render(
+      <CharacterWindow
+        character={{ ...baseCharacter, tags: [], canEdit: false }}
+        onEdit={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole('button', { name: 'Edit character' })).not.toBeInTheDocument();
+    expect(screen.queryByText(/#/)).not.toBeInTheDocument();
+  });
 });

--- a/tests/components/wiki/races/RaceWindow.test.tsx
+++ b/tests/components/wiki/races/RaceWindow.test.tsx
@@ -41,4 +41,11 @@ describe('RaceWindow', () => {
     render(<RaceWindow race={{ ...baseRace, canEdit: false }} onEdit={vi.fn()} />);
     expect(screen.queryByRole('button', { name: 'Edit race' })).not.toBeInTheDocument();
   });
+
+  it('hides the meta row entirely when there are no tags and canEdit is false', () => {
+    const { container } = render(
+      <RaceWindow race={{ ...baseRace, tags: [], canEdit: false }} onEdit={vi.fn()} />
+    );
+    expect(container.querySelector('.border-b')).not.toBeInTheDocument();
+  });
 });

--- a/tests/components/wiki/races/RaceWindow.test.tsx
+++ b/tests/components/wiki/races/RaceWindow.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RaceWindow } from '~/components/wiki/races/RaceWindow';
+import type { RaceData } from '~/types/race';
+
+const baseRace: RaceData = {
+  id: 'race-1',
+  campaignId: 'camp-1',
+  createdBy: 'user-1',
+  title: 'Dwarf',
+  content: '## Traits\nDarkvision, Stonecunning',
+  tags: ['playable', 'core'],
+  canEdit: true,
+  createdAt: '2026-01-01',
+  updatedAt: '2026-01-01',
+};
+
+describe('RaceWindow', () => {
+  it('does not render the title as a heading inside the window body', () => {
+    render(<RaceWindow race={baseRace} />);
+    expect(screen.queryByRole('heading', { name: 'Dwarf' })).not.toBeInTheDocument();
+  });
+
+  it('renders tags in the meta row', () => {
+    render(<RaceWindow race={baseRace} />);
+    expect(screen.getByText('#playable')).toBeInTheDocument();
+    expect(screen.getByText('#core')).toBeInTheDocument();
+  });
+
+  it('shows the edit button when race.canEdit and onEdit are provided', async () => {
+    const onEdit = vi.fn();
+    const user = userEvent.setup();
+    render(<RaceWindow race={baseRace} onEdit={onEdit} />);
+    await user.click(screen.getByRole('button', { name: 'Edit race' }));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the edit button when race.canEdit is false', () => {
+    render(<RaceWindow race={{ ...baseRace, canEdit: false }} onEdit={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: 'Edit race' })).not.toBeInTheDocument();
+  });
+});

--- a/tests/components/wiki/rules/RuleWindow.test.tsx
+++ b/tests/components/wiki/rules/RuleWindow.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RuleWindow } from '~/components/wiki/rules/RuleWindow';
+import type { RuleData } from '~/types/rule';
+
+const baseRule: RuleData = {
+  id: 'rule-1',
+  campaignId: 'camp-1',
+  createdBy: 'user-1',
+  title: 'Difficulty',
+  content: '# Setting a DC\nVery Easy: 5',
+  tags: ['rules', 'dc'],
+  isPublic: false,
+  createdAt: '2026-01-01',
+  updatedAt: '2026-01-01',
+};
+
+describe('RuleWindow', () => {
+  it('does not render the title as a heading inside the window body', () => {
+    render(<RuleWindow rule={baseRule} />);
+    expect(screen.queryByRole('heading', { name: 'Difficulty' })).not.toBeInTheDocument();
+  });
+
+  it('renders tags in the meta row', () => {
+    render(<RuleWindow rule={baseRule} />);
+    expect(screen.getByText('#rules')).toBeInTheDocument();
+    expect(screen.getByText('#dc')).toBeInTheDocument();
+  });
+
+  it('does not render a visibility badge', () => {
+    render(<RuleWindow rule={baseRule} />);
+    expect(screen.queryByText('Private')).not.toBeInTheDocument();
+    expect(screen.queryByText('Public')).not.toBeInTheDocument();
+  });
+
+  it('shows the edit button when isGM and onEdit are provided', async () => {
+    const onEdit = vi.fn();
+    const user = userEvent.setup();
+    render(<RuleWindow rule={baseRule} isGM onEdit={onEdit} />);
+    await user.click(screen.getByRole('button', { name: 'Edit rule' }));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the edit button when isGM is false', () => {
+    render(<RuleWindow rule={baseRule} isGM={false} onEdit={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: 'Edit rule' })).not.toBeInTheDocument();
+  });
+
+  it('hides the meta row when there are no tags and no edit button', () => {
+    render(<RuleWindow rule={{ ...baseRule, tags: [] }} />);
+    expect(screen.queryByRole('button', { name: 'Edit rule' })).not.toBeInTheDocument();
+  });
+});

--- a/tests/components/wiki/rules/RuleWindow.test.tsx
+++ b/tests/components/wiki/rules/RuleWindow.test.tsx
@@ -49,7 +49,8 @@ describe('RuleWindow', () => {
   });
 
   it('hides the meta row when there are no tags and no edit button', () => {
-    render(<RuleWindow rule={{ ...baseRule, tags: [] }} />);
+    const { container } = render(<RuleWindow rule={{ ...baseRule, tags: [] }} />);
     expect(screen.queryByRole('button', { name: 'Edit rule' })).not.toBeInTheDocument();
+    expect(container.querySelector('.border-b')).not.toBeInTheDocument();
   });
 });

--- a/tests/server/functions/gmscreens.test.ts
+++ b/tests/server/functions/gmscreens.test.ts
@@ -77,6 +77,8 @@ import { User } from '~/server/db/models/User';
 import { Campaign } from '~/server/db/models/Campaign';
 import { GMScreen } from '~/server/db/models/GMScreen';
 import { Note } from '~/server/db/models/Note';
+import { Character } from '~/server/db/models/Character';
+import { Rule } from '~/server/db/models/Rule';
 import {
   listGMScreens,
   createGMScreen,
@@ -1021,6 +1023,100 @@ describe('getGMScreen', () => {
     await expect(
       _getGMScreen({ data: { id: 'nonexistent', campaignId: 'camp-1' } })
     ).rejects.toThrow('Screen not found');
+  });
+
+  it('includes isPublic and link in hydrated character and isPublic in hydrated rule', async () => {
+    const screenDoc = {
+      _id: 'screen-x',
+      campaignId: 'camp-1',
+      name: 'Test',
+      tabOrder: 0,
+      createdBy: 'dbuser-1',
+      createdAt: new Date('2026-04-01'),
+      updatedAt: new Date('2026-04-01'),
+      windows: [
+        {
+          _id: 'win-c',
+          collection: 'character',
+          documentId: 'char-1',
+          state: 'open',
+          x: 0,
+          y: 0,
+          width: 300,
+          height: 400,
+          zIndex: 1,
+        },
+        {
+          _id: 'win-r',
+          collection: 'rule',
+          documentId: 'rule-1',
+          state: 'open',
+          x: 320,
+          y: 0,
+          width: 300,
+          height: 400,
+          zIndex: 2,
+        },
+      ],
+      stacks: [],
+    };
+
+    vi.mocked(GMScreen.findOne).mockReturnValue({
+      lean: vi.fn().mockResolvedValue(screenDoc),
+    } as never);
+
+    vi.mocked(Character.find).mockReturnValue({
+      lean: vi.fn().mockResolvedValue([
+        {
+          _id: 'char-1',
+          firstName: 'Thorin',
+          lastName: 'Grudgebearer',
+          notes: 'A dwarf warrior.',
+          isPublic: true,
+          link: 'https://example.com/thorin',
+        },
+      ]),
+    } as never);
+
+    vi.mocked(Rule.find).mockReturnValue({
+      lean: vi.fn().mockResolvedValue([
+        {
+          _id: 'rule-1',
+          title: 'Difficulty',
+          content: 'Setting a DC',
+          isPublic: false,
+        },
+      ]),
+    } as never);
+
+    const result = await _getGMScreen({ data: { id: 'screen-x', campaignId: 'camp-1' } });
+
+    expect(result.hydrated['character:char-1']).toEqual({
+      id: 'char-1',
+      collection: 'character',
+      title: 'Thorin Grudgebearer',
+      content: 'A dwarf warrior.',
+      isPublic: true,
+      link: 'https://example.com/thorin',
+    });
+
+    expect(result.hydrated['rule:rule-1']).toEqual({
+      id: 'rule-1',
+      collection: 'rule',
+      title: 'Difficulty',
+      content: 'Setting a DC',
+      isPublic: false,
+    });
+
+    expect(Character.find).toHaveBeenCalledWith(
+      { _id: { $in: ['char-1'] }, campaignId: 'camp-1' },
+      '_id firstName lastName notes isPublic link'
+    );
+
+    expect(Rule.find).toHaveBeenCalledWith(
+      { _id: { $in: ['rule-1'] }, campaignId: 'camp-1' },
+      '_id title content isPublic'
+    );
   });
 });
 


### PR DESCRIPTION
## Summary                                                    
                                                                                                                                                                                     
  - Removes duplicate titles from RuleWindow, RaceWindow, CharacterWindow bodies                                                                                                     
  - Moves Globe/Lock visibility icon into FloatingWindow title bar for rules and characters; ExternalLink icon for characters with a link                                          
  - Consolidates tags + edit button into a single compact meta row, replacing the absolute-positioned overlay button                                                                 
  - Updates RuleViewModal, RaceViewModal, CharacterViewModal headers to show actual titles and visibility icons                                                                    
  - Adds live Globe/Lock icon to NoteModal header driven by isPublic state                                                                                                           
                                                                                                                                                                                   
  ## Technical changes                                                                                                                                                               
                                                                                                                                                                                   
  - Extended HydratedDocument with isPublic? and link?; backend fetchers updated                                                                                                     
  - Added titleIcon?, titleSuffix?, iconKey? to FloatingWindow/ManagedWindow; GMScreensView builds icons from hydrated data                                                        
  - Staleness guard extended with iconKey so visibility changes re-render title bar icons correctly                                                                                
  - Edit button moved from wrapper overlay into each Window component via onEdit prop                                                                                              
                                                                                     
  ## Test Plan                                                      
  - [ ] 1079 tests passing (83 files)                                                                                                                                                
  - [ ] Rule window: title bar shows Globe/Lock, no duplicate title inside
  - [ ] Race window: compact tags + edit row, no h2                                                                                                                                  
  - [ ] Character window: title bar shows name + icon + ExternalLink, tags below portrait                                                                                            
  - [ ] RuleViewModal/RaceViewModal/CharacterViewModal: actual titles in headers                                                                                                     
  - [ ] NoteModal: Globe/Lock updates live when toggling visibility