### PR TITLE
Replace campaign page emojis with Lucide React icons

### DIFF
--- a/app/components/PixelButton.tsx
+++ b/app/components/PixelButton.tsx
@@ -1,21 +1,22 @@
-import React, { type ButtonHTMLAttributes, type AnchorHTMLAttributes, forwardRef } from 'react'
-import { Link, type LinkProps } from '@tanstack/react-router'
+import React, { type ButtonHTMLAttributes, type AnchorHTMLAttributes, forwardRef } from 'react';
+import { Link, type LinkProps } from '@tanstack/react-router';
 
-type Variant = 'primary' | 'secondary' | 'warning' | 'ghost' | 'danger'
-type Size = 'sm' | 'md' | 'lg'
+type Variant = 'primary' | 'secondary' | 'warning' | 'ghost' | 'danger';
+type Size = 'sm' | 'md' | 'lg';
 
 interface BaseProps {
-  variant?: Variant
-  size?: Size
-  icon?: string
-  fullWidth?: boolean
+  variant?: Variant;
+  size?: Size;
+  icon?: React.ReactNode;
+  fullWidth?: boolean;
 }
 
-type ButtonProps = BaseProps & ButtonHTMLAttributes<HTMLButtonElement> & { as?: 'button' }
-type AnchorProps = BaseProps & AnchorHTMLAttributes<HTMLAnchorElement> & { as: 'a' }
-type RouterLinkProps = BaseProps & Omit<LinkProps, 'className'> & { as: 'link'; className?: string }
+type ButtonProps = BaseProps & ButtonHTMLAttributes<HTMLButtonElement> & { as?: 'button' };
+type AnchorProps = BaseProps & AnchorHTMLAttributes<HTMLAnchorElement> & { as: 'a' };
+type RouterLinkProps = BaseProps &
+  Omit<LinkProps, 'className'> & { as: 'link'; className?: string };
 
-export type PixelButtonProps = ButtonProps | AnchorProps | RouterLinkProps
+export type PixelButtonProps = ButtonProps | AnchorProps | RouterLinkProps;
 
 const variantStyles: Record<Variant, string> = {
   primary: [
@@ -60,16 +61,16 @@ const variantStyles: Record<Variant, string> = {
     'hover:border-red-400/60 hover:text-red-300 hover:bg-red-500/[0.06]',
     'active:bg-red-500/[0.1]',
   ].join(' '),
-}
+};
 
 const sizeStyles: Record<Size, string> = {
   sm: 'px-3.5 py-2 text-[10px] gap-1.5',
   md: 'px-5 py-2.5 text-[11px] gap-2',
   lg: 'px-6 py-3.5 text-[13px] gap-2.5',
-}
+};
 
 function buildClassName(props: BaseProps & { className?: string }) {
-  const { variant = 'primary', size = 'md', fullWidth, className = '' } = props
+  const { variant = 'primary', size = 'md', fullWidth, className = '' } = props;
   return [
     'inline-flex items-center justify-center',
     'font-sans font-semibold leading-none',
@@ -84,23 +85,26 @@ function buildClassName(props: BaseProps & { className?: string }) {
     fullWidth ? 'w-full' : '',
     // Custom classes
     className,
-  ].filter(Boolean).join(' ')
+  ]
+    .filter(Boolean)
+    .join(' ');
 }
 
 export const PixelButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, PixelButtonProps>(
   function PixelButton(props, ref) {
-    const { variant, size, icon, fullWidth, ...rest } = props
+    const { variant, size, icon, fullWidth, ...rest } = props;
 
     const content = (
       <>
         {icon && <span className="inline-block">{icon}</span>}
         {props.children}
       </>
-    )
+    );
 
     if (props.as === 'link') {
-      const { as: _as, className, children: _children, ...linkProps } = rest as RouterLinkProps
-      void _as; void _children
+      const { as: _as, className, children: _children, ...linkProps } = rest as RouterLinkProps;
+      void _as;
+      void _children;
       return (
         <Link
           {...(linkProps as Omit<LinkProps, 'className'>)}
@@ -108,12 +112,13 @@ export const PixelButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, Pix
         >
           {content}
         </Link>
-      )
+      );
     }
 
     if (props.as === 'a') {
-      const { as: _as, className, children: _children, ...anchorProps } = rest as AnchorProps
-      void _as; void _children
+      const { as: _as, className, children: _children, ...anchorProps } = rest as AnchorProps;
+      void _as;
+      void _children;
       return (
         <a
           {...anchorProps}
@@ -122,11 +127,12 @@ export const PixelButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, Pix
         >
           {content}
         </a>
-      )
+      );
     }
 
-    const { as: _as, className, children: _children, ...buttonProps } = rest as ButtonProps
-    void _as; void _children
+    const { as: _as, className, children: _children, ...buttonProps } = rest as ButtonProps;
+    void _as;
+    void _children;
     return (
       <button
         {...buttonProps}
@@ -135,6 +141,6 @@ export const PixelButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, Pix
       >
         {content}
       </button>
-    )
+    );
   }
-)
+);

--- a/app/components/campaign/CampaignCard.tsx
+++ b/app/components/campaign/CampaignCard.tsx
@@ -1,17 +1,18 @@
-import React from 'react'
-import { CampaignHeroBanner } from './CampaignHeroBanner'
-import { CampaignDescription } from './CampaignDescription'
-import { NextSessionBadge } from './NextSessionBadge'
-import { PartyMemberList } from './PartyMemberList'
-import { InviteCodeField } from './InviteCodeField'
-import { ExternalLinkList } from './ExternalLinkList'
-import { PixelButton } from '~/components/PixelButton'
-import type { CampaignData } from '~/types/campaign'
+import React from 'react';
+import { CampaignHeroBanner } from './CampaignHeroBanner';
+import { CampaignDescription } from './CampaignDescription';
+import { NextSessionBadge } from './NextSessionBadge';
+import { PartyMemberList } from './PartyMemberList';
+import { InviteCodeField } from './InviteCodeField';
+import { ExternalLinkList } from './ExternalLinkList';
+import { PixelButton } from '~/components/PixelButton';
+import { Pencil } from 'lucide-react';
+import type { CampaignData } from '~/types/campaign';
 
-export type { CampaignData }
+export type { CampaignData };
 
 interface CampaignCardProps {
-  campaign: CampaignData
+  campaign: CampaignData;
 }
 
 export function CampaignCard({ campaign }: CampaignCardProps) {
@@ -27,14 +28,8 @@ export function CampaignCard({ campaign }: CampaignCardProps) {
         {/* Left column: description, next session, party */}
         <div className="flex-1 flex flex-col gap-6 min-w-0">
           <CampaignDescription description={campaign.description} />
-          <NextSessionBadge
-            nextSession={campaign.nextSession}
-            schedule={campaign.schedule}
-          />
-          <PartyMemberList
-            members={campaign.partyMembers}
-            maxPlayers={campaign.maxPlayers}
-          />
+          <NextSessionBadge nextSession={campaign.nextSession} schedule={campaign.schedule} />
+          <PartyMemberList members={campaign.partyMembers} maxPlayers={campaign.maxPlayers} />
         </div>
 
         {/* Right column: invite code, links, actions */}
@@ -61,7 +56,7 @@ export function CampaignCard({ campaign }: CampaignCardProps) {
                 as="link"
                 variant="warning"
                 size="md"
-                icon="✏️"
+                icon={<Pencil className="h-3.5 w-3.5" />}
                 to="/campaigns/$campaignId/edit"
                 params={{ campaignId: campaign.id }}
                 fullWidth
@@ -73,5 +68,5 @@ export function CampaignCard({ campaign }: CampaignCardProps) {
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/app/components/campaign/ExternalLinkItem.tsx
+++ b/app/components/campaign/ExternalLinkItem.tsx
@@ -1,21 +1,22 @@
-import React from 'react'
+import React from 'react';
+import { ExternalLink } from 'lucide-react';
 
 interface ExternalLinkItemProps {
-  name: string
-  url: string
+  name: string;
+  url: string;
 }
 
 function isSafeUrl(url: string): boolean {
   try {
-    const parsed = new URL(url)
-    return ['http:', 'https:', 'mailto:'].includes(parsed.protocol)
+    const parsed = new URL(url);
+    return ['http:', 'https:', 'mailto:'].includes(parsed.protocol);
   } catch {
-    return false
+    return false;
   }
 }
 
 export function ExternalLinkItem({ name, url }: ExternalLinkItemProps) {
-  if (!isSafeUrl(url)) return null
+  if (!isSafeUrl(url)) return null;
 
   return (
     <a
@@ -24,8 +25,8 @@ export function ExternalLinkItem({ name, url }: ExternalLinkItemProps) {
       rel="noopener noreferrer"
       className="flex items-center gap-2 text-sm text-slate-400 hover:text-blue-400 transition-colors py-0.5"
     >
-      <span className="text-base leading-none">🔗</span>
+      <ExternalLink className="h-3.5 w-3.5 shrink-0" />
       <span>{name}</span>
     </a>
-  )
+  );
 }

--- a/app/components/campaign/InviteCodeField.tsx
+++ b/app/components/campaign/InviteCodeField.tsx
@@ -1,8 +1,9 @@
-import React from 'react'
-import { showToast } from '~/components/Toast'
+import React from 'react';
+import { showToast } from '~/components/Toast';
+import { Copy } from 'lucide-react';
 
 interface InviteCodeFieldProps {
-  code: string
+  code: string;
 }
 
 export function InviteCodeField({ code }: InviteCodeFieldProps) {
@@ -10,16 +11,18 @@ export function InviteCodeField({ code }: InviteCodeFieldProps) {
     if (navigator.clipboard?.writeText) {
       navigator.clipboard
         .writeText(code)
-        .then(() => showToast(`✓ Invite code copied: ${code}`))
-        .catch(() => showToast(`Code: ${code}`))
+        .then(() => showToast(`Invite code copied: ${code}`))
+        .catch(() => showToast(`Code: ${code}`));
     } else {
-      showToast(`Code: ${code}`)
+      showToast(`Code: ${code}`);
     }
   }
 
   return (
     <div>
-      <div className="text-[10px] font-sans font-semibold text-slate-500 tracking-wide mb-2">INVITE CODE</div>
+      <div className="text-[10px] font-sans font-semibold text-slate-500 tracking-wide mb-2">
+        INVITE CODE
+      </div>
       <div className="flex items-center gap-2">
         <input
           type="text"
@@ -33,9 +36,9 @@ export function InviteCodeField({ code }: InviteCodeFieldProps) {
           className="px-3 py-2 rounded-lg bg-white/[0.04] border border-white/[0.08] text-slate-400 text-sm hover:text-white hover:bg-white/[0.08] transition-colors"
           aria-label="Copy invite code"
         >
-          📋
+          <Copy className="h-3.5 w-3.5" />
         </button>
       </div>
     </div>
-  )
+  );
 }

--- a/app/components/campaign/NextSessionBadge.tsx
+++ b/app/components/campaign/NextSessionBadge.tsx
@@ -1,20 +1,27 @@
-import React from 'react'
-import { formatNextSession } from '~/utils/date'
+import React from 'react';
+import { formatNextSession } from '~/utils/date';
+import { Calendar, CirclePause } from 'lucide-react';
 
 interface NextSessionBadgeProps {
-  nextSession: { day: string; time: string } | null
+  nextSession: { day: string; time: string } | null;
   schedule: {
-    time: string | null
-    timezone: string | null
-  }
+    time: string | null;
+    timezone: string | null;
+  };
 }
 
 export function NextSessionBadge({ nextSession, schedule }: NextSessionBadgeProps) {
   return (
     <div className="flex items-start gap-2.5">
-      <span className="text-sm mt-0.5">{nextSession ? '🗓' : '⏸'}</span>
+      {nextSession ? (
+        <Calendar className="h-4 w-4 mt-0.5 text-slate-400 shrink-0" />
+      ) : (
+        <CirclePause className="h-4 w-4 mt-0.5 text-slate-500 shrink-0" />
+      )}
       <div>
-        <div className="text-[10px] font-sans font-semibold text-slate-500 tracking-wide mb-0.5">NEXT SESSION</div>
+        <div className="text-[10px] font-sans font-semibold text-slate-500 tracking-wide mb-0.5">
+          NEXT SESSION
+        </div>
         {nextSession ? (
           <div className="text-sm text-slate-300">
             {formatNextSession(nextSession.day, schedule.time, schedule.timezone)}
@@ -24,5 +31,5 @@ export function NextSessionBadge({ nextSession, schedule }: NextSessionBadgeProp
         )}
       </div>
     </div>
-  )
+  );
 }

--- a/app/components/campaign/PartyMemberChip.tsx
+++ b/app/components/campaign/PartyMemberChip.tsx
@@ -1,9 +1,10 @@
-import React from 'react'
+import React from 'react';
+import { User } from 'lucide-react';
 
 interface PartyMemberChipProps {
-  characterName: string
-  characterClass: string
-  avatar: string | null
+  characterName: string;
+  characterClass: string;
+  avatar: string | null;
 }
 
 export function PartyMemberChip({ characterName, characterClass, avatar }: PartyMemberChipProps) {
@@ -13,13 +14,15 @@ export function PartyMemberChip({ characterName, characterClass, avatar }: Party
         {avatar ? (
           <img src={avatar} alt={characterName} className="w-full h-full object-cover" />
         ) : (
-          <span className="text-lg">🧙</span>
+          <User className="h-5 w-5 text-slate-500" />
         )}
       </div>
       <div className="min-w-0">
-        <div className="text-[10px] font-sans font-semibold text-slate-200 truncate leading-relaxed">{characterName}</div>
+        <div className="text-[10px] font-sans font-semibold text-slate-200 truncate leading-relaxed">
+          {characterName}
+        </div>
         <div className="text-xs text-slate-500 truncate">{characterClass}</div>
       </div>
     </div>
-  )
+  );
 }

--- a/app/components/mainview/CampaignHeader.tsx
+++ b/app/components/mainview/CampaignHeader.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from 'react';
 import { Link } from '@tanstack/react-router';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faGear } from '@fortawesome/pro-solid-svg-icons';
+import { Bell } from 'lucide-react';
 import { UserMenu } from '~/components/shared/UserMenu';
 import { TABS, handleTabsKeyDown } from './TabNavigation';
 import type { TabId } from './TabNavigation';
@@ -110,7 +111,7 @@ export function CampaignHeader({
           aria-label="Notifications"
           className="text-slate-400 hover:text-slate-200 transition-colors text-base"
         >
-          🔔
+          <Bell className="h-4 w-4" />
         </button>
 
         <UserMenu contextualAction={{ label: 'Close Campaign', to: '/campaigns' }} />

--- a/app/routes/campaigns/$campaignId/edit.tsx
+++ b/app/routes/campaigns/$campaignId/edit.tsx
@@ -8,6 +8,7 @@ import { queryKeys } from '~/utils/queryKeys';
 import { useUpdateCampaign } from '~/hooks/useCampaigns';
 import { Topbar } from '~/components/Topbar';
 import { PixelButton } from '~/components/PixelButton';
+import { ImagePlus } from 'lucide-react';
 import { TIMEZONES } from '~/constants/timezones';
 import { FormInput } from '~/components/FormInput';
 import { FormTextarea } from '~/components/FormTextarea';
@@ -162,7 +163,7 @@ function EditCampaignPage() {
               />
             ) : (
               <>
-                <div className="text-3xl mb-2">🖼️</div>
+                <ImagePlus className="h-8 w-8 text-slate-500 mb-2" />
                 <div className="text-sm text-slate-500">
                   Drop an image here or <span className="text-blue-400">browse</span>
                 </div>

--- a/app/routes/campaigns/index.tsx
+++ b/app/routes/campaigns/index.tsx
@@ -9,6 +9,7 @@ import { Toast } from '~/components/Toast';
 import { PixelButton } from '~/components/PixelButton';
 import { useJoinCampaign } from '~/hooks/useCampaigns';
 import { CampaignCard } from '~/components/campaign/CampaignCard';
+import { KeyRound, Swords } from 'lucide-react';
 
 export const Route = createFileRoute('/campaigns/')({
   beforeLoad: async () => {
@@ -75,14 +76,20 @@ function CampaignsListPage() {
               <PixelButton
                 variant="primary"
                 size="md"
-                icon="🗝️"
+                icon={<KeyRound className="h-3.5 w-3.5" />}
                 onClick={() => setShowJoinForm(true)}
               >
                 Join Campaign
               </PixelButton>
             )}
             {isGm && (
-              <PixelButton as="link" variant="primary" size="md" icon="⚔️" to="/campaigns/new">
+              <PixelButton
+                as="link"
+                variant="primary"
+                size="md"
+                icon={<Swords className="h-3.5 w-3.5" />}
+                to="/campaigns/new"
+              >
                 Create Campaign
               </PixelButton>
             )}
@@ -115,14 +122,20 @@ function CampaignsListPage() {
                 : 'Ask your GM for an invite code to join a campaign.'}
             </p>
             {isGm ? (
-              <PixelButton as="link" variant="primary" size="lg" icon="⚔️" to="/campaigns/new">
+              <PixelButton
+                as="link"
+                variant="primary"
+                size="lg"
+                icon={<Swords className="h-3.5 w-3.5" />}
+                to="/campaigns/new"
+              >
                 Create Campaign
               </PixelButton>
             ) : (
               <PixelButton
                 variant="primary"
                 size="lg"
-                icon="🗝️"
+                icon={<KeyRound className="h-3.5 w-3.5" />}
                 onClick={() => setShowJoinForm(true)}
               >
                 Join Campaign

--- a/app/routes/campaigns/new.tsx
+++ b/app/routes/campaigns/new.tsx
@@ -5,6 +5,7 @@ import { getMe } from '~/server/functions/auth';
 import { useCreateCampaign } from '~/hooks/useCampaigns';
 import { Topbar } from '~/components/Topbar';
 import { PixelButton } from '~/components/PixelButton';
+import { ImagePlus, Swords } from 'lucide-react';
 import { captureEvent } from '~/utils/posthog-client';
 import { FormInput } from '~/components/FormInput';
 import { FormTextarea } from '~/components/FormTextarea';
@@ -201,7 +202,7 @@ export function NewCampaignPage() {
                         />
                       ) : (
                         <>
-                          <div className="text-3xl mb-2">🖼</div>
+                          <ImagePlus className="h-8 w-8 text-slate-500 mb-2" />
                           <div className="text-sm text-slate-500">
                             Click to upload a banner image
                           </div>
@@ -460,7 +461,7 @@ export function NewCampaignPage() {
               <PixelButton
                 variant="primary"
                 size="sm"
-                icon="⚔"
+                icon={<Swords className="h-3.5 w-3.5" />}
                 onClick={handleSubmit}
                 disabled={isLoading}
                 type="button"

--- a/tests/components/campaign/ExternalLinkItem.test.tsx
+++ b/tests/components/campaign/ExternalLinkItem.test.tsx
@@ -1,29 +1,29 @@
-import React from 'react'
-import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import { ExternalLinkItem } from '~/components/campaign/ExternalLinkItem'
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ExternalLinkItem } from '~/components/campaign/ExternalLinkItem';
 
 describe('ExternalLinkItem', () => {
   it('renders the link name', () => {
-    render(<ExternalLinkItem name="Campaign Wiki" url="https://example.com/wiki" />)
-    expect(screen.getByText('Campaign Wiki')).toBeInTheDocument()
-  })
+    render(<ExternalLinkItem name="Campaign Wiki" url="https://example.com/wiki" />);
+    expect(screen.getByText('Campaign Wiki')).toBeInTheDocument();
+  });
 
   it('renders a link with correct href', () => {
-    render(<ExternalLinkItem name="Campaign Wiki" url="https://example.com/wiki" />)
-    const link = screen.getByRole('link', { name: /campaign wiki/i })
-    expect(link).toHaveAttribute('href', 'https://example.com/wiki')
-  })
+    render(<ExternalLinkItem name="Campaign Wiki" url="https://example.com/wiki" />);
+    const link = screen.getByRole('link', { name: /campaign wiki/i });
+    expect(link).toHaveAttribute('href', 'https://example.com/wiki');
+  });
 
   it('opens in a new tab', () => {
-    render(<ExternalLinkItem name="Notes" url="https://example.com" />)
-    const link = screen.getByRole('link')
-    expect(link).toHaveAttribute('target', '_blank')
-    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
-  })
+    render(<ExternalLinkItem name="Notes" url="https://example.com" />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
 
   it('renders the link icon', () => {
-    render(<ExternalLinkItem name="Wiki" url="https://example.com" />)
-    expect(screen.getByText('🔗')).toBeInTheDocument()
-  })
-})
+    const { container } = render(<ExternalLinkItem name="Wiki" url="https://example.com" />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+});

--- a/tests/components/campaign/InviteCodeField.test.tsx
+++ b/tests/components/campaign/InviteCodeField.test.tsx
@@ -1,62 +1,62 @@
-import React from 'react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 
-const mockShowToast = vi.fn()
+const mockShowToast = vi.fn();
 vi.mock('~/components/Toast', () => ({
   showToast: (msg: string) => mockShowToast(msg),
   Toast: () => null,
-}))
+}));
 
-import { InviteCodeField } from '~/components/campaign/InviteCodeField'
+import { InviteCodeField } from '~/components/campaign/InviteCodeField';
 
 describe('InviteCodeField', () => {
   beforeEach(() => {
-    vi.resetAllMocks()
-  })
+    vi.resetAllMocks();
+  });
 
   it('renders the invite code in a readonly input', () => {
-    render(<InviteCodeField code="ABCD-EFGH" />)
-    const input = screen.getByRole('textbox', { name: /invite code/i })
-    expect(input).toHaveValue('ABCD-EFGH')
-    expect(input).toHaveAttribute('readonly')
-  })
+    render(<InviteCodeField code="ABCD-EFGH" />);
+    const input = screen.getByRole('textbox', { name: /invite code/i });
+    expect(input).toHaveValue('ABCD-EFGH');
+    expect(input).toHaveAttribute('readonly');
+  });
 
   it('shows INVITE CODE label', () => {
-    render(<InviteCodeField code="ABCD-EFGH" />)
-    expect(screen.getByText('INVITE CODE')).toBeInTheDocument()
-  })
+    render(<InviteCodeField code="ABCD-EFGH" />);
+    expect(screen.getByText('INVITE CODE')).toBeInTheDocument();
+  });
 
   it('copies to clipboard and shows toast on button click', async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined)
+    const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, 'clipboard', {
       value: { writeText },
       writable: true,
       configurable: true,
-    })
+    });
 
-    render(<InviteCodeField code="ABCD-EFGH" />)
-    fireEvent.click(screen.getByRole('button', { name: /copy invite code/i }))
+    render(<InviteCodeField code="ABCD-EFGH" />);
+    fireEvent.click(screen.getByRole('button', { name: /copy invite code/i }));
 
-    expect(writeText).toHaveBeenCalledWith('ABCD-EFGH')
+    expect(writeText).toHaveBeenCalledWith('ABCD-EFGH');
     // wait for the promise to resolve
-    await Promise.resolve()
-    expect(mockShowToast).toHaveBeenCalledWith('✓ Invite code copied: ABCD-EFGH')
-  })
+    await Promise.resolve();
+    expect(mockShowToast).toHaveBeenCalledWith('Invite code copied: ABCD-EFGH');
+  });
 
   it('falls back to toast with code when clipboard fails', async () => {
-    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'));
     Object.defineProperty(navigator, 'clipboard', {
       value: { writeText },
       writable: true,
       configurable: true,
-    })
+    });
 
-    render(<InviteCodeField code="FAIL-CODE" />)
-    fireEvent.click(screen.getByRole('button', { name: /copy invite code/i }))
+    render(<InviteCodeField code="FAIL-CODE" />);
+    fireEvent.click(screen.getByRole('button', { name: /copy invite code/i }));
 
-    await Promise.resolve()
-    await Promise.resolve() // rejection propagates one extra tick
-    expect(mockShowToast).toHaveBeenCalledWith('Code: FAIL-CODE')
-  })
-})
+    await Promise.resolve();
+    await Promise.resolve(); // rejection propagates one extra tick
+    expect(mockShowToast).toHaveBeenCalledWith('Code: FAIL-CODE');
+  });
+});

--- a/tests/components/campaign/PartyMemberChip.test.tsx
+++ b/tests/components/campaign/PartyMemberChip.test.tsx
@@ -1,16 +1,14 @@
-import React from 'react'
-import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import { PartyMemberChip } from '~/components/campaign/PartyMemberChip'
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PartyMemberChip } from '~/components/campaign/PartyMemberChip';
 
 describe('PartyMemberChip', () => {
   it('renders characterName and characterClass', () => {
-    render(
-      <PartyMemberChip characterName="Thalion" characterClass="Ranger" avatar={null} />
-    )
-    expect(screen.getByText('Thalion')).toBeInTheDocument()
-    expect(screen.getByText('Ranger')).toBeInTheDocument()
-  })
+    render(<PartyMemberChip characterName="Thalion" characterClass="Ranger" avatar={null} />);
+    expect(screen.getByText('Thalion')).toBeInTheDocument();
+    expect(screen.getByText('Ranger')).toBeInTheDocument();
+  });
 
   it('renders avatar image when provided', () => {
     render(
@@ -19,16 +17,16 @@ describe('PartyMemberChip', () => {
         characterClass="Wizard"
         avatar="https://example.com/avatar.jpg"
       />
-    )
-    const img = screen.getByRole('img', { name: 'Lyra' })
-    expect(img).toHaveAttribute('src', 'https://example.com/avatar.jpg')
-  })
+    );
+    const img = screen.getByRole('img', { name: 'Lyra' });
+    expect(img).toHaveAttribute('src', 'https://example.com/avatar.jpg');
+  });
 
-  it('renders placeholder emoji when no avatar', () => {
-    render(
+  it('renders placeholder icon when no avatar', () => {
+    const { container } = render(
       <PartyMemberChip characterName="Grax" characterClass="Barbarian" avatar={null} />
-    )
-    expect(screen.getByText('🧙')).toBeInTheDocument()
-    expect(screen.queryByRole('img')).not.toBeInTheDocument()
-  })
-})
+    );
+    expect(container.querySelector('svg')).toBeInTheDocument();
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Widen `PixelButton` `icon` prop from `string` to `ReactNode` to support icon components
- Replace all emoji characters across campaigns list, edit, new pages, and campaign header with proper Lucide React icons (`KeyRound`, `Swords`, `Pencil`, `Calendar`, `CirclePause`, `Copy`, `User`, `ExternalLink`, `Bell`, `ImagePlus`)
- Update tests to assert on SVG elements instead of emoji text content

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 72 campaign-area tests pass
- [x] Pre-commit hooks (prettier + eslint) pass
- [x] Pre-push hooks (typecheck + unit tests) pass
- [ ] Visual check: navigate to `/campaigns` and verify icons render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)