### PR TITLE
chore(security): close remaining alert + supply-chain defence (cooldown + CI age guard)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,14 @@ updates:
       - 'dependencies'
     commit-message:
       prefix: 'chore(deps)'
+    # Cooldown — wait 10 days after a version is published before opening
+    # a PR for it. Defends against supply-chain attacks where a compromised
+    # maintainer publishes a malicious version: 10 days is well within the
+    # typical window for the npm community to spot and yank. The CI guard
+    # in `scripts/check-package-age.mjs` enforces the same threshold on
+    # manual installs.
+    cooldown:
+      default-days: 10
     ignore:
       # Only accept patch and minor updates for major version packages
       - dependency-name: 'mongoose'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,20 @@ jobs:
       - name: Security audit
         run: npm audit --audit-level=high --omit=dev
 
+      - name: Package age guard (supply-chain defence)
+        # Fail if any direct dep was published less than MIN_AGE_DAYS (10) ago.
+        # Mirrors the `cooldown` rule in `.github/dependabot.yml`. To bypass
+        # for an emergency CVE fix, set SKIP_AGE_CHECK=1 in the workflow run
+        # and document in the PR. STRICT_AGE_CHECK=1 also gates transitives.
+        #
+        # `continue-on-error: true` during rollout — the existing lockfile
+        # was regenerated recently (#432) and has ~20 direct deps published
+        # in the last 10 days. They will age out by ~2026-06-11, after
+        # which this flag should be removed so the step becomes blocking.
+        # TODO(2026-06-12): drop `continue-on-error` once the lockfile ages.
+        continue-on-error: true
+        run: npm run check:deps-age
+
       - name: Type check
         run: npm run typecheck
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "konva": "^10.2.5",
         "lucide-react": "^1.6.0",
         "mongoose": "^9.3.3",
-        "nitro": "^3.0.260311-beta",
+        "nitro": "^3.0.260522-beta",
         "partysocket": "^1.1.16",
         "posthog-js": "^1.363.3",
         "posthog-node": "^5.28.5",
@@ -12036,25 +12036,25 @@
       "license": "MIT"
     },
     "node_modules/nitro": {
-      "version": "3.0.260311-beta",
-      "resolved": "https://registry.npmjs.org/nitro/-/nitro-3.0.260311-beta.tgz",
-      "integrity": "sha512-0o0fJ9LUh4WKUqJNX012jyieUOtMCnadkNDWr0mHzdraoHpJP/1CGNefjRyZyMXSpoJfwoWdNEZu2iGf35TUvQ==",
+      "version": "3.0.260522-beta",
+      "resolved": "https://registry.npmjs.org/nitro/-/nitro-3.0.260522-beta.tgz",
+      "integrity": "sha512-L/z2eOWgkiQHc65kv+SEMgau505afSRF7NJlbooaaZEZscFrNSD7rXZzeVubQlgIzPbhOG8o73bk9soIiGTHRA==",
       "license": "MIT",
       "dependencies": {
         "consola": "^3.4.2",
-        "crossws": "^0.4.4",
+        "crossws": "^0.4.5",
         "db0": "^0.3.4",
-        "env-runner": "^0.1.6",
-        "h3": "^2.0.1-rc.16",
-        "hookable": "^6.0.1",
-        "nf3": "^0.3.11",
-        "ocache": "^0.1.2",
+        "env-runner": "^0.1.9",
+        "h3": "^2.0.1-rc.22",
+        "hookable": "^6.1.1",
+        "nf3": "^0.3.17",
+        "ocache": "^0.1.4",
         "ofetch": "^2.0.0-alpha.3",
         "ohash": "^2.0.11",
-        "rolldown": "^1.0.0-rc.8",
-        "srvx": "^0.11.9",
+        "rolldown": "^1.0.2",
+        "srvx": "^0.11.15",
         "unenv": "^2.0.0-rc.24",
-        "unstorage": "^2.0.0-alpha.6"
+        "unstorage": "^2.0.0-alpha.7"
       },
       "bin": {
         "nitro": "dist/cli/index.mjs"
@@ -12063,15 +12063,19 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
+        "@vercel/queue": "^0.2.0",
         "dotenv": "*",
         "giget": "*",
         "jiti": "^2.6.1",
-        "rollup": "^4.59.0",
-        "vite": "^7 || ^8 || >=8.0.0-0",
+        "rollup": "^4.60.3",
+        "vite": "^7 || ^8",
         "xml2js": "^0.6.2",
-        "zephyr-agent": "^0.1.15"
+        "zephyr-agent": "^0.2.0"
       },
       "peerDependenciesMeta": {
+        "@vercel/queue": {
+          "optional": true
+        },
         "dotenv": {
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "konva": "^10.2.5",
     "lucide-react": "^1.6.0",
     "mongoose": "^9.3.3",
-    "nitro": "^3.0.260311-beta",
+    "nitro": "^3.0.260522-beta",
     "partysocket": "^1.1.16",
     "posthog-js": "^1.363.3",
     "posthog-node": "^5.28.5",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "build-storybook": "storybook build",
     "build-storybook:full": "node scripts/build-storybook-with-iframe.mjs",
     "party:dev": "npx partykit dev",
+    "check:deps-age": "node scripts/check-package-age.mjs",
     "db:verify": "tsx scripts/mongo-admin.ts verify",
     "db:sync": "tsx scripts/mongo-admin.ts sync",
     "dev:clear": "node scripts/run-python.cjs dev_clear.py",

--- a/scripts/check-package-age.mjs
+++ b/scripts/check-package-age.mjs
@@ -115,7 +115,7 @@ async function pool(items, limit, fn) {
 }
 
 /**
- * Fetch the published-time map for a package. Returns null on any error so a
+ * Fetch the published-time map for a package. Returns `{ ok: false, error }` on any error so a
  * registry hiccup doesn't block the build — failing-open here is the right
  * trade because the dependabot cooldown layer already gives belt-and-braces.
  */

--- a/scripts/check-package-age.mjs
+++ b/scripts/check-package-age.mjs
@@ -48,6 +48,13 @@ if (!Number.isFinite(MIN_AGE_DAYS) || MIN_AGE_DAYS < 0) {
   process.exit(2);
 }
 
+if (!Number.isInteger(CONCURRENCY) || CONCURRENCY < 1) {
+  console.error(
+    `[check-package-age] Invalid AGE_CHECK_CONCURRENCY=${process.env.AGE_CHECK_CONCURRENCY} (expected a positive integer)`
+  );
+  process.exit(2);
+}
+
 const thresholdMs = Date.now() - MIN_AGE_DAYS * 24 * 60 * 60 * 1000;
 const threshold = new Date(thresholdMs).toISOString();
 

--- a/scripts/check-package-age.mjs
+++ b/scripts/check-package-age.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+/**
+ * Supply-chain defence: fail if any **direct** dep was installed at a
+ * version published within the last N days. Pairs with the `cooldown` block
+ * in `.github/dependabot.yml`, which prevents Dependabot from opening PRs
+ * for freshly-published versions. This script catches the manual
+ * `npm install foo@latest` path.
+ *
+ * Only direct deps (package.json `dependencies` + `devDependencies`) are
+ * gated, because:
+ *   - That's the surface where a maintainer-compromise attack actually
+ *     reaches our code (we explicitly chose to depend on them).
+ *   - Transitives churn at very high velocity (eg. @babel/* publishes
+ *     daily) and we don't control them — gating on transitives would
+ *     break CI almost continuously without a real security upside.
+ *
+ * Set STRICT_AGE_CHECK=1 to also fail on too-new transitives (still useful
+ * as a periodic audit, just impractical as a default CI gate).
+ *
+ * Usage:
+ *   node scripts/check-package-age.mjs              # defaults to MIN_AGE_DAYS=10
+ *   MIN_AGE_DAYS=14 node scripts/check-package-age.mjs
+ *   STRICT_AGE_CHECK=1 node scripts/check-package-age.mjs   # also gate transitives
+ *   SKIP_AGE_CHECK=1 node scripts/check-package-age.mjs     # emergency bypass
+ *
+ * Reads `package-lock.json` directly (no node_modules needed). Queries the
+ * npm registry once per unique package name and looks up each pinned
+ * version's publish timestamp from the `time` map. Concurrency-limited so
+ * we don't hammer the registry.
+ */
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const LOCKFILE = resolve(__dirname, '..', 'package-lock.json');
+const MIN_AGE_DAYS = Number(process.env.MIN_AGE_DAYS ?? 10);
+const CONCURRENCY = Number(process.env.AGE_CHECK_CONCURRENCY ?? 16);
+const REGISTRY = (process.env.NPM_REGISTRY ?? 'https://registry.npmjs.org').replace(/\/+$/, '');
+
+if (process.env.SKIP_AGE_CHECK === '1') {
+  console.warn('[check-package-age] SKIP_AGE_CHECK=1 — bypassing age check.');
+  process.exit(0);
+}
+
+if (!Number.isFinite(MIN_AGE_DAYS) || MIN_AGE_DAYS < 0) {
+  console.error(`[check-package-age] Invalid MIN_AGE_DAYS=${process.env.MIN_AGE_DAYS}`);
+  process.exit(2);
+}
+
+const thresholdMs = Date.now() - MIN_AGE_DAYS * 24 * 60 * 60 * 1000;
+const threshold = new Date(thresholdMs).toISOString();
+
+/**
+ * @returns {Promise<{ versions: Map<string, Set<string>>, directNames: Set<string> }>}
+ *   `versions` — every (name, version) pair in the resolved tree
+ *   `directNames` — names listed in package.json dependencies/devDependencies
+ */
+async function loadLockfile() {
+  const raw = await readFile(LOCKFILE, 'utf8');
+  const lock = JSON.parse(raw);
+  if (lock.lockfileVersion < 2) {
+    throw new Error(`Unsupported lockfileVersion=${lock.lockfileVersion}; expected v2 or v3.`);
+  }
+  const versions = new Map();
+  const root = lock.packages?.[''] ?? {};
+  const directNames = new Set([
+    ...Object.keys(root.dependencies ?? {}),
+    ...Object.keys(root.devDependencies ?? {}),
+  ]);
+  for (const [path, entry] of Object.entries(lock.packages ?? {})) {
+    if (!path || path === '') continue; // root package
+    if (entry.link) continue; // workspace / link:
+    const resolvedUrl = entry.resolved ?? '';
+    if (!resolvedUrl.startsWith('https://')) continue; // file:, git+, link:, no resolved
+    if (!entry.version) continue;
+    if (entry.version.startsWith('file:') || entry.version.startsWith('link:')) continue;
+    const name = pathToPackageName(path);
+    if (!name) continue;
+    if (!versions.has(name)) versions.set(name, new Set());
+    versions.get(name).add(entry.version);
+  }
+  return { versions, directNames };
+}
+
+/** Convert lockfile key like `node_modules/foo/node_modules/@scope/bar` → `@scope/bar`. */
+function pathToPackageName(key) {
+  const idx = key.lastIndexOf('node_modules/');
+  if (idx < 0) return null;
+  const tail = key.slice(idx + 'node_modules/'.length);
+  return tail || null;
+}
+
+/** Async pool: run `fn` over `items` with bounded concurrency. */
+async function pool(items, limit, fn) {
+  const results = new Array(items.length);
+  let cursor = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, async () => {
+      while (true) {
+        const i = cursor++;
+        if (i >= items.length) return;
+        results[i] = await fn(items[i], i);
+      }
+    })
+  );
+  return results;
+}
+
+/**
+ * Fetch the published-time map for a package. Returns null on any error so a
+ * registry hiccup doesn't block the build — failing-open here is the right
+ * trade because the dependabot cooldown layer already gives belt-and-braces.
+ */
+async function fetchPackageTimes(name) {
+  // Full packument required for the `time` map; abbreviated format omits it.
+  const url = `${REGISTRY}/${encodeURIComponent(name).replace('%40', '@')}`;
+  try {
+    const resp = await fetch(url, { headers: { Accept: 'application/json' } });
+    if (!resp.ok) {
+      return { ok: false, error: `HTTP ${resp.status}` };
+    }
+    const body = await resp.json();
+    return { ok: true, times: body.time ?? {} };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+async function main() {
+  const strict = process.env.STRICT_AGE_CHECK === '1';
+  console.log(
+    `[check-package-age] threshold: published before ${threshold} (MIN_AGE_DAYS=${MIN_AGE_DAYS}, mode=${strict ? 'strict (all deps)' : 'direct deps only'})`
+  );
+
+  const { versions: versionMap, directNames } = await loadLockfile();
+  const names = [...versionMap.keys()].sort();
+  console.log(
+    `[check-package-age] inspecting ${names.length} unique packages (${directNames.size} direct)...`
+  );
+
+  /** @type {Array<{name: string, version: string, publishedAt: string, direct: boolean}>} */
+  const tooNew = [];
+  const fetchErrors = [];
+  let inspected = 0;
+
+  await pool(names, CONCURRENCY, async (name) => {
+    const result = await fetchPackageTimes(name);
+    if (!result.ok) {
+      fetchErrors.push({ name, error: result.error });
+      return;
+    }
+    for (const version of versionMap.get(name)) {
+      const publishTime = result.times[version];
+      if (!publishTime) continue;
+      if (Date.parse(publishTime) > thresholdMs) {
+        tooNew.push({ name, version, publishedAt: publishTime, direct: directNames.has(name) });
+      }
+      inspected++;
+    }
+  });
+
+  console.log(`[check-package-age] checked ${inspected} (name, version) pairs`);
+
+  if (fetchErrors.length > 0) {
+    console.warn(
+      `[check-package-age] ${fetchErrors.length} registry fetch errors (treated as pass):`
+    );
+    for (const e of fetchErrors.slice(0, 10)) {
+      console.warn(`  - ${e.name}: ${e.error}`);
+    }
+    if (fetchErrors.length > 10) console.warn(`  ... and ${fetchErrors.length - 10} more`);
+  }
+
+  tooNew.sort((a, b) => b.publishedAt.localeCompare(a.publishedAt));
+  const directTooNew = tooNew.filter((p) => p.direct);
+  const transitiveTooNew = tooNew.filter((p) => !p.direct);
+
+  // Always surface transitive churn as a soft signal — useful context, never blocks.
+  if (transitiveTooNew.length > 0) {
+    console.log(
+      `[check-package-age] ℹ ${transitiveTooNew.length} transitive dep(s) published in last ${MIN_AGE_DAYS} days (informational):`
+    );
+    for (const p of transitiveTooNew.slice(0, 5)) {
+      console.log(`  - ${p.name}@${p.version}  (${p.publishedAt})`);
+    }
+    if (transitiveTooNew.length > 5) {
+      console.log(`  ... and ${transitiveTooNew.length - 5} more`);
+    }
+  }
+
+  const failing = strict ? tooNew : directTooNew;
+  if (failing.length === 0) {
+    console.log('[check-package-age] ✓ no direct deps newer than threshold');
+    return;
+  }
+
+  console.error('');
+  console.error(
+    `[check-package-age] ✗ ${failing.length} ${strict ? 'package' : 'direct dep'} version(s) were published less than ${MIN_AGE_DAYS} days ago:`
+  );
+  for (const p of failing) {
+    const tag = p.direct ? 'direct' : 'transitive';
+    console.error(`  - ${p.name}@${p.version}  [${tag}]  (published ${p.publishedAt})`);
+  }
+  console.error('');
+  console.error(
+    'If you intentionally accept the risk (e.g. urgent CVE fix), set SKIP_AGE_CHECK=1 for this run and document why in the PR.'
+  );
+  process.exit(1);
+}
+
+await main().catch((err) => {
+  console.error(`[check-package-age] unexpected failure: ${err?.stack ?? err}`);
+  process.exit(2);
+});

--- a/scripts/check-package-age.mjs
+++ b/scripts/check-package-age.mjs
@@ -79,7 +79,7 @@ async function loadLockfile() {
     if (!path || path === '') continue; // root package
     if (entry.link) continue; // workspace / link:
     const resolvedUrl = entry.resolved ?? '';
-    if (!resolvedUrl.startsWith('https://')) continue; // file:, git+, link:, no resolved
+    if (!/^https?:\/\//.test(resolvedUrl)) continue; // file:, git+, link:, no resolved
     if (!entry.version) continue;
     if (entry.version.startsWith('file:') || entry.version.startsWith('link:')) continue;
     const name = pathToPackageName(path);


### PR DESCRIPTION
## Summary

Two commits:

1. **`5027fee`** — bump `nitro` 3.0.260311-beta → 3.0.260522-beta to close the one genuine vulnerability remaining from the 19 Dependabot alerts. (The other 18 alerts were stale post-#432 and will auto-resolve on Dependabot's next rescan.)
2. **`8f669a9`** — supply-chain defence: Dependabot 10-day cooldown + CI publish-age guard, addressing the \"freshly-published compromised version\" attack class.

## Layer 1 — Dependabot cooldown

`.github/dependabot.yml`:

```yaml
cooldown:
  default-days: 10
```

Dependabot will only open a PR once a version has been on the registry ≥ 10 days. Catches the automated-bump attack path.

## Layer 2 — CI publish-age guard

`scripts/check-package-age.mjs` reads `package-lock.json`, queries the npm registry for publish timestamps, and fails CI if any **direct** dep was published less than `MIN_AGE_DAYS` (10) ago. Catches manual `npm install foo@latest` bypassing Dependabot.

Direct-only by default — transitives churn at ~10s of publishes/day and we don't pick them. They still surface as informational warnings.

**Escape hatches:**
- `SKIP_AGE_CHECK=1` — total bypass for emergency CVE fixes
- `STRICT_AGE_CHECK=1` — also gate transitives (useful for periodic audit)
- `MIN_AGE_DAYS=N` — adjust the threshold

## Rollout transition

The current lockfile was regenerated last week (#432) and has ~20 direct deps still within the 10-day window. The CI step is therefore `continue-on-error: true` initially. They age out by ~2026-06-11 — drop the flag in a follow-up PR after that so the step becomes blocking. A TODO note is in the workflow.

## Test plan

- [x] `node scripts/check-package-age.mjs` runs locally, correctly flags the ~20 fresh direct deps
- [x] `SKIP_AGE_CHECK=1 node scripts/check-package-age.mjs` bypasses cleanly
- [x] `MIN_AGE_DAYS=0` would pass everything; `MIN_AGE_DAYS=10` is the default
- [x] `npm audit --audit-level=high --omit=dev` → 0 vulnerabilities
- [x] `npm run typecheck` → clean
- [x] `npm run test` → 1140 passed (1140)
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)