### PR TITLE
fix: message sorting, scroll, timestamps, and PartyKit deploy

### DIFF
--- a/.github/workflows/partykit-deploy.yml
+++ b/.github/workflows/partykit-deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy PartyKit
+
+on:
+  push:
+    branches: [dev, main]
+    paths:
+      - 'party/**'
+      - 'partykit.json'
+
+jobs:
+  deploy:
+    name: Deploy PartyKit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '25'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Deploy to dev
+        if: github.ref == 'refs/heads/dev'
+        run: npx partykit deploy --name cartyx-party-dev
+        env:
+          PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
+
+      - name: Deploy to production
+        if: github.ref == 'refs/heads/main'
+        run: npx partykit deploy --name cartyx-party
+        env:
+          PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}

--- a/app/components/mainview/ChatPanel.tsx
+++ b/app/components/mainview/ChatPanel.tsx
@@ -13,10 +13,8 @@ function SpellCard({ message }: { message: ChatMessage }) {
   const data = message.beyond20Data;
   if (!data) return null;
 
-  const time = new Date(message.timestamp).toLocaleTimeString([], {
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+  const d = new Date(message.timestamp);
+  const time = `${d.toLocaleDateString([], { month: 'short', day: 'numeric' })} ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}`;
 
   return (
     <div className="mb-3">
@@ -56,10 +54,8 @@ function SpellCard({ message }: { message: ChatMessage }) {
 }
 
 function ChatMessageBubble({ message }: { message: ChatMessage }) {
-  const time = new Date(message.timestamp).toLocaleTimeString([], {
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+  const d = new Date(message.timestamp);
+  const time = `${d.toLocaleDateString([], { month: 'short', day: 'numeric' })} ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}`;
 
   return (
     <div className="mb-3">
@@ -152,7 +148,7 @@ export function ChatPanel({
   }
 
   return (
-    <div className="flex h-full flex-col bg-[#080A12] w-full">
+    <div className="flex h-full min-h-0 flex-col bg-[#080A12] w-full">
       {/* Session selector */}
       <div className="border-b border-white/[0.07] p-3">
         <label htmlFor="chat-session-selector" className="sr-only">

--- a/app/hooks/useChatMessages.ts
+++ b/app/hooks/useChatMessages.ts
@@ -45,7 +45,7 @@ function mergeMessages(fromMongo: ChatMessage[], fromParty: ChatMessage[]): Chat
   for (const m of fromParty) {
     if (!seen.has(m.id)) seen.set(m.id, m);
   }
-  return [...seen.values()].sort((a, b) => a.seq - b.seq || a.timestamp - b.timestamp);
+  return [...seen.values()].sort((a, b) => a.timestamp - b.timestamp || a.seq - b.seq);
 }
 
 export function useChatMessages(sessionId: string, campaignId: string, isActiveSession: boolean) {

--- a/app/hooks/useDiceRolls.ts
+++ b/app/hooks/useDiceRolls.ts
@@ -56,7 +56,7 @@ function mergeRolls(fromMongo: DiceRollMessage[], fromParty: DiceRollMessage[]):
   for (const m of fromParty) {
     if (!seen.has(m.id)) seen.set(m.id, m);
   }
-  return [...seen.values()].sort((a, b) => a.seq - b.seq || a.timestamp - b.timestamp);
+  return [...seen.values()].sort((a, b) => a.timestamp - b.timestamp || a.seq - b.seq);
 }
 
 export function useDiceRolls(sessionId: string, campaignId: string, isActiveSession: boolean) {

--- a/party/index.ts
+++ b/party/index.ts
@@ -1,4 +1,5 @@
 import type * as Party from 'partykit/server';
+import { jwtVerify } from 'jose';
 
 const HISTORY_LIMIT = 50;
 
@@ -94,7 +95,6 @@ export default class SessionRoom implements Party.Server {
     }
 
     try {
-      const { jwtVerify } = await import('jose');
       const secret = new TextEncoder().encode(sessionSecret);
       const { payload } = await jwtVerify(token, secret, {
         algorithms: ['HS256'],


### PR DESCRIPTION
## Summary
- Sort merged messages by timestamp (not seq) so new messages always appear at the bottom even after PartyKit seq counter resets
- Add `min-h-0` to ChatPanel for proper flex scroll behavior
- Show date + seconds in chat message timestamps (matching DicePanel)
- Use static `jose` import in PartyKit server for Workers runtime compatibility

## Test plan
- [ ] New dice rolls appear at the bottom of the list
- [ ] New chat messages appear at the bottom and auto-scroll
- [ ] Chat timestamps show date and seconds
- [ ] PartyKit WebSocket connects on deployed environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)