### PR TITLE
fix: expand Session modal to 90% screen size and keep buttons always visible

### DIFF
--- a/app/components/sessions/SessionModal.tsx
+++ b/app/components/sessions/SessionModal.tsx
@@ -110,7 +110,7 @@ export function SessionModal({ isOpen, onClose, onSubmit, isLoading, session }: 
     // role="presentation": backdrop click-to-close is a convenience; Escape key handler closes the dialog
     <div
       role="presentation"
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-2 sm:p-4 backdrop-blur-sm"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-4 sm:p-6 backdrop-blur-sm"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
@@ -120,7 +120,7 @@ export function SessionModal({ isOpen, onClose, onSubmit, isLoading, session }: 
         role="dialog"
         aria-modal="true"
         aria-labelledby="session-modal-title"
-        className="w-full max-w-2xl bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col"
+        className="w-[90vw] max-w-[90vw] max-h-[90vh] bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col"
       >
         {/* Header */}
         <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">

--- a/app/components/sessions/SessionModal.tsx
+++ b/app/components/sessions/SessionModal.tsx
@@ -110,7 +110,7 @@ export function SessionModal({ isOpen, onClose, onSubmit, isLoading, session }: 
     // role="presentation": backdrop click-to-close is a convenience; Escape key handler closes the dialog
     <div
       role="presentation"
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-4 sm:p-6 backdrop-blur-sm"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-2 sm:p-4 backdrop-blur-sm"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}

--- a/app/components/sessions/SessionModal.tsx
+++ b/app/components/sessions/SessionModal.tsx
@@ -120,7 +120,7 @@ export function SessionModal({ isOpen, onClose, onSubmit, isLoading, session }: 
         role="dialog"
         aria-modal="true"
         aria-labelledby="session-modal-title"
-        className="w-[90vw] max-w-[90vw] max-h-[90vh] bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col"
+        className="w-full max-w-[90vw] max-h-[90vh] bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col"
       >
         {/* Header */}
         <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">


### PR DESCRIPTION
## Summary

- Expands the Session modal to `90vw` width and constrains height to `90vh`, so it uses ~90% of available screen space
- The `max-h-[90vh]` cap ensures the form never grows taller than the viewport — the scrollable body handles overflow while the header and footer (Cancel/Save buttons) stay pinned with `shrink-0`

## Problem

When entering a large amount of Markdown in the **Catch Up** field, the modal grew beyond the viewport height, pushing the Cancel and Save buttons off screen with no way to reach them.

## Test plan

- [ ] Open a Session in edit mode
- [ ] Paste a large block of Markdown into the Catch Up field
- [ ] Confirm the modal body scrolls and the Cancel/Save buttons remain visible at all times
- [ ] Confirm the modal now occupies ~90% of screen width on both small and large screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)