### PR TITLE
fix: add PARTYKIT_LOGIN to deploy workflow

### DIFF
--- a/.github/workflows/partykit-deploy.yml
+++ b/.github/workflows/partykit-deploy.yml
@@ -31,9 +31,11 @@ jobs:
         run: npx partykit deploy --name cartyx-party-dev
         env:
           PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
+          PARTYKIT_LOGIN: ${{ secrets.PARTYKIT_LOGIN }}
 
       - name: Deploy to production
         if: github.ref == 'refs/heads/main'
         run: npx partykit deploy --name cartyx-party
         env:
           PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
+          PARTYKIT_LOGIN: ${{ secrets.PARTYKIT_LOGIN }}


### PR DESCRIPTION
## Summary
- PartyKit CLI requires both `PARTYKIT_TOKEN` and `PARTYKIT_LOGIN` env vars for non-interactive deployment
- Missing `PARTYKIT_LOGIN` caused the deploy step to hang waiting for interactive login

## Setup required
Add `PARTYKIT_LOGIN` as a GitHub repository secret (Settings → Secrets → Actions) with your PartyKit username.

🤖 Generated with [Claude Code](https://claude.com/claude-code)