### PR TITLE
fix: restore CharacterWindow scroll in GM Screen floating window

### DIFF
--- a/app/components/wiki/characters/CharacterWindow.tsx
+++ b/app/components/wiki/characters/CharacterWindow.tsx
@@ -96,7 +96,7 @@ export function CharacterWindow({ character, onEdit }: CharacterWindowProps) {
   const showMeta = character.tags.length > 0 || (character.canEdit && !!onEdit);
 
   return (
-    <div className="flex flex-col gap-3 p-4 overflow-y-auto h-full">
+    <div className="flex flex-col gap-3 p-4">
       {/* Portrait */}
       <div className="flex justify-center">
         <div


### PR DESCRIPTION
## Summary

- Removes erroneous `overflow-y-auto h-full` from `CharacterWindow`'s root `flex flex-col` div introduced in the UI space optimization PR (#372)
- **Root cause:** placing `overflow-y-auto` directly on a `flex-col` container means flex shrinks children to fit the container height (default `flex-shrink: 1`) instead of overflowing it — no scrollbar ever appears
- **Fix:** remove those classes so `CharacterWindow` renders at natural content height and the `FloatingWindow` content wrapper's existing `overflow-auto` handles scrolling (identical to pre-#372 behavior)
- `RuleWindow` and `RaceWindow` are unaffected — they correctly use `flex-1 overflow-y-auto min-h-0` on an inner div within a `flex flex-col h-full` outer wrapper

## Change

`app/components/wiki/characters/CharacterWindow.tsx` — one line, root div class change:
```diff
- <div className="flex flex-col gap-3 p-4 overflow-y-auto h-full">
+ <div className="flex flex-col gap-3 p-4">
```

## Test plan

- [ ] Open GM Screen, open a character window and expand Detail or GM Notes — content scrolls
- [ ] Resize the floating window to a small height — scrollbar appears when content overflows
- [ ] RuleWindow and RaceWindow floating windows still scroll correctly (unaffected)
- [ ] `npx vitest run --project=unit` — 83 test files, 1079 tests pass
- [ ] TypeScript clean (`tsc --noEmit` via pre-push hook)
- [ ] Prettier + ESLint clean (via pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)