### PR TITLE
fix: include catchUp data when editing sessions

### DIFF
--- a/app/server/functions/sessions.ts
+++ b/app/server/functions/sessions.ts
@@ -46,7 +46,7 @@ export const listSessions = createServerFn({ method: 'GET' })
 
       const sessions = await Session.find(
         filter,
-        '_id name number startDate endDate status createdAt updatedAt'
+        '_id name number startDate endDate status summary createdAt updatedAt'
       )
         .sort({ startDate: -1 })
         .lean();
@@ -59,6 +59,7 @@ export const listSessions = createServerFn({ method: 'GET' })
           startDate: Date;
           endDate: Date | null;
           status: string;
+          summary?: string | null;
         }>
       ).map((s) => ({
         id: String(s._id),
@@ -67,6 +68,7 @@ export const listSessions = createServerFn({ method: 'GET' })
         startDate: s.startDate.toISOString(),
         endDate: s.endDate ? s.endDate.toISOString() : null,
         status: (s.status ?? 'not_started') as 'not_started' | 'active' | 'completed',
+        catchUp: s.summary ?? null,
       }));
     } catch (e) {
       serverCaptureException(e, undefined, {

--- a/tests/server/functions/sessions.test.ts
+++ b/tests/server/functions/sessions.test.ts
@@ -125,7 +125,7 @@ describe('listSessions', () => {
 
     expect(Session.find).toHaveBeenCalledWith(
       { campaignId: 'camp-1', status: { $ne: 'completed' } },
-      '_id name number startDate endDate status createdAt updatedAt'
+      '_id name number startDate endDate status summary createdAt updatedAt'
     );
     expect(mockSort).toHaveBeenCalledWith({ startDate: -1 });
     expect(result).toEqual([
@@ -136,6 +136,7 @@ describe('listSessions', () => {
         startDate: baseSessions[0].startDate.toISOString(),
         endDate: null,
         status: 'active',
+        catchUp: null,
       },
     ]);
   });
@@ -148,7 +149,7 @@ describe('listSessions', () => {
 
     expect(Session.find).toHaveBeenCalledWith(
       { campaignId: 'camp-1' },
-      '_id name number startDate endDate status createdAt updatedAt'
+      '_id name number startDate endDate status summary createdAt updatedAt'
     );
     expect(result).toHaveLength(2);
   });

--- a/tests/server/functions/sessions.test.ts
+++ b/tests/server/functions/sessions.test.ts
@@ -154,6 +154,28 @@ describe('listSessions', () => {
     expect(result).toHaveLength(2);
   });
 
+  it('maps summary field to catchUp when present', async () => {
+    const sessionsWithSummary = [
+      {
+        ...baseSessions[0],
+        summary: 'The party defeated the dragon and claimed the treasure.',
+      },
+    ];
+    const mockSort = vi
+      .fn()
+      .mockReturnValue({ lean: vi.fn().mockResolvedValue(sessionsWithSummary) });
+    vi.mocked(Session.find).mockReturnValue({ sort: mockSort } as never);
+
+    const result = await _listSessions({ data: { campaignId: 'camp-1' } });
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: 's1',
+        catchUp: 'The party defeated the dragon and claimed the treasure.',
+      }),
+    ]);
+  });
+
   it('throws when user is not the GM of the campaign', async () => {
     vi.mocked(Campaign.findById).mockResolvedValue({
       ...mockCampaign,


### PR DESCRIPTION
## Summary
- `listSessions()` was not fetching the `summary` field from MongoDB, so the Catch Up text was always empty when opening the session edit modal
- Added `summary` to the MongoDB projection and mapped it to `catchUp` in the response
- Updated corresponding unit tests

## Test plan
- [x] Unit tests pass (`tests/server/functions/sessions.test.ts`)
- [ ] As GM, go to Dashboard > Sessions, click a session that has Catch Up text — verify the text appears in the editor
- [ ] Edit the Catch Up text, save, reopen — verify the updated text persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)