### PR TITLE
feat: player characters with join wizard, relationships, and wiki integration

### DIFF
--- a/app/components/join-wizard/JoinWizard.tsx
+++ b/app/components/join-wizard/JoinWizard.tsx
@@ -76,7 +76,7 @@ function defaultPlayer(): WizardPlayerState {
     pictureCrop: null,
     description: '',
     backstory: '',
-    color: '',
+    color: '#3498db',
     eyeColor: '',
     hairColor: '',
     weight: null,
@@ -143,7 +143,7 @@ const STEPS = ['INVITE', 'PLAYER', 'BACKSTORY', 'CHARACTERS', 'REVIEW'];
 // ---------------------------------------------------------------------------
 
 export function JoinWizard() {
-  const { step, code } = Route.useSearch();
+  const { step, code, campaignId: searchCampaignId } = Route.useSearch();
   const navigate = useNavigate();
 
   const [wizardState, setWizardState] = useState<WizardState>(defaultState);
@@ -167,7 +167,17 @@ export function JoinWizard() {
         }
       }
     }
-  }, []);
+
+    // If campaignId is provided in search params (re-entry flow), use it
+    if (searchCampaignId) {
+      setWizardState((prev) => {
+        if (!prev.campaignId) {
+          return { ...prev, campaignId: searchCampaignId };
+        }
+        return prev;
+      });
+    }
+  }, [searchCampaignId]);
 
   // Persist to localStorage whenever state changes
   useEffect(() => {

--- a/app/components/join-wizard/JoinWizard.tsx
+++ b/app/components/join-wizard/JoinWizard.tsx
@@ -1,0 +1,279 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import { Route } from '~/routes/campaign/join';
+import { Topbar } from '~/components/Topbar';
+import { StepWizard } from '~/components/StepWizard';
+import { StepInviteCode } from './StepInviteCode';
+import { StepPlayerInfo } from './StepPlayerInfo';
+import { StepBackstory } from './StepBackstory';
+import { StepRelatedCharacters } from './StepRelatedCharacters';
+import { StepReview } from './StepReview';
+import type { PictureCrop } from '~/types/character';
+
+// ---------------------------------------------------------------------------
+// Wizard state shape
+// ---------------------------------------------------------------------------
+
+export interface WizardPlayerState {
+  firstName: string;
+  lastName: string;
+  race: string;
+  characterClass: string;
+  age: number | null;
+  gender: string;
+  location: string;
+  link: string;
+  picture: string;
+  pictureCrop: PictureCrop | null;
+  description: string;
+  backstory: string;
+  color: string;
+  eyeColor: string;
+  hairColor: string;
+  weight: number | null;
+  height: string;
+  size: string;
+  appearance: string;
+}
+
+export interface WizardCharacter {
+  firstName: string;
+  lastName: string;
+  race: string;
+  characterClass: string;
+  age: number | null;
+  location: string;
+  link: string;
+  picture: string;
+  pictureCrop: PictureCrop | null;
+  notes: string;
+  isPublic: boolean;
+  relationship: { descriptor: string; isPublic: boolean };
+}
+
+export interface WizardState {
+  campaignId: string;
+  campaignName: string;
+  player: WizardPlayerState;
+  characters: WizardCharacter[];
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+function defaultPlayer(): WizardPlayerState {
+  return {
+    firstName: '',
+    lastName: '',
+    race: '',
+    characterClass: '',
+    age: null,
+    gender: '',
+    location: '',
+    link: '',
+    picture: '',
+    pictureCrop: null,
+    description: '',
+    backstory: '',
+    color: '',
+    eyeColor: '',
+    hairColor: '',
+    weight: null,
+    height: '',
+    size: '',
+    appearance: '',
+  };
+}
+
+function defaultState(): WizardState {
+  return {
+    campaignId: '',
+    campaignName: '',
+    player: defaultPlayer(),
+    characters: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// localStorage helpers
+// ---------------------------------------------------------------------------
+
+function storageKey(campaignId: string) {
+  return `join-wizard-${campaignId}`;
+}
+
+function loadFromStorage(campaignId: string): WizardState | null {
+  try {
+    const raw = localStorage.getItem(storageKey(campaignId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as WizardState;
+    if (parsed.campaignId === campaignId) return parsed;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function saveToStorage(state: WizardState) {
+  if (!state.campaignId) return;
+  try {
+    localStorage.setItem(storageKey(state.campaignId), JSON.stringify(state));
+  } catch {
+    // storage full or unavailable — ignore
+  }
+}
+
+export function clearStorage(campaignId: string) {
+  try {
+    localStorage.removeItem(storageKey(campaignId));
+  } catch {
+    // ignore
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Step labels
+// ---------------------------------------------------------------------------
+
+const STEPS = ['INVITE', 'PLAYER', 'BACKSTORY', 'CHARACTERS', 'REVIEW'];
+
+// ---------------------------------------------------------------------------
+// JoinWizard component
+// ---------------------------------------------------------------------------
+
+export function JoinWizard() {
+  const { step, code } = Route.useSearch();
+  const navigate = useNavigate();
+
+  const [wizardState, setWizardState] = useState<WizardState>(defaultState);
+  const initialized = useRef(false);
+
+  // On mount, restore state from localStorage if we have a campaignId already saved
+  useEffect(() => {
+    if (initialized.current) return;
+    initialized.current = true;
+
+    // Try to recover from localStorage using any previously-stored campaignId
+    // We iterate localStorage keys that start with "join-wizard-" to find the right one
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key?.startsWith('join-wizard-')) {
+        const cId = key.replace('join-wizard-', '');
+        const saved = loadFromStorage(cId);
+        if (saved) {
+          setWizardState(saved);
+          break;
+        }
+      }
+    }
+  }, []);
+
+  // Persist to localStorage whenever state changes
+  useEffect(() => {
+    if (wizardState.campaignId) {
+      saveToStorage(wizardState);
+    }
+  }, [wizardState]);
+
+  const goToStep = useCallback(
+    (s: number) => {
+      navigate({
+        to: '/campaign/join',
+        search: (prev: Record<string, unknown>) => ({ ...prev, step: s }),
+        replace: true,
+      });
+    },
+    [navigate]
+  );
+
+  const updateState = useCallback((partial: Partial<WizardState>) => {
+    setWizardState((prev) => ({ ...prev, ...partial }));
+  }, []);
+
+  const updatePlayer = useCallback((partial: Partial<WizardPlayerState>) => {
+    setWizardState((prev) => ({
+      ...prev,
+      player: { ...prev.player, ...partial },
+    }));
+  }, []);
+
+  const setCharacters = useCallback((characters: WizardCharacter[]) => {
+    setWizardState((prev) => ({ ...prev, characters }));
+  }, []);
+
+  // Only allow step navigation to already-visited steps
+  const handleStepClick = useCallback(
+    (s: number) => {
+      // Allow going back, but not forward past current
+      if (s <= step) goToStep(s);
+    },
+    [step, goToStep]
+  );
+
+  return (
+    <div className="min-h-screen flex flex-col bg-[#080A12]">
+      <Topbar />
+      <main className="flex-1 w-full max-w-[680px] mx-auto px-6 py-10">
+        <div className="flex items-center justify-between mb-8">
+          <h1 className="font-sans font-semibold text-[13px] text-white tracking-widest">
+            JOIN CAMPAIGN
+          </h1>
+          <a
+            href="/campaigns"
+            className="text-xs text-slate-500 hover:text-slate-400 transition-colors font-medium"
+          >
+            &larr; Back
+          </a>
+        </div>
+
+        <StepWizard steps={STEPS} currentStep={step} onStepClick={handleStepClick} />
+
+        {step === 1 && (
+          <StepInviteCode
+            initialCode={code}
+            wizardState={wizardState}
+            onValidated={(campaignId, campaignName) => {
+              updateState({ campaignId, campaignName });
+              goToStep(2);
+            }}
+          />
+        )}
+
+        {step === 2 && (
+          <StepPlayerInfo
+            player={wizardState.player}
+            campaignId={wizardState.campaignId}
+            onUpdate={updatePlayer}
+            onNext={() => goToStep(3)}
+            onBack={() => goToStep(1)}
+          />
+        )}
+
+        {step === 3 && (
+          <StepBackstory
+            backstory={wizardState.player.backstory}
+            onUpdate={(backstory) => updatePlayer({ backstory })}
+            onNext={() => goToStep(4)}
+            onSkip={() => {
+              updatePlayer({ backstory: '' });
+              goToStep(4);
+            }}
+            onBack={() => goToStep(2)}
+          />
+        )}
+
+        {step === 4 && (
+          <StepRelatedCharacters
+            characters={wizardState.characters}
+            onUpdate={setCharacters}
+            onNext={() => goToStep(5)}
+            onBack={() => goToStep(3)}
+          />
+        )}
+
+        {step === 5 && <StepReview wizardState={wizardState} onBack={() => goToStep(4)} />}
+      </main>
+    </div>
+  );
+}

--- a/app/components/join-wizard/StepBackstory.tsx
+++ b/app/components/join-wizard/StepBackstory.tsx
@@ -1,0 +1,60 @@
+import { PixelButton } from '~/components/PixelButton';
+import { MarkdownEditor } from '~/components/shared/MarkdownEditor';
+import { SectionHeader } from '~/components/SectionHeader';
+import { ShieldAlert } from 'lucide-react';
+
+interface StepBackstoryProps {
+  backstory: string;
+  onUpdate: (backstory: string) => void;
+  onNext: () => void;
+  onSkip: () => void;
+  onBack: () => void;
+}
+
+export function StepBackstory({ backstory, onUpdate, onNext, onSkip, onBack }: StepBackstoryProps) {
+  return (
+    <div className="bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden">
+      <div className="p-8 pb-6 space-y-5">
+        <SectionHeader size="xs" tracking="tracking-[3px]" className="mb-7">
+          BACKSTORY
+        </SectionHeader>
+
+        {/* Privacy banner */}
+        <div className="flex items-start gap-3 p-4 bg-amber-500/5 border border-amber-500/20 rounded-xl">
+          <ShieldAlert className="h-5 w-5 text-amber-400 mt-0.5 shrink-0" />
+          <p className="text-xs text-amber-300/80 leading-relaxed">
+            Only you and the Game Master can see your backstory. Other players will not have access
+            to this information.
+          </p>
+        </div>
+
+        <MarkdownEditor
+          label="Character Backstory"
+          value={backstory}
+          onChange={onUpdate}
+          placeholder="Write your character's backstory here... What shaped them? What drives them?"
+          minHeight="240px"
+          id="join-backstory-editor"
+        />
+
+        <button
+          type="button"
+          onClick={onSkip}
+          className="text-xs text-slate-500 hover:text-slate-400 transition-colors font-medium"
+        >
+          Skip for now &rarr;
+        </button>
+      </div>
+
+      {/* Footer nav */}
+      <div className="flex items-center justify-between px-8 py-5 border-t border-white/[0.06]">
+        <PixelButton variant="secondary" size="sm" onClick={onBack} type="button">
+          &larr; Back
+        </PixelButton>
+        <PixelButton variant="primary" size="sm" onClick={onNext} type="button">
+          Next: Related Characters &rarr;
+        </PixelButton>
+      </div>
+    </div>
+  );
+}

--- a/app/components/join-wizard/StepInviteCode.tsx
+++ b/app/components/join-wizard/StepInviteCode.tsx
@@ -1,0 +1,113 @@
+import { useState, useEffect } from 'react';
+import { PixelButton } from '~/components/PixelButton';
+import { FormInput } from '~/components/FormInput';
+import { StatusBanner } from '~/components/StatusBanner';
+import { SectionHeader } from '~/components/SectionHeader';
+import { useValidateInviteCode } from '~/hooks/usePlayers';
+import { KeyRound, CheckCircle2 } from 'lucide-react';
+import type { WizardState } from './JoinWizard';
+
+interface StepInviteCodeProps {
+  initialCode?: string;
+  wizardState: WizardState;
+  onValidated: (campaignId: string, campaignName: string) => void;
+}
+
+export function StepInviteCode({ initialCode, wizardState, onValidated }: StepInviteCodeProps) {
+  const [code, setCode] = useState(initialCode ?? '');
+  const [validated, setValidated] = useState<{
+    campaignId: string;
+    name: string;
+    description: string;
+  } | null>(null);
+
+  const { validate, isLoading, error } = useValidateInviteCode();
+
+  // If we already have a campaignId from a previous visit, show it as validated
+  useEffect(() => {
+    if (wizardState.campaignId && wizardState.campaignName) {
+      setValidated({
+        campaignId: wizardState.campaignId,
+        name: wizardState.campaignName,
+        description: '',
+      });
+    }
+  }, [wizardState.campaignId, wizardState.campaignName]);
+
+  async function handleValidate() {
+    const trimmed = code.trim();
+    if (!trimmed) return;
+    const result = await validate({ inviteCode: trimmed });
+    if (result) {
+      setValidated(result);
+    }
+  }
+
+  return (
+    <div className="bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden">
+      <div className="p-8 pb-6">
+        <SectionHeader size="xs" tracking="tracking-[3px]" className="mb-7">
+          INVITE CODE
+        </SectionHeader>
+
+        {!validated ? (
+          <div className="space-y-5">
+            <FormInput
+              label="Enter your invite code"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              placeholder="e.g. ABCD-EFGH"
+              disabled={isLoading}
+            />
+
+            {error && <StatusBanner variant="error" message={error} />}
+
+            <PixelButton
+              variant="primary"
+              size="md"
+              icon={<KeyRound className="h-3.5 w-3.5" />}
+              onClick={handleValidate}
+              disabled={isLoading || !code.trim()}
+              type="button"
+            >
+              {isLoading ? 'Validating...' : 'Validate Code'}
+            </PixelButton>
+          </div>
+        ) : (
+          <div className="space-y-5">
+            <div className="flex items-start gap-3 p-4 bg-emerald-500/5 border border-emerald-500/20 rounded-xl">
+              <CheckCircle2 className="h-5 w-5 text-emerald-400 mt-0.5 shrink-0" />
+              <div>
+                <p className="text-sm font-semibold text-white">{validated.name}</p>
+                {validated.description && (
+                  <p className="text-xs text-slate-400 mt-1 leading-relaxed">
+                    {validated.description}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            <div className="flex gap-3">
+              <PixelButton
+                variant="secondary"
+                size="md"
+                onClick={() => setValidated(null)}
+                type="button"
+              >
+                Try Different Code
+              </PixelButton>
+              <PixelButton
+                variant="primary"
+                size="md"
+                onClick={() => onValidated(validated.campaignId, validated.name)}
+                type="button"
+              >
+                Join this Campaign &rarr;
+              </PixelButton>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/join-wizard/StepPlayerInfo.tsx
+++ b/app/components/join-wizard/StepPlayerInfo.tsx
@@ -31,6 +31,10 @@ export function StepPlayerInfo({
   const [fieldErrors, setFieldErrors] = useState<{
     firstName?: string;
     lastName?: string;
+    race?: string;
+    characterClass?: string;
+    age?: string;
+    color?: string;
     link?: string;
   }>({});
 
@@ -41,9 +45,21 @@ export function StepPlayerInfo({
   }, []);
 
   function validate(): boolean {
-    const errors: { firstName?: string; lastName?: string; link?: string } = {};
+    const errors: {
+      firstName?: string;
+      lastName?: string;
+      race?: string;
+      characterClass?: string;
+      age?: string;
+      color?: string;
+      link?: string;
+    } = {};
     if (!player.firstName.trim()) errors.firstName = 'First name is required';
     if (!player.lastName.trim()) errors.lastName = 'Last name is required';
+    if (!player.race.trim()) errors.race = 'Race is required';
+    if (!player.characterClass.trim()) errors.characterClass = 'Class is required';
+    if (!player.age || player.age <= 0) errors.age = 'Age must be a positive number';
+    if (player.color && !/^#[0-9a-fA-F]{6}$/.test(player.color)) errors.color = 'Invalid color';
     if (player.link.trim() && !/^https?:\/\/.+/.test(player.link.trim())) {
       errors.link = 'Must be a valid HTTP or HTTPS URL';
     }
@@ -109,6 +125,8 @@ export function StepPlayerInfo({
               label="Race"
               value={player.race}
               onChange={(e) => onUpdate({ race: e.target.value })}
+              error={fieldErrors.race}
+              required
               placeholder="e.g. Half-Elf"
               list={raceDatalistId}
             />
@@ -122,6 +140,8 @@ export function StepPlayerInfo({
             label="Class"
             value={player.characterClass}
             onChange={(e) => onUpdate({ characterClass: e.target.value })}
+            error={fieldErrors.characterClass}
+            required
             placeholder="e.g. Ranger / Druid"
           />
           <FormInput
@@ -131,6 +151,8 @@ export function StepPlayerInfo({
             onChange={(e) =>
               onUpdate({ age: e.target.value ? parseInt(e.target.value, 10) : null })
             }
+            error={fieldErrors.age}
+            required
             placeholder="Age"
           />
         </div>

--- a/app/components/join-wizard/StepPlayerInfo.tsx
+++ b/app/components/join-wizard/StepPlayerInfo.tsx
@@ -1,0 +1,237 @@
+import { useState, useCallback, useId } from 'react';
+import { PixelButton } from '~/components/PixelButton';
+import { FormInput } from '~/components/FormInput';
+import { MarkdownEditor } from '~/components/shared/MarkdownEditor';
+import { ColorPicker } from '~/components/shared/ColorPicker';
+import { ImageCropInput } from '~/components/wiki/characters/ImageCropInput';
+import { SectionHeader } from '~/components/SectionHeader';
+import { StatusBanner } from '~/components/StatusBanner';
+import { useRaces } from '~/hooks/useRaces';
+import { uploadToR2 } from '~/utils/uploadToR2';
+import { compressImage } from '~/utils/compressImage';
+import type { WizardPlayerState } from './JoinWizard';
+
+interface StepPlayerInfoProps {
+  player: WizardPlayerState;
+  campaignId: string;
+  onUpdate: (partial: Partial<WizardPlayerState>) => void;
+  onNext: () => void;
+  onBack: () => void;
+}
+
+export function StepPlayerInfo({
+  player,
+  campaignId,
+  onUpdate,
+  onNext,
+  onBack,
+}: StepPlayerInfoProps) {
+  const raceDatalistId = useId();
+  const { races } = useRaces(campaignId, { enabled: !!campaignId });
+  const [fieldErrors, setFieldErrors] = useState<{
+    firstName?: string;
+    lastName?: string;
+    link?: string;
+  }>({});
+
+  const handleUpload = useCallback(async (file: File): Promise<string> => {
+    const compressed = await compressImage(file);
+    const { publicUrl } = await uploadToR2(compressed, 'uploads/players');
+    return publicUrl;
+  }, []);
+
+  function validate(): boolean {
+    const errors: { firstName?: string; lastName?: string; link?: string } = {};
+    if (!player.firstName.trim()) errors.firstName = 'First name is required';
+    if (!player.lastName.trim()) errors.lastName = 'Last name is required';
+    if (player.link.trim() && !/^https?:\/\/.+/.test(player.link.trim())) {
+      errors.link = 'Must be a valid HTTP or HTTPS URL';
+    }
+    setFieldErrors(errors);
+    return Object.keys(errors).length === 0;
+  }
+
+  function handleNext() {
+    if (validate()) onNext();
+  }
+
+  return (
+    <div className="bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden">
+      <div className="p-8 pb-6 space-y-5">
+        <SectionHeader size="xs" tracking="tracking-[3px]" className="mb-7">
+          YOUR CHARACTER
+        </SectionHeader>
+
+        {Object.keys(fieldErrors).length > 0 && (
+          <StatusBanner variant="error" message="Please fix the errors below before continuing." />
+        )}
+
+        {/* Picture upload */}
+        <ImageCropInput
+          imageUrl={player.picture}
+          crop={player.pictureCrop}
+          onImageChange={(url) => onUpdate({ picture: url })}
+          onCropChange={(crop) => onUpdate({ pictureCrop: crop })}
+          onUpload={handleUpload}
+        />
+
+        {/* Color picker */}
+        <ColorPicker
+          label="Player Color"
+          value={player.color}
+          onChange={(color) => onUpdate({ color })}
+        />
+
+        {/* First Name + Last Name */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+          <FormInput
+            label="First Name"
+            value={player.firstName}
+            onChange={(e) => onUpdate({ firstName: e.target.value })}
+            error={fieldErrors.firstName}
+            required
+            placeholder="First name"
+          />
+          <FormInput
+            label="Last Name"
+            value={player.lastName}
+            onChange={(e) => onUpdate({ lastName: e.target.value })}
+            error={fieldErrors.lastName}
+            required
+            placeholder="Last name"
+          />
+        </div>
+
+        {/* Race + Class + Age */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+          <div>
+            <FormInput
+              label="Race"
+              value={player.race}
+              onChange={(e) => onUpdate({ race: e.target.value })}
+              placeholder="e.g. Half-Elf"
+              list={raceDatalistId}
+            />
+            <datalist id={raceDatalistId}>
+              {races.map((r) => (
+                <option key={r.id} value={r.title} />
+              ))}
+            </datalist>
+          </div>
+          <FormInput
+            label="Class"
+            value={player.characterClass}
+            onChange={(e) => onUpdate({ characterClass: e.target.value })}
+            placeholder="e.g. Ranger / Druid"
+          />
+          <FormInput
+            label="Age"
+            type="number"
+            value={player.age != null ? String(player.age) : ''}
+            onChange={(e) =>
+              onUpdate({ age: e.target.value ? parseInt(e.target.value, 10) : null })
+            }
+            placeholder="Age"
+          />
+        </div>
+
+        {/* Gender + Location */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+          <FormInput
+            label="Gender"
+            value={player.gender}
+            onChange={(e) => onUpdate({ gender: e.target.value })}
+            placeholder="Gender"
+          />
+          <FormInput
+            label="Location"
+            value={player.location}
+            onChange={(e) => onUpdate({ location: e.target.value })}
+            placeholder="Current residence"
+          />
+        </div>
+
+        {/* Eye Color + Hair Color */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+          <FormInput
+            label="Eye Color"
+            value={player.eyeColor}
+            onChange={(e) => onUpdate({ eyeColor: e.target.value })}
+            placeholder="e.g. Blue"
+          />
+          <FormInput
+            label="Hair Color"
+            value={player.hairColor}
+            onChange={(e) => onUpdate({ hairColor: e.target.value })}
+            placeholder="e.g. Auburn"
+          />
+        </div>
+
+        {/* Height + Weight + Size */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+          <FormInput
+            label="Height"
+            value={player.height}
+            onChange={(e) => onUpdate({ height: e.target.value })}
+            placeholder={`e.g. 5'10"`}
+          />
+          <FormInput
+            label="Weight"
+            type="number"
+            value={player.weight != null ? String(player.weight) : ''}
+            onChange={(e) =>
+              onUpdate({ weight: e.target.value ? parseInt(e.target.value, 10) : null })
+            }
+            placeholder="lbs"
+          />
+          <FormInput
+            label="Size"
+            value={player.size}
+            onChange={(e) => onUpdate({ size: e.target.value })}
+            placeholder="e.g. Medium"
+          />
+        </div>
+
+        {/* External Link */}
+        <FormInput
+          label="External Link"
+          type="url"
+          value={player.link}
+          onChange={(e) => onUpdate({ link: e.target.value })}
+          error={fieldErrors.link}
+          placeholder="https://..."
+        />
+
+        {/* Description */}
+        <MarkdownEditor
+          label="Description"
+          value={player.description}
+          onChange={(v) => onUpdate({ description: v })}
+          placeholder="A brief description of this player character..."
+          minHeight="120px"
+          id="join-player-description-editor"
+        />
+
+        {/* Appearance */}
+        <MarkdownEditor
+          label="Appearance"
+          value={player.appearance}
+          onChange={(v) => onUpdate({ appearance: v })}
+          placeholder="Physical appearance details..."
+          minHeight="120px"
+          id="join-player-appearance-editor"
+        />
+      </div>
+
+      {/* Footer nav */}
+      <div className="flex items-center justify-between px-8 py-5 border-t border-white/[0.06]">
+        <PixelButton variant="secondary" size="sm" onClick={onBack} type="button">
+          &larr; Back
+        </PixelButton>
+        <PixelButton variant="primary" size="sm" onClick={handleNext} type="button">
+          Next: Backstory &rarr;
+        </PixelButton>
+      </div>
+    </div>
+  );
+}

--- a/app/components/join-wizard/StepRelatedCharacters.tsx
+++ b/app/components/join-wizard/StepRelatedCharacters.tsx
@@ -1,0 +1,311 @@
+import { useState, useCallback } from 'react';
+import { PixelButton } from '~/components/PixelButton';
+import { FormInput } from '~/components/FormInput';
+import { ImageCropInput } from '~/components/wiki/characters/ImageCropInput';
+import { SectionHeader } from '~/components/SectionHeader';
+import { uploadToR2 } from '~/utils/uploadToR2';
+import { compressImage } from '~/utils/compressImage';
+import { Plus, Pencil, Trash2 } from 'lucide-react';
+import type { WizardCharacter } from './JoinWizard';
+
+interface StepRelatedCharactersProps {
+  characters: WizardCharacter[];
+  onUpdate: (characters: WizardCharacter[]) => void;
+  onNext: () => void;
+  onBack: () => void;
+}
+
+function emptyCharacter(): WizardCharacter {
+  return {
+    firstName: '',
+    lastName: '',
+    race: '',
+    characterClass: '',
+    age: null,
+    location: '',
+    link: '',
+    picture: '',
+    pictureCrop: null,
+    notes: '',
+    isPublic: true,
+    relationship: { descriptor: '', isPublic: true },
+  };
+}
+
+export function StepRelatedCharacters({
+  characters,
+  onUpdate,
+  onNext,
+  onBack,
+}: StepRelatedCharactersProps) {
+  const [editing, setEditing] = useState<{ index: number | null; char: WizardCharacter } | null>(
+    null
+  );
+
+  const handleUpload = useCallback(async (file: File): Promise<string> => {
+    const compressed = await compressImage(file);
+    const { publicUrl } = await uploadToR2(compressed, 'uploads/characters');
+    return publicUrl;
+  }, []);
+
+  function handleAdd() {
+    setEditing({ index: null, char: emptyCharacter() });
+  }
+
+  function handleEdit(index: number) {
+    setEditing({ index, char: { ...characters[index] } });
+  }
+
+  function handleRemove(index: number) {
+    onUpdate(characters.filter((_, i) => i !== index));
+  }
+
+  function handleSave() {
+    if (!editing) return;
+    if (!editing.char.firstName.trim()) return;
+
+    if (editing.index !== null) {
+      const updated = [...characters];
+      updated[editing.index] = editing.char;
+      onUpdate(updated);
+    } else {
+      onUpdate([...characters, editing.char]);
+    }
+    setEditing(null);
+  }
+
+  function handleCancel() {
+    setEditing(null);
+  }
+
+  function updateEditing(partial: Partial<WizardCharacter>) {
+    if (!editing) return;
+    setEditing({ ...editing, char: { ...editing.char, ...partial } });
+  }
+
+  function updateRelationship(partial: Partial<WizardCharacter['relationship']>) {
+    if (!editing) return;
+    setEditing({
+      ...editing,
+      char: {
+        ...editing.char,
+        relationship: { ...editing.char.relationship, ...partial },
+      },
+    });
+  }
+
+  return (
+    <div className="bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden">
+      <div className="p-8 pb-6 space-y-5">
+        <SectionHeader size="xs" tracking="tracking-[3px]" className="mb-7">
+          RELATED CHARACTERS
+        </SectionHeader>
+
+        <p className="text-xs text-slate-500 leading-relaxed">
+          Add NPCs or other characters related to your player. These are optional and can be added
+          later.
+        </p>
+
+        {/* Character list */}
+        {characters.length > 0 && !editing && (
+          <div className="space-y-3">
+            {characters.map((char, i) => (
+              <div
+                key={i}
+                className="flex items-center gap-4 p-4 bg-white/[0.03] border border-white/[0.07] rounded-xl"
+              >
+                {char.picture ? (
+                  <img
+                    src={char.picture}
+                    alt={char.firstName}
+                    className="w-10 h-10 rounded-full object-cover border border-white/10"
+                  />
+                ) : (
+                  <div className="w-10 h-10 rounded-full bg-white/[0.06] border border-white/10 flex items-center justify-center text-xs text-slate-500 font-bold">
+                    {char.firstName.charAt(0).toUpperCase()}
+                  </div>
+                )}
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm text-white font-medium truncate">
+                    {char.firstName} {char.lastName}
+                  </p>
+                  {char.relationship.descriptor && (
+                    <p className="text-xs text-slate-500 truncate">
+                      {char.relationship.descriptor}
+                    </p>
+                  )}
+                </div>
+                <div className="flex gap-2 shrink-0">
+                  <button
+                    type="button"
+                    onClick={() => handleEdit(i)}
+                    className="p-1.5 rounded-lg text-slate-500 hover:text-blue-400 hover:bg-white/[0.05] transition-colors"
+                    aria-label={`Edit ${char.firstName}`}
+                  >
+                    <Pencil className="h-3.5 w-3.5" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleRemove(i)}
+                    className="p-1.5 rounded-lg text-slate-500 hover:text-rose-400 hover:bg-white/[0.05] transition-colors"
+                    aria-label={`Remove ${char.firstName}`}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Inline form */}
+        {editing && (
+          <div className="p-5 bg-white/[0.02] border border-white/[0.1] rounded-xl space-y-4">
+            <SectionHeader size="xs" color="muted" tracking="tracking-widest" className="mb-4">
+              {editing.index !== null ? 'EDIT CHARACTER' : 'NEW CHARACTER'}
+            </SectionHeader>
+
+            <ImageCropInput
+              imageUrl={editing.char.picture}
+              crop={editing.char.pictureCrop}
+              onImageChange={(url) => updateEditing({ picture: url })}
+              onCropChange={(crop) => updateEditing({ pictureCrop: crop })}
+              onUpload={handleUpload}
+            />
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <FormInput
+                label="First Name"
+                value={editing.char.firstName}
+                onChange={(e) => updateEditing({ firstName: e.target.value })}
+                required
+                placeholder="First name"
+              />
+              <FormInput
+                label="Last Name"
+                value={editing.char.lastName}
+                onChange={(e) => updateEditing({ lastName: e.target.value })}
+                placeholder="Last name"
+              />
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <FormInput
+                label="Race"
+                value={editing.char.race}
+                onChange={(e) => updateEditing({ race: e.target.value })}
+                placeholder="e.g. Human"
+              />
+              <FormInput
+                label="Class"
+                value={editing.char.characterClass}
+                onChange={(e) => updateEditing({ characterClass: e.target.value })}
+                placeholder="e.g. Merchant"
+              />
+              <FormInput
+                label="Age"
+                type="number"
+                value={editing.char.age != null ? String(editing.char.age) : ''}
+                onChange={(e) =>
+                  updateEditing({ age: e.target.value ? parseInt(e.target.value, 10) : null })
+                }
+                placeholder="Age"
+              />
+            </div>
+
+            <FormInput
+              label="Location"
+              value={editing.char.location}
+              onChange={(e) => updateEditing({ location: e.target.value })}
+              placeholder="Where can this character be found?"
+            />
+
+            <FormInput
+              label="Notes"
+              value={editing.char.notes}
+              onChange={(e) => updateEditing({ notes: e.target.value })}
+              placeholder="Any notes about this character..."
+            />
+
+            <div className="border-t border-white/[0.06] pt-4 space-y-4">
+              <FormInput
+                label="Relationship to your player"
+                value={editing.char.relationship.descriptor}
+                onChange={(e) => updateRelationship({ descriptor: e.target.value })}
+                placeholder="e.g. Childhood friend, Mentor, Rival..."
+              />
+
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={editing.char.relationship.isPublic}
+                  onChange={(e) => updateRelationship({ isPublic: e.target.checked })}
+                  className="rounded border-white/20 bg-white/[0.05] text-blue-500 focus:ring-blue-500/30"
+                />
+                <span className="text-xs text-slate-400">
+                  Make this relationship visible to other players
+                </span>
+              </label>
+
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={editing.char.isPublic}
+                  onChange={(e) => updateEditing({ isPublic: e.target.checked })}
+                  className="rounded border-white/20 bg-white/[0.05] text-blue-500 focus:ring-blue-500/30"
+                />
+                <span className="text-xs text-slate-400">
+                  Make this character visible to other players
+                </span>
+              </label>
+            </div>
+
+            <div className="flex gap-3 pt-2">
+              <PixelButton variant="secondary" size="sm" onClick={handleCancel} type="button">
+                Cancel
+              </PixelButton>
+              <PixelButton
+                variant="primary"
+                size="sm"
+                onClick={handleSave}
+                disabled={!editing.char.firstName.trim()}
+                type="button"
+              >
+                {editing.index !== null ? 'Update Character' : 'Save Character'}
+              </PixelButton>
+            </div>
+          </div>
+        )}
+
+        {/* Add button */}
+        {!editing && (
+          <PixelButton
+            variant="secondary"
+            size="md"
+            icon={<Plus className="h-3.5 w-3.5" />}
+            onClick={handleAdd}
+            type="button"
+          >
+            Add a Character
+          </PixelButton>
+        )}
+      </div>
+
+      {/* Footer nav */}
+      <div className="flex items-center justify-between px-8 py-5 border-t border-white/[0.06]">
+        <PixelButton variant="secondary" size="sm" onClick={onBack} type="button">
+          &larr; Back
+        </PixelButton>
+        <PixelButton
+          variant="primary"
+          size="sm"
+          onClick={onNext}
+          disabled={!!editing}
+          type="button"
+        >
+          Continue &rarr;
+        </PixelButton>
+      </div>
+    </div>
+  );
+}

--- a/app/components/join-wizard/StepReview.tsx
+++ b/app/components/join-wizard/StepReview.tsx
@@ -1,0 +1,242 @@
+import { useState } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import { PixelButton } from '~/components/PixelButton';
+import { SectionHeader } from '~/components/SectionHeader';
+import { StatusBanner } from '~/components/StatusBanner';
+import { useCompleteJoinWizard } from '~/hooks/usePlayers';
+import { clearStorage } from './JoinWizard';
+import type { WizardState } from './JoinWizard';
+import { Swords, CheckCircle2 } from 'lucide-react';
+
+interface StepReviewProps {
+  wizardState: WizardState;
+  onBack: () => void;
+}
+
+export function StepReview({ wizardState, onBack }: StepReviewProps) {
+  const navigate = useNavigate();
+  const { complete, isLoading, error } = useCompleteJoinWizard();
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const { player, characters, campaignId, campaignName } = wizardState;
+
+  async function handleJoin() {
+    setSubmitError(null);
+
+    const result = await complete({
+      campaignId,
+      player: {
+        firstName: player.firstName.trim(),
+        lastName: player.lastName.trim(),
+        race: player.race.trim(),
+        characterClass: player.characterClass.trim(),
+        age: player.age ?? 0,
+        gender: player.gender.trim(),
+        location: player.location.trim(),
+        link: player.link.trim(),
+        picture: player.picture,
+        pictureCrop: player.pictureCrop
+          ? {
+              x: player.pictureCrop.x,
+              y: player.pictureCrop.y,
+              width: player.pictureCrop.width,
+              height: player.pictureCrop.height,
+            }
+          : null,
+        description: player.description,
+        backstory: player.backstory,
+        color: player.color,
+        eyeColor: player.eyeColor.trim(),
+        hairColor: player.hairColor.trim(),
+        weight: player.weight,
+        height: player.height.trim(),
+        size: player.size.trim(),
+        appearance: player.appearance,
+      },
+      characters: characters.map((c) => ({
+        firstName: c.firstName.trim(),
+        lastName: c.lastName.trim(),
+        race: c.race.trim(),
+        characterClass: c.characterClass.trim(),
+        age: c.age,
+        location: c.location.trim(),
+        link: c.link.trim(),
+        picture: c.picture,
+        pictureCrop: c.pictureCrop
+          ? {
+              x: c.pictureCrop.x,
+              y: c.pictureCrop.y,
+              width: c.pictureCrop.width,
+              height: c.pictureCrop.height,
+            }
+          : null,
+        notes: c.notes,
+        isPublic: c.isPublic,
+        relationship: {
+          descriptor: c.relationship.descriptor.trim(),
+          isPublic: c.relationship.isPublic,
+        },
+      })),
+    });
+
+    if (result) {
+      clearStorage(campaignId);
+      navigate({
+        to: '/campaigns/$campaignId/play',
+        params: { campaignId },
+        search: { tab: 'dashboard' },
+      });
+    } else {
+      setSubmitError('Failed to join campaign. Please try again.');
+    }
+  }
+
+  const displayError = error || submitError;
+
+  return (
+    <div className="bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden">
+      <div className="p-8 pb-6 space-y-5">
+        <SectionHeader size="xs" tracking="tracking-[3px]" className="mb-7">
+          REVIEW
+        </SectionHeader>
+
+        {displayError && <StatusBanner variant="error" message={displayError} />}
+
+        {/* Campaign */}
+        <div>
+          <SectionHeader color="muted" tracking="tracking-widest" className="mb-2">
+            CAMPAIGN
+          </SectionHeader>
+          <div className="bg-white/[0.03] border border-white/[0.07] rounded-xl px-4 py-3">
+            <p className="text-sm text-white font-medium">{campaignName}</p>
+          </div>
+        </div>
+
+        {/* Player character card */}
+        <div>
+          <SectionHeader color="muted" tracking="tracking-widest" className="mb-2">
+            YOUR CHARACTER
+          </SectionHeader>
+          <div className="bg-white/[0.03] border border-white/[0.07] rounded-xl px-4 py-3">
+            <div className="flex items-center gap-4">
+              {player.picture ? (
+                <img
+                  src={player.picture}
+                  alt={player.firstName}
+                  className="w-12 h-12 rounded-full object-cover border border-white/10"
+                />
+              ) : (
+                <div className="w-12 h-12 rounded-full bg-white/[0.06] border border-white/10 flex items-center justify-center text-sm text-slate-500 font-bold">
+                  {player.firstName.charAt(0).toUpperCase() || '?'}
+                </div>
+              )}
+              <div className="flex-1 min-w-0">
+                <p className="text-sm text-white font-medium truncate">
+                  {player.firstName} {player.lastName}
+                </p>
+                <p className="text-xs text-slate-500 truncate">
+                  {[player.race, player.characterClass].filter(Boolean).join(' / ') ||
+                    'No race or class set'}
+                </p>
+              </div>
+              {player.color && (
+                <div
+                  className="w-5 h-5 rounded-full border border-white/10 shrink-0"
+                  style={{ backgroundColor: player.color }}
+                  title="Player color"
+                />
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Backstory status */}
+        <div>
+          <SectionHeader color="muted" tracking="tracking-widest" className="mb-2">
+            BACKSTORY
+          </SectionHeader>
+          <div className="bg-white/[0.03] border border-white/[0.07] rounded-xl px-4 py-3 flex items-center gap-2">
+            {player.backstory ? (
+              <>
+                <CheckCircle2 className="h-4 w-4 text-emerald-400 shrink-0" />
+                <span className="text-xs text-slate-400">
+                  Written ({player.backstory.length} characters)
+                </span>
+              </>
+            ) : (
+              <span className="text-xs text-slate-600 italic">Skipped — can be added later</span>
+            )}
+          </div>
+        </div>
+
+        {/* Characters */}
+        <div>
+          <SectionHeader color="muted" tracking="tracking-widest" className="mb-2">
+            RELATED CHARACTERS ({characters.length})
+          </SectionHeader>
+          {characters.length > 0 ? (
+            <div className="space-y-2">
+              {characters.map((char, i) => (
+                <div
+                  key={i}
+                  className="flex items-center gap-3 bg-white/[0.03] border border-white/[0.07] rounded-xl px-4 py-3"
+                >
+                  {char.picture ? (
+                    <img
+                      src={char.picture}
+                      alt={char.firstName}
+                      className="w-8 h-8 rounded-full object-cover border border-white/10"
+                    />
+                  ) : (
+                    <div className="w-8 h-8 rounded-full bg-white/[0.06] border border-white/10 flex items-center justify-center text-xs text-slate-500 font-bold">
+                      {char.firstName.charAt(0).toUpperCase()}
+                    </div>
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <p className="text-xs text-white font-medium truncate">
+                      {char.firstName} {char.lastName}
+                    </p>
+                    {char.relationship.descriptor && (
+                      <p className="text-[10px] text-slate-500 truncate">
+                        {char.relationship.descriptor}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="bg-white/[0.03] border border-white/[0.07] rounded-xl px-4 py-3">
+              <span className="text-xs text-slate-600 italic">
+                No related characters — can be added later
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Footer nav */}
+      <div className="flex items-center justify-between px-8 py-5 border-t border-white/[0.06]">
+        <PixelButton
+          variant="secondary"
+          size="sm"
+          onClick={onBack}
+          disabled={isLoading}
+          type="button"
+        >
+          &larr; Back
+        </PixelButton>
+        <PixelButton
+          variant="primary"
+          size="sm"
+          icon={<Swords className="h-3.5 w-3.5" />}
+          onClick={handleJoin}
+          disabled={isLoading}
+          type="button"
+        >
+          {isLoading ? 'Joining...' : 'Join Campaign'}
+        </PixelButton>
+      </div>
+    </div>
+  );
+}

--- a/app/components/join-wizard/StepReview.tsx
+++ b/app/components/join-wizard/StepReview.tsx
@@ -30,7 +30,7 @@ export function StepReview({ wizardState, onBack }: StepReviewProps) {
         lastName: player.lastName.trim(),
         race: player.race.trim(),
         characterClass: player.characterClass.trim(),
-        age: player.age ?? 0,
+        age: player.age ?? 1,
         gender: player.gender.trim(),
         location: player.location.trim(),
         link: player.link.trim(),

--- a/app/components/shared/ColorPicker.tsx
+++ b/app/components/shared/ColorPicker.tsx
@@ -1,0 +1,75 @@
+// app/components/shared/ColorPicker.tsx
+
+interface ColorPickerProps {
+  value: string;
+  onChange: (color: string) => void;
+  label?: string;
+  disabled?: boolean;
+}
+
+const PRESET_COLORS = [
+  '#e74c3c',
+  '#e67e22',
+  '#f1c40f',
+  '#2ecc71',
+  '#1abc9c',
+  '#3498db',
+  '#9b59b6',
+  '#e91e63',
+  '#00bcd4',
+  '#8bc34a',
+  '#ff5722',
+  '#795548',
+  '#607d8b',
+  '#c0392b',
+  '#8e44ad',
+];
+
+export function ColorPicker({ value, onChange, label, disabled }: ColorPickerProps) {
+  return (
+    <div>
+      {label && (
+        <label className="block text-[10px] font-sans font-semibold text-slate-500 tracking-wide mb-2">
+          {label}
+        </label>
+      )}
+      <div className="flex flex-wrap gap-2 mb-2">
+        {PRESET_COLORS.map((color) => (
+          <button
+            key={color}
+            type="button"
+            disabled={disabled}
+            onClick={() => onChange(color)}
+            className={`w-7 h-7 rounded-full border-2 transition-transform ${
+              value === color ? 'border-white scale-110' : 'border-transparent hover:scale-105'
+            } ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+            style={{ backgroundColor: color }}
+            aria-label={`Select color ${color}`}
+          />
+        ))}
+      </div>
+      <div className="flex items-center gap-2">
+        <input
+          type="color"
+          value={value || '#3498db'}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          className="w-8 h-8 rounded cursor-pointer border border-white/[0.1] bg-transparent"
+          aria-label="Custom color"
+        />
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => {
+            const v = e.target.value;
+            if (/^#[0-9a-fA-F]{0,6}$/.test(v)) onChange(v);
+          }}
+          disabled={disabled}
+          placeholder="#3498db"
+          className="w-24 px-2 py-1.5 rounded-lg bg-white/[0.04] border border-white/[0.1] text-slate-300 text-xs font-mono focus:outline-none focus:border-blue-500/40"
+          aria-label="Hex color code"
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/components/shared/RelationshipList.tsx
+++ b/app/components/shared/RelationshipList.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { Pencil, Trash2, Plus } from 'lucide-react';
+import { useCharacters } from '~/hooks/useCharacters';
+import type { PictureCrop } from '~/types/character';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RelationshipListProps {
+  relationships: Array<{ characterId: string; descriptor: string; isPublic: boolean }>;
+  campaignId: string;
+  canManage: boolean;
+  onAdd: () => void;
+  onEdit: (characterId: string) => void;
+  onRemove: (characterId: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (reuse the same avatar approach from Character/PlayerWindow)
+// ---------------------------------------------------------------------------
+
+const GRADIENT_PAIRS = [
+  ['#3b82f6', '#8b5cf6'],
+  ['#f59e0b', '#ef4444'],
+  ['#10b981', '#06b6d4'],
+  ['#ec4899', '#8b5cf6'],
+  ['#f97316', '#eab308'],
+  ['#14b8a6', '#3b82f6'],
+];
+
+function hashName(name: string): number {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash << 5) - hash + name.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+
+function getInitials(firstName: string, lastName: string): string {
+  const f = firstName.charAt(0).toUpperCase();
+  const l = lastName.charAt(0).toUpperCase();
+  return l ? `${f}${l}` : f;
+}
+
+function getCropStyle(crop: PictureCrop): React.CSSProperties {
+  const centerX = (crop.x + crop.width / 2) * 100;
+  const centerY = (crop.y + crop.height / 2) * 100;
+  const scale = 1 / crop.width;
+  return {
+    objectPosition: `${centerX}% ${centerY}%`,
+    transform: `scale(${scale})`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function RelationshipList({
+  relationships,
+  campaignId,
+  canManage,
+  onAdd,
+  onEdit,
+  onRemove,
+}: RelationshipListProps) {
+  const { characters } = useCharacters(campaignId);
+
+  const characterMap = React.useMemo(() => {
+    const map = new Map<
+      string,
+      { firstName: string; lastName: string; picture: string; pictureCrop: PictureCrop | null }
+    >();
+    for (const c of characters) {
+      map.set(c.id, {
+        firstName: c.firstName,
+        lastName: c.lastName,
+        picture: c.picture,
+        pictureCrop: c.pictureCrop,
+      });
+    }
+    return map;
+  }, [characters]);
+
+  return (
+    <div className="flex flex-col gap-2">
+      {canManage && (
+        <button
+          type="button"
+          onClick={onAdd}
+          className="flex items-center gap-1.5 text-xs text-blue-400 hover:text-blue-300 transition-colors mb-1"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Add Relationship
+        </button>
+      )}
+
+      {relationships.length === 0 && (
+        <p className="text-xs text-slate-500">No relationships yet.</p>
+      )}
+
+      {relationships.map((rel) => {
+        const charInfo = characterMap.get(rel.characterId);
+        const firstName = charInfo?.firstName ?? 'Unknown';
+        const lastName = charInfo?.lastName ?? '';
+        const fullName = `${firstName} ${lastName}`.trim();
+        const initials = getInitials(firstName, lastName);
+        const gradientIndex = hashName(fullName) % GRADIENT_PAIRS.length;
+        const [gradFrom, gradTo] = GRADIENT_PAIRS[gradientIndex]!;
+
+        return (
+          <div
+            key={rel.characterId}
+            className="flex items-center gap-3 rounded-md border border-white/[0.06] bg-white/[0.02] px-3 py-2"
+          >
+            {/* Avatar */}
+            <div
+              className="w-8 h-8 rounded-full flex-shrink-0 flex items-center justify-center overflow-hidden"
+              style={
+                charInfo?.picture
+                  ? undefined
+                  : { background: `linear-gradient(135deg, ${gradFrom}, ${gradTo})` }
+              }
+            >
+              {charInfo?.picture ? (
+                <img
+                  src={charInfo.picture}
+                  alt={fullName}
+                  className="w-full h-full object-cover"
+                  style={charInfo.pictureCrop ? getCropStyle(charInfo.pictureCrop) : undefined}
+                />
+              ) : (
+                <span className="text-[10px] text-white font-semibold">{initials}</span>
+              )}
+            </div>
+
+            {/* Name + descriptor */}
+            <div className="flex-1 min-w-0">
+              <p className="text-xs font-bold text-slate-200 truncate">{fullName}</p>
+              <p className="text-[11px] text-blue-400 truncate">{rel.descriptor}</p>
+            </div>
+
+            {/* Public / Private badge */}
+            {rel.isPublic ? (
+              <span className="shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-semibold bg-emerald-500/15 text-emerald-400 border border-emerald-500/20">
+                Public
+              </span>
+            ) : (
+              <span className="shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-semibold bg-red-500/15 text-red-400 border border-red-500/20">
+                Private
+              </span>
+            )}
+
+            {/* Action buttons */}
+            {canManage && (
+              <div className="flex items-center gap-1 shrink-0">
+                <button
+                  type="button"
+                  onClick={() => onEdit(rel.characterId)}
+                  className="p-1 rounded text-slate-500 hover:text-slate-300 hover:bg-white/[0.05] transition-colors"
+                  aria-label={`Edit relationship with ${fullName}`}
+                >
+                  <Pencil className="h-3 w-3" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onRemove(rel.characterId)}
+                  className="p-1 rounded text-slate-500 hover:text-red-400 hover:bg-white/[0.05] transition-colors"
+                  aria-label={`Remove relationship with ${fullName}`}
+                >
+                  <Trash2 className="h-3 w-3" />
+                </button>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/components/shared/RelationshipModal.tsx
+++ b/app/components/shared/RelationshipModal.tsx
@@ -1,0 +1,299 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { createPortal } from 'react-dom';
+import { X, Globe, Lock, Search } from 'lucide-react';
+import { useCharacters } from '~/hooks/useCharacters';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RelationshipModalProps {
+  campaignId: string;
+  mode: 'add' | 'edit';
+  showReciprocal: boolean;
+  existingRelationship?: { characterId: string; descriptor: string; isPublic: boolean };
+  excludeCharacterIds?: string[];
+  onSave: (data: {
+    characterId: string;
+    descriptor: string;
+    reciprocalDescriptor?: string;
+    isPublic: boolean;
+  }) => void;
+  onClose: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function RelationshipModal({
+  campaignId,
+  mode,
+  showReciprocal,
+  existingRelationship,
+  excludeCharacterIds = [],
+  onSave,
+  onClose,
+}: RelationshipModalProps) {
+  const { characters } = useCharacters(campaignId);
+
+  const [selectedCharacterId, setSelectedCharacterId] = useState(
+    existingRelationship?.characterId ?? ''
+  );
+  const [descriptor, setDescriptor] = useState(existingRelationship?.descriptor ?? '');
+  const [reciprocalDescriptor, setReciprocalDescriptor] = useState('');
+  const [isPublic, setIsPublic] = useState(existingRelationship?.isPublic ?? false);
+  const [search, setSearch] = useState('');
+  const [showDropdown, setShowDropdown] = useState(false);
+
+  // Close on Escape
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [onClose]);
+
+  // Characters available for selection (exclude already-related + self)
+  const excludeSet = useMemo(() => new Set(excludeCharacterIds), [excludeCharacterIds]);
+
+  const availableCharacters = useMemo(() => {
+    return characters.filter((c) => !excludeSet.has(c.id));
+  }, [characters, excludeSet]);
+
+  const filteredCharacters = useMemo(() => {
+    if (!search.trim()) return availableCharacters;
+    const q = search.toLowerCase();
+    return availableCharacters.filter(
+      (c) =>
+        c.firstName.toLowerCase().includes(q) ||
+        c.lastName.toLowerCase().includes(q) ||
+        `${c.firstName} ${c.lastName}`.toLowerCase().includes(q)
+    );
+  }, [availableCharacters, search]);
+
+  // Resolve selected character name for display
+  const selectedCharacter = useMemo(
+    () => characters.find((c) => c.id === selectedCharacterId),
+    [characters, selectedCharacterId]
+  );
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedCharacterId || !descriptor.trim()) return;
+    onSave({
+      characterId: selectedCharacterId,
+      descriptor: descriptor.trim(),
+      reciprocalDescriptor: showReciprocal ? reciprocalDescriptor.trim() || undefined : undefined,
+      isPublic,
+    });
+  };
+
+  const isValid = !!selectedCharacterId && !!descriptor.trim();
+
+  return createPortal(
+    <div
+      role="presentation"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-2 sm:p-4 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="relationship-modal-title"
+        className="w-full max-w-md bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col"
+      >
+        {/* Header */}
+        <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
+          <h2
+            id="relationship-modal-title"
+            className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest"
+          >
+            {mode === 'add' ? 'Add Relationship' : 'Edit Relationship'}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-slate-500 hover:text-white transition-colors"
+            aria-label="Close modal"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </header>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto p-4 sm:p-6 space-y-5 min-h-0">
+          {/* Character Selector */}
+          <div>
+            <label
+              htmlFor="rel-character-selector"
+              className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide"
+            >
+              Character
+            </label>
+            {mode === 'edit' && selectedCharacter ? (
+              <div
+                id="rel-character-selector"
+                className="px-3 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-xs text-slate-300"
+              >
+                {selectedCharacter.firstName} {selectedCharacter.lastName}
+              </div>
+            ) : (
+              <div className="relative">
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-slate-500" />
+                  <input
+                    id="rel-character-selector"
+                    type="text"
+                    value={
+                      selectedCharacter && !showDropdown
+                        ? `${selectedCharacter.firstName} ${selectedCharacter.lastName}`.trim()
+                        : search
+                    }
+                    onChange={(e) => {
+                      setSearch(e.target.value);
+                      setSelectedCharacterId('');
+                      setShowDropdown(true);
+                    }}
+                    onFocus={() => setShowDropdown(true)}
+                    placeholder="Search characters..."
+                    className="w-full pl-9 pr-3 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-xs text-slate-200 placeholder:text-slate-600 focus:border-blue-500/50 focus:outline-none transition-colors"
+                  />
+                </div>
+                {showDropdown && (
+                  <div className="absolute z-10 mt-1 w-full max-h-40 overflow-y-auto rounded-lg bg-[#161B22] border border-white/[0.08] shadow-xl">
+                    {filteredCharacters.length === 0 ? (
+                      <p className="px-3 py-2 text-xs text-slate-500">No characters found.</p>
+                    ) : (
+                      filteredCharacters.map((c) => (
+                        <button
+                          key={c.id}
+                          type="button"
+                          onClick={() => {
+                            setSelectedCharacterId(c.id);
+                            setSearch('');
+                            setShowDropdown(false);
+                          }}
+                          className="w-full text-left px-3 py-2 text-xs text-slate-300 hover:bg-white/[0.06] transition-colors"
+                        >
+                          {c.firstName} {c.lastName}
+                        </button>
+                      ))
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Descriptor */}
+          <div>
+            <label
+              htmlFor="rel-descriptor"
+              className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide"
+            >
+              Relationship Descriptor
+            </label>
+            <input
+              id="rel-descriptor"
+              type="text"
+              value={descriptor}
+              onChange={(e) => setDescriptor(e.target.value)}
+              placeholder="e.g. Ally, Rival, Mentor..."
+              className="w-full px-3 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-xs text-slate-200 placeholder:text-slate-600 focus:border-blue-500/50 focus:outline-none transition-colors"
+            />
+          </div>
+
+          {/* Reciprocal Descriptor */}
+          {showReciprocal && (
+            <div>
+              <label
+                htmlFor="rel-reciprocal-descriptor"
+                className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide"
+              >
+                Reciprocal Descriptor
+              </label>
+              <input
+                id="rel-reciprocal-descriptor"
+                type="text"
+                value={reciprocalDescriptor}
+                onChange={(e) => setReciprocalDescriptor(e.target.value)}
+                placeholder="How the other character sees this relationship..."
+                className="w-full px-3 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-xs text-slate-200 placeholder:text-slate-600 focus:border-blue-500/50 focus:outline-none transition-colors"
+              />
+              <p className="text-[10px] text-slate-600 mt-1">
+                Optional: describes the reverse side of the relationship.
+              </p>
+            </div>
+          )}
+
+          {/* Public/Private toggle */}
+          <div className="flex items-center gap-4 pt-1">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="rel-visibility"
+                checked={!isPublic}
+                onChange={() => setIsPublic(false)}
+                className="sr-only"
+              />
+              <div
+                className={`h-8 px-3 rounded-lg border flex items-center gap-2 transition-all text-xs ${
+                  !isPublic
+                    ? 'bg-blue-600/10 border-blue-500/50 text-blue-300 shadow-sm shadow-blue-500/10'
+                    : 'bg-white/[0.03] border-white/[0.07] text-slate-500 hover:border-white/20'
+                }`}
+              >
+                <Lock className="h-3 w-3" />
+                <span className="font-bold">Private</span>
+              </div>
+            </label>
+
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="rel-visibility"
+                checked={isPublic}
+                onChange={() => setIsPublic(true)}
+                className="sr-only"
+              />
+              <div
+                className={`h-8 px-3 rounded-lg border flex items-center gap-2 transition-all text-xs ${
+                  isPublic
+                    ? 'bg-emerald-600/10 border-emerald-500/50 text-emerald-300 shadow-sm shadow-emerald-500/10'
+                    : 'bg-white/[0.03] border-white/[0.07] text-slate-500 hover:border-white/20'
+                }`}
+              >
+                <Globe className="h-3 w-3" />
+                <span className="font-bold">Public</span>
+              </div>
+            </label>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <footer className="flex items-center justify-end gap-3 px-4 sm:px-6 py-4 border-t border-white/[0.07] bg-white/[0.01] shrink-0">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 rounded-lg text-xs font-semibold text-slate-400 bg-white/[0.04] border border-white/[0.06] hover:bg-white/[0.07] transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={!isValid}
+            className="px-4 py-2 rounded-lg text-xs font-semibold text-white bg-blue-600 hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            {mode === 'add' ? 'Add Relationship' : 'Save Changes'}
+          </button>
+        </footer>
+      </form>
+    </div>,
+    document.body
+  );
+}

--- a/app/components/shared/RelationshipModal.tsx
+++ b/app/components/shared/RelationshipModal.tsx
@@ -82,6 +82,7 @@ export function RelationshipModal({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!selectedCharacterId || !descriptor.trim()) return;
+    if (showReciprocal && !reciprocalDescriptor.trim()) return;
     onSave({
       characterId: selectedCharacterId,
       descriptor: descriptor.trim(),
@@ -90,7 +91,10 @@ export function RelationshipModal({
     });
   };
 
-  const isValid = !!selectedCharacterId && !!descriptor.trim();
+  const isValid =
+    !!selectedCharacterId &&
+    !!descriptor.trim() &&
+    (!showReciprocal || !!reciprocalDescriptor.trim());
 
   return createPortal(
     <div
@@ -226,7 +230,7 @@ export function RelationshipModal({
                 className="w-full px-3 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-xs text-slate-200 placeholder:text-slate-600 focus:border-blue-500/50 focus:outline-none transition-colors"
               />
               <p className="text-[10px] text-slate-600 mt-1">
-                Optional: describes the reverse side of the relationship.
+                Required: describes the reverse side of the relationship.
               </p>
             </div>
           )}

--- a/app/components/shared/TabBar.tsx
+++ b/app/components/shared/TabBar.tsx
@@ -1,0 +1,38 @@
+import { type ReactNode } from 'react';
+
+export interface Tab {
+  id: string;
+  label: string;
+  icon?: ReactNode;
+  hidden?: boolean;
+}
+
+interface TabBarProps {
+  tabs: Tab[];
+  activeTab: string;
+  onTabChange: (tabId: string) => void;
+  accentColor?: string;
+}
+
+export function TabBar({ tabs, activeTab, onTabChange, accentColor = '#3498db' }: TabBarProps) {
+  const visibleTabs = tabs.filter((t) => !t.hidden);
+  return (
+    <div className="flex border-b border-white/[0.06] bg-[#0D1117]">
+      {visibleTabs.map((tab) => (
+        <button
+          key={tab.id}
+          onClick={() => onTabChange(tab.id)}
+          className={`px-5 py-2.5 text-xs font-medium transition-colors flex items-center gap-1.5 ${
+            activeTab === tab.id
+              ? 'text-slate-200 border-b-2'
+              : 'text-slate-500 hover:text-slate-400'
+          }`}
+          style={activeTab === tab.id ? { borderBottomColor: accentColor } : undefined}
+        >
+          {tab.icon}
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/app/components/wiki/WikiPanel.tsx
+++ b/app/components/wiki/WikiPanel.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
-import { Users, Dna, ScrollText } from 'lucide-react';
+import { Users, Dna, ScrollText, UserCircle } from 'lucide-react';
 import { CharactersPanel } from './characters/CharactersPanel';
 import { RacesPanel } from './races/RacesPanel';
 import { RulesPanel } from './rules/RulesPanel';
+import { PlayersPanel } from './players/PlayersPanel';
 
-type WikiCategoryId = 'characters' | 'races' | 'rules';
+type WikiCategoryId = 'characters' | 'players' | 'races' | 'rules';
 
 interface WikiCategory {
   id: WikiCategoryId;
@@ -14,6 +15,7 @@ interface WikiCategory {
 
 const WIKI_CATEGORIES: WikiCategory[] = [
   { id: 'characters', label: 'Characters', icon: Users },
+  { id: 'players', label: 'Players', icon: UserCircle },
   { id: 'races', label: 'Races', icon: Dna },
   { id: 'rules', label: 'Rules', icon: ScrollText },
 ];
@@ -47,6 +49,8 @@ export function WikiPanel() {
         </div>
       ) : selectedCategory === 'characters' ? (
         <CharactersPanel onBack={() => setSelectedCategory(null)} />
+      ) : selectedCategory === 'players' ? (
+        <PlayersPanel onBack={() => setSelectedCategory(null)} />
       ) : selectedCategory === 'races' ? (
         <RacesPanel onBack={() => setSelectedCategory(null)} />
       ) : selectedCategory === 'rules' ? (

--- a/app/components/wiki/characters/CharacterCard.tsx
+++ b/app/components/wiki/characters/CharacterCard.tsx
@@ -46,6 +46,7 @@ export function CharacterCard({ character, onClick }: CharacterCardProps) {
   const initials = getInitials(character.firstName, character.lastName);
   const gradientIndex = hashName(fullName) % GRADIENT_PAIRS.length;
   const [gradFrom, gradTo] = GRADIENT_PAIRS[gradientIndex]!;
+  const isDeceased = character.status?.value === 'deceased';
 
   const infoSegments: string[] = [];
   if (character.race) infoSegments.push(character.race);
@@ -79,7 +80,7 @@ export function CharacterCard({ character, onClick }: CharacterCardProps) {
           onClick(character);
         }
       }}
-      className="flex items-start gap-3 px-4 py-3 border-b border-white/[0.05] hover:bg-white/[0.03] transition-colors group cursor-grab active:cursor-grabbing"
+      className={`flex items-start gap-3 px-4 py-3 border-b border-white/[0.05] hover:bg-white/[0.03] transition-colors group cursor-grab active:cursor-grabbing${isDeceased ? ' opacity-60' : ''}`}
     >
       {/* Avatar */}
       <div
@@ -124,6 +125,9 @@ export function CharacterCard({ character, onClick }: CharacterCardProps) {
             >
               <ExternalLink className="h-3 w-3 text-slate-500 hover:text-blue-400 transition-colors" />
             </a>
+          )}
+          {isDeceased && (
+            <span className="ml-auto text-[10px] text-red-400 shrink-0">Deceased</span>
           )}
         </div>
 

--- a/app/components/wiki/characters/CharacterWindow.tsx
+++ b/app/components/wiki/characters/CharacterWindow.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
-import { ChevronDown, Pencil } from 'lucide-react';
+import { Pencil } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { CharacterData, PictureCrop } from '~/types/character';
 import { MARKDOWN_PROSE_CLASSES } from '~/utils/markdownProseClasses';
+import { TabBar } from '~/components/shared/TabBar';
 
 function getCropStyle(crop: PictureCrop): React.CSSProperties {
   const centerX = (crop.x + crop.width / 2) * 100;
@@ -53,35 +54,9 @@ function StatBlock({ label, value }: { label: string; value: string }) {
   );
 }
 
-function Accordion({
-  title,
-  defaultOpen = false,
-  children,
-}: {
-  title: string;
-  defaultOpen?: boolean;
-  children: React.ReactNode;
-}) {
-  const [open, setOpen] = useState(defaultOpen);
-
-  return (
-    <div className="border border-white/[0.06] rounded-md overflow-hidden">
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center justify-between px-3 py-2 text-xs font-semibold text-slate-300 hover:bg-white/[0.03] transition-colors"
-      >
-        {title}
-        <ChevronDown
-          className={`h-3.5 w-3.5 text-slate-500 transition-transform ${open ? 'rotate-180' : ''}`}
-        />
-      </button>
-      {open && <div className="px-3 pb-3">{children}</div>}
-    </div>
-  );
-}
-
 export function CharacterWindow({ character, onEdit }: CharacterWindowProps) {
+  const [activeTab, setActiveTab] = useState('general');
+
   const fullName = `${character.firstName} ${character.lastName}`.trim();
   const initials = getInitials(character.firstName, character.lastName);
   const gradientIndex = hashName(fullName) % GRADIENT_PAIRS.length;
@@ -94,82 +69,128 @@ export function CharacterWindow({ character, onEdit }: CharacterWindowProps) {
   if (character.location) stats.push({ label: 'Location', value: character.location });
 
   const showMeta = character.tags.length > 0 || (character.canEdit && !!onEdit);
+  const isDeceased = character.status?.value === 'deceased';
+
+  const tabs = [
+    { id: 'general', label: 'General' },
+    { id: 'gmnotes', label: 'GM Notes', hidden: !character.canEdit },
+    { id: 'relationships', label: 'Relationships' },
+  ];
 
   return (
-    <div className="flex flex-col gap-3 p-4">
-      {/* Portrait */}
-      <div className="flex justify-center">
-        <div
-          className="w-24 h-24 rounded-full flex-shrink-0 flex items-center justify-center overflow-hidden"
-          style={
-            character.picture
-              ? undefined
-              : { background: `linear-gradient(135deg, ${gradFrom}, ${gradTo})` }
-          }
-        >
-          {character.picture ? (
-            <img
-              src={character.picture}
-              alt={fullName}
-              className="w-full h-full object-cover"
-              style={character.pictureCrop ? getCropStyle(character.pictureCrop) : undefined}
-            />
-          ) : (
-            <span className="text-2xl text-white font-semibold">{initials}</span>
-          )}
+    <div className="flex flex-col">
+      {/* Header area */}
+      <div className="flex flex-col gap-3 p-4">
+        {/* Portrait */}
+        <div className="flex justify-center">
+          <div
+            className="w-24 h-24 rounded-full flex-shrink-0 flex items-center justify-center overflow-hidden"
+            style={
+              character.picture
+                ? undefined
+                : { background: `linear-gradient(135deg, ${gradFrom}, ${gradTo})` }
+            }
+          >
+            {character.picture ? (
+              <img
+                src={character.picture}
+                alt={fullName}
+                className="w-full h-full object-cover"
+                style={character.pictureCrop ? getCropStyle(character.pictureCrop) : undefined}
+              />
+            ) : (
+              <span className="text-2xl text-white font-semibold">{initials}</span>
+            )}
+          </div>
         </div>
+
+        {/* Tags + edit button below portrait */}
+        {showMeta && (
+          <div className="flex items-center justify-center gap-1.5 flex-wrap">
+            {character.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[9px] tracking-tight"
+              >
+                #{tag}
+              </span>
+            ))}
+            {character.canEdit && onEdit && (
+              <button
+                type="button"
+                onClick={onEdit}
+                className="shrink-0 p-1 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors"
+                aria-label="Edit character"
+              >
+                <Pencil className="h-3.5 w-3.5" />
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* Stats grid + deceased indicator */}
+        {(stats.length > 0 || isDeceased) && (
+          <div className="flex flex-col gap-2">
+            {isDeceased && (
+              <div className="flex justify-center">
+                <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-semibold bg-red-500/15 text-red-400 border border-red-500/20">
+                  Deceased
+                </span>
+              </div>
+            )}
+            {stats.length > 0 && (
+              <div className="grid grid-cols-2 gap-2">
+                {stats.map((s) => (
+                  <StatBlock key={s.label} label={s.label} value={s.value} />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
-      {/* Tags + edit button below portrait */}
-      {showMeta && (
-        <div className="flex items-center justify-center gap-1.5 flex-wrap">
-          {character.tags.map((tag) => (
-            <span
-              key={tag}
-              className="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[9px] tracking-tight"
-            >
-              #{tag}
-            </span>
-          ))}
-          {character.canEdit && onEdit && (
-            <button
-              type="button"
-              onClick={onEdit}
-              className="shrink-0 p-1 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors"
-              aria-label="Edit character"
-            >
-              <Pencil className="h-3.5 w-3.5" />
-            </button>
-          )}
-        </div>
-      )}
+      {/* Tab bar */}
+      <TabBar tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab} />
 
-      {/* Stats grid */}
-      {stats.length > 0 && (
-        <div className="grid grid-cols-2 gap-2">
-          {stats.map((s) => (
-            <StatBlock key={s.label} label={s.label} value={s.value} />
-          ))}
-        </div>
-      )}
-
-      {/* Details accordion */}
-      {character.notes && (
-        <Accordion title="Details" defaultOpen>
-          <div className={MARKDOWN_PROSE_CLASSES}>
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{character.notes}</ReactMarkdown>
+      {/* Tab content */}
+      <div className="p-4">
+        {activeTab === 'general' && (
+          <div>
+            {character.notes ? (
+              <div className={MARKDOWN_PROSE_CLASSES}>
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{character.notes}</ReactMarkdown>
+              </div>
+            ) : (
+              <p className="text-xs text-slate-500">No details yet.</p>
+            )}
+            {character.sessions && character.sessions.length > 0 && (
+              <div className="mt-4">
+                <p className="text-[10px] uppercase tracking-wider text-slate-500 mb-1">Sessions</p>
+                <p className="text-xs text-slate-400">
+                  Appeared in {character.sessions.length} session
+                  {character.sessions.length !== 1 ? 's' : ''}
+                </p>
+              </div>
+            )}
           </div>
-        </Accordion>
-      )}
+        )}
 
-      {/* GM Notes accordion */}
-      {character.gmNotes && (
-        <Accordion title="GM Notes">
-          <div className={MARKDOWN_PROSE_CLASSES}>
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{character.gmNotes}</ReactMarkdown>
+        {activeTab === 'gmnotes' && (
+          <div>
+            {character.gmNotes ? (
+              <div className={MARKDOWN_PROSE_CLASSES}>
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{character.gmNotes}</ReactMarkdown>
+              </div>
+            ) : (
+              <p className="text-xs text-slate-500">No GM notes yet.</p>
+            )}
           </div>
-        </Accordion>
-      )}
+        )}
+
+        {activeTab === 'relationships' && (
+          <p className="text-xs text-slate-500">No relationships yet.</p>
+        )}
+      </div>
     </div>
   );
 }

--- a/app/components/wiki/characters/CharacterWindow.tsx
+++ b/app/components/wiki/characters/CharacterWindow.tsx
@@ -244,7 +244,7 @@ export function CharacterWindow({ character, onEdit }: CharacterWindowProps) {
                       campaignId: character.campaignId,
                       targetCharacterId: data.characterId,
                       descriptor: data.descriptor,
-                      reciprocalDescriptor: data.reciprocalDescriptor ?? '',
+                      reciprocalDescriptor: data.reciprocalDescriptor!,
                       isPublic: data.isPublic,
                     });
                   } else {

--- a/app/components/wiki/characters/CharacterWindow.tsx
+++ b/app/components/wiki/characters/CharacterWindow.tsx
@@ -5,6 +5,13 @@ import remarkGfm from 'remark-gfm';
 import type { CharacterData, PictureCrop } from '~/types/character';
 import { MARKDOWN_PROSE_CLASSES } from '~/utils/markdownProseClasses';
 import { TabBar } from '~/components/shared/TabBar';
+import { RelationshipList } from '~/components/shared/RelationshipList';
+import { RelationshipModal } from '~/components/shared/RelationshipModal';
+import {
+  useAddCharacterRelationship,
+  useUpdateCharacterRelationship,
+  useRemoveCharacterRelationship,
+} from '~/hooks/useCharacters';
 
 function getCropStyle(crop: PictureCrop): React.CSSProperties {
   const centerX = (crop.x + crop.width / 2) * 100;
@@ -56,6 +63,15 @@ function StatBlock({ label, value }: { label: string; value: string }) {
 
 export function CharacterWindow({ character, onEdit }: CharacterWindowProps) {
   const [activeTab, setActiveTab] = useState('general');
+  const [relationshipModal, setRelationshipModal] = useState<{
+    open: boolean;
+    mode: 'add' | 'edit';
+    editCharacterId?: string;
+  }>({ open: false, mode: 'add' });
+
+  const { addRelationship } = useAddCharacterRelationship();
+  const { updateRelationship } = useUpdateCharacterRelationship();
+  const { removeRelationship } = useRemoveCharacterRelationship();
 
   const fullName = `${character.firstName} ${character.lastName}`.trim();
   const initials = getInitials(character.firstName, character.lastName);
@@ -188,7 +204,65 @@ export function CharacterWindow({ character, onEdit }: CharacterWindowProps) {
         )}
 
         {activeTab === 'relationships' && (
-          <p className="text-xs text-slate-500">No relationships yet.</p>
+          <>
+            <RelationshipList
+              relationships={character.relationships}
+              campaignId={character.campaignId}
+              canManage={character.canEdit}
+              onAdd={() => setRelationshipModal({ open: true, mode: 'add' })}
+              onEdit={(charId) =>
+                setRelationshipModal({ open: true, mode: 'edit', editCharacterId: charId })
+              }
+              onRemove={(charId) => {
+                removeRelationship({
+                  characterId: character.id,
+                  campaignId: character.campaignId,
+                  targetCharacterId: charId,
+                });
+              }}
+            />
+            {relationshipModal.open && (
+              <RelationshipModal
+                campaignId={character.campaignId}
+                mode={relationshipModal.mode}
+                showReciprocal
+                existingRelationship={
+                  relationshipModal.mode === 'edit' && relationshipModal.editCharacterId
+                    ? character.relationships.find(
+                        (r) => r.characterId === relationshipModal.editCharacterId
+                      )
+                    : undefined
+                }
+                excludeCharacterIds={[
+                  character.id,
+                  ...character.relationships.map((r) => r.characterId),
+                ]}
+                onSave={(data) => {
+                  if (relationshipModal.mode === 'add') {
+                    addRelationship({
+                      characterId: character.id,
+                      campaignId: character.campaignId,
+                      targetCharacterId: data.characterId,
+                      descriptor: data.descriptor,
+                      reciprocalDescriptor: data.reciprocalDescriptor ?? '',
+                      isPublic: data.isPublic,
+                    });
+                  } else {
+                    updateRelationship({
+                      characterId: character.id,
+                      campaignId: character.campaignId,
+                      targetCharacterId: data.characterId,
+                      descriptor: data.descriptor,
+                      reciprocalDescriptor: data.reciprocalDescriptor,
+                      isPublic: data.isPublic,
+                    });
+                  }
+                  setRelationshipModal({ open: false, mode: 'add' });
+                }}
+                onClose={() => setRelationshipModal({ open: false, mode: 'add' })}
+              />
+            )}
+          </>
         )}
       </div>
     </div>

--- a/app/components/wiki/characters/CharactersPanel.tsx
+++ b/app/components/wiki/characters/CharactersPanel.tsx
@@ -69,7 +69,7 @@ export function CharactersPanel({ onBack }: CharactersPanelProps) {
         visibility={visibility}
         onVisibilityChange={setVisibility}
         sessions={sessions}
-        onCreateClick={campaign?.isGM ? handleCreateClick : undefined}
+        onCreateClick={handleCreateClick}
         campaignId={campaignId}
         filterTags={filterTags}
         onFilterTagsChange={setFilterTags}

--- a/app/components/wiki/players/PlayerCard.tsx
+++ b/app/components/wiki/players/PlayerCard.tsx
@@ -1,0 +1,73 @@
+import type { PlayerListItem } from '~/types/player';
+
+interface PlayerCardProps {
+  player: PlayerListItem;
+  onClick: () => void;
+}
+
+function getInitials(firstName: string, lastName: string): string {
+  const f = firstName.charAt(0).toUpperCase();
+  const l = lastName.charAt(0).toUpperCase();
+  return l ? `${f}${l}` : f;
+}
+
+export function PlayerCard({ player, onClick }: PlayerCardProps) {
+  const fullName = `${player.firstName} ${player.lastName}`.trim();
+  const initials = getInitials(player.firstName, player.lastName);
+  const isDeceased = player.status?.value === 'deceased';
+
+  const infoSegments: string[] = [];
+  if (player.race) infoSegments.push(player.race);
+  if (player.characterClass) infoSegments.push(player.characterClass);
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center gap-3 w-full px-4 py-3 border-b border-white/[0.05] hover:bg-white/[0.03] transition-colors text-left${isDeceased ? ' opacity-70' : ''}`}
+      style={
+        isDeceased
+          ? {
+              borderLeftWidth: 4,
+              borderLeftStyle: 'solid',
+              borderLeftColor: player.color,
+              backgroundColor: `${player.color}08`,
+            }
+          : { borderLeftWidth: 4, borderLeftStyle: 'solid', borderLeftColor: player.color }
+      }
+    >
+      {/* Avatar */}
+      <div
+        className="w-10 h-10 rounded-full flex-shrink-0 flex items-center justify-center overflow-hidden"
+        style={player.picture ? undefined : { backgroundColor: player.color }}
+      >
+        {player.picture ? (
+          <img src={player.picture} alt={fullName} className="w-full h-full object-cover" />
+        ) : (
+          <span className="text-sm text-white font-semibold">{initials}</span>
+        )}
+      </div>
+
+      {/* Details */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-0.5">
+          <span className="text-sm font-semibold text-slate-200 truncate">{fullName}</span>
+          {isDeceased && (
+            <span className="ml-auto text-[10px] text-red-400 shrink-0">Deceased</span>
+          )}
+        </div>
+
+        {infoSegments.length > 0 && (
+          <div className="flex items-center gap-1.5 text-xs text-slate-500">
+            {infoSegments.map((segment, i) => (
+              <span key={segment} className="flex items-center gap-1.5">
+                {i > 0 && <span className="opacity-40">&middot;</span>}
+                <span>{segment}</span>
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </button>
+  );
+}

--- a/app/components/wiki/players/PlayerModal.tsx
+++ b/app/components/wiki/players/PlayerModal.tsx
@@ -1,0 +1,540 @@
+import React, { useState, useEffect, useId, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { X } from 'lucide-react';
+import { FormInput } from '~/components/FormInput';
+import { PixelButton } from '~/components/PixelButton';
+import { MarkdownEditor } from '~/components/shared/MarkdownEditor';
+import { ColorPicker } from '~/components/shared/ColorPicker';
+import { ImageCropInput } from '~/components/wiki/characters/ImageCropInput';
+import { usePlayer, useUpdatePlayer, useDeletePlayer } from '~/hooks/usePlayers';
+import { useCampaign } from '~/hooks/useCampaigns';
+import { useRaces } from '~/hooks/useRaces';
+import type { PictureCrop } from '~/types/character';
+import { uploadToR2 } from '~/utils/uploadToR2';
+import { compressImage } from '~/utils/compressImage';
+
+interface PlayerModalProps {
+  campaignId: string;
+  playerId?: string;
+  onClose: () => void;
+}
+
+interface FieldErrors {
+  firstName?: string;
+  lastName?: string;
+  link?: string;
+}
+
+export function PlayerModal({ campaignId, playerId, onClose }: PlayerModalProps) {
+  const isEdit = !!playerId;
+  const raceDatalistId = useId();
+
+  const { player: existingPlayer, isLoading: isFetchingPlayer } = usePlayer(
+    playerId ?? '',
+    campaignId
+  );
+  const { update, isLoading: isUpdating } = useUpdatePlayer();
+  const { remove, isLoading: isDeleting } = useDeletePlayer();
+  const { campaign } = useCampaign(campaignId);
+  const { races } = useRaces(campaignId, { enabled: true });
+
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [race, setRace] = useState('');
+  const [characterClass, setCharacterClass] = useState('');
+  const [age, setAge] = useState('');
+  const [gender, setGender] = useState('');
+  const [location, setLocation] = useState('');
+  const [link, setLink] = useState('');
+  const [picture, setPicture] = useState('');
+  const [pictureCrop, setPictureCrop] = useState<PictureCrop | null>(null);
+  const [color, setColor] = useState('');
+  const [eyeColor, setEyeColor] = useState('');
+  const [hairColor, setHairColor] = useState('');
+  const [weight, setWeight] = useState('');
+  const [height, setHeight] = useState('');
+  const [size, setSize] = useState('');
+  const [description, setDescription] = useState('');
+  const [appearance, setAppearance] = useState('');
+  const [backstory, setBackstory] = useState('');
+  const [gmNotes, setGmNotes] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [hasSubmitted, setHasSubmitted] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  // Close on Escape key
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [onClose]);
+
+  // Reset form when playerId changes
+  useEffect(() => {
+    setFirstName('');
+    setLastName('');
+    setRace('');
+    setCharacterClass('');
+    setAge('');
+    setGender('');
+    setLocation('');
+    setLink('');
+    setPicture('');
+    setPictureCrop(null);
+    setColor('');
+    setEyeColor('');
+    setHairColor('');
+    setWeight('');
+    setHeight('');
+    setSize('');
+    setDescription('');
+    setAppearance('');
+    setBackstory('');
+    setGmNotes('');
+    setError(null);
+    setFieldErrors({});
+    setHasSubmitted(false);
+    setShowDeleteConfirm(false);
+  }, [playerId]);
+
+  // Populate form once the fetched player resolves in edit mode
+  useEffect(() => {
+    if (isEdit && existingPlayer) {
+      setFirstName(existingPlayer.firstName);
+      setLastName(existingPlayer.lastName);
+      setRace(existingPlayer.race);
+      setCharacterClass(existingPlayer.characterClass);
+      setAge(existingPlayer.age != null ? String(existingPlayer.age) : '');
+      setGender(existingPlayer.gender);
+      setLocation(existingPlayer.location);
+      setLink(existingPlayer.link);
+      setPicture(existingPlayer.picture);
+      setPictureCrop(existingPlayer.pictureCrop);
+      setColor(existingPlayer.color);
+      setEyeColor(existingPlayer.eyeColor);
+      setHairColor(existingPlayer.hairColor);
+      setWeight(existingPlayer.weight != null ? String(existingPlayer.weight) : '');
+      setHeight(existingPlayer.height);
+      setSize(existingPlayer.size);
+      setDescription(existingPlayer.description);
+      setAppearance(existingPlayer.appearance);
+      setBackstory(existingPlayer.backstory);
+      setGmNotes(existingPlayer.gmNotes);
+    }
+  }, [isEdit, existingPlayer]);
+
+  const validate = useCallback((): FieldErrors => {
+    const errors: FieldErrors = {};
+    if (!firstName.trim()) errors.firstName = 'First name is required';
+    if (!lastName.trim()) errors.lastName = 'Last name is required';
+    if (link.trim() && !/^https?:\/\/.+/.test(link.trim())) {
+      errors.link = 'Must be a valid HTTP or HTTPS URL';
+    }
+    return errors;
+  }, [firstName, lastName, link]);
+
+  useEffect(() => {
+    if (hasSubmitted) setFieldErrors(validate());
+  }, [hasSubmitted, validate]);
+
+  const handleUpload = useCallback(async (file: File): Promise<string> => {
+    const compressed = await compressImage(file);
+    const { publicUrl } = await uploadToR2(compressed, 'uploads/players');
+    return publicUrl;
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setHasSubmitted(true);
+    setError(null);
+
+    const errors = validate();
+    setFieldErrors(errors);
+    if (Object.keys(errors).length > 0) return;
+
+    const parsedAge = age.trim() ? parseInt(age, 10) : 0;
+    const parsedWeight = weight.trim() ? parseInt(weight, 10) : null;
+
+    const input = {
+      campaignId,
+      firstName: firstName.trim(),
+      lastName: lastName.trim(),
+      race: race.trim(),
+      characterClass: characterClass.trim(),
+      age: parsedAge,
+      gender: gender.trim(),
+      location: location.trim(),
+      link: link.trim(),
+      picture,
+      pictureCrop: pictureCrop
+        ? {
+            x: pictureCrop.x,
+            y: pictureCrop.y,
+            width: pictureCrop.width,
+            height: pictureCrop.height,
+          }
+        : null,
+      description,
+      backstory,
+      gmNotes,
+      color,
+      eyeColor: eyeColor.trim(),
+      hairColor: hairColor.trim(),
+      weight: parsedWeight,
+      height: height.trim(),
+      size: size.trim(),
+      appearance,
+    };
+
+    let success = false;
+    if (isEdit && playerId) {
+      const result = await update({ ...input, id: playerId });
+      success = !!result;
+    }
+
+    if (success) {
+      onClose();
+    } else {
+      setError('Failed to update player. Please try again.');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!playerId) return;
+    setError(null);
+    const result = await remove({ id: playerId, campaignId });
+    if (result) {
+      onClose();
+    } else {
+      setError('Failed to delete player. Please try again.');
+      setShowDeleteConfirm(false);
+    }
+  };
+
+  const isLoadingPlayer = !!(isEdit && isFetchingPlayer);
+  const isSaving = isUpdating;
+  const isDisabled = isLoadingPlayer || isSaving || isDeleting;
+
+  return createPortal(
+    <div
+      role="presentation"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-2 sm:p-4 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="player-modal-title"
+        className="w-full h-full max-w-[90vw] max-h-[90vh] sm:max-w-[90vw] sm:max-h-[90vh] bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col"
+      >
+        <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
+          <h2
+            id="player-modal-title"
+            className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest"
+          >
+            {isEdit ? 'Edit Player' : 'Create Player'}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-slate-500 hover:text-white transition-colors"
+            aria-label="Close modal"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto p-4 sm:p-6 space-y-5 min-h-0">
+          {error && (
+            <div className="p-3 bg-rose-500/10 border border-rose-500/20 rounded-lg text-rose-400 text-xs font-semibold">
+              {error}
+            </div>
+          )}
+
+          {isLoadingPlayer ? (
+            <div className="flex items-center justify-center py-12">
+              <p className="text-xs text-slate-500 animate-pulse">Loading player...</p>
+            </div>
+          ) : (
+            <>
+              {/* Picture upload */}
+              <ImageCropInput
+                imageUrl={picture}
+                crop={pictureCrop}
+                onImageChange={setPicture}
+                onCropChange={setPictureCrop}
+                onUpload={handleUpload}
+                disabled={isDisabled}
+              />
+
+              {/* Color picker */}
+              <ColorPicker
+                label="Player Color"
+                value={color}
+                onChange={setColor}
+                disabled={isDisabled}
+              />
+
+              {/* First Name + Last Name */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+                <FormInput
+                  label="First Name"
+                  value={firstName}
+                  onChange={(e) => setFirstName(e.target.value)}
+                  error={fieldErrors.firstName}
+                  required
+                  disabled={isDisabled}
+                  placeholder="First name"
+                />
+                <FormInput
+                  label="Last Name"
+                  value={lastName}
+                  onChange={(e) => setLastName(e.target.value)}
+                  error={fieldErrors.lastName}
+                  required
+                  disabled={isDisabled}
+                  placeholder="Last name"
+                />
+              </div>
+
+              {/* Race + Class + Age */}
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+                <div>
+                  <FormInput
+                    label="Race"
+                    value={race}
+                    onChange={(e) => setRace(e.target.value)}
+                    disabled={isDisabled}
+                    placeholder="e.g. Half-Elf"
+                    list={raceDatalistId}
+                  />
+                  <datalist id={raceDatalistId}>
+                    {races.map((r) => (
+                      <option key={r.id} value={r.title} />
+                    ))}
+                  </datalist>
+                </div>
+                <FormInput
+                  label="Class"
+                  value={characterClass}
+                  onChange={(e) => setCharacterClass(e.target.value)}
+                  disabled={isDisabled}
+                  placeholder="e.g. Ranger / Druid"
+                />
+                <FormInput
+                  label="Age"
+                  type="number"
+                  value={age}
+                  onChange={(e) => setAge(e.target.value)}
+                  disabled={isDisabled}
+                  placeholder="Age"
+                />
+              </div>
+
+              {/* Gender + Location */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+                <FormInput
+                  label="Gender"
+                  value={gender}
+                  onChange={(e) => setGender(e.target.value)}
+                  disabled={isDisabled}
+                  placeholder="Gender"
+                />
+                <FormInput
+                  label="Location"
+                  value={location}
+                  onChange={(e) => setLocation(e.target.value)}
+                  disabled={isDisabled}
+                  placeholder="Current residence"
+                />
+              </div>
+
+              {/* Eye Color + Hair Color */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+                <FormInput
+                  label="Eye Color"
+                  value={eyeColor}
+                  onChange={(e) => setEyeColor(e.target.value)}
+                  disabled={isDisabled}
+                  placeholder="e.g. Blue"
+                />
+                <FormInput
+                  label="Hair Color"
+                  value={hairColor}
+                  onChange={(e) => setHairColor(e.target.value)}
+                  disabled={isDisabled}
+                  placeholder="e.g. Auburn"
+                />
+              </div>
+
+              {/* Height + Weight + Size */}
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+                <FormInput
+                  label="Height"
+                  value={height}
+                  onChange={(e) => setHeight(e.target.value)}
+                  disabled={isDisabled}
+                  placeholder={`e.g. 5'10"`}
+                />
+                <FormInput
+                  label="Weight"
+                  type="number"
+                  value={weight}
+                  onChange={(e) => setWeight(e.target.value)}
+                  disabled={isDisabled}
+                  placeholder="lbs"
+                />
+                <FormInput
+                  label="Size"
+                  value={size}
+                  onChange={(e) => setSize(e.target.value)}
+                  disabled={isDisabled}
+                  placeholder="e.g. Medium"
+                />
+              </div>
+
+              {/* External Link */}
+              <FormInput
+                label="External Link"
+                type="url"
+                value={link}
+                onChange={(e) => setLink(e.target.value)}
+                error={fieldErrors.link}
+                disabled={isDisabled}
+                placeholder="https://..."
+              />
+
+              {/* Description */}
+              <MarkdownEditor
+                label="Description"
+                value={description}
+                onChange={setDescription}
+                placeholder="A brief description of this player character..."
+                disabled={isDisabled}
+                minHeight="120px"
+                id="player-description-editor"
+              />
+
+              {/* Appearance */}
+              <MarkdownEditor
+                label="Appearance"
+                value={appearance}
+                onChange={setAppearance}
+                placeholder="Physical appearance details..."
+                disabled={isDisabled}
+                minHeight="120px"
+                id="player-appearance-editor"
+              />
+
+              {/* Backstory */}
+              <MarkdownEditor
+                label={
+                  <span>
+                    Backstory{' '}
+                    <span className="text-amber-500 text-[10px] font-normal">
+                      (visible to campaign members)
+                    </span>
+                  </span>
+                }
+                value={backstory}
+                onChange={setBackstory}
+                placeholder="Character backstory..."
+                disabled={isDisabled}
+                minHeight="160px"
+                id="player-backstory-editor"
+              />
+
+              {/* GM Notes — only visible to GM */}
+              {campaign?.isGM && (
+                <MarkdownEditor
+                  label={
+                    <span>
+                      GM Notes{' '}
+                      <span className="text-amber-500 text-[10px] font-normal">
+                        (only visible to GM)
+                      </span>
+                    </span>
+                  }
+                  value={gmNotes}
+                  onChange={setGmNotes}
+                  placeholder="Secret GM-only notes..."
+                  disabled={isDisabled}
+                  minHeight="120px"
+                  id="player-gmnotes-editor"
+                />
+              )}
+            </>
+          )}
+        </div>
+
+        <footer className="flex items-center justify-between px-4 sm:px-6 py-4 border-t border-white/[0.07] bg-white/[0.01] shrink-0">
+          <div>
+            {isEdit && campaign?.isGM && !showDeleteConfirm && (
+              <PixelButton
+                variant="secondary"
+                size="sm"
+                onClick={() => setShowDeleteConfirm(true)}
+                disabled={isDisabled}
+                type="button"
+              >
+                <span className="text-rose-400">Delete</span>
+              </PixelButton>
+            )}
+            {isEdit && campaign?.isGM && showDeleteConfirm && (
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-rose-400 font-semibold">Delete this player?</span>
+                <PixelButton
+                  variant="secondary"
+                  size="sm"
+                  onClick={handleDelete}
+                  disabled={isDeleting}
+                  type="button"
+                >
+                  <span className="text-rose-400">
+                    {isDeleting ? 'Deleting...' : 'Yes, delete'}
+                  </span>
+                </PixelButton>
+                <PixelButton
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => setShowDeleteConfirm(false)}
+                  disabled={isDeleting}
+                  type="button"
+                >
+                  Cancel
+                </PixelButton>
+              </div>
+            )}
+          </div>
+          <div className="flex items-center gap-3">
+            <PixelButton
+              variant="secondary"
+              size="sm"
+              onClick={onClose}
+              disabled={isSaving || isDeleting}
+              type="button"
+            >
+              Cancel
+            </PixelButton>
+            <PixelButton variant="primary" size="sm" disabled={isDisabled} type="submit">
+              {isSaving
+                ? 'Saving...'
+                : isLoadingPlayer
+                  ? 'Loading...'
+                  : isEdit
+                    ? 'Update Player'
+                    : 'Create Player'}
+            </PixelButton>
+          </div>
+        </footer>
+      </form>
+    </div>,
+    document.body
+  );
+}

--- a/app/components/wiki/players/PlayerModal.tsx
+++ b/app/components/wiki/players/PlayerModal.tsx
@@ -438,7 +438,7 @@ export function PlayerModal({ campaignId, playerId, onClose }: PlayerModalProps)
                   <span>
                     Backstory{' '}
                     <span className="text-amber-500 text-[10px] font-normal">
-                      (visible to campaign members)
+                      (Only you and the Game Master can see your backstory)
                     </span>
                   </span>
                 }

--- a/app/components/wiki/players/PlayerWindow.tsx
+++ b/app/components/wiki/players/PlayerWindow.tsx
@@ -1,0 +1,235 @@
+import React, { useState } from 'react';
+import { Pencil } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { PlayerData } from '~/types/player';
+import type { PictureCrop } from '~/types/character';
+import { MARKDOWN_PROSE_CLASSES } from '~/utils/markdownProseClasses';
+import { TabBar } from '~/components/shared/TabBar';
+
+function getCropStyle(crop: PictureCrop): React.CSSProperties {
+  const centerX = (crop.x + crop.width / 2) * 100;
+  const centerY = (crop.y + crop.height / 2) * 100;
+  const scale = 1 / crop.width;
+  return {
+    objectPosition: `${centerX}% ${centerY}%`,
+    transform: `scale(${scale})`,
+  };
+}
+
+interface PlayerWindowProps {
+  player: PlayerData;
+  onEdit?: () => void;
+}
+
+const GRADIENT_PAIRS = [
+  ['#3b82f6', '#8b5cf6'],
+  ['#f59e0b', '#ef4444'],
+  ['#10b981', '#06b6d4'],
+  ['#ec4899', '#8b5cf6'],
+  ['#f97316', '#eab308'],
+  ['#14b8a6', '#3b82f6'],
+];
+
+function hashName(name: string): number {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash << 5) - hash + name.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+
+function getInitials(firstName: string, lastName: string): string {
+  const f = firstName.charAt(0).toUpperCase();
+  const l = lastName.charAt(0).toUpperCase();
+  return l ? `${f}${l}` : f;
+}
+
+function StatBlock({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md bg-white/[0.04] border border-white/[0.06] px-3 py-2">
+      <p className="text-[10px] uppercase tracking-wider text-slate-500 mb-0.5">{label}</p>
+      <p className="text-xs text-slate-300 font-medium truncate">{value}</p>
+    </div>
+  );
+}
+
+function FieldCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-[10px] uppercase tracking-wider text-slate-500 mb-0.5">{label}</p>
+      <p className="text-xs text-slate-300">{value}</p>
+    </div>
+  );
+}
+
+export function PlayerWindow({ player, onEdit }: PlayerWindowProps) {
+  const [activeTab, setActiveTab] = useState('general');
+
+  const fullName = `${player.firstName} ${player.lastName}`.trim();
+  const initials = getInitials(player.firstName, player.lastName);
+  const gradientIndex = hashName(fullName) % GRADIENT_PAIRS.length;
+  const [gradFrom, gradTo] = GRADIENT_PAIRS[gradientIndex]!;
+
+  const isDeceased = player.status?.value === 'deceased';
+
+  const headerStats: { label: string; value: string }[] = [];
+  if (player.race) headerStats.push({ label: 'Race', value: player.race });
+  if (player.characterClass) headerStats.push({ label: 'Class', value: player.characterClass });
+
+  const tabs = [
+    { id: 'general', label: 'General' },
+    { id: 'backstory', label: 'Backstory', hidden: player.backstory === '' },
+    { id: 'gmnotes', label: 'GM Notes', hidden: player.gmNotes === '' },
+    { id: 'relationships', label: 'Relationships' },
+  ];
+
+  return (
+    <div className="flex flex-col">
+      {/* Header area */}
+      <div className="flex flex-col gap-3 p-4">
+        {/* Portrait */}
+        <div className="flex justify-center">
+          <div
+            className="w-24 h-24 rounded-full flex-shrink-0 flex items-center justify-center overflow-hidden"
+            style={
+              player.picture
+                ? undefined
+                : { background: `linear-gradient(135deg, ${gradFrom}, ${gradTo})` }
+            }
+          >
+            {player.picture ? (
+              <img
+                src={player.picture}
+                alt={fullName}
+                className="w-full h-full object-cover"
+                style={player.pictureCrop ? getCropStyle(player.pictureCrop) : undefined}
+              />
+            ) : (
+              <span className="text-2xl text-white font-semibold">{initials}</span>
+            )}
+          </div>
+        </div>
+
+        {/* Edit button */}
+        {onEdit && (
+          <div className="flex items-center justify-center">
+            <button
+              type="button"
+              onClick={onEdit}
+              className="shrink-0 p-1 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors"
+              aria-label="Edit player"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        )}
+
+        {/* Stats grid + deceased indicator */}
+        {(headerStats.length > 0 || isDeceased) && (
+          <div className="flex flex-col gap-2">
+            {isDeceased && (
+              <div className="flex justify-center">
+                <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-semibold bg-red-500/15 text-red-400 border border-red-500/20">
+                  Deceased
+                </span>
+              </div>
+            )}
+            {headerStats.length > 0 && (
+              <div className="grid grid-cols-2 gap-2">
+                {headerStats.map((s) => (
+                  <StatBlock key={s.label} label={s.label} value={s.value} />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Tab bar */}
+      <TabBar
+        tabs={tabs}
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+        accentColor={player.color || '#3498db'}
+      />
+
+      {/* Tab content */}
+      <div className="p-4">
+        {activeTab === 'general' && (
+          <div className="flex flex-col gap-4">
+            {/* Fields grid */}
+            <div className="grid grid-cols-2 gap-3">
+              {player.characterClass && <FieldCell label="Class" value={player.characterClass} />}
+              {player.age != null && <FieldCell label="Age" value={String(player.age)} />}
+              {player.gender && <FieldCell label="Gender" value={player.gender} />}
+              {player.location && <FieldCell label="Location" value={player.location} />}
+              {player.eyeColor && <FieldCell label="Eye Color" value={player.eyeColor} />}
+              {player.hairColor && <FieldCell label="Hair Color" value={player.hairColor} />}
+              {player.height && <FieldCell label="Height" value={player.height} />}
+              {player.weight != null && <FieldCell label="Weight" value={String(player.weight)} />}
+              {player.size && <FieldCell label="Size" value={player.size} />}
+            </div>
+
+            {/* Description */}
+            {player.description ? (
+              <div>
+                <p className="text-[10px] uppercase tracking-wider text-slate-500 mb-1">
+                  Description
+                </p>
+                <div className={MARKDOWN_PROSE_CLASSES}>
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{player.description}</ReactMarkdown>
+                </div>
+              </div>
+            ) : null}
+
+            {/* Appearance */}
+            {player.appearance ? (
+              <div>
+                <p className="text-[10px] uppercase tracking-wider text-slate-500 mb-1">
+                  Appearance
+                </p>
+                <div className={MARKDOWN_PROSE_CLASSES}>
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{player.appearance}</ReactMarkdown>
+                </div>
+              </div>
+            ) : null}
+
+            {!player.description && !player.appearance && (
+              <p className="text-xs text-slate-500">No details yet.</p>
+            )}
+          </div>
+        )}
+
+        {activeTab === 'backstory' && (
+          <div>
+            <div className="mb-3 rounded-md bg-amber-500/10 border border-amber-500/20 px-3 py-2">
+              <p className="text-[10px] text-amber-400">
+                Backstory is only visible to you and the GM.
+              </p>
+            </div>
+            <div className={MARKDOWN_PROSE_CLASSES}>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{player.backstory}</ReactMarkdown>
+            </div>
+          </div>
+        )}
+
+        {activeTab === 'gmnotes' && (
+          <div>
+            <div className="mb-3 rounded-md bg-amber-500/10 border border-amber-500/20 px-3 py-2">
+              <p className="text-[10px] text-amber-400">GM Notes are only visible to the GM.</p>
+            </div>
+            <div className={MARKDOWN_PROSE_CLASSES}>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{player.gmNotes}</ReactMarkdown>
+            </div>
+          </div>
+        )}
+
+        {activeTab === 'relationships' && (
+          <p className="text-xs text-slate-500">No relationships yet.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/wiki/players/PlayerWindow.tsx
+++ b/app/components/wiki/players/PlayerWindow.tsx
@@ -6,6 +6,13 @@ import type { PlayerData } from '~/types/player';
 import type { PictureCrop } from '~/types/character';
 import { MARKDOWN_PROSE_CLASSES } from '~/utils/markdownProseClasses';
 import { TabBar } from '~/components/shared/TabBar';
+import { RelationshipList } from '~/components/shared/RelationshipList';
+import { RelationshipModal } from '~/components/shared/RelationshipModal';
+import {
+  useAddPlayerRelationship,
+  useUpdatePlayerRelationship,
+  useRemovePlayerRelationship,
+} from '~/hooks/usePlayers';
 
 function getCropStyle(crop: PictureCrop): React.CSSProperties {
   const centerX = (crop.x + crop.width / 2) * 100;
@@ -66,6 +73,15 @@ function FieldCell({ label, value }: { label: string; value: string }) {
 
 export function PlayerWindow({ player, onEdit }: PlayerWindowProps) {
   const [activeTab, setActiveTab] = useState('general');
+  const [relationshipModal, setRelationshipModal] = useState<{
+    open: boolean;
+    mode: 'add' | 'edit';
+    editCharacterId?: string;
+  }>({ open: false, mode: 'add' });
+
+  const { addRelationship } = useAddPlayerRelationship();
+  const { updateRelationship } = useUpdatePlayerRelationship();
+  const { removeRelationship } = useRemovePlayerRelationship();
 
   const fullName = `${player.firstName} ${player.lastName}`.trim();
   const initials = getInitials(player.firstName, player.lastName);
@@ -227,7 +243,60 @@ export function PlayerWindow({ player, onEdit }: PlayerWindowProps) {
         )}
 
         {activeTab === 'relationships' && (
-          <p className="text-xs text-slate-500">No relationships yet.</p>
+          <>
+            <RelationshipList
+              relationships={player.relationships}
+              campaignId={player.campaignId}
+              canManage={player.canEdit}
+              onAdd={() => setRelationshipModal({ open: true, mode: 'add' })}
+              onEdit={(charId) =>
+                setRelationshipModal({ open: true, mode: 'edit', editCharacterId: charId })
+              }
+              onRemove={(charId) => {
+                removeRelationship({
+                  playerId: player.id,
+                  campaignId: player.campaignId,
+                  characterId: charId,
+                });
+              }}
+            />
+            {relationshipModal.open && (
+              <RelationshipModal
+                campaignId={player.campaignId}
+                mode={relationshipModal.mode}
+                showReciprocal={false}
+                existingRelationship={
+                  relationshipModal.mode === 'edit' && relationshipModal.editCharacterId
+                    ? player.relationships.find(
+                        (r) => r.characterId === relationshipModal.editCharacterId
+                      )
+                    : undefined
+                }
+                excludeCharacterIds={player.relationships.map((r) => r.characterId)}
+                onSave={(data) => {
+                  if (relationshipModal.mode === 'add') {
+                    addRelationship({
+                      playerId: player.id,
+                      campaignId: player.campaignId,
+                      characterId: data.characterId,
+                      descriptor: data.descriptor,
+                      isPublic: data.isPublic,
+                    });
+                  } else {
+                    updateRelationship({
+                      playerId: player.id,
+                      campaignId: player.campaignId,
+                      characterId: data.characterId,
+                      descriptor: data.descriptor,
+                      isPublic: data.isPublic,
+                    });
+                  }
+                  setRelationshipModal({ open: false, mode: 'add' });
+                }}
+                onClose={() => setRelationshipModal({ open: false, mode: 'add' })}
+              />
+            )}
+          </>
         )}
       </div>
     </div>

--- a/app/components/wiki/players/PlayerWindowWrapper.tsx
+++ b/app/components/wiki/players/PlayerWindowWrapper.tsx
@@ -1,0 +1,43 @@
+import { Loader2 } from 'lucide-react';
+import { usePlayer } from '~/hooks/usePlayers';
+import { PlayerWindow } from './PlayerWindow';
+
+export function EditPlayerModalWrapper({
+  campaignId,
+  playerId,
+  onClose,
+}: {
+  campaignId: string;
+  playerId: string;
+  onClose: () => void;
+}) {
+  // Placeholder for now - will be connected to PlayerModal in Task 13
+  return null;
+}
+
+export function PlayerWindowWrapper({
+  playerId,
+  campaignId,
+  onEdit,
+}: {
+  playerId: string;
+  campaignId: string;
+  onEdit: () => void;
+}) {
+  const { player, isLoading } = usePlayer(playerId, campaignId);
+
+  if (isLoading)
+    return (
+      <div className="flex items-center justify-center h-full">
+        <Loader2 className="h-5 w-5 animate-spin text-slate-500" />
+      </div>
+    );
+  if (!player)
+    return (
+      <div className="flex items-center justify-center h-full text-slate-500 text-sm">
+        Player not found
+      </div>
+    );
+
+  return <PlayerWindow player={player} onEdit={onEdit} />;
+}

--- a/app/components/wiki/players/PlayerWindowWrapper.tsx
+++ b/app/components/wiki/players/PlayerWindowWrapper.tsx
@@ -1,18 +1,18 @@
 import { Loader2 } from 'lucide-react';
 import { usePlayer } from '~/hooks/usePlayers';
 import { PlayerWindow } from './PlayerWindow';
+import { PlayerModal } from './PlayerModal';
 
 export function EditPlayerModalWrapper({
-  campaignId: _campaignId,
-  playerId: _playerId,
-  onClose: _onClose,
+  campaignId,
+  playerId,
+  onClose,
 }: {
   campaignId: string;
   playerId: string;
   onClose: () => void;
 }) {
-  // Placeholder for now - will be connected to PlayerModal in Task 13
-  return null;
+  return <PlayerModal campaignId={campaignId} playerId={playerId} onClose={onClose} />;
 }
 
 export function PlayerWindowWrapper({

--- a/app/components/wiki/players/PlayerWindowWrapper.tsx
+++ b/app/components/wiki/players/PlayerWindowWrapper.tsx
@@ -3,9 +3,9 @@ import { usePlayer } from '~/hooks/usePlayers';
 import { PlayerWindow } from './PlayerWindow';
 
 export function EditPlayerModalWrapper({
-  campaignId,
-  playerId,
-  onClose,
+  campaignId: _campaignId,
+  playerId: _playerId,
+  onClose: _onClose,
 }: {
   campaignId: string;
   playerId: string;

--- a/app/components/wiki/players/PlayersPanel.tsx
+++ b/app/components/wiki/players/PlayersPanel.tsx
@@ -3,6 +3,7 @@ import { useParams } from '@tanstack/react-router';
 import { UserCircle, Loader2 } from 'lucide-react';
 import { WikiCategoryHeader } from '~/components/wiki/shared/WikiCategoryHeader';
 import { PlayerCard } from './PlayerCard';
+import { PlayerModal } from './PlayerModal';
 import { usePlayers } from '~/hooks/usePlayers';
 
 interface PlayersPanelProps {
@@ -12,11 +13,12 @@ interface PlayersPanelProps {
 export function PlayersPanel({ onBack }: PlayersPanelProps) {
   const { campaignId } = useParams({ from: '/campaigns/$campaignId/play' });
   const [search, setSearch] = useState('');
+  const [selectedPlayerId, setSelectedPlayerId] = useState<string | null>(null);
 
   const { players, isLoading, error } = usePlayers(campaignId, search || undefined);
 
   const handlePlayerClick = (playerId: string) => {
-    console.log('Open player window:', playerId);
+    setSelectedPlayerId(playerId);
   };
 
   return (
@@ -61,6 +63,13 @@ export function PlayersPanel({ onBack }: PlayersPanelProps) {
             ))}
           </div>
         </div>
+      )}
+      {selectedPlayerId && (
+        <PlayerModal
+          campaignId={campaignId}
+          playerId={selectedPlayerId}
+          onClose={() => setSelectedPlayerId(null)}
+        />
       )}
     </div>
   );

--- a/app/components/wiki/players/PlayersPanel.tsx
+++ b/app/components/wiki/players/PlayersPanel.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { useParams } from '@tanstack/react-router';
+import { UserCircle, Loader2 } from 'lucide-react';
+import { WikiCategoryHeader } from '~/components/wiki/shared/WikiCategoryHeader';
+import { PlayerCard } from './PlayerCard';
+import { usePlayers } from '~/hooks/usePlayers';
+
+interface PlayersPanelProps {
+  onBack: () => void;
+}
+
+export function PlayersPanel({ onBack }: PlayersPanelProps) {
+  const { campaignId } = useParams({ from: '/campaigns/$campaignId/play' });
+  const [search, setSearch] = useState('');
+
+  const { players, isLoading, error } = usePlayers(campaignId, search || undefined);
+
+  const handlePlayerClick = (playerId: string) => {
+    console.log('Open player window:', playerId);
+  };
+
+  return (
+    <div className="flex flex-col h-full w-full bg-[#080A12]">
+      <WikiCategoryHeader title="Players" onBack={onBack} />
+
+      {/* Search */}
+      <div className="px-3 py-2 border-b border-white/[0.05]">
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search players..."
+          className="w-full bg-white/[0.05] border border-white/[0.08] rounded px-3 py-1.5 text-xs text-slate-300 placeholder-slate-500 focus:outline-none focus:border-blue-500/50 transition-colors"
+        />
+      </div>
+
+      {isLoading ? (
+        <div className="flex flex-1 items-center justify-center p-8">
+          <Loader2 className="h-5 w-5 text-slate-500 animate-spin" />
+        </div>
+      ) : error ? (
+        <div className="flex flex-1 items-center justify-center p-8 text-center">
+          <p className="font-sans font-semibold text-xs text-rose-400">{error}</p>
+        </div>
+      ) : players.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center p-8 text-center">
+          <div className="h-12 w-12 rounded-full bg-white/[0.03] flex items-center justify-center mb-3">
+            <UserCircle className="h-6 w-6 text-slate-600" />
+          </div>
+          <p className="font-sans font-semibold text-xs text-slate-500">No players found.</p>
+        </div>
+      ) : (
+        <div className="flex-1 overflow-y-auto min-h-0">
+          <div className="flex flex-col">
+            {players.map((player) => (
+              <PlayerCard
+                key={player.id}
+                player={player}
+                onClick={() => handlePlayerClick(player.id)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/hooks/useCharacters.ts
+++ b/app/hooks/useCharacters.ts
@@ -9,6 +9,10 @@ import {
   createCharacterSchema,
   updateCharacterSchema,
   deleteCharacterSchema,
+  updateCharacterStatusSchema,
+  addCharacterRelationshipSchema,
+  updateCharacterRelationshipSchema,
+  removeCharacterRelationshipSchema,
 } from '~/types/schemas/characters';
 
 // ---------------------------------------------------------------------------
@@ -49,6 +53,34 @@ const deleteCharacterFn = createServerFn({ method: 'POST' })
   .handler(async ({ data }) => {
     const { deleteCharacter } = await import('~/server/functions/characters');
     return deleteCharacter({ data });
+  });
+
+const updateCharacterStatusFn = createServerFn({ method: 'POST' })
+  .inputValidator(updateCharacterStatusSchema)
+  .handler(async ({ data }) => {
+    const { updateCharacterStatus } = await import('~/server/functions/characters');
+    return updateCharacterStatus({ data });
+  });
+
+const addCharacterRelationshipFn = createServerFn({ method: 'POST' })
+  .inputValidator(addCharacterRelationshipSchema)
+  .handler(async ({ data }) => {
+    const { addCharacterRelationship } = await import('~/server/functions/characters');
+    return addCharacterRelationship({ data });
+  });
+
+const updateCharacterRelationshipFn = createServerFn({ method: 'POST' })
+  .inputValidator(updateCharacterRelationshipSchema)
+  .handler(async ({ data }) => {
+    const { updateCharacterRelationship } = await import('~/server/functions/characters');
+    return updateCharacterRelationship({ data });
+  });
+
+const removeCharacterRelationshipFn = createServerFn({ method: 'POST' })
+  .inputValidator(removeCharacterRelationshipSchema)
+  .handler(async ({ data }) => {
+    const { removeCharacterRelationship } = await import('~/server/functions/characters');
+    return removeCharacterRelationship({ data });
   });
 
 // ---------------------------------------------------------------------------
@@ -260,6 +292,226 @@ export function useDeleteCharacter() {
 
   return {
     remove,
+    isLoading: mutation.isPending,
+    error:
+      mutation.error instanceof Error
+        ? mutation.error.message
+        : mutation.error
+          ? String(mutation.error)
+          : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// useUpdateCharacterStatus
+// ---------------------------------------------------------------------------
+
+interface UpdateCharacterStatusInput {
+  id: string;
+  campaignId: string;
+  value: 'alive' | 'deceased';
+}
+
+export function useUpdateCharacterStatus() {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (input: UpdateCharacterStatusInput) =>
+      updateCharacterStatusFn({ data: input }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['characters', 'list', variables.campaignId],
+        exact: false,
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.characters.detail(variables.id, variables.campaignId),
+      });
+    },
+    onError: (e, variables) => {
+      captureException(e, { action: 'updateCharacterStatus', characterId: variables.id });
+    },
+  });
+
+  const updateStatus = async (input: UpdateCharacterStatusInput) => {
+    try {
+      return await mutation.mutateAsync(input);
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    updateStatus,
+    isLoading: mutation.isPending,
+    error:
+      mutation.error instanceof Error
+        ? mutation.error.message
+        : mutation.error
+          ? String(mutation.error)
+          : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// useAddCharacterRelationship
+// ---------------------------------------------------------------------------
+
+interface AddCharacterRelationshipInput {
+  characterId: string;
+  campaignId: string;
+  targetCharacterId: string;
+  descriptor: string;
+  reciprocalDescriptor: string;
+  isPublic?: boolean;
+}
+
+export function useAddCharacterRelationship() {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (input: AddCharacterRelationshipInput) =>
+      addCharacterRelationshipFn({ data: input }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['characters', 'list', variables.campaignId],
+        exact: false,
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.characters.detail(variables.characterId, variables.campaignId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.characters.detail(variables.targetCharacterId, variables.campaignId),
+      });
+    },
+    onError: (e, variables) => {
+      captureException(e, {
+        action: 'addCharacterRelationship',
+        characterId: variables.characterId,
+      });
+    },
+  });
+
+  const addRelationship = async (input: AddCharacterRelationshipInput) => {
+    try {
+      return await mutation.mutateAsync(input);
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    addRelationship,
+    isLoading: mutation.isPending,
+    error:
+      mutation.error instanceof Error
+        ? mutation.error.message
+        : mutation.error
+          ? String(mutation.error)
+          : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// useUpdateCharacterRelationship
+// ---------------------------------------------------------------------------
+
+interface UpdateCharacterRelationshipInput {
+  characterId: string;
+  campaignId: string;
+  targetCharacterId: string;
+  descriptor?: string;
+  reciprocalDescriptor?: string;
+  isPublic?: boolean;
+}
+
+export function useUpdateCharacterRelationship() {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (input: UpdateCharacterRelationshipInput) =>
+      updateCharacterRelationshipFn({ data: input }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['characters', 'list', variables.campaignId],
+        exact: false,
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.characters.detail(variables.characterId, variables.campaignId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.characters.detail(variables.targetCharacterId, variables.campaignId),
+      });
+    },
+    onError: (e, variables) => {
+      captureException(e, {
+        action: 'updateCharacterRelationship',
+        characterId: variables.characterId,
+      });
+    },
+  });
+
+  const updateRelationship = async (input: UpdateCharacterRelationshipInput) => {
+    try {
+      return await mutation.mutateAsync(input);
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    updateRelationship,
+    isLoading: mutation.isPending,
+    error:
+      mutation.error instanceof Error
+        ? mutation.error.message
+        : mutation.error
+          ? String(mutation.error)
+          : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// useRemoveCharacterRelationship
+// ---------------------------------------------------------------------------
+
+interface RemoveCharacterRelationshipInput {
+  characterId: string;
+  campaignId: string;
+  targetCharacterId: string;
+}
+
+export function useRemoveCharacterRelationship() {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (input: RemoveCharacterRelationshipInput) =>
+      removeCharacterRelationshipFn({ data: input }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['characters', 'list', variables.campaignId],
+        exact: false,
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.characters.detail(variables.characterId, variables.campaignId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.characters.detail(variables.targetCharacterId, variables.campaignId),
+      });
+    },
+    onError: (e, variables) => {
+      captureException(e, {
+        action: 'removeCharacterRelationship',
+        characterId: variables.characterId,
+      });
+    },
+  });
+
+  const removeRelationship = async (input: RemoveCharacterRelationshipInput) => {
+    try {
+      return await mutation.mutateAsync(input);
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    removeRelationship,
     isLoading: mutation.isPending,
     error:
       mutation.error instanceof Error

--- a/app/hooks/usePlayers.ts
+++ b/app/hooks/usePlayers.ts
@@ -1,0 +1,555 @@
+import { createServerFn } from '@tanstack/react-start';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { PlayerData, PlayerListItem } from '~/types/player';
+import { captureException } from '~/providers/PostHogProvider';
+import { queryKeys } from '~/utils/queryKeys';
+import {
+  listPlayersSchema,
+  getPlayerSchema,
+  updatePlayerSchema,
+  deletePlayerSchema,
+  updatePlayerStatusSchema,
+  playerRelationshipSchema,
+  removePlayerRelationshipSchema,
+  validateInviteCodeSchema,
+  completeJoinWizardSchema,
+} from '~/types/schemas/players';
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function extractErrorMessage(error: unknown): string | null {
+  if (!error) return null;
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+// ---------------------------------------------------------------------------
+// Server function wrappers — dynamic imports keep Mongoose server-only.
+// TanStack Start compiles these to RPC stubs on the client.
+// ---------------------------------------------------------------------------
+
+const listPlayersFn = createServerFn({ method: 'GET' })
+  .inputValidator(listPlayersSchema)
+  .handler(async ({ data }) => {
+    const { listPlayers } = await import('~/server/functions/players');
+    return listPlayers({ data });
+  });
+
+const getPlayerFn = createServerFn({ method: 'GET' })
+  .inputValidator(getPlayerSchema)
+  .handler(async ({ data }) => {
+    const { getPlayer } = await import('~/server/functions/players');
+    return getPlayer({ data });
+  });
+
+const updatePlayerFn = createServerFn({ method: 'POST' })
+  .inputValidator(updatePlayerSchema)
+  .handler(async ({ data }) => {
+    const { updatePlayer } = await import('~/server/functions/players');
+    return updatePlayer({ data });
+  });
+
+const deletePlayerFn = createServerFn({ method: 'POST' })
+  .inputValidator(deletePlayerSchema)
+  .handler(async ({ data }) => {
+    const { deletePlayer } = await import('~/server/functions/players');
+    return deletePlayer({ data });
+  });
+
+const updatePlayerStatusFn = createServerFn({ method: 'POST' })
+  .inputValidator(updatePlayerStatusSchema)
+  .handler(async ({ data }) => {
+    const { updatePlayerStatus } = await import('~/server/functions/players');
+    return updatePlayerStatus({ data });
+  });
+
+const addPlayerRelationshipFn = createServerFn({ method: 'POST' })
+  .inputValidator(playerRelationshipSchema)
+  .handler(async ({ data }) => {
+    const { addPlayerRelationship } = await import('~/server/functions/players');
+    return addPlayerRelationship({ data });
+  });
+
+const updatePlayerRelationshipFn = createServerFn({ method: 'POST' })
+  .inputValidator(playerRelationshipSchema)
+  .handler(async ({ data }) => {
+    const { updatePlayerRelationship } = await import('~/server/functions/players');
+    return updatePlayerRelationship({ data });
+  });
+
+const removePlayerRelationshipFn = createServerFn({ method: 'POST' })
+  .inputValidator(removePlayerRelationshipSchema)
+  .handler(async ({ data }) => {
+    const { removePlayerRelationship } = await import('~/server/functions/players');
+    return removePlayerRelationship({ data });
+  });
+
+const validateInviteCodeFn = createServerFn({ method: 'POST' })
+  .inputValidator(validateInviteCodeSchema)
+  .handler(async ({ data }) => {
+    const { validateInviteCode } = await import('~/server/functions/players');
+    return validateInviteCode({ data });
+  });
+
+const completeJoinWizardFn = createServerFn({ method: 'POST' })
+  .inputValidator(completeJoinWizardSchema)
+  .handler(async ({ data }) => {
+    const { completeJoinWizard } = await import('~/server/functions/players');
+    return completeJoinWizard({ data });
+  });
+
+const getActivePlayerSchema = z.object({
+  campaignId: z.string().min(1),
+});
+
+const getActivePlayerFn = createServerFn({ method: 'GET' })
+  .inputValidator(getActivePlayerSchema)
+  .handler(async ({ data }) => {
+    const { getActivePlayer } = await import('~/server/functions/players');
+    return getActivePlayer({ data });
+  });
+
+// ---------------------------------------------------------------------------
+// Query Hooks
+// ---------------------------------------------------------------------------
+
+export function usePlayers(campaignId: string, search?: string) {
+  const {
+    data: players = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.players.list(campaignId, search),
+    queryFn: () =>
+      listPlayersFn({
+        data: {
+          campaignId,
+          search,
+        },
+      }),
+    enabled: !!campaignId,
+  });
+
+  return {
+    players: players as PlayerListItem[],
+    isLoading,
+    error: extractErrorMessage(error),
+  };
+}
+
+export function usePlayer(id: string, campaignId: string) {
+  const {
+    data: player = null,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.players.detail(id, campaignId),
+    queryFn: () => getPlayerFn({ data: { id, campaignId } }),
+    enabled: !!id && !!campaignId,
+  });
+
+  return {
+    player: player as PlayerData | null,
+    isLoading,
+    error: extractErrorMessage(error),
+  };
+}
+
+export function useActivePlayer(campaignId: string) {
+  const {
+    data: player = null,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.players.active(campaignId),
+    queryFn: () => getActivePlayerFn({ data: { campaignId } }),
+    enabled: !!campaignId,
+  });
+
+  return {
+    player: player as PlayerData | null,
+    isLoading,
+    error: extractErrorMessage(error),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mutation Hooks
+// ---------------------------------------------------------------------------
+
+interface UpdatePlayerInput {
+  id: string;
+  campaignId: string;
+  firstName: string;
+  lastName: string;
+  race: string;
+  characterClass: string;
+  age: number;
+  gender?: string;
+  location?: string;
+  link?: string;
+  picture?: string;
+  pictureCrop?: { x: number; y: number; width: number; height: number } | null;
+  description?: string;
+  backstory?: string;
+  gmNotes?: string;
+  color?: string;
+  eyeColor?: string;
+  hairColor?: string;
+  weight?: number | null;
+  height?: string;
+  size?: string;
+  appearance?: string;
+}
+
+export function useUpdatePlayer() {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (input: UpdatePlayerInput) => updatePlayerFn({ data: input }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['players', 'list', variables.campaignId],
+        exact: false,
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.players.detail(variables.id, variables.campaignId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.players.active(variables.campaignId),
+      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+    },
+    onError: (e, variables) => {
+      captureException(e, { action: 'updatePlayer', playerId: variables.id });
+    },
+  });
+
+  const update = async (input: UpdatePlayerInput) => {
+    try {
+      return await mutation.mutateAsync(input);
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    update,
+    isLoading: mutation.isPending,
+    error: extractErrorMessage(mutation.error),
+  };
+}
+
+interface DeletePlayerInput {
+  id: string;
+  campaignId: string;
+}
+
+export function useDeletePlayer() {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (input: DeletePlayerInput) => deletePlayerFn({ data: input }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['players', 'list', variables.campaignId],
+        exact: false,
+      });
+      queryClient.removeQueries({
+        queryKey: queryKeys.players.detail(variables.id, variables.campaignId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.players.active(variables.campaignId),
+      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+    },
+    onError: (e, variables) => {
+      captureException(e, { action: 'deletePlayer', playerId: variables.id });
+    },
+  });
+
+  const remove = async (input: DeletePlayerInput) => {
+    try {
+      return await mutation.mutateAsync(input);
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    remove,
+    isLoading: mutation.isPending,
+    error: extractErrorMessage(mutation.error),
+  };
+}
+
+interface UpdatePlayerStatusInput {
+  id: string;
+  campaignId: string;
+  value: 'alive' | 'deceased';
+}
+
+export function useUpdatePlayerStatus() {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (input: UpdatePlayerStatusInput) => updatePlayerStatusFn({ data: input }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['players', 'list', variables.campaignId],
+        exact: false,
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.players.detail(variables.id, variables.campaignId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.players.active(variables.campaignId),
+      });
+    },
+    onError: (e, variables) => {
+      captureException(e, { action: 'updatePlayerStatus', playerId: variables.id });
+    },
+  });
+
+  const updateStatus = async (input: UpdatePlayerStatusInput) => {
+    try {
+      return await mutation.mutateAsync(input);
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    updateStatus,
+    isLoading: mutation.isPending,
+    error: extractErrorMessage(mutation.error),
+  };
+}
+
+interface AddPlayerRelationshipInput {
+  playerId: string;
+  campaignId: string;
+  characterId: string;
+  descriptor: string;
+  isPublic?: boolean;
+}
+
+export function useAddPlayerRelationship() {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (input: AddPlayerRelationshipInput) =>
+      addPlayerRelationshipFn({ data: input }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.players.detail(variables.playerId, variables.campaignId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.players.active(variables.campaignId),
+      });
+    },
+    onError: (e, variables) => {
+      captureException(e, {
+        action: 'addPlayerRelationship',
+        playerId: variables.playerId,
+      });
+    },
+  });
+
+  const addRelationship = async (input: AddPlayerRelationshipInput) => {
+    try {
+      return await mutation.mutateAsync(input);
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    addRelationship,
+    isLoading: mutation.isPending,
+    error: extractErrorMessage(mutation.error),
+  };
+}
+
+interface UpdatePlayerRelationshipInput {
+  playerId: string;
+  campaignId: string;
+  characterId: string;
+  descriptor: string;
+  isPublic?: boolean;
+}
+
+export function useUpdatePlayerRelationship() {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (input: UpdatePlayerRelationshipInput) =>
+      updatePlayerRelationshipFn({ data: input }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.players.detail(variables.playerId, variables.campaignId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.players.active(variables.campaignId),
+      });
+    },
+    onError: (e, variables) => {
+      captureException(e, {
+        action: 'updatePlayerRelationship',
+        playerId: variables.playerId,
+      });
+    },
+  });
+
+  const updateRelationship = async (input: UpdatePlayerRelationshipInput) => {
+    try {
+      return await mutation.mutateAsync(input);
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    updateRelationship,
+    isLoading: mutation.isPending,
+    error: extractErrorMessage(mutation.error),
+  };
+}
+
+interface RemovePlayerRelationshipInput {
+  playerId: string;
+  campaignId: string;
+  characterId: string;
+}
+
+export function useRemovePlayerRelationship() {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (input: RemovePlayerRelationshipInput) =>
+      removePlayerRelationshipFn({ data: input }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.players.detail(variables.playerId, variables.campaignId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.players.active(variables.campaignId),
+      });
+    },
+    onError: (e, variables) => {
+      captureException(e, {
+        action: 'removePlayerRelationship',
+        playerId: variables.playerId,
+      });
+    },
+  });
+
+  const removeRelationship = async (input: RemovePlayerRelationshipInput) => {
+    try {
+      return await mutation.mutateAsync(input);
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    removeRelationship,
+    isLoading: mutation.isPending,
+    error: extractErrorMessage(mutation.error),
+  };
+}
+
+interface ValidateInviteCodeInput {
+  inviteCode: string;
+}
+
+export function useValidateInviteCode() {
+  const mutation = useMutation({
+    mutationFn: async (input: ValidateInviteCodeInput) => validateInviteCodeFn({ data: input }),
+    onError: (e) => {
+      captureException(e, { action: 'validateInviteCode' });
+    },
+  });
+
+  const validate = async (input: ValidateInviteCodeInput) => {
+    try {
+      return await mutation.mutateAsync(input);
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    validate,
+    isLoading: mutation.isPending,
+    error: extractErrorMessage(mutation.error),
+  };
+}
+
+interface CompleteJoinWizardInput {
+  campaignId: string;
+  player: {
+    firstName: string;
+    lastName: string;
+    race: string;
+    characterClass: string;
+    age: number;
+    gender?: string;
+    location?: string;
+    link?: string;
+    picture?: string;
+    pictureCrop?: { x: number; y: number; width: number; height: number } | null;
+    description?: string;
+    backstory?: string;
+    color?: string;
+    eyeColor?: string;
+    hairColor?: string;
+    weight?: number | null;
+    height?: string;
+    size?: string;
+    appearance?: string;
+  };
+  characters?: Array<{
+    firstName: string;
+    lastName: string;
+    race?: string;
+    characterClass?: string;
+    age?: number | null;
+    location?: string;
+    link?: string;
+    picture?: string;
+    pictureCrop?: { x: number; y: number; width: number; height: number } | null;
+    notes?: string;
+    gmNotes?: string;
+    tags?: string[];
+    isPublic?: boolean;
+    relationship: {
+      descriptor: string;
+      isPublic?: boolean;
+    };
+  }>;
+}
+
+export function useCompleteJoinWizard() {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (input: CompleteJoinWizardInput) => completeJoinWizardFn({ data: input }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.campaigns.list() });
+    },
+    onError: (e) => {
+      captureException(e, { action: 'completeJoinWizard' });
+    },
+  });
+
+  const complete = async (input: CompleteJoinWizardInput) => {
+    try {
+      return await mutation.mutateAsync(input);
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    complete,
+    isLoading: mutation.isPending,
+    error: extractErrorMessage(mutation.error),
+  };
+}

--- a/app/providers/ActivePlayerProvider.tsx
+++ b/app/providers/ActivePlayerProvider.tsx
@@ -1,0 +1,33 @@
+import { createContext, useContext, type ReactNode } from 'react';
+import { useActivePlayer } from '~/hooks/usePlayers';
+import type { PlayerData } from '~/types/player';
+
+interface ActivePlayerContextValue {
+  activePlayer: PlayerData | null;
+  isLoading: boolean;
+}
+
+const ActivePlayerContext = createContext<ActivePlayerContextValue>({
+  activePlayer: null,
+  isLoading: true,
+});
+
+export function ActivePlayerProvider({
+  campaignId,
+  children,
+}: {
+  campaignId: string;
+  children: ReactNode;
+}) {
+  const { player: activePlayer, isLoading } = useActivePlayer(campaignId);
+
+  return (
+    <ActivePlayerContext.Provider value={{ activePlayer, isLoading }}>
+      {children}
+    </ActivePlayerContext.Provider>
+  );
+}
+
+export function useActivePlayerContext() {
+  return useContext(ActivePlayerContext);
+}

--- a/app/routeTree.gen.ts
+++ b/app/routeTree.gen.ts
@@ -8,127 +8,135 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as TermsRouteImport } from './routes/terms'
-import { Route as PrivacyRouteImport } from './routes/privacy'
-import { Route as DashboardRouteImport } from './routes/dashboard'
-import { Route as IndexRouteImport } from './routes/index'
-import { Route as CampaignsIndexRouteImport } from './routes/campaigns/index'
-import { Route as CampaignsNewRouteImport } from './routes/campaigns/new'
-import { Route as AuthLogoutRouteImport } from './routes/auth/logout'
-import { Route as AuthProviderRouteImport } from './routes/auth/$provider'
-import { Route as CampaignsCampaignIdSessionsRouteImport } from './routes/campaigns/$campaignId/sessions'
-import { Route as CampaignsCampaignIdPlayRouteImport } from './routes/campaigns/$campaignId/play'
-import { Route as CampaignsCampaignIdEditRouteImport } from './routes/campaigns/$campaignId/edit'
-import { Route as AuthCallbackProviderRouteImport } from './routes/auth/callback/$provider'
+import { Route as rootRouteImport } from './routes/__root';
+import { Route as TermsRouteImport } from './routes/terms';
+import { Route as PrivacyRouteImport } from './routes/privacy';
+import { Route as DashboardRouteImport } from './routes/dashboard';
+import { Route as IndexRouteImport } from './routes/index';
+import { Route as CampaignsIndexRouteImport } from './routes/campaigns/index';
+import { Route as CampaignsNewRouteImport } from './routes/campaigns/new';
+import { Route as AuthLogoutRouteImport } from './routes/auth/logout';
+import { Route as AuthProviderRouteImport } from './routes/auth/$provider';
+import { Route as CampaignsCampaignIdSessionsRouteImport } from './routes/campaigns/$campaignId/sessions';
+import { Route as CampaignsCampaignIdPlayRouteImport } from './routes/campaigns/$campaignId/play';
+import { Route as CampaignsCampaignIdEditRouteImport } from './routes/campaigns/$campaignId/edit';
+import { Route as CampaignJoinRouteImport } from './routes/campaign/join';
+import { Route as AuthCallbackProviderRouteImport } from './routes/auth/callback/$provider';
 
 const TermsRoute = TermsRouteImport.update({
   id: '/terms',
   path: '/terms',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const PrivacyRoute = PrivacyRouteImport.update({
   id: '/privacy',
   path: '/privacy',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const DashboardRoute = DashboardRouteImport.update({
   id: '/dashboard',
   path: '/dashboard',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const CampaignsIndexRoute = CampaignsIndexRouteImport.update({
   id: '/campaigns/',
   path: '/campaigns/',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const CampaignsNewRoute = CampaignsNewRouteImport.update({
   id: '/campaigns/new',
   path: '/campaigns/new',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const AuthLogoutRoute = AuthLogoutRouteImport.update({
   id: '/auth/logout',
   path: '/auth/logout',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const AuthProviderRoute = AuthProviderRouteImport.update({
   id: '/auth/$provider',
   path: '/auth/$provider',
   getParentRoute: () => rootRouteImport,
-} as any)
-const CampaignsCampaignIdSessionsRoute =
-  CampaignsCampaignIdSessionsRouteImport.update({
-    id: '/campaigns/$campaignId/sessions',
-    path: '/campaigns/$campaignId/sessions',
-    getParentRoute: () => rootRouteImport,
-  } as any)
+} as any);
+const CampaignsCampaignIdSessionsRoute = CampaignsCampaignIdSessionsRouteImport.update({
+  id: '/campaigns/$campaignId/sessions',
+  path: '/campaigns/$campaignId/sessions',
+  getParentRoute: () => rootRouteImport,
+} as any);
 const CampaignsCampaignIdPlayRoute = CampaignsCampaignIdPlayRouteImport.update({
   id: '/campaigns/$campaignId/play',
   path: '/campaigns/$campaignId/play',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const CampaignsCampaignIdEditRoute = CampaignsCampaignIdEditRouteImport.update({
   id: '/campaigns/$campaignId/edit',
   path: '/campaigns/$campaignId/edit',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
+const CampaignJoinRoute = CampaignJoinRouteImport.update({
+  id: '/campaign/join',
+  path: '/campaign/join',
+  getParentRoute: () => rootRouteImport,
+} as any);
 const AuthCallbackProviderRoute = AuthCallbackProviderRouteImport.update({
   id: '/auth/callback/$provider',
   path: '/auth/callback/$provider',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/dashboard': typeof DashboardRoute
-  '/privacy': typeof PrivacyRoute
-  '/terms': typeof TermsRoute
-  '/auth/$provider': typeof AuthProviderRoute
-  '/auth/logout': typeof AuthLogoutRoute
-  '/campaigns/new': typeof CampaignsNewRoute
-  '/campaigns/': typeof CampaignsIndexRoute
-  '/auth/callback/$provider': typeof AuthCallbackProviderRoute
-  '/campaigns/$campaignId/edit': typeof CampaignsCampaignIdEditRoute
-  '/campaigns/$campaignId/play': typeof CampaignsCampaignIdPlayRoute
-  '/campaigns/$campaignId/sessions': typeof CampaignsCampaignIdSessionsRoute
+  '/': typeof IndexRoute;
+  '/dashboard': typeof DashboardRoute;
+  '/privacy': typeof PrivacyRoute;
+  '/terms': typeof TermsRoute;
+  '/auth/$provider': typeof AuthProviderRoute;
+  '/auth/logout': typeof AuthLogoutRoute;
+  '/campaign/join': typeof CampaignJoinRoute;
+  '/campaigns/new': typeof CampaignsNewRoute;
+  '/campaigns/': typeof CampaignsIndexRoute;
+  '/auth/callback/$provider': typeof AuthCallbackProviderRoute;
+  '/campaigns/$campaignId/edit': typeof CampaignsCampaignIdEditRoute;
+  '/campaigns/$campaignId/play': typeof CampaignsCampaignIdPlayRoute;
+  '/campaigns/$campaignId/sessions': typeof CampaignsCampaignIdSessionsRoute;
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/dashboard': typeof DashboardRoute
-  '/privacy': typeof PrivacyRoute
-  '/terms': typeof TermsRoute
-  '/auth/$provider': typeof AuthProviderRoute
-  '/auth/logout': typeof AuthLogoutRoute
-  '/campaigns/new': typeof CampaignsNewRoute
-  '/campaigns': typeof CampaignsIndexRoute
-  '/auth/callback/$provider': typeof AuthCallbackProviderRoute
-  '/campaigns/$campaignId/edit': typeof CampaignsCampaignIdEditRoute
-  '/campaigns/$campaignId/play': typeof CampaignsCampaignIdPlayRoute
-  '/campaigns/$campaignId/sessions': typeof CampaignsCampaignIdSessionsRoute
+  '/': typeof IndexRoute;
+  '/dashboard': typeof DashboardRoute;
+  '/privacy': typeof PrivacyRoute;
+  '/terms': typeof TermsRoute;
+  '/auth/$provider': typeof AuthProviderRoute;
+  '/auth/logout': typeof AuthLogoutRoute;
+  '/campaign/join': typeof CampaignJoinRoute;
+  '/campaigns/new': typeof CampaignsNewRoute;
+  '/campaigns': typeof CampaignsIndexRoute;
+  '/auth/callback/$provider': typeof AuthCallbackProviderRoute;
+  '/campaigns/$campaignId/edit': typeof CampaignsCampaignIdEditRoute;
+  '/campaigns/$campaignId/play': typeof CampaignsCampaignIdPlayRoute;
+  '/campaigns/$campaignId/sessions': typeof CampaignsCampaignIdSessionsRoute;
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
-  '/dashboard': typeof DashboardRoute
-  '/privacy': typeof PrivacyRoute
-  '/terms': typeof TermsRoute
-  '/auth/$provider': typeof AuthProviderRoute
-  '/auth/logout': typeof AuthLogoutRoute
-  '/campaigns/new': typeof CampaignsNewRoute
-  '/campaigns/': typeof CampaignsIndexRoute
-  '/auth/callback/$provider': typeof AuthCallbackProviderRoute
-  '/campaigns/$campaignId/edit': typeof CampaignsCampaignIdEditRoute
-  '/campaigns/$campaignId/play': typeof CampaignsCampaignIdPlayRoute
-  '/campaigns/$campaignId/sessions': typeof CampaignsCampaignIdSessionsRoute
+  __root__: typeof rootRouteImport;
+  '/': typeof IndexRoute;
+  '/dashboard': typeof DashboardRoute;
+  '/privacy': typeof PrivacyRoute;
+  '/terms': typeof TermsRoute;
+  '/auth/$provider': typeof AuthProviderRoute;
+  '/auth/logout': typeof AuthLogoutRoute;
+  '/campaign/join': typeof CampaignJoinRoute;
+  '/campaigns/new': typeof CampaignsNewRoute;
+  '/campaigns/': typeof CampaignsIndexRoute;
+  '/auth/callback/$provider': typeof AuthCallbackProviderRoute;
+  '/campaigns/$campaignId/edit': typeof CampaignsCampaignIdEditRoute;
+  '/campaigns/$campaignId/play': typeof CampaignsCampaignIdPlayRoute;
+  '/campaigns/$campaignId/sessions': typeof CampaignsCampaignIdSessionsRoute;
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
+  fileRoutesByFullPath: FileRoutesByFullPath;
   fullPaths:
     | '/'
     | '/dashboard'
@@ -136,13 +144,14 @@ export interface FileRouteTypes {
     | '/terms'
     | '/auth/$provider'
     | '/auth/logout'
+    | '/campaign/join'
     | '/campaigns/new'
     | '/campaigns/'
     | '/auth/callback/$provider'
     | '/campaigns/$campaignId/edit'
     | '/campaigns/$campaignId/play'
-    | '/campaigns/$campaignId/sessions'
-  fileRoutesByTo: FileRoutesByTo
+    | '/campaigns/$campaignId/sessions';
+  fileRoutesByTo: FileRoutesByTo;
   to:
     | '/'
     | '/dashboard'
@@ -150,12 +159,13 @@ export interface FileRouteTypes {
     | '/terms'
     | '/auth/$provider'
     | '/auth/logout'
+    | '/campaign/join'
     | '/campaigns/new'
     | '/campaigns'
     | '/auth/callback/$provider'
     | '/campaigns/$campaignId/edit'
     | '/campaigns/$campaignId/play'
-    | '/campaigns/$campaignId/sessions'
+    | '/campaigns/$campaignId/sessions';
   id:
     | '__root__'
     | '/'
@@ -164,115 +174,124 @@ export interface FileRouteTypes {
     | '/terms'
     | '/auth/$provider'
     | '/auth/logout'
+    | '/campaign/join'
     | '/campaigns/new'
     | '/campaigns/'
     | '/auth/callback/$provider'
     | '/campaigns/$campaignId/edit'
     | '/campaigns/$campaignId/play'
-    | '/campaigns/$campaignId/sessions'
-  fileRoutesById: FileRoutesById
+    | '/campaigns/$campaignId/sessions';
+  fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  DashboardRoute: typeof DashboardRoute
-  PrivacyRoute: typeof PrivacyRoute
-  TermsRoute: typeof TermsRoute
-  AuthProviderRoute: typeof AuthProviderRoute
-  AuthLogoutRoute: typeof AuthLogoutRoute
-  CampaignsNewRoute: typeof CampaignsNewRoute
-  CampaignsIndexRoute: typeof CampaignsIndexRoute
-  AuthCallbackProviderRoute: typeof AuthCallbackProviderRoute
-  CampaignsCampaignIdEditRoute: typeof CampaignsCampaignIdEditRoute
-  CampaignsCampaignIdPlayRoute: typeof CampaignsCampaignIdPlayRoute
-  CampaignsCampaignIdSessionsRoute: typeof CampaignsCampaignIdSessionsRoute
+  IndexRoute: typeof IndexRoute;
+  DashboardRoute: typeof DashboardRoute;
+  PrivacyRoute: typeof PrivacyRoute;
+  TermsRoute: typeof TermsRoute;
+  AuthProviderRoute: typeof AuthProviderRoute;
+  AuthLogoutRoute: typeof AuthLogoutRoute;
+  CampaignJoinRoute: typeof CampaignJoinRoute;
+  CampaignsNewRoute: typeof CampaignsNewRoute;
+  CampaignsIndexRoute: typeof CampaignsIndexRoute;
+  AuthCallbackProviderRoute: typeof AuthCallbackProviderRoute;
+  CampaignsCampaignIdEditRoute: typeof CampaignsCampaignIdEditRoute;
+  CampaignsCampaignIdPlayRoute: typeof CampaignsCampaignIdPlayRoute;
+  CampaignsCampaignIdSessionsRoute: typeof CampaignsCampaignIdSessionsRoute;
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
     '/terms': {
-      id: '/terms'
-      path: '/terms'
-      fullPath: '/terms'
-      preLoaderRoute: typeof TermsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/terms';
+      path: '/terms';
+      fullPath: '/terms';
+      preLoaderRoute: typeof TermsRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/privacy': {
-      id: '/privacy'
-      path: '/privacy'
-      fullPath: '/privacy'
-      preLoaderRoute: typeof PrivacyRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/privacy';
+      path: '/privacy';
+      fullPath: '/privacy';
+      preLoaderRoute: typeof PrivacyRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/dashboard': {
-      id: '/dashboard'
-      path: '/dashboard'
-      fullPath: '/dashboard'
-      preLoaderRoute: typeof DashboardRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/dashboard';
+      path: '/dashboard';
+      fullPath: '/dashboard';
+      preLoaderRoute: typeof DashboardRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/';
+      path: '/';
+      fullPath: '/';
+      preLoaderRoute: typeof IndexRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    '/campaign/join': {
+      id: '/campaign/join';
+      path: '/campaign/join';
+      fullPath: '/campaign/join';
+      preLoaderRoute: typeof CampaignJoinRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/campaigns/': {
-      id: '/campaigns/'
-      path: '/campaigns'
-      fullPath: '/campaigns/'
-      preLoaderRoute: typeof CampaignsIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/campaigns/';
+      path: '/campaigns';
+      fullPath: '/campaigns/';
+      preLoaderRoute: typeof CampaignsIndexRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/campaigns/new': {
-      id: '/campaigns/new'
-      path: '/campaigns/new'
-      fullPath: '/campaigns/new'
-      preLoaderRoute: typeof CampaignsNewRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/campaigns/new';
+      path: '/campaigns/new';
+      fullPath: '/campaigns/new';
+      preLoaderRoute: typeof CampaignsNewRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/auth/logout': {
-      id: '/auth/logout'
-      path: '/auth/logout'
-      fullPath: '/auth/logout'
-      preLoaderRoute: typeof AuthLogoutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/auth/logout';
+      path: '/auth/logout';
+      fullPath: '/auth/logout';
+      preLoaderRoute: typeof AuthLogoutRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/auth/$provider': {
-      id: '/auth/$provider'
-      path: '/auth/$provider'
-      fullPath: '/auth/$provider'
-      preLoaderRoute: typeof AuthProviderRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/auth/$provider';
+      path: '/auth/$provider';
+      fullPath: '/auth/$provider';
+      preLoaderRoute: typeof AuthProviderRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/campaigns/$campaignId/sessions': {
-      id: '/campaigns/$campaignId/sessions'
-      path: '/campaigns/$campaignId/sessions'
-      fullPath: '/campaigns/$campaignId/sessions'
-      preLoaderRoute: typeof CampaignsCampaignIdSessionsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/campaigns/$campaignId/sessions';
+      path: '/campaigns/$campaignId/sessions';
+      fullPath: '/campaigns/$campaignId/sessions';
+      preLoaderRoute: typeof CampaignsCampaignIdSessionsRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/campaigns/$campaignId/play': {
-      id: '/campaigns/$campaignId/play'
-      path: '/campaigns/$campaignId/play'
-      fullPath: '/campaigns/$campaignId/play'
-      preLoaderRoute: typeof CampaignsCampaignIdPlayRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/campaigns/$campaignId/play';
+      path: '/campaigns/$campaignId/play';
+      fullPath: '/campaigns/$campaignId/play';
+      preLoaderRoute: typeof CampaignsCampaignIdPlayRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/campaigns/$campaignId/edit': {
-      id: '/campaigns/$campaignId/edit'
-      path: '/campaigns/$campaignId/edit'
-      fullPath: '/campaigns/$campaignId/edit'
-      preLoaderRoute: typeof CampaignsCampaignIdEditRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/campaigns/$campaignId/edit';
+      path: '/campaigns/$campaignId/edit';
+      fullPath: '/campaigns/$campaignId/edit';
+      preLoaderRoute: typeof CampaignsCampaignIdEditRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/auth/callback/$provider': {
-      id: '/auth/callback/$provider'
-      path: '/auth/callback/$provider'
-      fullPath: '/auth/callback/$provider'
-      preLoaderRoute: typeof AuthCallbackProviderRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/auth/callback/$provider';
+      path: '/auth/callback/$provider';
+      fullPath: '/auth/callback/$provider';
+      preLoaderRoute: typeof AuthCallbackProviderRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
   }
 }
 
@@ -283,22 +302,23 @@ const rootRouteChildren: RootRouteChildren = {
   TermsRoute: TermsRoute,
   AuthProviderRoute: AuthProviderRoute,
   AuthLogoutRoute: AuthLogoutRoute,
+  CampaignJoinRoute: CampaignJoinRoute,
   CampaignsNewRoute: CampaignsNewRoute,
   CampaignsIndexRoute: CampaignsIndexRoute,
   AuthCallbackProviderRoute: AuthCallbackProviderRoute,
   CampaignsCampaignIdEditRoute: CampaignsCampaignIdEditRoute,
   CampaignsCampaignIdPlayRoute: CampaignsCampaignIdPlayRoute,
   CampaignsCampaignIdSessionsRoute: CampaignsCampaignIdSessionsRoute,
-}
+};
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+  ._addFileTypes<FileRouteTypes>();
 
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
+import type { getRouter } from './router.tsx';
+import type { createStart } from '@tanstack/react-start';
 declare module '@tanstack/react-start' {
   interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
+    ssr: true;
+    router: Awaited<ReturnType<typeof getRouter>>;
   }
 }

--- a/app/routes/campaign/join.tsx
+++ b/app/routes/campaign/join.tsx
@@ -1,0 +1,23 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+import { z } from 'zod';
+import { getMe } from '~/server/functions/auth';
+import { JoinWizard } from '~/components/join-wizard/JoinWizard';
+
+export const joinSearchSchema = z.object({
+  code: z.string().optional(),
+  step: z.coerce.number().min(1).max(5).catch(1),
+});
+
+export const Route = createFileRoute('/campaign/join')({
+  validateSearch: (search: Record<string, unknown>) => joinSearchSchema.parse(search),
+  beforeLoad: async () => {
+    const user = await getMe();
+    if (!user) throw redirect({ to: '/', search: { reason: 'session_expired' } });
+    return { user };
+  },
+  component: JoinPage,
+});
+
+function JoinPage() {
+  return <JoinWizard />;
+}

--- a/app/routes/campaign/join.tsx
+++ b/app/routes/campaign/join.tsx
@@ -6,6 +6,7 @@ import { JoinWizard } from '~/components/join-wizard/JoinWizard';
 export const joinSearchSchema = z.object({
   code: z.string().optional(),
   step: z.coerce.number().min(1).max(5).catch(1),
+  campaignId: z.string().optional(),
 });
 
 export const Route = createFileRoute('/campaign/join')({

--- a/app/routes/campaigns/$campaignId/play.tsx
+++ b/app/routes/campaigns/$campaignId/play.tsx
@@ -1,7 +1,9 @@
 import { z } from 'zod';
-import { createFileRoute, redirect } from '@tanstack/react-router';
+import { createFileRoute, redirect, Link } from '@tanstack/react-router';
+import { Plus } from 'lucide-react';
 import { getMe } from '~/server/functions/auth';
 import { useCampaign } from '~/hooks/useCampaigns';
+import { useActivePlayerContext } from '~/providers/ActivePlayerProvider';
 import { CampaignHeader } from '~/components/mainview/CampaignHeader';
 import { DashboardView } from '~/components/mainview/DashboardView';
 import { MainView } from '~/components/mainview/MainView';
@@ -30,12 +32,26 @@ export const Route = createFileRoute('/campaigns/$campaignId/play')({
 });
 
 function PlayPage() {
+  const { campaignId } = Route.useParams();
+
+  return (
+    <ActivePlayerProvider campaignId={campaignId}>
+      <PlayPageContent />
+    </ActivePlayerProvider>
+  );
+}
+
+function PlayPageContent() {
   const { tab: activeTab } = Route.useSearch();
   const { campaignId } = Route.useParams();
   const navigate = Route.useNavigate();
   const { campaign, isLoading: isCampaignLoading } = useCampaign(campaignId);
 
+  const { activePlayer, isLoading: isPlayerLoading } = useActivePlayerContext();
+
   const activeSession = campaign?.sessions.find((s) => s.status === 'active');
+
+  const needsNewPlayer = !isPlayerLoading && !activePlayer && !campaign?.isGM;
 
   // Coerce non-GMs away from the GM-only tab
   const effectiveTab =
@@ -46,62 +62,80 @@ function PlayPage() {
   }
 
   return (
-    <ActivePlayerProvider campaignId={campaignId}>
-      <div className="flex flex-col h-screen bg-[#080A12]">
-        <CampaignHeader
+    <div className="flex flex-col h-screen bg-[#080A12]">
+      <CampaignHeader
+        campaignId={campaignId}
+        isOwner={campaign?.isOwner}
+        isGM={campaign?.isGM}
+        activeSessionName={activeSession?.name}
+        activeTab={effectiveTab}
+        onTabChange={handleTabChange}
+      />
+      <div className="flex-1 overflow-hidden">
+        <MainView
+          showToolbar={effectiveTab === 'tabletop'}
           campaignId={campaignId}
-          isOwner={campaign?.isOwner}
-          isGM={campaign?.isGM}
-          activeSessionName={activeSession?.name}
-          activeTab={effectiveTab}
-          onTabChange={handleTabChange}
-        />
-        <div className="flex-1 overflow-hidden">
-          <MainView
-            showToolbar={effectiveTab === 'tabletop'}
-            campaignId={campaignId}
-            sessions={campaign?.sessions}
-          >
-            <div
-              className="h-full overflow-y-auto"
-              role="tabpanel"
-              id="tab-panel-dashboard"
-              aria-labelledby="tab-dashboard"
-              hidden={effectiveTab !== 'dashboard'}
-            >
-              <DashboardView>
-                <CatchUpWidget
-                  catchUp={isCampaignLoading ? undefined : (activeSession?.catchUp ?? null)}
-                />
-                <PartyMembersWidget />
-                <KeyAlliesWidget />
-                <SessionsListWidget campaignId={campaignId} className="col-span-full" />
-                <CampaignTimelineWidget className="xl:col-span-2" />
-              </DashboardView>
-            </div>
-            <div
-              className="flex items-center justify-center h-full text-slate-400 font-sans font-semibold text-xs"
-              role="tabpanel"
-              id="tab-panel-tabletop"
-              aria-labelledby="tab-tabletop"
-              hidden={effectiveTab !== 'tabletop'}
-            >
-              <TabletopView />
-            </div>
-            {campaign?.isGM && (
-              <div
-                className="h-full"
-                role="tabpanel"
-                id="tab-panel-gmscreens"
-                aria-labelledby="tab-gmscreens"
-                hidden={effectiveTab !== 'gmscreens'}
-              >
-                <GMScreensView campaignId={campaignId} isGM={campaign?.isGM} />
+          sessions={campaign?.sessions}
+        >
+          {needsNewPlayer && (
+            <div className="mx-4 mt-4 p-4 rounded-xl bg-amber-500/10 border border-amber-500/20 flex items-center gap-3">
+              <div className="flex-1">
+                <p className="text-sm text-amber-200 font-medium">
+                  Your player character needs to be created
+                </p>
+                <p className="text-xs text-amber-200/60 mt-1">
+                  Create a player character to fully participate in this campaign.
+                </p>
               </div>
-            )}
-          </MainView>
-        </div>
+              <Link
+                to="/campaign/join"
+                search={{ step: 2, campaignId }}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-amber-500/20 text-amber-200 text-xs font-medium hover:bg-amber-500/30 transition-colors"
+              >
+                <Plus className="h-3.5 w-3.5" />
+                Create Character
+              </Link>
+            </div>
+          )}
+          <div
+            className="h-full overflow-y-auto"
+            role="tabpanel"
+            id="tab-panel-dashboard"
+            aria-labelledby="tab-dashboard"
+            hidden={effectiveTab !== 'dashboard'}
+          >
+            <DashboardView>
+              <CatchUpWidget
+                catchUp={isCampaignLoading ? undefined : (activeSession?.catchUp ?? null)}
+              />
+              <PartyMembersWidget />
+              <KeyAlliesWidget />
+              <SessionsListWidget campaignId={campaignId} className="col-span-full" />
+              <CampaignTimelineWidget className="xl:col-span-2" />
+            </DashboardView>
+          </div>
+          <div
+            className="flex items-center justify-center h-full text-slate-400 font-sans font-semibold text-xs"
+            role="tabpanel"
+            id="tab-panel-tabletop"
+            aria-labelledby="tab-tabletop"
+            hidden={effectiveTab !== 'tabletop'}
+          >
+            <TabletopView />
+          </div>
+          {campaign?.isGM && (
+            <div
+              className="h-full"
+              role="tabpanel"
+              id="tab-panel-gmscreens"
+              aria-labelledby="tab-gmscreens"
+              hidden={effectiveTab !== 'gmscreens'}
+            >
+              <GMScreensView campaignId={campaignId} isGM={campaign?.isGM} />
+            </div>
+          )}
+        </MainView>
       </div>
-    </ActivePlayerProvider>
+    </div>
   );
 }

--- a/app/routes/campaigns/$campaignId/play.tsx
+++ b/app/routes/campaigns/$campaignId/play.tsx
@@ -13,6 +13,7 @@ import { CampaignTimelineWidget } from '~/components/mainview/widgets/CampaignTi
 import { KeyAlliesWidget } from '~/components/mainview/widgets/KeyAlliesWidget';
 import { PartyMembersWidget } from '~/components/mainview/widgets/PartyMembersWidget';
 import { SessionsListWidget } from '~/components/mainview/widgets/SessionsListWidget';
+import { ActivePlayerProvider } from '~/providers/ActivePlayerProvider';
 
 export const playSearchSchema = z.object({
   tab: z.enum(['dashboard', 'tabletop', 'gmscreens']).catch('dashboard'),
@@ -45,60 +46,62 @@ function PlayPage() {
   }
 
   return (
-    <div className="flex flex-col h-screen bg-[#080A12]">
-      <CampaignHeader
-        campaignId={campaignId}
-        isOwner={campaign?.isOwner}
-        isGM={campaign?.isGM}
-        activeSessionName={activeSession?.name}
-        activeTab={effectiveTab}
-        onTabChange={handleTabChange}
-      />
-      <div className="flex-1 overflow-hidden">
-        <MainView
-          showToolbar={effectiveTab === 'tabletop'}
+    <ActivePlayerProvider campaignId={campaignId}>
+      <div className="flex flex-col h-screen bg-[#080A12]">
+        <CampaignHeader
           campaignId={campaignId}
-          sessions={campaign?.sessions}
-        >
-          <div
-            className="h-full overflow-y-auto"
-            role="tabpanel"
-            id="tab-panel-dashboard"
-            aria-labelledby="tab-dashboard"
-            hidden={effectiveTab !== 'dashboard'}
+          isOwner={campaign?.isOwner}
+          isGM={campaign?.isGM}
+          activeSessionName={activeSession?.name}
+          activeTab={effectiveTab}
+          onTabChange={handleTabChange}
+        />
+        <div className="flex-1 overflow-hidden">
+          <MainView
+            showToolbar={effectiveTab === 'tabletop'}
+            campaignId={campaignId}
+            sessions={campaign?.sessions}
           >
-            <DashboardView>
-              <CatchUpWidget
-                catchUp={isCampaignLoading ? undefined : (activeSession?.catchUp ?? null)}
-              />
-              <PartyMembersWidget />
-              <KeyAlliesWidget />
-              <SessionsListWidget campaignId={campaignId} className="col-span-full" />
-              <CampaignTimelineWidget className="xl:col-span-2" />
-            </DashboardView>
-          </div>
-          <div
-            className="flex items-center justify-center h-full text-slate-400 font-sans font-semibold text-xs"
-            role="tabpanel"
-            id="tab-panel-tabletop"
-            aria-labelledby="tab-tabletop"
-            hidden={effectiveTab !== 'tabletop'}
-          >
-            <TabletopView />
-          </div>
-          {campaign?.isGM && (
             <div
-              className="h-full"
+              className="h-full overflow-y-auto"
               role="tabpanel"
-              id="tab-panel-gmscreens"
-              aria-labelledby="tab-gmscreens"
-              hidden={effectiveTab !== 'gmscreens'}
+              id="tab-panel-dashboard"
+              aria-labelledby="tab-dashboard"
+              hidden={effectiveTab !== 'dashboard'}
             >
-              <GMScreensView campaignId={campaignId} isGM={campaign?.isGM} />
+              <DashboardView>
+                <CatchUpWidget
+                  catchUp={isCampaignLoading ? undefined : (activeSession?.catchUp ?? null)}
+                />
+                <PartyMembersWidget />
+                <KeyAlliesWidget />
+                <SessionsListWidget campaignId={campaignId} className="col-span-full" />
+                <CampaignTimelineWidget className="xl:col-span-2" />
+              </DashboardView>
             </div>
-          )}
-        </MainView>
+            <div
+              className="flex items-center justify-center h-full text-slate-400 font-sans font-semibold text-xs"
+              role="tabpanel"
+              id="tab-panel-tabletop"
+              aria-labelledby="tab-tabletop"
+              hidden={effectiveTab !== 'tabletop'}
+            >
+              <TabletopView />
+            </div>
+            {campaign?.isGM && (
+              <div
+                className="h-full"
+                role="tabpanel"
+                id="tab-panel-gmscreens"
+                aria-labelledby="tab-gmscreens"
+                hidden={effectiveTab !== 'gmscreens'}
+              >
+                <GMScreensView campaignId={campaignId} isGM={campaign?.isGM} />
+              </div>
+            )}
+          </MainView>
+        </div>
       </div>
-    </div>
+    </ActivePlayerProvider>
   );
 }

--- a/app/routes/campaigns/$campaignId/play.tsx
+++ b/app/routes/campaigns/$campaignId/play.tsx
@@ -51,7 +51,7 @@ function PlayPageContent() {
 
   const activeSession = campaign?.sessions.find((s) => s.status === 'active');
 
-  const needsNewPlayer = !isPlayerLoading && !activePlayer && !campaign?.isGM;
+  const needsNewPlayer = !isCampaignLoading && !isPlayerLoading && !activePlayer && !campaign?.isGM;
 
   // Coerce non-GMs away from the GM-only tab
   const effectiveTab =

--- a/app/routes/campaigns/index.tsx
+++ b/app/routes/campaigns/index.tsx
@@ -7,7 +7,6 @@ import { queryKeys } from '~/utils/queryKeys';
 import { Topbar } from '~/components/Topbar';
 import { Toast } from '~/components/Toast';
 import { PixelButton } from '~/components/PixelButton';
-import { useJoinCampaign } from '~/hooks/useCampaigns';
 import { CampaignCard } from '~/components/campaign/CampaignCard';
 import { KeyRound, Swords } from 'lucide-react';
 
@@ -34,7 +33,6 @@ function CampaignsListPage() {
   const navigate = useNavigate();
   const [showJoinForm, setShowJoinForm] = useState(false);
   const [joinCode, setJoinCode] = useState('');
-  const { join, isLoading: isJoining, error: joinError } = useJoinCampaign();
 
   const closeJoinForm = useCallback(() => {
     setShowJoinForm(false);
@@ -53,14 +51,10 @@ function CampaignsListPage() {
 
   async function handleJoin(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    const result = await join(joinCode.trim());
-    if (result) {
-      navigate({
-        to: '/campaigns/$campaignId/play',
-        params: { campaignId: result.campaignId },
-        search: { tab: 'dashboard' },
-      });
-    }
+    navigate({
+      to: '/campaign/join',
+      search: { code: joinCode.trim(), step: 1 },
+    });
   }
 
   return (
@@ -174,22 +168,15 @@ function CampaignsListPage() {
                 onChange={(e) => setJoinCode(e.target.value)}
                 placeholder="Enter invite code (e.g. ABCD-EFGH)"
                 className="w-full px-4 py-3 rounded-xl bg-white/[0.04] border border-white/[0.1] text-white text-sm placeholder-slate-600 focus:outline-none focus:border-blue-500/40"
-                disabled={isJoining}
                 // eslint-disable-next-line jsx-a11y/no-autofocus -- autoFocus is intentional: this is the primary input inside a modal dialog, and focusing it on open is the expected accessible UX pattern
                 autoFocus
                 aria-label="Invite code"
               />
-              {joinError && (
-                <p className="text-red-400 text-xs" role="alert">
-                  {joinError}
-                </p>
-              )}
               <div className="flex gap-3">
                 <PixelButton
                   variant="secondary"
                   size="md"
                   onClick={closeJoinForm}
-                  disabled={isJoining}
                   className="flex-1"
                   type="button"
                 >
@@ -199,10 +186,10 @@ function CampaignsListPage() {
                   variant="primary"
                   size="md"
                   type="submit"
-                  disabled={isJoining || !joinCode.trim()}
+                  disabled={!joinCode.trim()}
                   className="flex-1"
                 >
-                  {isJoining ? 'Joining...' : 'Join Campaign'}
+                  Join Campaign
                 </PixelButton>
               </div>
             </form>

--- a/app/server/db/governance.ts
+++ b/app/server/db/governance.ts
@@ -27,13 +27,13 @@
  */
 
 /** Severity level for an index declaration. */
-export type IndexSeverity = 'critical' | 'optional'
+export type IndexSeverity = 'critical' | 'optional';
 
 export interface GovernanceEntry {
   /** Index key pattern — must match the schema declaration exactly. */
-  key: Record<string, unknown>
+  key: Record<string, unknown>;
   /** Operational importance classification. */
-  severity: IndexSeverity
+  severity: IndexSeverity;
 }
 
 /**
@@ -58,12 +58,25 @@ export const INDEX_GOVERNANCE: Record<string, GovernanceEntry[]> = {
     { key: { campaignId: 1, startDate: -1 }, severity: 'optional' },
   ],
   Player: [
-    { key: { campaignId: 1, userId: 1 }, severity: 'critical' },
     { key: { campaignId: 1 }, severity: 'optional' },
+    { key: { campaignId: 1, updatedAt: -1 }, severity: 'optional' },
+    { key: { createdBy: 1 }, severity: 'optional' },
+    { key: { 'status.value': 1 }, severity: 'optional' },
+    { key: { _fts: 'text', _ftsx: 1 }, severity: 'optional' },
   ],
   GMScreen: [
     { key: { campaignId: 1, tabOrder: 1 }, severity: 'critical' },
     { key: { campaignId: 1, name: 1 }, severity: 'critical' },
+  ],
+  Character: [
+    { key: { campaignId: 1 }, severity: 'optional' },
+    { key: { campaignId: 1, updatedAt: -1 }, severity: 'optional' },
+    { key: { sessionId: 1 }, severity: 'optional' },
+    { key: { sessions: 1 }, severity: 'optional' },
+    { key: { createdBy: 1 }, severity: 'optional' },
+    { key: { tags: 1 }, severity: 'optional' },
+    { key: { isPublic: 1 }, severity: 'optional' },
+    { key: { _fts: 'text', _ftsx: 1 }, severity: 'optional' },
   ],
   Note: [
     { key: { sessionId: 1 }, severity: 'optional' },
@@ -74,7 +87,7 @@ export const INDEX_GOVERNANCE: Record<string, GovernanceEntry[]> = {
     { key: { isPublic: 1 }, severity: 'optional' },
     { key: { _fts: 'text', _ftsx: 1 }, severity: 'optional' },
   ],
-}
+};
 
 /**
  * Normalise a text index key to the canonical form that MongoDB reports
@@ -84,17 +97,17 @@ export const INDEX_GOVERNANCE: Record<string, GovernanceEntry[]> = {
  * both forms to the canonical DB shape so comparisons are stable.
  */
 export function normalizeIndexKey(key: Record<string, unknown>): Record<string, unknown> {
-  const hasText = Object.values(key).some((v) => v === 'text')
-  if (!hasText) return key
+  const hasText = Object.values(key).some((v) => v === 'text');
+  if (!hasText) return key;
   // Preserve non-text prefix fields (e.g. campaignId in a compound text index)
   // and collapse text fields to MongoDB's canonical { _fts: 'text', _ftsx: 1 }.
-  const prefix: Record<string, unknown> = {}
+  const prefix: Record<string, unknown> = {};
   for (const [field, dir] of Object.entries(key)) {
     if (dir !== 'text' && field !== '_fts' && field !== '_ftsx') {
-      prefix[field] = dir
+      prefix[field] = dir;
     }
   }
-  return { ...prefix, _fts: 'text', _ftsx: 1 }
+  return { ...prefix, _fts: 'text', _ftsx: 1 };
 }
 
 /**
@@ -103,10 +116,10 @@ export function normalizeIndexKey(key: Record<string, unknown>): Record<string, 
  * schema-declared keys and DB-reported keys produce identical signatures.
  */
 export function keySignature(key: Record<string, unknown>): string {
-  const normalized = normalizeIndexKey(key)
+  const normalized = normalizeIndexKey(key);
   return Object.entries(normalized)
     .map(([field, dir]) => `${field}:${typeof dir === 'string' ? dir : Number(dir)}`)
-    .join(',')
+    .join(',');
 }
 
 /**
@@ -116,11 +129,11 @@ export function keySignature(key: Record<string, unknown>): string {
  */
 export function getSeverity(
   modelName: string,
-  key: Record<string, unknown>,
+  key: Record<string, unknown>
 ): IndexSeverity | undefined {
-  const entries = INDEX_GOVERNANCE[modelName]
-  if (!entries) return undefined
-  const sig = keySignature(key)
-  const entry = entries.find((e) => keySignature(e.key) === sig)
-  return entry?.severity
+  const entries = INDEX_GOVERNANCE[modelName];
+  if (!entries) return undefined;
+  const sig = keySignature(key);
+  const entry = entries.find((e) => keySignature(e.key) === sig);
+  return entry?.severity;
 }

--- a/app/server/db/models/Character.ts
+++ b/app/server/db/models/Character.ts
@@ -11,6 +11,24 @@ const pictureCropSchema = new mongoose.Schema(
   { _id: false }
 );
 
+const relationshipSchema = new mongoose.Schema(
+  {
+    characterId: { type: mongoose.Schema.Types.ObjectId, ref: 'Character', required: true },
+    descriptor: { type: String, required: true },
+    isPublic: { type: Boolean, default: false },
+  },
+  { _id: false }
+);
+
+const statusSchema = new mongoose.Schema(
+  {
+    value: { type: String, enum: ['alive', 'deceased'], default: 'alive' },
+    changedAt: { type: Date, default: null },
+    changedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+  },
+  { _id: false }
+);
+
 const characterSchema = new mongoose.Schema({
   firstName: { type: String, required: true },
   lastName: { type: String, required: true },
@@ -31,6 +49,8 @@ const characterSchema = new mongoose.Schema({
   createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   createdAt: { type: Date, default: Date.now },
   updatedAt: { type: Date, default: Date.now },
+  status: { type: statusSchema, default: () => ({ value: 'alive' }) },
+  relationships: { type: [relationshipSchema], default: [] },
 });
 
 characterSchema.pre('save', function () {

--- a/app/server/db/models/Player.ts
+++ b/app/server/db/models/Player.ts
@@ -1,19 +1,106 @@
-import mongoose from 'mongoose'
+import mongoose from 'mongoose';
+
+const pictureCropSchema = new mongoose.Schema(
+  {
+    x: { type: Number, required: true },
+    y: { type: Number, required: true },
+    width: { type: Number, required: true },
+    height: { type: Number, required: true },
+  },
+  { _id: false }
+);
+
+const relationshipSchema = new mongoose.Schema(
+  {
+    characterId: { type: mongoose.Schema.Types.ObjectId, ref: 'Character', required: true },
+    descriptor: { type: String, required: true },
+    isPublic: { type: Boolean, default: false },
+  },
+  { _id: false }
+);
+
+const statusSchema = new mongoose.Schema(
+  {
+    value: { type: String, enum: ['alive', 'deceased'], default: 'alive' },
+    changedAt: { type: Date, default: null },
+    changedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+  },
+  { _id: false }
+);
 
 const playerSchema = new mongoose.Schema({
-  campaignId: { type: mongoose.Schema.Types.ObjectId, ref: 'Campaign', required: true },
-  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
-  characterName: { type: String, required: true },
+  firstName: { type: String, required: true },
+  lastName: { type: String, required: true },
+  race: { type: String, required: true },
   characterClass: { type: String, required: true },
-  avatar: { type: String },
-  joinedAt: { type: Date, default: Date.now },
-})
+  age: { type: Number, required: true },
+  gender: { type: String, default: '' },
+  location: { type: String, default: '' },
+  link: { type: String, default: '' },
+  picture: { type: String, default: '' },
+  pictureCrop: { type: pictureCropSchema, default: null },
+  description: { type: String, default: '' },
+  backstory: { type: String, default: '' },
+  gmNotes: { type: String, default: '' },
+  color: { type: String, default: '#3498db' },
+  eyeColor: { type: String, default: '' },
+  hairColor: { type: String, default: '' },
+  weight: { type: Number, default: null },
+  height: { type: String, default: '' },
+  size: { type: String, default: '' },
+  appearance: { type: String, default: '' },
+  status: { type: statusSchema, default: () => ({ value: 'alive' }) },
+  relationships: { type: [relationshipSchema], default: [] },
+  campaignId: { type: mongoose.Schema.Types.ObjectId, ref: 'Campaign', required: true },
+  createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+});
+
+playerSchema.pre('save', function () {
+  this.updatedAt = new Date();
+});
+
+playerSchema.pre('findOneAndUpdate', function () {
+  const update = this.getUpdate() as unknown;
+  if (!update) return;
+
+  if (Array.isArray(update)) {
+    let hasSetStage = false;
+    update.forEach((stage) => {
+      if (!stage || typeof stage !== 'object') return;
+      const stageObj = stage as Record<string, unknown>;
+      if (!('$set' in stageObj)) return;
+      hasSetStage = true;
+      (stageObj.$set as Record<string, unknown>).updatedAt = new Date();
+    });
+    if (!hasSetStage) {
+      update.push({ $set: { updatedAt: new Date() } });
+    }
+    this.setUpdate(update);
+    return;
+  }
+
+  const updateObj = update as Record<string, unknown>;
+  if ('$set' in updateObj) {
+    ((updateObj.$set as Record<string, unknown>) ??= {}).updatedAt = new Date();
+  } else {
+    updateObj.updatedAt = new Date();
+  }
+});
 
 // istanbul ignore next
 if (typeof (playerSchema as { index?: unknown }).index === 'function') {
-  playerSchema.index({ campaignId: 1, userId: 1 }, { unique: true })
-  playerSchema.index({ campaignId: 1 })
+  playerSchema.index({ campaignId: 1 });
+  playerSchema.index({ campaignId: 1, updatedAt: -1 });
+  playerSchema.index({ createdBy: 1 });
+  playerSchema.index({ 'status.value': 1 });
+  playerSchema.index({
+    firstName: 'text',
+    lastName: 'text',
+    race: 'text',
+    location: 'text',
+  });
 }
 
-export const Player =
-  mongoose.models.Player || mongoose.model('Player', playerSchema)
+export const Player = mongoose.models.Player || mongoose.model('Player', playerSchema);

--- a/app/server/functions/campaigns.ts
+++ b/app/server/functions/campaigns.ts
@@ -572,6 +572,7 @@ export const updateCampaign = createServerFn({ method: 'POST' })
     }
   });
 
+/** @deprecated Use completeJoinWizard in players.ts instead. Kept for backwards compatibility. */
 export const joinCampaign = createServerFn({ method: 'POST' })
   .inputValidator(joinCampaignSchema)
   .handler(async ({ data }) => {

--- a/app/server/functions/characters.ts
+++ b/app/server/functions/characters.ts
@@ -15,6 +15,10 @@ import {
   deleteCharacterSchema,
   listCharactersSchema,
   getCharacterSchema,
+  updateCharacterStatusSchema,
+  addCharacterRelationshipSchema,
+  updateCharacterRelationshipSchema,
+  removeCharacterRelationshipSchema,
 } from '~/types/schemas/characters';
 
 function serializeCharacter(c: {
@@ -483,6 +487,208 @@ export const getCharacter = createServerFn({ method: 'GET' })
       return { ...serialized, canEdit };
     } catch (e) {
       serverCaptureException(e, sessionUserId, { action: 'getCharacter', characterId: data.id });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// updateCharacterStatus
+// ---------------------------------------------------------------------------
+
+export { updateCharacterStatusSchema };
+
+export const updateCharacterStatus = createServerFn({ method: 'POST' })
+  .inputValidator(updateCharacterStatusSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      sessionUserId = member.sessionUserId;
+      const userId = member.userId;
+
+      const character = await Character.findById(data.id);
+      if (!character) throw new Error('Character not found');
+      if (String(character.campaignId) !== data.campaignId) throw new Error('Forbidden');
+      if (String(character.createdBy) !== userId && !member.isGM) throw new Error('Forbidden');
+
+      character.status = { value: data.value, changedAt: new Date(), changedBy: userId };
+      character.updatedAt = new Date();
+      await character.save();
+
+      serverCaptureEvent(sessionUserId, 'character_status_updated', {
+        campaign_id: data.campaignId,
+        character_id: data.id,
+        status: data.value,
+      });
+
+      return { success: true, character: { ...serializeCharacter(character), canEdit: true } };
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, {
+        action: 'updateCharacterStatus',
+        characterId: data.id,
+      });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// addCharacterRelationship
+// ---------------------------------------------------------------------------
+
+export { addCharacterRelationshipSchema };
+
+export const addCharacterRelationship = createServerFn({ method: 'POST' })
+  .inputValidator(addCharacterRelationshipSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      sessionUserId = member.sessionUserId;
+      const userId = member.userId;
+
+      const source = await Character.findById(data.characterId);
+      if (!source) throw new Error('Character not found');
+      if (String(source.campaignId) !== data.campaignId) throw new Error('Forbidden');
+      if (String(source.createdBy) !== userId && !member.isGM) throw new Error('Forbidden');
+
+      const target = await Character.findById(data.targetCharacterId);
+      if (!target) throw new Error('Target character not found');
+      if (String(target.campaignId) !== data.campaignId)
+        throw new Error('Target character not in same campaign');
+
+      await Character.updateOne(
+        { _id: data.characterId },
+        {
+          $push: {
+            relationships: {
+              characterId: data.targetCharacterId,
+              descriptor: data.descriptor,
+              isPublic: data.isPublic,
+            },
+          },
+        }
+      );
+
+      await Character.updateOne(
+        { _id: data.targetCharacterId },
+        {
+          $push: {
+            relationships: {
+              characterId: data.characterId,
+              descriptor: data.reciprocalDescriptor,
+              isPublic: data.isPublic,
+            },
+          },
+        }
+      );
+
+      serverCaptureEvent(sessionUserId, 'character_relationship_added', {
+        campaign_id: data.campaignId,
+        source_character_id: data.characterId,
+        target_character_id: data.targetCharacterId,
+      });
+
+      return { success: true };
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, {
+        action: 'addCharacterRelationship',
+        characterId: data.characterId,
+      });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// updateCharacterRelationship
+// ---------------------------------------------------------------------------
+
+export { updateCharacterRelationshipSchema };
+
+export const updateCharacterRelationship = createServerFn({ method: 'POST' })
+  .inputValidator(updateCharacterRelationshipSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      sessionUserId = member.sessionUserId;
+      const userId = member.userId;
+
+      const source = await Character.findById(data.characterId);
+      if (!source) throw new Error('Character not found');
+      if (String(source.campaignId) !== data.campaignId) throw new Error('Forbidden');
+      if (String(source.createdBy) !== userId && !member.isGM) throw new Error('Forbidden');
+
+      // Build source-side update
+      const sourceSet: Record<string, unknown> = {};
+      if (data.descriptor !== undefined) sourceSet['relationships.$.descriptor'] = data.descriptor;
+      if (data.isPublic !== undefined) sourceSet['relationships.$.isPublic'] = data.isPublic;
+
+      if (Object.keys(sourceSet).length > 0) {
+        await Character.updateOne(
+          { _id: data.characterId, 'relationships.characterId': data.targetCharacterId },
+          { $set: sourceSet }
+        );
+      }
+
+      // Build reciprocal-side update
+      const reciprocalSet: Record<string, unknown> = {};
+      if (data.reciprocalDescriptor !== undefined)
+        reciprocalSet['relationships.$.descriptor'] = data.reciprocalDescriptor;
+      if (data.isPublic !== undefined) reciprocalSet['relationships.$.isPublic'] = data.isPublic;
+
+      if (Object.keys(reciprocalSet).length > 0) {
+        await Character.updateOne(
+          { _id: data.targetCharacterId, 'relationships.characterId': data.characterId },
+          { $set: reciprocalSet }
+        );
+      }
+
+      return { success: true };
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, {
+        action: 'updateCharacterRelationship',
+        characterId: data.characterId,
+      });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// removeCharacterRelationship
+// ---------------------------------------------------------------------------
+
+export { removeCharacterRelationshipSchema };
+
+export const removeCharacterRelationship = createServerFn({ method: 'POST' })
+  .inputValidator(removeCharacterRelationshipSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      sessionUserId = member.sessionUserId;
+      const userId = member.userId;
+
+      const source = await Character.findById(data.characterId);
+      if (!source) throw new Error('Character not found');
+      if (String(source.campaignId) !== data.campaignId) throw new Error('Forbidden');
+      if (String(source.createdBy) !== userId && !member.isGM) throw new Error('Forbidden');
+
+      await Character.updateOne(
+        { _id: data.characterId },
+        { $pull: { relationships: { characterId: data.targetCharacterId } } }
+      );
+
+      await Character.updateOne(
+        { _id: data.targetCharacterId },
+        { $pull: { relationships: { characterId: data.characterId } } }
+      );
+
+      return { success: true };
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, {
+        action: 'removeCharacterRelationship',
+        characterId: data.characterId,
+      });
       throw e;
     }
   });

--- a/app/server/functions/characters.ts
+++ b/app/server/functions/characters.ts
@@ -570,10 +570,18 @@ export const addCharacterRelationship = createServerFn({ method: 'POST' })
       if (String(source.campaignId) !== data.campaignId) throw new Error('Forbidden');
       if (String(source.createdBy) !== userId && !member.isGM) throw new Error('Forbidden');
 
+      if (data.characterId === data.targetCharacterId)
+        throw new Error('Cannot create relationship with self');
+
       const target = await Character.findById(data.targetCharacterId);
       if (!target) throw new Error('Target character not found');
       if (String(target.campaignId) !== data.campaignId)
         throw new Error('Target character not in same campaign');
+
+      const existing = source.relationships?.find(
+        (r: { characterId: unknown }) => String(r.characterId) === data.targetCharacterId
+      );
+      if (existing) throw new Error('Relationship already exists');
 
       await Character.updateOne(
         { _id: data.characterId },

--- a/app/server/functions/characters.ts
+++ b/app/server/functions/characters.ts
@@ -38,6 +38,8 @@ function serializeCharacter(c: {
   sessions?: unknown[];
   createdAt?: Date;
   updatedAt?: Date;
+  status?: { value?: string; changedAt?: Date | null; changedBy?: unknown };
+  relationships?: Array<{ characterId: unknown; descriptor?: string; isPublic?: boolean }>;
 }): Omit<CharacterData, 'canEdit'> {
   return {
     id: String(c._id),
@@ -67,6 +69,18 @@ function serializeCharacter(c: {
     sessions: (c.sessions ?? []).map((s) => String(s)),
     createdAt: c.createdAt instanceof Date ? c.createdAt.toISOString() : '',
     updatedAt: c.updatedAt instanceof Date ? c.updatedAt.toISOString() : '',
+    status: {
+      value: (c.status?.value as 'alive' | 'deceased') ?? 'alive',
+      changedAt: c.status?.changedAt ? new Date(c.status.changedAt as Date).toISOString() : null,
+      changedBy: c.status?.changedBy ? String(c.status.changedBy) : null,
+    },
+    relationships: (c.relationships ?? []).map(
+      (r: { characterId: unknown; descriptor?: string; isPublic?: boolean }) => ({
+        characterId: String(r.characterId),
+        descriptor: r.descriptor ?? '',
+        isPublic: r.isPublic ?? false,
+      })
+    ),
   };
 }
 
@@ -89,6 +103,7 @@ function serializeCharacterListItem(c: {
   sessions?: unknown[];
   createdAt?: Date;
   updatedAt?: Date;
+  status?: { value?: string; changedAt?: Date | null; changedBy?: unknown };
 }): Omit<CharacterListItem, 'canEdit'> {
   return {
     id: String(c._id),
@@ -116,6 +131,11 @@ function serializeCharacterListItem(c: {
     sessions: (c.sessions ?? []).map((s) => String(s)),
     createdAt: c.createdAt instanceof Date ? c.createdAt.toISOString() : '',
     updatedAt: c.updatedAt instanceof Date ? c.updatedAt.toISOString() : '',
+    status: {
+      value: (c.status?.value as 'alive' | 'deceased') ?? 'alive',
+      changedAt: c.status?.changedAt ? new Date(c.status.changedAt as Date).toISOString() : null,
+      changedBy: c.status?.changedBy ? String(c.status.changedBy) : null,
+    },
   };
 }
 
@@ -413,6 +433,7 @@ export const listCharacters = createServerFn({ method: 'GET' })
           sessions?: unknown[];
           createdAt?: Date;
           updatedAt?: Date;
+          status?: { value?: string; changedAt?: Date | null; changedBy?: unknown };
         }>
       ).map((doc) => ({
         ...serializeCharacterListItem(doc),

--- a/app/server/functions/characters.ts
+++ b/app/server/functions/characters.ts
@@ -327,6 +327,19 @@ export const deleteCharacter = createServerFn({ method: 'POST' })
         });
       }
 
+      // Clean up character-to-character relationships referencing this character
+      await Character.updateMany(
+        { campaignId: data.campaignId, 'relationships.characterId': data.id },
+        { $pull: { relationships: { characterId: data.id } } }
+      );
+
+      // Clean up player-to-character relationships referencing this character
+      const { Player } = await import('../db/models/Player');
+      await Player.updateMany(
+        { campaignId: data.campaignId, 'relationships.characterId': data.id },
+        { $pull: { relationships: { characterId: data.id } } }
+      );
+
       serverCaptureEvent(sessionUserId, 'character_deleted', {
         campaign_id: data.campaignId,
         character_id: data.id,

--- a/app/server/functions/characters.ts
+++ b/app/server/functions/characters.ts
@@ -496,7 +496,13 @@ export const getCharacter = createServerFn({ method: 'GET' })
         serialized.gmNotes = '';
       }
 
-      const canEdit = String(doc.createdBy) === userId || member.isGM;
+      // Strip private relationships for non-creator/non-GM
+      const isCreator = String(doc.createdBy) === userId;
+      if (!isCreator && !member.isGM) {
+        serialized.relationships = serialized.relationships.filter((r) => r.isPublic);
+      }
+
+      const canEdit = isCreator || member.isGM;
       return { ...serialized, canEdit };
     } catch (e) {
       serverCaptureException(e, sessionUserId, { action: 'getCharacter', characterId: data.id });

--- a/app/server/functions/gmscreens.ts
+++ b/app/server/functions/gmscreens.ts
@@ -198,6 +198,34 @@ const COLLECTION_REGISTRY: Record<string, CollectionFetcher> = {
       >;
     },
   },
+  player: {
+    async fetch(ids: string[], campaignId: string) {
+      const { Player } = await import('../db/models/Player');
+      return Player.find(
+        { _id: { $in: ids }, campaignId },
+        '_id firstName lastName description color'
+      )
+        .lean()
+        .then(
+          (
+            docs: Array<{
+              _id: unknown;
+              firstName?: string;
+              lastName?: string;
+              description?: string;
+              color?: string;
+            }>
+          ) =>
+            docs.map((d) => ({
+              _id: d._id,
+              title: `${d.firstName ?? ''} ${d.lastName ?? ''}`.trim(),
+              content: d.description ?? '',
+              isPublic: true,
+              color: d.color ?? '#3498db',
+            }))
+        );
+    },
+  },
 };
 
 /**

--- a/app/server/functions/players.ts
+++ b/app/server/functions/players.ts
@@ -664,7 +664,15 @@ export const completeJoinWizard = createServerFn({ method: 'POST' })
         }
       );
 
-      // 3. Create Player document
+      // 3. Guard against duplicate player (race condition / double-submit)
+      const existingPlayer = await Player.findOne({
+        campaignId: data.campaignId,
+        createdBy: userId,
+        'status.value': 'alive',
+      });
+      if (existingPlayer) throw new Error('Player already exists for this campaign');
+
+      // 4. Create Player document
       const playerDoc = await Player.create({
         campaignId: data.campaignId,
         createdBy: userId,

--- a/app/server/functions/players.ts
+++ b/app/server/functions/players.ts
@@ -1,0 +1,793 @@
+import { createServerFn } from '@tanstack/react-start';
+import { z } from 'zod';
+import { getSession } from '../session';
+import { connectDB, isDBConnected } from '../db/connection';
+import { User } from '../db/models/User';
+import { Campaign } from '../db/models/Campaign';
+import { Player } from '../db/models/Player';
+import { Character } from '../db/models/Character';
+import { serverCaptureException, serverCaptureEvent } from '../utils/posthog';
+import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
+import type { PlayerData, PlayerListItem } from '~/types/player';
+import type { PictureCrop } from '~/types/character';
+import {
+  listPlayersSchema,
+  getPlayerSchema,
+  updatePlayerSchema,
+  deletePlayerSchema,
+  updatePlayerStatusSchema,
+  playerRelationshipSchema,
+  removePlayerRelationshipSchema,
+  validateInviteCodeSchema,
+  completeJoinWizardSchema,
+} from '~/types/schemas/players';
+
+// ---------------------------------------------------------------------------
+// Serializers
+// ---------------------------------------------------------------------------
+
+function serializePlayer(c: {
+  _id: unknown;
+  campaignId: unknown;
+  createdBy: unknown;
+  firstName?: string;
+  lastName?: string;
+  race?: string;
+  characterClass?: string;
+  age?: number;
+  gender?: string;
+  location?: string;
+  link?: string;
+  picture?: string;
+  pictureCrop?: PictureCrop | null;
+  description?: string;
+  backstory?: string;
+  gmNotes?: string;
+  color?: string;
+  eyeColor?: string;
+  hairColor?: string;
+  weight?: number | null;
+  height?: string;
+  size?: string;
+  appearance?: string;
+  status?: { value?: string; changedAt?: Date | null; changedBy?: unknown };
+  relationships?: Array<{ characterId: unknown; descriptor?: string; isPublic?: boolean }>;
+  createdAt?: Date;
+  updatedAt?: Date;
+}): Omit<PlayerData, 'canEdit'> {
+  return {
+    id: String(c._id),
+    campaignId: String(c.campaignId),
+    createdBy: String(c.createdBy),
+    firstName: c.firstName ?? '',
+    lastName: c.lastName ?? '',
+    race: c.race ?? '',
+    characterClass: c.characterClass ?? '',
+    age: c.age ?? 0,
+    gender: c.gender ?? '',
+    location: c.location ?? '',
+    link: c.link ?? '',
+    picture: c.picture ?? '',
+    pictureCrop: c.pictureCrop
+      ? {
+          x: Number(c.pictureCrop.x),
+          y: Number(c.pictureCrop.y),
+          width: Number(c.pictureCrop.width),
+          height: Number(c.pictureCrop.height),
+        }
+      : null,
+    description: c.description ?? '',
+    backstory: c.backstory ?? '',
+    gmNotes: c.gmNotes ?? '',
+    color: c.color ?? '#3498db',
+    eyeColor: c.eyeColor ?? '',
+    hairColor: c.hairColor ?? '',
+    weight: c.weight ?? null,
+    height: c.height ?? '',
+    size: c.size ?? '',
+    appearance: c.appearance ?? '',
+    status: {
+      value: (c.status?.value as 'alive' | 'deceased') ?? 'alive',
+      changedAt: c.status?.changedAt ? new Date(c.status.changedAt as Date).toISOString() : null,
+      changedBy: c.status?.changedBy ? String(c.status.changedBy) : null,
+    },
+    relationships: (c.relationships ?? []).map(
+      (r: { characterId: unknown; descriptor?: string; isPublic?: boolean }) => ({
+        characterId: String(r.characterId),
+        descriptor: r.descriptor ?? '',
+        isPublic: r.isPublic ?? false,
+      })
+    ),
+    createdAt: c.createdAt instanceof Date ? c.createdAt.toISOString() : '',
+    updatedAt: c.updatedAt instanceof Date ? c.updatedAt.toISOString() : '',
+  };
+}
+
+function serializePlayerListItem(c: {
+  _id: unknown;
+  campaignId: unknown;
+  createdBy: unknown;
+  firstName?: string;
+  lastName?: string;
+  race?: string;
+  characterClass?: string;
+  color?: string;
+  picture?: string;
+  pictureCrop?: PictureCrop | null;
+  status?: { value?: string; changedAt?: Date | null; changedBy?: unknown };
+}): Omit<PlayerListItem, 'canEdit'> {
+  return {
+    id: String(c._id),
+    campaignId: String(c.campaignId),
+    createdBy: String(c.createdBy),
+    firstName: c.firstName ?? '',
+    lastName: c.lastName ?? '',
+    race: c.race ?? '',
+    characterClass: c.characterClass ?? '',
+    color: c.color ?? '#3498db',
+    picture: c.picture ?? '',
+    pictureCrop: c.pictureCrop
+      ? {
+          x: Number(c.pictureCrop.x),
+          y: Number(c.pictureCrop.y),
+          width: Number(c.pictureCrop.width),
+          height: Number(c.pictureCrop.height),
+        }
+      : null,
+    status: {
+      value: (c.status?.value as 'alive' | 'deceased') ?? 'alive',
+      changedAt: c.status?.changedAt ? new Date(c.status.changedAt as Date).toISOString() : null,
+      changedBy: c.status?.changedBy ? String(c.status.changedBy) : null,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// requireCampaignMember
+// ---------------------------------------------------------------------------
+
+async function requireCampaignMember(
+  campaignId: string
+): Promise<{ userId: string; sessionUserId: string; isGM: boolean }> {
+  const user = await getSession();
+  if (!user) throw new Error('Not authenticated');
+
+  await connectDB();
+  if (!isDBConnected()) throw new Error('Database not available');
+
+  const dbUser = await User.findOne({ providerId: user.id });
+  if (!dbUser) throw new Error('User not found');
+
+  const campaign = await Campaign.findById(campaignId);
+  if (!campaign) throw new Error('Campaign not found');
+
+  const userId = String(dbUser._id);
+  const members = campaign.members ?? [];
+  const member = members.find(
+    (m: { userId: unknown; role?: string }) => String(m.userId) === userId
+  );
+  const isGM = String(campaign.gameMasterId) === userId || member?.role === 'gm';
+  const isMember = !!member || isGM;
+  if (!isMember) throw new Error('Forbidden');
+
+  return { userId, sessionUserId: user.id, isGM };
+}
+
+// ---------------------------------------------------------------------------
+// listPlayers
+// ---------------------------------------------------------------------------
+
+export { listPlayersSchema };
+
+export const listPlayers = createServerFn({ method: 'GET' })
+  .inputValidator(listPlayersSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      sessionUserId = member.sessionUserId;
+      const userId = member.userId;
+
+      const filter: Record<string, unknown> = { campaignId: data.campaignId };
+
+      if (data.search && data.search.trim()) {
+        filter.$text = { $search: data.search.trim() };
+      }
+
+      const docs = await Player.find(filter)
+        .select('-backstory -gmNotes -description -appearance -relationships')
+        .sort({ updatedAt: -1 })
+        .lean();
+
+      return (
+        docs as Array<{
+          _id: unknown;
+          campaignId: unknown;
+          createdBy: unknown;
+          firstName?: string;
+          lastName?: string;
+          race?: string;
+          characterClass?: string;
+          color?: string;
+          picture?: string;
+          pictureCrop?: PictureCrop | null;
+          status?: { value?: string; changedAt?: Date | null; changedBy?: unknown };
+        }>
+      ).map((doc) => ({
+        ...serializePlayerListItem(doc),
+        canEdit: String(doc.createdBy) === userId || member.isGM,
+      }));
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, {
+        action: 'listPlayers',
+        campaignId: data.campaignId,
+      });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// getPlayer
+// ---------------------------------------------------------------------------
+
+export { getPlayerSchema };
+
+export const getPlayer = createServerFn({ method: 'GET' })
+  .inputValidator(getPlayerSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      sessionUserId = member.sessionUserId;
+      const userId = member.userId;
+
+      const doc = await Player.findById(data.id);
+      if (!doc) return null;
+      if (String(doc.campaignId) !== data.campaignId) return null;
+
+      const serialized = serializePlayer(doc);
+      const isOwner = String(doc.createdBy) === userId;
+
+      // Strip backstory for non-owner/non-GM
+      if (!isOwner && !member.isGM) {
+        serialized.backstory = '';
+      }
+
+      // Strip gmNotes for non-GM
+      if (!member.isGM) {
+        serialized.gmNotes = '';
+      }
+
+      // Filter private relationships for non-owner/non-GM
+      if (!isOwner && !member.isGM) {
+        serialized.relationships = serialized.relationships.filter((r) => r.isPublic);
+      }
+
+      const canEdit = isOwner || member.isGM;
+      return { ...serialized, canEdit };
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, { action: 'getPlayer', playerId: data.id });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// updatePlayer
+// ---------------------------------------------------------------------------
+
+export { updatePlayerSchema };
+
+export const updatePlayer = createServerFn({ method: 'POST' })
+  .inputValidator(updatePlayerSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      sessionUserId = member.sessionUserId;
+      const userId = member.userId;
+
+      const existing = await Player.findById(data.id);
+      if (!existing) throw new Error('Player not found');
+      if (String(existing.campaignId) !== data.campaignId) throw new Error('Forbidden');
+
+      const isOwner = String(existing.createdBy) === userId;
+      if (!isOwner && !member.isGM) throw new Error('Forbidden');
+
+      const $set: Record<string, unknown> = {
+        firstName: data.firstName.trim(),
+        lastName: data.lastName.trim(),
+        race: data.race.trim(),
+        characterClass: data.characterClass.trim(),
+        age: data.age,
+        gender: (data.gender ?? '').trim(),
+        location: (data.location ?? '').trim(),
+        link: (data.link ?? '').trim(),
+        picture: data.picture ?? '',
+        pictureCrop: data.pictureCrop ?? null,
+        description: (data.description ?? '').trim(),
+        backstory: (data.backstory ?? '').trim(),
+        color: data.color ?? '#3498db',
+        eyeColor: (data.eyeColor ?? '').trim(),
+        hairColor: (data.hairColor ?? '').trim(),
+        weight: data.weight ?? null,
+        height: (data.height ?? '').trim(),
+        size: (data.size ?? '').trim(),
+        appearance: (data.appearance ?? '').trim(),
+      };
+
+      // Only GM can set gmNotes
+      if (member.isGM && data.gmNotes !== undefined) {
+        $set.gmNotes = data.gmNotes;
+      }
+
+      await Player.findByIdAndUpdate(data.id, { $set });
+
+      const updated = await Player.findById(data.id);
+      if (!updated) throw new Error('Player not found after update');
+
+      serverCaptureEvent(sessionUserId, 'player_updated', {
+        campaign_id: data.campaignId,
+        player_id: data.id,
+        updated_by: userId,
+      });
+
+      return { success: true, player: { ...serializePlayer(updated), canEdit: true } };
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, { action: 'updatePlayer', playerId: data.id });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// deletePlayer
+// ---------------------------------------------------------------------------
+
+export { deletePlayerSchema };
+
+export const deletePlayer = createServerFn({ method: 'POST' })
+  .inputValidator(deletePlayerSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      sessionUserId = member.sessionUserId;
+
+      if (!member.isGM) throw new Error('Forbidden');
+
+      const existing = await Player.findById(data.id);
+      if (!existing) throw new Error('Player not found');
+      if (String(existing.campaignId) !== data.campaignId) throw new Error('Forbidden');
+
+      await existing.deleteOne();
+
+      // Clean up GM Screen references to this player.
+      try {
+        await removeDocumentRefsFromScreens(data.campaignId, 'player', data.id);
+      } catch (cleanupError) {
+        serverCaptureException(cleanupError, sessionUserId, {
+          action: 'deletePlayer.cleanup',
+          campaignId: data.campaignId,
+          playerId: data.id,
+        });
+      }
+
+      serverCaptureEvent(sessionUserId, 'player_deleted', {
+        campaign_id: data.campaignId,
+        player_id: data.id,
+        deleted_by: member.userId,
+      });
+
+      return { success: true };
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, { action: 'deletePlayer', playerId: data.id });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// updatePlayerStatus
+// ---------------------------------------------------------------------------
+
+export { updatePlayerStatusSchema };
+
+export const updatePlayerStatus = createServerFn({ method: 'POST' })
+  .inputValidator(updatePlayerStatusSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      sessionUserId = member.sessionUserId;
+
+      if (!member.isGM) throw new Error('Forbidden');
+
+      const player = await Player.findById(data.id);
+      if (!player) throw new Error('Player not found');
+      if (String(player.campaignId) !== data.campaignId) throw new Error('Forbidden');
+
+      player.status = { value: data.value, changedAt: new Date(), changedBy: member.userId };
+      player.updatedAt = new Date();
+      await player.save();
+
+      serverCaptureEvent(sessionUserId, 'player_status_updated', {
+        campaign_id: data.campaignId,
+        player_id: data.id,
+        status: data.value,
+      });
+
+      return { success: true, player: { ...serializePlayer(player), canEdit: true } };
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, {
+        action: 'updatePlayerStatus',
+        playerId: data.id,
+      });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// addPlayerRelationship
+// ---------------------------------------------------------------------------
+
+export { playerRelationshipSchema };
+
+export const addPlayerRelationship = createServerFn({ method: 'POST' })
+  .inputValidator(playerRelationshipSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      sessionUserId = member.sessionUserId;
+      const userId = member.userId;
+
+      const player = await Player.findById(data.playerId);
+      if (!player) throw new Error('Player not found');
+      if (String(player.campaignId) !== data.campaignId) throw new Error('Forbidden');
+      if (String(player.createdBy) !== userId && !member.isGM) throw new Error('Forbidden');
+
+      // Verify the character exists in the same campaign
+      const target = await Character.findById(data.characterId);
+      if (!target) throw new Error('Character not found');
+      if (String(target.campaignId) !== data.campaignId)
+        throw new Error('Character not in same campaign');
+
+      await Player.updateOne(
+        { _id: data.playerId },
+        {
+          $push: {
+            relationships: {
+              characterId: data.characterId,
+              descriptor: data.descriptor,
+              isPublic: data.isPublic,
+            },
+          },
+        }
+      );
+
+      serverCaptureEvent(sessionUserId, 'player_relationship_added', {
+        campaign_id: data.campaignId,
+        player_id: data.playerId,
+        character_id: data.characterId,
+      });
+
+      return { success: true };
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, {
+        action: 'addPlayerRelationship',
+        playerId: data.playerId,
+      });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// updatePlayerRelationship
+// ---------------------------------------------------------------------------
+
+export const updatePlayerRelationship = createServerFn({ method: 'POST' })
+  .inputValidator(playerRelationshipSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      sessionUserId = member.sessionUserId;
+      const userId = member.userId;
+
+      const player = await Player.findById(data.playerId);
+      if (!player) throw new Error('Player not found');
+      if (String(player.campaignId) !== data.campaignId) throw new Error('Forbidden');
+      if (String(player.createdBy) !== userId && !member.isGM) throw new Error('Forbidden');
+
+      const updateSet: Record<string, unknown> = {};
+      if (data.descriptor !== undefined) updateSet['relationships.$.descriptor'] = data.descriptor;
+      if (data.isPublic !== undefined) updateSet['relationships.$.isPublic'] = data.isPublic;
+
+      if (Object.keys(updateSet).length > 0) {
+        await Player.updateOne(
+          { _id: data.playerId, 'relationships.characterId': data.characterId },
+          { $set: updateSet }
+        );
+      }
+
+      return { success: true };
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, {
+        action: 'updatePlayerRelationship',
+        playerId: data.playerId,
+      });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// removePlayerRelationship
+// ---------------------------------------------------------------------------
+
+export { removePlayerRelationshipSchema };
+
+export const removePlayerRelationship = createServerFn({ method: 'POST' })
+  .inputValidator(removePlayerRelationshipSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      sessionUserId = member.sessionUserId;
+      const userId = member.userId;
+
+      const player = await Player.findById(data.playerId);
+      if (!player) throw new Error('Player not found');
+      if (String(player.campaignId) !== data.campaignId) throw new Error('Forbidden');
+      if (String(player.createdBy) !== userId && !member.isGM) throw new Error('Forbidden');
+
+      await Player.updateOne(
+        { _id: data.playerId },
+        { $pull: { relationships: { characterId: data.characterId } } }
+      );
+
+      return { success: true };
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, {
+        action: 'removePlayerRelationship',
+        playerId: data.playerId,
+      });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// validateInviteCode
+// ---------------------------------------------------------------------------
+
+export { validateInviteCodeSchema };
+
+export const validateInviteCode = createServerFn({ method: 'POST' })
+  .inputValidator(validateInviteCodeSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const user = await getSession();
+      if (!user) throw new Error('Not authenticated');
+      sessionUserId = user.id;
+
+      await connectDB();
+      if (!isDBConnected()) throw new Error('Database not available');
+
+      const dbUser = await User.findOne({ providerId: user.id });
+      if (!dbUser) throw new Error('User not found');
+
+      const normalizedInviteCode = data.inviteCode.trim().toUpperCase();
+      const campaign = await Campaign.findOne({ inviteCode: normalizedInviteCode });
+      if (!campaign) throw new Error('Invalid invite code');
+      if (campaign.status !== 'active') throw new Error('Campaign is not active');
+
+      // Check if user is already a member
+      const userId = String(dbUser._id);
+      const alreadyMember =
+        (campaign.members ?? []).some((m: { userId: unknown }) => String(m.userId) === userId) ||
+        String(campaign.gameMasterId) === userId;
+      if (alreadyMember) throw new Error('Already a member of this campaign');
+
+      return {
+        campaignId: String(campaign._id),
+        name: campaign.name as string,
+        description: (campaign.description as string) ?? '',
+      };
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, { action: 'validateInviteCode' });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// completeJoinWizard
+// ---------------------------------------------------------------------------
+
+export { completeJoinWizardSchema };
+
+export const completeJoinWizard = createServerFn({ method: 'POST' })
+  .inputValidator(completeJoinWizardSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const user = await getSession();
+      if (!user) throw new Error('Not authenticated');
+      sessionUserId = user.id;
+
+      await connectDB();
+      if (!isDBConnected()) throw new Error('Database not available');
+
+      const dbUser = await User.findOne({ providerId: user.id });
+      if (!dbUser) throw new Error('User not found');
+
+      const userId = String(dbUser._id);
+      const now = new Date();
+
+      // 1. Add user to campaign members (with capacity check)
+      const updatedCampaign = await Campaign.findOneAndUpdate(
+        {
+          _id: data.campaignId,
+          status: 'active',
+          'members.userId': { $ne: dbUser._id },
+          $expr: {
+            $lt: [
+              {
+                $size: {
+                  $filter: {
+                    input: { $ifNull: ['$members', []] },
+                    as: 'm',
+                    cond: { $eq: ['$$m.role', 'player'] },
+                  },
+                },
+              },
+              { $ifNull: ['$maxPlayers', 4] },
+            ],
+          },
+        },
+        {
+          $addToSet: { members: { userId: dbUser._id, role: 'player', joinedAt: now } },
+        },
+        {
+          new: true,
+        }
+      );
+
+      if (!updatedCampaign) {
+        throw new Error('Campaign is full');
+      }
+
+      // 2. Update User.campaigns
+      await User.updateOne(
+        { _id: dbUser._id },
+        {
+          $addToSet: {
+            campaigns: { campaignId: updatedCampaign._id, status: 'active', joinedAt: now },
+          },
+        }
+      );
+
+      // 3. Create Player document
+      const playerDoc = await Player.create({
+        campaignId: data.campaignId,
+        createdBy: userId,
+        firstName: data.player.firstName.trim(),
+        lastName: data.player.lastName.trim(),
+        race: data.player.race.trim(),
+        characterClass: data.player.characterClass.trim(),
+        age: data.player.age,
+        gender: (data.player.gender ?? '').trim(),
+        location: (data.player.location ?? '').trim(),
+        link: (data.player.link ?? '').trim(),
+        picture: data.player.picture ?? '',
+        pictureCrop: data.player.pictureCrop ?? null,
+        description: (data.player.description ?? '').trim(),
+        backstory: (data.player.backstory ?? '').trim(),
+        color: data.player.color ?? '#3498db',
+        eyeColor: (data.player.eyeColor ?? '').trim(),
+        hairColor: (data.player.hairColor ?? '').trim(),
+        weight: data.player.weight ?? null,
+        height: (data.player.height ?? '').trim(),
+        size: (data.player.size ?? '').trim(),
+        appearance: (data.player.appearance ?? '').trim(),
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      // 4. Create all Character documents
+      const characterDocs = [];
+      for (const charInput of data.characters) {
+        const charDoc = await Character.create({
+          campaignId: data.campaignId,
+          createdBy: userId,
+          firstName: charInput.firstName.trim(),
+          lastName: charInput.lastName.trim(),
+          race: (charInput.race ?? '').trim(),
+          characterClass: (charInput.characterClass ?? '').trim(),
+          age: charInput.age ?? null,
+          location: (charInput.location ?? '').trim(),
+          link: (charInput.link ?? '').trim(),
+          picture: charInput.picture ?? '',
+          pictureCrop: charInput.pictureCrop ?? null,
+          notes: (charInput.notes ?? '').trim(),
+          gmNotes: (charInput.gmNotes ?? '').trim(),
+          tags: charInput.tags ?? [],
+          isPublic: charInput.isPublic ?? false,
+          createdAt: now,
+          updatedAt: now,
+        });
+        characterDocs.push({ doc: charDoc, relationship: charInput.relationship });
+      }
+
+      // 5. Set up player-to-character relationships
+      for (const { doc: charDoc, relationship } of characterDocs) {
+        await Player.updateOne(
+          { _id: playerDoc._id },
+          {
+            $push: {
+              relationships: {
+                characterId: charDoc._id,
+                descriptor: relationship.descriptor,
+                isPublic: relationship.isPublic ?? false,
+              },
+            },
+          }
+        );
+      }
+
+      serverCaptureEvent(sessionUserId, 'join_wizard_completed', {
+        campaign_id: data.campaignId,
+        player_id: String(playerDoc._id),
+        character_count: characterDocs.length,
+      });
+
+      return {
+        success: true,
+        campaignId: data.campaignId,
+        playerId: String(playerDoc._id),
+      };
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, {
+        action: 'completeJoinWizard',
+        campaignId: data.campaignId,
+      });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// getActivePlayer
+// ---------------------------------------------------------------------------
+
+const getActivePlayerSchema = z.object({
+  campaignId: z.string().min(1),
+});
+
+export { getActivePlayerSchema };
+
+export const getActivePlayer = createServerFn({ method: 'GET' })
+  .inputValidator(getActivePlayerSchema)
+  .handler(async ({ data }) => {
+    let sessionUserId: string | undefined;
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      sessionUserId = member.sessionUserId;
+      const userId = member.userId;
+
+      const doc = await Player.findOne({
+        campaignId: data.campaignId,
+        createdBy: userId,
+        'status.value': 'alive',
+      })
+        .sort({ createdAt: -1 })
+        .limit(1);
+
+      if (!doc) return null;
+
+      const serialized = serializePlayer(doc);
+      return { ...serialized, canEdit: true };
+    } catch (e) {
+      serverCaptureException(e, sessionUserId, {
+        action: 'getActivePlayer',
+        campaignId: data.campaignId,
+      });
+      throw e;
+    }
+  });

--- a/app/server/functions/players.ts
+++ b/app/server/functions/players.ts
@@ -450,6 +450,11 @@ export const addPlayerRelationship = createServerFn({ method: 'POST' })
       if (String(target.campaignId) !== data.campaignId)
         throw new Error('Character not in same campaign');
 
+      const existing = player.relationships?.find(
+        (r: { characterId: unknown }) => String(r.characterId) === data.characterId
+      );
+      if (existing) throw new Error('Relationship already exists');
+
       await Player.updateOne(
         { _id: data.playerId },
         {
@@ -460,6 +465,7 @@ export const addPlayerRelationship = createServerFn({ method: 'POST' })
               isPublic: data.isPublic,
             },
           },
+          $set: { updatedAt: new Date() },
         }
       );
 
@@ -502,6 +508,7 @@ export const updatePlayerRelationship = createServerFn({ method: 'POST' })
       if (data.isPublic !== undefined) updateSet['relationships.$.isPublic'] = data.isPublic;
 
       if (Object.keys(updateSet).length > 0) {
+        updateSet.updatedAt = new Date();
         await Player.updateOne(
           { _id: data.playerId, 'relationships.characterId': data.characterId },
           { $set: updateSet }
@@ -540,7 +547,10 @@ export const removePlayerRelationship = createServerFn({ method: 'POST' })
 
       await Player.updateOne(
         { _id: data.playerId },
-        { $pull: { relationships: { characterId: data.characterId } } }
+        {
+          $pull: { relationships: { characterId: data.characterId } },
+          $set: { updatedAt: new Date() },
+        }
       );
 
       return { success: true };

--- a/app/types/character.ts
+++ b/app/types/character.ts
@@ -1,3 +1,15 @@
+export interface CharacterStatus {
+  value: 'alive' | 'deceased';
+  changedAt: string | null;
+  changedBy: string | null;
+}
+
+export interface CharacterRelationship {
+  characterId: string;
+  descriptor: string;
+  isPublic: boolean;
+}
+
 export interface PictureCrop {
   x: number;
   y: number;
@@ -26,6 +38,8 @@ export interface CharacterData {
   sessions: string[];
   createdAt: string;
   updatedAt: string;
+  status: CharacterStatus;
+  relationships: CharacterRelationship[];
   canEdit: boolean;
 }
 
@@ -48,5 +62,6 @@ export interface CharacterListItem {
   sessions: string[];
   createdAt: string;
   updatedAt: string;
+  status: CharacterStatus;
   canEdit: boolean;
 }

--- a/app/types/player.ts
+++ b/app/types/player.ts
@@ -1,0 +1,59 @@
+import type { PictureCrop } from './character';
+
+export interface PlayerStatus {
+  value: 'alive' | 'deceased';
+  changedAt: string | null;
+  changedBy: string | null;
+}
+
+export interface PlayerRelationship {
+  characterId: string;
+  descriptor: string;
+  isPublic: boolean;
+}
+
+export interface PlayerData {
+  id: string;
+  campaignId: string;
+  createdBy: string;
+  firstName: string;
+  lastName: string;
+  race: string;
+  characterClass: string;
+  age: number;
+  gender: string;
+  location: string;
+  link: string;
+  picture: string;
+  pictureCrop: PictureCrop | null;
+  description: string;
+  backstory: string;
+  gmNotes: string;
+  color: string;
+  eyeColor: string;
+  hairColor: string;
+  weight: number | null;
+  height: string;
+  size: string;
+  appearance: string;
+  status: PlayerStatus;
+  relationships: PlayerRelationship[];
+  createdAt: string;
+  updatedAt: string;
+  canEdit: boolean;
+}
+
+export interface PlayerListItem {
+  id: string;
+  campaignId: string;
+  createdBy: string;
+  firstName: string;
+  lastName: string;
+  race: string;
+  characterClass: string;
+  color: string;
+  picture: string;
+  pictureCrop: PictureCrop | null;
+  status: PlayerStatus;
+  canEdit: boolean;
+}

--- a/app/types/schemas/characters.ts
+++ b/app/types/schemas/characters.ts
@@ -1,11 +1,11 @@
-import { z } from 'zod'
+import { z } from 'zod';
 
 const pictureCropSchema = z.object({
   x: z.number().finite().min(0).max(1),
   y: z.number().finite().min(0).max(1),
   width: z.number().finite().gt(0).max(1),
   height: z.number().finite().gt(0).max(1),
-})
+});
 
 export const createCharacterSchema = z.object({
   campaignId: z.string().trim().min(1),
@@ -15,7 +15,12 @@ export const createCharacterSchema = z.object({
   characterClass: z.string().trim().optional().default(''),
   age: z.number().int().positive().nullable().optional().default(null),
   location: z.string().trim().optional().default(''),
-  link: z.string().trim().regex(/^(https?:\/\/.+)?$/, 'Must be an HTTP or HTTPS URL').optional().default(''),
+  link: z
+    .string()
+    .trim()
+    .regex(/^(https?:\/\/.+)?$/, 'Must be an HTTP or HTTPS URL')
+    .optional()
+    .default(''),
   picture: z.string().optional().default(''),
   pictureCrop: pictureCropSchema.nullable().optional().default(null),
   notes: z.string().optional().default(''),
@@ -24,7 +29,7 @@ export const createCharacterSchema = z.object({
   isPublic: z.boolean().optional().default(false),
   sessionId: z.string().trim().min(1).optional(),
   sessions: z.array(z.string()).optional().default([]),
-})
+});
 
 export const updateCharacterSchema = z.object({
   id: z.string().trim().min(1),
@@ -35,7 +40,12 @@ export const updateCharacterSchema = z.object({
   characterClass: z.string().trim().optional().default(''),
   age: z.number().int().positive().nullable().optional().default(null),
   location: z.string().trim().optional().default(''),
-  link: z.string().trim().regex(/^(https?:\/\/.+)?$/, 'Must be an HTTP or HTTPS URL').optional().default(''),
+  link: z
+    .string()
+    .trim()
+    .regex(/^(https?:\/\/.+)?$/, 'Must be an HTTP or HTTPS URL')
+    .optional()
+    .default(''),
   picture: z.string().optional().default(''),
   pictureCrop: pictureCropSchema.nullable().optional().default(null),
   notes: z.string().optional().default(''),
@@ -44,12 +54,12 @@ export const updateCharacterSchema = z.object({
   isPublic: z.boolean().optional(),
   sessionId: z.string().trim().min(1).optional(),
   sessions: z.array(z.string()).optional().default([]),
-})
+});
 
 export const deleteCharacterSchema = z.object({
   id: z.string().trim().min(1),
   campaignId: z.string().trim().min(1),
-})
+});
 
 export const listCharactersSchema = z.object({
   campaignId: z.string().min(1),
@@ -57,9 +67,39 @@ export const listCharactersSchema = z.object({
   search: z.string().optional(),
   visibility: z.enum(['all', 'public', 'private']).optional().default('all'),
   tags: z.array(z.string()).optional(),
-})
+});
 
 export const getCharacterSchema = z.object({
   id: z.string().trim().min(1),
   campaignId: z.string().trim().min(1),
-})
+});
+
+export const updateCharacterStatusSchema = z.object({
+  id: z.string().min(1),
+  campaignId: z.string().min(1),
+  value: z.enum(['alive', 'deceased']),
+});
+
+export const addCharacterRelationshipSchema = z.object({
+  characterId: z.string().min(1),
+  campaignId: z.string().min(1),
+  targetCharacterId: z.string().min(1),
+  descriptor: z.string().trim().min(1),
+  reciprocalDescriptor: z.string().trim().min(1),
+  isPublic: z.boolean().optional().default(false),
+});
+
+export const updateCharacterRelationshipSchema = z.object({
+  characterId: z.string().min(1),
+  campaignId: z.string().min(1),
+  targetCharacterId: z.string().min(1),
+  descriptor: z.string().trim().min(1).optional(),
+  reciprocalDescriptor: z.string().trim().min(1).optional(),
+  isPublic: z.boolean().optional(),
+});
+
+export const removeCharacterRelationshipSchema = z.object({
+  characterId: z.string().min(1),
+  campaignId: z.string().min(1),
+  targetCharacterId: z.string().min(1),
+});

--- a/app/types/schemas/gmscreens.ts
+++ b/app/types/schemas/gmscreens.ts
@@ -5,7 +5,13 @@ import { WINDOW_STATES } from '~/types/gmscreen';
  * Collection names that can be opened as windows or referenced in stacks.
  * Must stay in sync with COLLECTION_REGISTRY in the server implementation.
  */
-export const SUPPORTED_COLLECTIONS: [string, ...string[]] = ['note', 'character', 'race', 'rule'];
+export const SUPPORTED_COLLECTIONS: [string, ...string[]] = [
+  'note',
+  'character',
+  'race',
+  'rule',
+  'player',
+];
 
 // ---------------------------------------------------------------------------
 // Screen CRUD

--- a/app/types/schemas/players.ts
+++ b/app/types/schemas/players.ts
@@ -1,0 +1,118 @@
+import { z } from 'zod';
+
+export const pictureCropSchema = z.object({
+  x: z.number().finite().min(0).max(1),
+  y: z.number().finite().min(0).max(1),
+  width: z.number().finite().gt(0).max(1),
+  height: z.number().finite().gt(0).max(1),
+});
+
+export const createPlayerSchema = z.object({
+  campaignId: z.string().min(1),
+  firstName: z.string().trim().min(1),
+  lastName: z.string().trim().min(1),
+  race: z.string().trim().min(1),
+  characterClass: z.string().trim().min(1),
+  age: z.number().int().positive(),
+  gender: z.string().trim().optional().default(''),
+  location: z.string().trim().optional().default(''),
+  link: z
+    .string()
+    .trim()
+    .regex(/^(https?:\/\/.+)?$/)
+    .optional()
+    .default(''),
+  picture: z.string().optional().default(''),
+  pictureCrop: pictureCropSchema.nullable().optional().default(null),
+  description: z.string().optional().default(''),
+  backstory: z.string().optional().default(''),
+  color: z
+    .string()
+    .regex(/^#[0-9a-fA-F]{6}$/)
+    .optional()
+    .default('#3498db'),
+  eyeColor: z.string().trim().optional().default(''),
+  hairColor: z.string().trim().optional().default(''),
+  weight: z.number().positive().nullable().optional().default(null),
+  height: z.string().trim().optional().default(''),
+  size: z.string().trim().optional().default(''),
+  appearance: z.string().optional().default(''),
+});
+
+export const updatePlayerSchema = createPlayerSchema.extend({
+  id: z.string().min(1),
+  gmNotes: z.string().optional(),
+});
+
+export const getPlayerSchema = z.object({
+  id: z.string().trim().min(1),
+  campaignId: z.string().trim().min(1),
+});
+
+export const deletePlayerSchema = z.object({
+  id: z.string().trim().min(1),
+  campaignId: z.string().trim().min(1),
+});
+
+export const listPlayersSchema = z.object({
+  campaignId: z.string().min(1),
+  search: z.string().optional(),
+});
+
+export const updatePlayerStatusSchema = z.object({
+  id: z.string().min(1),
+  campaignId: z.string().min(1),
+  value: z.enum(['alive', 'deceased']),
+});
+
+export const playerRelationshipSchema = z.object({
+  playerId: z.string().min(1),
+  campaignId: z.string().min(1),
+  characterId: z.string().min(1),
+  descriptor: z.string().trim().min(1),
+  isPublic: z.boolean().optional().default(false),
+});
+
+export const removePlayerRelationshipSchema = z.object({
+  playerId: z.string().min(1),
+  campaignId: z.string().min(1),
+  characterId: z.string().min(1),
+});
+
+export const validateInviteCodeSchema = z.object({
+  inviteCode: z.string().min(1),
+});
+
+export const completeJoinWizardSchema = z.object({
+  campaignId: z.string().min(1),
+  player: createPlayerSchema.omit({ campaignId: true }),
+  characters: z
+    .array(
+      z.object({
+        firstName: z.string().trim().min(1),
+        lastName: z.string().trim().min(1),
+        race: z.string().trim().optional().default(''),
+        characterClass: z.string().trim().optional().default(''),
+        age: z.number().int().positive().nullable().optional().default(null),
+        location: z.string().trim().optional().default(''),
+        link: z
+          .string()
+          .trim()
+          .regex(/^(https?:\/\/.+)?$/)
+          .optional()
+          .default(''),
+        picture: z.string().optional().default(''),
+        pictureCrop: pictureCropSchema.nullable().optional().default(null),
+        notes: z.string().optional().default(''),
+        gmNotes: z.string().optional().default(''),
+        tags: z.array(z.string()).optional().default([]),
+        isPublic: z.boolean().optional().default(false),
+        relationship: z.object({
+          descriptor: z.string().trim().min(1),
+          isPublic: z.boolean().optional().default(false),
+        }),
+      })
+    )
+    .optional()
+    .default([]),
+});

--- a/app/utils/queryKeys.ts
+++ b/app/utils/queryKeys.ts
@@ -59,6 +59,14 @@ export const queryKeys = {
     detail: (id: string, campaignId?: string) =>
       ['characters', 'detail', campaignId ?? '', id] as const,
   },
+  players: {
+    all: ['players'] as const,
+    list: (campaignId: string, search?: string) =>
+      ['players', 'list', campaignId, search ?? ''] as const,
+    detail: (id: string, campaignId?: string) =>
+      ['players', 'detail', campaignId ?? '', id] as const,
+    active: (campaignId: string) => ['players', 'active', campaignId] as const,
+  },
   rules: {
     all: ['rules'] as const,
     list: (campaignId: string, search?: string, visibility?: string, tags?: string[]) =>

--- a/tests/components/mainview/WikiPanel.test.tsx
+++ b/tests/components/mainview/WikiPanel.test.tsx
@@ -36,11 +36,12 @@ describe('WikiPanel', () => {
     expect(screen.getByRole('button', { name: 'Characters' })).toBeInTheDocument();
   });
 
-  it('shows Characters, Races, and Rules categories', () => {
+  it('shows Characters, Players, Races, and Rules categories', () => {
     render(<WikiPanel />);
 
-    expect(screen.getAllByRole('button')).toHaveLength(3);
+    expect(screen.getAllByRole('button')).toHaveLength(4);
     expect(screen.getByRole('button', { name: 'Characters' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Players' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Races' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Rules' })).toBeInTheDocument();
   });

--- a/tests/components/wiki/characters/CharacterWindow.test.tsx
+++ b/tests/components/wiki/characters/CharacterWindow.test.tsx
@@ -26,6 +26,8 @@ const baseCharacter: CharacterData = {
   sessions: [],
   createdAt: '2026-01-01',
   updatedAt: '2026-01-01',
+  status: { value: 'alive', changedAt: null, changedBy: null },
+  relationships: [],
 };
 
 describe('CharacterWindow', () => {

--- a/tests/components/wiki/characters/CharacterWindow.test.tsx
+++ b/tests/components/wiki/characters/CharacterWindow.test.tsx
@@ -77,4 +77,54 @@ describe('CharacterWindow', () => {
     expect(screen.queryByRole('button', { name: 'Edit character' })).not.toBeInTheDocument();
     expect(screen.queryByText(/#/)).not.toBeInTheDocument();
   });
+
+  describe('tabs', () => {
+    it('renders General tab content by default with notes', () => {
+      render(<CharacterWindow character={baseCharacter} />);
+      expect(screen.getByText('A steadfast warrior.')).toBeInTheDocument();
+    });
+
+    it('shows GM Notes tab when canEdit is true', () => {
+      render(<CharacterWindow character={baseCharacter} />);
+      expect(screen.getByText('GM Notes')).toBeInTheDocument();
+    });
+
+    it('hides GM Notes tab when canEdit is false', () => {
+      render(<CharacterWindow character={{ ...baseCharacter, canEdit: false }} />);
+      expect(screen.queryByText('GM Notes')).not.toBeInTheDocument();
+    });
+
+    it('switches to GM Notes tab on click', async () => {
+      const user = userEvent.setup();
+      render(
+        <CharacterWindow character={{ ...baseCharacter, gmNotes: 'Secret villain plans.' }} />
+      );
+      await user.click(screen.getByText('GM Notes'));
+      expect(screen.getByText('Secret villain plans.')).toBeInTheDocument();
+    });
+
+    it('switches to Relationships tab showing placeholder', async () => {
+      const user = userEvent.setup();
+      render(<CharacterWindow character={baseCharacter} />);
+      await user.click(screen.getByText('Relationships'));
+      expect(screen.getByText('No relationships yet.')).toBeInTheDocument();
+    });
+
+    it('shows Deceased label when status is deceased', () => {
+      render(
+        <CharacterWindow
+          character={{
+            ...baseCharacter,
+            status: { value: 'deceased', changedAt: '2026-03-01', changedBy: 'user-1' },
+          }}
+        />
+      );
+      expect(screen.getByText('Deceased')).toBeInTheDocument();
+    });
+
+    it('does not show Deceased label when status is alive', () => {
+      render(<CharacterWindow character={baseCharacter} />);
+      expect(screen.queryByText('Deceased')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/tests/components/wiki/characters/CharacterWindow.test.tsx
+++ b/tests/components/wiki/characters/CharacterWindow.test.tsx
@@ -1,9 +1,17 @@
-import React from 'react';
+import React, { type ReactNode } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { CharacterWindow } from '~/components/wiki/characters/CharacterWindow';
 import type { CharacterData } from '~/types/character';
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const [queryClient] = React.useState(() => new QueryClient({ defaultOptions: { queries: { retry: false } } }));
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+const customRender: typeof render = (ui, options) => render(ui, { wrapper: Wrapper, ...options });
 
 const baseCharacter: CharacterData = {
   id: 'char-1',
@@ -32,18 +40,18 @@ const baseCharacter: CharacterData = {
 
 describe('CharacterWindow', () => {
   it('does not render the full name as a heading below the portrait', () => {
-    render(<CharacterWindow character={baseCharacter} />);
+    customRender(<CharacterWindow character={baseCharacter} />);
     expect(screen.queryByRole('heading', { name: 'Thorin Grudgebearer' })).not.toBeInTheDocument();
   });
 
   it('does not render a visibility badge', () => {
-    render(<CharacterWindow character={baseCharacter} />);
+    customRender(<CharacterWindow character={baseCharacter} />);
     expect(screen.queryByText('Public')).not.toBeInTheDocument();
     expect(screen.queryByText('Private')).not.toBeInTheDocument();
   });
 
   it('renders tags below the portrait', () => {
-    render(<CharacterWindow character={baseCharacter} />);
+    customRender(<CharacterWindow character={baseCharacter} />);
     expect(screen.getByText('#guard')).toBeInTheDocument();
     expect(screen.getByText('#dwarf')).toBeInTheDocument();
   });
@@ -51,24 +59,26 @@ describe('CharacterWindow', () => {
   it('shows the edit button when character.canEdit and onEdit are provided', async () => {
     const onEdit = vi.fn();
     const user = userEvent.setup();
-    render(<CharacterWindow character={baseCharacter} onEdit={onEdit} />);
+    customRender(<CharacterWindow character={baseCharacter} onEdit={onEdit} />);
     await user.click(screen.getByRole('button', { name: 'Edit character' }));
     expect(onEdit).toHaveBeenCalledTimes(1);
   });
 
   it('hides the edit button when canEdit is false', () => {
-    render(<CharacterWindow character={{ ...baseCharacter, canEdit: false }} onEdit={vi.fn()} />);
+    customRender(
+      <CharacterWindow character={{ ...baseCharacter, canEdit: false }} onEdit={vi.fn()} />
+    );
     expect(screen.queryByRole('button', { name: 'Edit character' })).not.toBeInTheDocument();
   });
 
   it('still renders stat blocks', () => {
-    render(<CharacterWindow character={baseCharacter} />);
+    customRender(<CharacterWindow character={baseCharacter} />);
     expect(screen.getByText('Dwarf')).toBeInTheDocument();
     expect(screen.getByText('208')).toBeInTheDocument();
   });
 
   it('hides the meta row entirely when there are no tags and canEdit is false', () => {
-    render(
+    customRender(
       <CharacterWindow
         character={{ ...baseCharacter, tags: [], canEdit: false }}
         onEdit={vi.fn()}
@@ -80,23 +90,23 @@ describe('CharacterWindow', () => {
 
   describe('tabs', () => {
     it('renders General tab content by default with notes', () => {
-      render(<CharacterWindow character={baseCharacter} />);
+      customRender(<CharacterWindow character={baseCharacter} />);
       expect(screen.getByText('A steadfast warrior.')).toBeInTheDocument();
     });
 
     it('shows GM Notes tab when canEdit is true', () => {
-      render(<CharacterWindow character={baseCharacter} />);
+      customRender(<CharacterWindow character={baseCharacter} />);
       expect(screen.getByText('GM Notes')).toBeInTheDocument();
     });
 
     it('hides GM Notes tab when canEdit is false', () => {
-      render(<CharacterWindow character={{ ...baseCharacter, canEdit: false }} />);
+      customRender(<CharacterWindow character={{ ...baseCharacter, canEdit: false }} />);
       expect(screen.queryByText('GM Notes')).not.toBeInTheDocument();
     });
 
     it('switches to GM Notes tab on click', async () => {
       const user = userEvent.setup();
-      render(
+      customRender(
         <CharacterWindow character={{ ...baseCharacter, gmNotes: 'Secret villain plans.' }} />
       );
       await user.click(screen.getByText('GM Notes'));
@@ -105,13 +115,13 @@ describe('CharacterWindow', () => {
 
     it('switches to Relationships tab showing placeholder', async () => {
       const user = userEvent.setup();
-      render(<CharacterWindow character={baseCharacter} />);
+      customRender(<CharacterWindow character={baseCharacter} />);
       await user.click(screen.getByText('Relationships'));
       expect(screen.getByText('No relationships yet.')).toBeInTheDocument();
     });
 
     it('shows Deceased label when status is deceased', () => {
-      render(
+      customRender(
         <CharacterWindow
           character={{
             ...baseCharacter,
@@ -123,7 +133,7 @@ describe('CharacterWindow', () => {
     });
 
     it('does not show Deceased label when status is alive', () => {
-      render(<CharacterWindow character={baseCharacter} />);
+      customRender(<CharacterWindow character={baseCharacter} />);
       expect(screen.queryByText('Deceased')).not.toBeInTheDocument();
     });
   });

--- a/tests/components/wiki/characters/CharacterWindow.test.tsx
+++ b/tests/components/wiki/characters/CharacterWindow.test.tsx
@@ -7,11 +7,15 @@ import { CharacterWindow } from '~/components/wiki/characters/CharacterWindow';
 import type { CharacterData } from '~/types/character';
 
 function Wrapper({ children }: { children: ReactNode }) {
-  const [queryClient] = React.useState(() => new QueryClient({ defaultOptions: { queries: { retry: false } } }));
+  const [queryClient] = React.useState(
+    () => new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  );
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 }
 
-const customRender: typeof render = (ui, options) => render(ui, { wrapper: Wrapper, ...options });
+function customRender(ui: React.ReactNode, options?: Parameters<typeof render>[1]) {
+  return render(ui, { wrapper: Wrapper, ...options });
+}
 
 const baseCharacter: CharacterData = {
   id: 'char-1',

--- a/tests/server/db/governance.test.ts
+++ b/tests/server/db/governance.test.ts
@@ -2,9 +2,17 @@ import { describe, it, expect } from 'vitest';
 import { INDEX_GOVERNANCE, getSeverity, normalizeIndexKey } from '~/server/db/governance';
 
 describe('INDEX_GOVERNANCE registry', () => {
-  it('contains entries for all six models', () => {
+  it('contains entries for all models', () => {
     expect(Object.keys(INDEX_GOVERNANCE)).toEqual(
-      expect.arrayContaining(['User', 'Campaign', 'Session', 'Player', 'GMScreen', 'Note'])
+      expect.arrayContaining([
+        'User',
+        'Campaign',
+        'Session',
+        'Player',
+        'GMScreen',
+        'Note',
+        'Character',
+      ])
     );
   });
 

--- a/tests/server/db/governance.test.ts
+++ b/tests/server/db/governance.test.ts
@@ -1,81 +1,81 @@
-import { describe, it, expect } from 'vitest'
-import { INDEX_GOVERNANCE, getSeverity, normalizeIndexKey } from '~/server/db/governance'
+import { describe, it, expect } from 'vitest';
+import { INDEX_GOVERNANCE, getSeverity, normalizeIndexKey } from '~/server/db/governance';
 
 describe('INDEX_GOVERNANCE registry', () => {
   it('contains entries for all six models', () => {
     expect(Object.keys(INDEX_GOVERNANCE)).toEqual(
-      expect.arrayContaining(['User', 'Campaign', 'Session', 'Player', 'GMScreen', 'Note']),
-    )
-  })
+      expect.arrayContaining(['User', 'Campaign', 'Session', 'Player', 'GMScreen', 'Note'])
+    );
+  });
 
   it('every entry has a valid severity', () => {
     for (const [, entries] of Object.entries(INDEX_GOVERNANCE)) {
       for (const entry of entries) {
-        expect(['critical', 'optional']).toContain(entry.severity)
-        expect(Object.keys(entry.key).length).toBeGreaterThan(0)
+        expect(['critical', 'optional']).toContain(entry.severity);
+        expect(Object.keys(entry.key).length).toBeGreaterThan(0);
       }
     }
-  })
-})
+  });
+});
 
 describe('getSeverity', () => {
   it('returns critical for User email index', () => {
-    expect(getSeverity('User', { email: 1 })).toBe('critical')
-  })
+    expect(getSeverity('User', { email: 1 })).toBe('critical');
+  });
 
   it('returns optional for User role index', () => {
-    expect(getSeverity('User', { role: 1 })).toBe('optional')
-  })
+    expect(getSeverity('User', { role: 1 })).toBe('optional');
+  });
 
-  it('returns critical for Player unique compound index', () => {
-    expect(getSeverity('Player', { campaignId: 1, userId: 1 })).toBe('critical')
-  })
+  it('returns optional for Player campaignId index', () => {
+    expect(getSeverity('Player', { campaignId: 1 })).toBe('optional');
+  });
 
   it('returns critical for GMScreen campaignId+tabOrder unique index', () => {
-    expect(getSeverity('GMScreen', { campaignId: 1, tabOrder: 1 })).toBe('critical')
-  })
+    expect(getSeverity('GMScreen', { campaignId: 1, tabOrder: 1 })).toBe('critical');
+  });
 
   it('returns critical for GMScreen campaignId+name unique index', () => {
-    expect(getSeverity('GMScreen', { campaignId: 1, name: 1 })).toBe('critical')
-  })
+    expect(getSeverity('GMScreen', { campaignId: 1, name: 1 })).toBe('critical');
+  });
 
   it('returns undefined for unknown model', () => {
-    expect(getSeverity('Unknown', { foo: 1 })).toBeUndefined()
-  })
+    expect(getSeverity('Unknown', { foo: 1 })).toBeUndefined();
+  });
 
   it('returns undefined for unregistered index key', () => {
-    expect(getSeverity('User', { firstName: 1 })).toBeUndefined()
-  })
+    expect(getSeverity('User', { firstName: 1 })).toBeUndefined();
+  });
 
   it('returns optional for Note campaignId+updatedAt compound index', () => {
-    expect(getSeverity('Note', { campaignId: 1, updatedAt: -1 })).toBe('optional')
-  })
+    expect(getSeverity('Note', { campaignId: 1, updatedAt: -1 })).toBe('optional');
+  });
 
   it('returns optional for Note text index via schema-declared key form', () => {
-    expect(getSeverity('Note', { title: 'text', note: 'text' })).toBe('optional')
-  })
-})
+    expect(getSeverity('Note', { title: 'text', note: 'text' })).toBe('optional');
+  });
+});
 
 describe('normalizeIndexKey', () => {
   it('collapses pure text index to canonical MongoDB form', () => {
     expect(normalizeIndexKey({ title: 'text', note: 'text' })).toEqual({
       _fts: 'text',
       _ftsx: 1,
-    })
-  })
+    });
+  });
 
   it('preserves non-text prefix fields in compound text indexes', () => {
     expect(normalizeIndexKey({ campaignId: 1, title: 'text', note: 'text' })).toEqual({
       campaignId: 1,
       _fts: 'text',
       _ftsx: 1,
-    })
-  })
+    });
+  });
 
   it('returns non-text index keys unchanged', () => {
     expect(normalizeIndexKey({ campaignId: 1, updatedAt: -1 })).toEqual({
       campaignId: 1,
       updatedAt: -1,
-    })
-  })
-})
+    });
+  });
+});

--- a/tests/server/functions/gmscreens.test.ts
+++ b/tests/server/functions/gmscreens.test.ts
@@ -1870,6 +1870,7 @@ describe('SUPPORTED_COLLECTIONS', () => {
     expect(SUPPORTED_COLLECTIONS).toContain('note');
     expect(SUPPORTED_COLLECTIONS).toContain('character');
     expect(SUPPORTED_COLLECTIONS).toContain('rule');
+    expect(SUPPORTED_COLLECTIONS).toContain('player');
     expect(SUPPORTED_COLLECTIONS.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

- **Player Characters system** — New `players` collection with full model (25+ fields including physical attributes, backstory, GM notes, identity color, status tracking, and relationships)
- **Join Campaign Wizard** — 5-step wizard replacing the old direct-join flow: invite code → player info → backstory → related characters → review & confirm. State persisted to localStorage for resume support.
- **Character Relationships** — Bidirectional character-to-character relationships with public/private visibility. Player-to-character relationships (one-directional). Shared RelationshipList and RelationshipModal UI components.
- **Character Status** — Alive/deceased tracking with audit trail on both Players and Characters. Deceased styling in wiki lists with faded player-color backgrounds.
- **Wiki Inspector** — New "Players" category with PlayerCard list, search filtering, and floating window integration via collection registry
- **Player Floating Window** — 4-tab layout (General, Backstory, GM Notes, Relationships) with player identity color in title bar
- **Character Window Refactor** — Replaced accordion layout with tab-based UI (General, GM Notes, Relationships) matching the player window pattern
- **Active Player Context** — Campaign-scoped `ActivePlayerProvider` that loads the current user's alive player character into React context, accessible from any campaign UI via `useActivePlayerContext()`. Foundation for future chat integration (player name + color instead of user name).
- **Permission Changes** — Character creation opened to all campaign members (was GM-only). Visibility rules enforce backstory/gmNotes/private relationship access per spec.

## Test plan

- [ ] TypeScript compiles clean (`tsc --noEmit` passes)
- [ ] All 1104 unit tests pass (86 test files)
- [ ] Pre-push hooks (typecheck + unit tests) pass
- [ ] Manual: Log in as GM, create campaign with invite code
- [ ] Manual: Log in as player, join campaign via wizard (all 5 steps)
- [ ] Manual: Verify player appears in wiki inspector Players section
- [ ] Manual: Click player card → floating window opens with tabs
- [ ] Manual: Edit player via modal
- [ ] Manual: Create characters as non-GM player
- [ ] Manual: Add character-to-character relationships (verify bidirectional)
- [ ] Manual: Add player-to-character relationships
- [ ] Manual: Mark player deceased (GM only) → verify deceased styling
- [ ] Manual: Log in as deceased player → verify re-entry banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)