### PR TITLE
chore(deps): pin zod and typescript to current majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,6 +61,20 @@ updates:
       - dependency-name: '@typescript-eslint/parser'
         versions: ['>=9.0.0']
 
+      # --- zod 5 boundary ---
+      # zod 5 will be the next breaking release after 4. The 3→4 migration
+      # (PR #439) renamed errorMap → error and required explicit key schemas
+      # on z.record(); hold at v4 until we're ready to vet the next break.
+      - dependency-name: 'zod'
+        versions: ['>=5.0.0']
+
+      # --- TypeScript 7 boundary ---
+      # TypeScript follows a roughly 6-month major cadence and routinely
+      # ships breaking type-checker changes. Hold at v6 to keep upgrades
+      # an intentional, manually-validated step rather than a surprise PR.
+      - dependency-name: 'typescript'
+        versions: ['>=7.0.0']
+
   - package-ecosystem: 'github-actions'
     directory: '/'
     target-branch: 'dev'


### PR DESCRIPTION
## Summary

- Adds dependabot ignore rules for `zod>=5.0.0` and `typescript>=7.0.0`, following the existing boundary pattern in `.github/dependabot.yml` (vite, vitest, eslint, fontawesome).
- PR #439 just migrated the codebase to zod 4 (renamed `errorMap` → `error`, required explicit key schemas on `z.record()`) and TypeScript 6 — pinning these keeps the next breaking majors from arriving as routine dependabot PRs that quietly break server functions or type checking.
- Minor/patch updates within zod 4.x and typescript 6.x continue to flow normally for security fixes.

When we're ready to take zod 5 or typescript 7, removing the relevant entry will let dependabot file the PR.

## Test plan

- [x] yaml parses (`node` + `yaml` module)
- [x] Full CI pipeline locally: `npm ci`, `npm audit`, `check:deps-age`, `typecheck`, `lint`, `test:ci` (1140 passed), `build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)