### PR TITLE
Tech-debt & security batch: IDOR fix, OAuth hardening, refactors, e2e in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,9 @@ jobs:
         # for an emergency CVE fix, set SKIP_AGE_CHECK=1 in the workflow run
         # and document in the PR. STRICT_AGE_CHECK=1 also gates transitives.
         #
-        # `continue-on-error: true` during rollout — the existing lockfile
-        # was regenerated recently (#432) and has ~20 direct deps published
-        # in the last 10 days. They will age out by ~2026-06-11, after
-        # which this flag should be removed so the step becomes blocking.
-        # TODO(2026-06-12): drop `continue-on-error` once the lockfile ages.
-        continue-on-error: true
+        # Rollout `continue-on-error` removed 2026-06-15: the #432 lockfile
+        # regeneration has aged past the 10-day window, so this step is now
+        # blocking as intended.
         run: npm run check:deps-age
 
       - name: Type check
@@ -87,3 +84,82 @@ jobs:
           SESSION_SECRET: build-placeholder-secret-at-least-32-chars
           NODE_ENV: production
           BASE_URL: https://cartyx.io
+
+  e2e:
+    name: E2E (Playwright)
+    runs-on: ubuntu-latest
+    needs: quality
+    # E2E is heavier than the unit suite (spins up Mongo + the dev server and
+    # drives a real browser), so we only run it on PRs — not on every branch
+    # push. The repo convention is PRs target `dev`/`main` (see the top-level
+    # `on:` block), so this still gates every change before it merges.
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    services:
+      # Ephemeral MongoDB for the run — no external/Atlas secret required.
+      # The suite refuses any URI matching /prod/i (see e2e/globalSetup.ts),
+      # and this DB is torn down with the job.
+      mongo:
+        image: mongo:8
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.runCommand({ ping: 1 })'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      # Reuse the same throwaway value pattern as the unit-test job; this is a
+      # test fixture, not a secret.
+      SESSION_SECRET: ci-test-secret-at-least-32-characters-long
+      MONGODB_URI: mongodb://localhost:27017
+      MONGODB_DB: cartyx_e2e
+      NODE_ENV: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '25'
+          cache: 'npm'
+
+      - name: Set up Python (for the DB seed)
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Create Python venv for seed scripts
+        run: |
+          python -m venv scripts/.venv
+          scripts/.venv/bin/pip install -r scripts/requirements.txt
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Seed database
+        # globalSetup.ts looks up a GM user + seeded campaign/location/screen.
+        # seed-gm.cjs bootstraps the GM user, then dev:seed populates campaigns.
+        run: |
+          node scripts/seed-gm.cjs
+          npm run dev:seed
+
+      - name: Run Playwright tests
+        # Retries (2) and webServer timeout are configured in playwright.config.ts
+        # so a slow cold first-route compile of the dev server doesn't flake the run.
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,11 @@ jobs:
       MONGODB_URI: mongodb://localhost:27017
       MONGODB_DB: cartyx_e2e
       NODE_ENV: test
+      # The dev server reads BASE_URL when building OAuth redirect URIs and for
+      # isOAuthConfigured(); point it at the Playwright dev-server origin so no
+      # code path throws on a missing BASE_URL even though e2e uses a pre-minted
+      # session cookie rather than the live OAuth flow.
+      BASE_URL: http://localhost:3000
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/app/components/wiki/characters/CharacterModal.tsx
+++ b/app/components/wiki/characters/CharacterModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback, useId } from 'react';
+import React, { useState, useMemo, useCallback, useId } from 'react';
 import { createPortal } from 'react-dom';
 import { X, Globe, Lock } from 'lucide-react';
 import { FormInput } from '~/components/FormInput';
@@ -16,6 +16,7 @@ import {
 } from '~/hooks/useCharacters';
 import { useRaces } from '~/hooks/useRaces';
 import { useCampaign } from '~/hooks/useCampaigns';
+import { useModalForm } from '~/hooks/useModalForm';
 import { ShowOnTabletopButton } from '~/components/wiki/shared/ShowOnTabletopButton';
 import type { CampaignData } from '~/types/campaign';
 import type { PictureCrop } from '~/types/character';
@@ -73,63 +74,62 @@ export function CharacterModal({
   const [tags, setTags] = useState<string[]>([]);
   const [isPublic, setIsPublic] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
-  const [hasSubmitted, setHasSubmitted] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
-  // Close on Escape key — only active when modal is open to avoid interfering with other dialogs
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    document.addEventListener('keydown', handleEscape);
-    return () => document.removeEventListener('keydown', handleEscape);
-  }, [isOpen, onClose]);
-
-  // Reset form when opening — clears stale values from a previous character
-  useEffect(() => {
-    setFirstName('');
-    setLastName('');
-    setRace('');
-    setCharacterClass('');
-    setAge('');
-    setLocation('');
-    setLink('');
-    setPicture('');
-    setPictureCrop(null);
-    setSessionId('');
-    setSelectedSessions([]);
-    setNotes('');
-    setGmNotes('');
-    setTags([]);
-    setIsPublic(false);
-    setError(null);
-    setFieldErrors({});
-    setHasSubmitted(false);
-    setShowDeleteConfirm(false);
-  }, [characterId, isOpen]);
-
-  // Populate form once the fetched character resolves in edit mode
-  useEffect(() => {
-    if (isEdit && existingCharacter) {
-      setFirstName(existingCharacter.firstName);
-      setLastName(existingCharacter.lastName);
-      setRace(existingCharacter.race);
-      setCharacterClass(existingCharacter.characterClass);
-      setAge(existingCharacter.age != null ? String(existingCharacter.age) : '');
-      setLocation(existingCharacter.location);
-      setLink(existingCharacter.link);
-      setPicture(existingCharacter.picture);
-      setPictureCrop(existingCharacter.pictureCrop);
-      setSessionId(existingCharacter.sessionId ?? '');
-      setSelectedSessions(existingCharacter.sessions);
-      setNotes(existingCharacter.notes);
-      setGmNotes(existingCharacter.gmNotes);
-      setTags(existingCharacter.tags);
-      setIsPublic(existingCharacter.isPublic);
+  const validate = useCallback((): FieldErrors => {
+    const errors: FieldErrors = {};
+    if (!firstName.trim()) errors.firstName = 'First name is required';
+    if (!lastName.trim()) errors.lastName = 'Last name is required';
+    if (link.trim() && !/^https?:\/\/.+/.test(link.trim())) {
+      errors.link = 'Must be a valid HTTP or HTTPS URL';
     }
-  }, [isEdit, existingCharacter]);
+    return errors;
+  }, [firstName, lastName, link]);
+
+  const { fieldErrors, runValidation } = useModalForm({
+    isOpen,
+    onClose,
+    recordId: characterId,
+    isEdit,
+    record: existingCharacter,
+    reset: () => {
+      setFirstName('');
+      setLastName('');
+      setRace('');
+      setCharacterClass('');
+      setAge('');
+      setLocation('');
+      setLink('');
+      setPicture('');
+      setPictureCrop(null);
+      setSessionId('');
+      setSelectedSessions([]);
+      setNotes('');
+      setGmNotes('');
+      setTags([]);
+      setIsPublic(false);
+      setError(null);
+      setShowDeleteConfirm(false);
+    },
+    populate: (c) => {
+      setFirstName(c.firstName);
+      setLastName(c.lastName);
+      setRace(c.race);
+      setCharacterClass(c.characterClass);
+      setAge(c.age != null ? String(c.age) : '');
+      setLocation(c.location);
+      setLink(c.link);
+      setPicture(c.picture);
+      setPictureCrop(c.pictureCrop);
+      setSessionId(c.sessionId ?? '');
+      setSelectedSessions(c.sessions);
+      setNotes(c.notes);
+      setGmNotes(c.gmNotes);
+      setTags(c.tags);
+      setIsPublic(c.isPublic);
+    },
+    validate,
+  });
 
   const sessionOptions = useMemo(
     () => [
@@ -142,20 +142,6 @@ export function CharacterModal({
     [sessions]
   );
 
-  const validate = useCallback((): FieldErrors => {
-    const errors: FieldErrors = {};
-    if (!firstName.trim()) errors.firstName = 'First name is required';
-    if (!lastName.trim()) errors.lastName = 'Last name is required';
-    if (link.trim() && !/^https?:\/\/.+/.test(link.trim())) {
-      errors.link = 'Must be a valid HTTP or HTTPS URL';
-    }
-    return errors;
-  }, [firstName, lastName, link]);
-
-  useEffect(() => {
-    if (hasSubmitted) setFieldErrors(validate());
-  }, [hasSubmitted, validate]);
-
   const handleUpload = useCallback(async (file: File): Promise<string> => {
     const compressed = await compressImage(file);
     const { publicUrl } = await uploadToR2(compressed, 'uploads/characters');
@@ -164,11 +150,9 @@ export function CharacterModal({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setHasSubmitted(true);
     setError(null);
 
-    const errors = validate();
-    setFieldErrors(errors);
+    const errors = runValidation();
     if (Object.keys(errors).length > 0) return;
 
     const parsedAge = age.trim() ? parseInt(age, 10) : null;

--- a/app/components/wiki/players/PlayerModal.tsx
+++ b/app/components/wiki/players/PlayerModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useId, useCallback } from 'react';
+import React, { useState, useId, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 import { FormInput } from '~/components/FormInput';
@@ -9,6 +9,7 @@ import { ImageCropInput } from '~/components/wiki/characters/ImageCropInput';
 import { usePlayer, useUpdatePlayer, useDeletePlayer } from '~/hooks/usePlayers';
 import { useCampaign } from '~/hooks/useCampaigns';
 import { useRaces } from '~/hooks/useRaces';
+import { useModalForm } from '~/hooks/useModalForm';
 import type { PictureCrop } from '~/types/character';
 import { uploadToR2 } from '~/utils/uploadToR2';
 import { compressImage } from '~/utils/compressImage';
@@ -59,72 +60,7 @@ export function PlayerModal({ campaignId, playerId, onClose }: PlayerModalProps)
   const [backstory, setBackstory] = useState('');
   const [gmNotes, setGmNotes] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
-  const [hasSubmitted, setHasSubmitted] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-
-  // Close on Escape key
-  useEffect(() => {
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    document.addEventListener('keydown', handleEscape);
-    return () => document.removeEventListener('keydown', handleEscape);
-  }, [onClose]);
-
-  // Reset form when playerId changes
-  useEffect(() => {
-    setFirstName('');
-    setLastName('');
-    setRace('');
-    setCharacterClass('');
-    setAge('');
-    setGender('');
-    setLocation('');
-    setLink('');
-    setPicture('');
-    setPictureCrop(null);
-    setColor('');
-    setEyeColor('');
-    setHairColor('');
-    setWeight('');
-    setHeight('');
-    setSize('');
-    setDescription('');
-    setAppearance('');
-    setBackstory('');
-    setGmNotes('');
-    setError(null);
-    setFieldErrors({});
-    setHasSubmitted(false);
-    setShowDeleteConfirm(false);
-  }, [playerId]);
-
-  // Populate form once the fetched player resolves in edit mode
-  useEffect(() => {
-    if (isEdit && existingPlayer) {
-      setFirstName(existingPlayer.firstName);
-      setLastName(existingPlayer.lastName);
-      setRace(existingPlayer.race);
-      setCharacterClass(existingPlayer.characterClass);
-      setAge(existingPlayer.age != null ? String(existingPlayer.age) : '');
-      setGender(existingPlayer.gender);
-      setLocation(existingPlayer.location);
-      setLink(existingPlayer.link);
-      setPicture(existingPlayer.picture);
-      setPictureCrop(existingPlayer.pictureCrop);
-      setColor(existingPlayer.color);
-      setEyeColor(existingPlayer.eyeColor);
-      setHairColor(existingPlayer.hairColor);
-      setWeight(existingPlayer.weight != null ? String(existingPlayer.weight) : '');
-      setHeight(existingPlayer.height);
-      setSize(existingPlayer.size);
-      setDescription(existingPlayer.description);
-      setAppearance(existingPlayer.appearance);
-      setBackstory(existingPlayer.backstory);
-      setGmNotes(existingPlayer.gmNotes);
-    }
-  }, [isEdit, existingPlayer]);
 
   const validate = useCallback((): FieldErrors => {
     const errors: FieldErrors = {};
@@ -136,9 +72,63 @@ export function PlayerModal({ campaignId, playerId, onClose }: PlayerModalProps)
     return errors;
   }, [firstName, lastName, link]);
 
-  useEffect(() => {
-    if (hasSubmitted) setFieldErrors(validate());
-  }, [hasSubmitted, validate]);
+  // PlayerModal is mounted only while open (the parent renders it conditionally),
+  // so `isOpen` is effectively always true: the Escape listener stays active for
+  // the modal's lifetime and reset keys only off `playerId`.
+  const { fieldErrors, runValidation } = useModalForm({
+    isOpen: true,
+    onClose,
+    recordId: playerId,
+    isEdit,
+    record: existingPlayer,
+    reset: () => {
+      setFirstName('');
+      setLastName('');
+      setRace('');
+      setCharacterClass('');
+      setAge('');
+      setGender('');
+      setLocation('');
+      setLink('');
+      setPicture('');
+      setPictureCrop(null);
+      setColor('');
+      setEyeColor('');
+      setHairColor('');
+      setWeight('');
+      setHeight('');
+      setSize('');
+      setDescription('');
+      setAppearance('');
+      setBackstory('');
+      setGmNotes('');
+      setError(null);
+      setShowDeleteConfirm(false);
+    },
+    populate: (p) => {
+      setFirstName(p.firstName);
+      setLastName(p.lastName);
+      setRace(p.race);
+      setCharacterClass(p.characterClass);
+      setAge(p.age != null ? String(p.age) : '');
+      setGender(p.gender);
+      setLocation(p.location);
+      setLink(p.link);
+      setPicture(p.picture);
+      setPictureCrop(p.pictureCrop);
+      setColor(p.color);
+      setEyeColor(p.eyeColor);
+      setHairColor(p.hairColor);
+      setWeight(p.weight != null ? String(p.weight) : '');
+      setHeight(p.height);
+      setSize(p.size);
+      setDescription(p.description);
+      setAppearance(p.appearance);
+      setBackstory(p.backstory);
+      setGmNotes(p.gmNotes);
+    },
+    validate,
+  });
 
   const handleUpload = useCallback(async (file: File): Promise<string> => {
     const compressed = await compressImage(file);
@@ -148,11 +138,9 @@ export function PlayerModal({ campaignId, playerId, onClose }: PlayerModalProps)
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setHasSubmitted(true);
     setError(null);
 
-    const errors = validate();
-    setFieldErrors(errors);
+    const errors = runValidation();
     if (Object.keys(errors).length > 0) return;
 
     const parsedAge = age.trim() ? parseInt(age, 10) : 0;

--- a/app/components/wiki/races/RaceModal.tsx
+++ b/app/components/wiki/races/RaceModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 import { FormInput } from '~/components/FormInput';
@@ -8,6 +8,7 @@ import { TagAutocompleteInput } from '~/components/shared/TagAutocompleteInput';
 import { useRace, useCreateRace, useUpdateRace, useDeleteRace } from '~/hooks/useRaces';
 import { useCampaign } from '~/hooks/useCampaigns';
 import { ShowOnTabletopButton } from '~/components/wiki/shared/ShowOnTabletopButton';
+import { useModalForm } from '~/hooks/useModalForm';
 
 interface RaceModalProps {
   isOpen: boolean;
@@ -35,38 +36,7 @@ export function RaceModal({ isOpen, onClose, campaignId, raceId }: RaceModalProp
   const [content, setContent] = useState('');
   const [tags, setTags] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
-  const [hasSubmitted, setHasSubmitted] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-
-  // Close on Escape key — only active when the modal is open
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    document.addEventListener('keydown', handleEscape);
-    return () => document.removeEventListener('keydown', handleEscape);
-  }, [isOpen, onClose]);
-
-  // Reset form when opening
-  useEffect(() => {
-    setTitle('');
-    setContent('');
-    setTags([]);
-    setError(null);
-    setFieldErrors({});
-    setHasSubmitted(false);
-    setShowDeleteConfirm(false);
-  }, [raceId, isOpen]);
-
-  // Populate form with existing race data when editing
-  useEffect(() => {
-    if (!isEdit || !existingRace) return;
-    setTitle(existingRace.title);
-    setContent(existingRace.content);
-    setTags(existingRace.tags);
-  }, [isEdit, existingRace]);
 
   const validate = useCallback((): FieldErrors => {
     const errors: FieldErrors = {};
@@ -75,15 +45,33 @@ export function RaceModal({ isOpen, onClose, campaignId, raceId }: RaceModalProp
     return errors;
   }, [title, content]);
 
+  const { fieldErrors, runValidation } = useModalForm({
+    isOpen,
+    onClose,
+    recordId: raceId,
+    isEdit,
+    record: existingRace,
+    reset: () => {
+      setTitle('');
+      setContent('');
+      setTags([]);
+      setError(null);
+      setShowDeleteConfirm(false);
+    },
+    populate: (race) => {
+      setTitle(race.title);
+      setContent(race.content);
+      setTags(race.tags);
+    },
+    validate,
+  });
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setHasSubmitted(true);
-    const errors = validate();
+    const errors = runValidation();
     if (Object.keys(errors).length > 0) {
-      setFieldErrors(errors);
       return;
     }
-    setFieldErrors({});
     setError(null);
 
     let success = false;
@@ -113,12 +101,6 @@ export function RaceModal({ isOpen, onClose, campaignId, raceId }: RaceModalProp
       setShowDeleteConfirm(false);
     }
   };
-
-  // Update field errors on change if user has already submitted
-  useEffect(() => {
-    if (!isOpen || !hasSubmitted) return;
-    setFieldErrors(validate());
-  }, [isOpen, hasSubmitted, validate]);
 
   if (!isOpen) return null;
 

--- a/app/hooks/createMutationHook.ts
+++ b/app/hooks/createMutationHook.ts
@@ -1,0 +1,77 @@
+import { useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query';
+import { captureException } from '~/providers/PostHogProvider';
+import { extractErrorMessage } from '~/utils/errors';
+
+/**
+ * Shared scaffolding for the wiki mutation hooks (players / characters /
+ * locations). These hooks all repeated the same structure:
+ *
+ *   - a `useMutation` whose `mutationFn` calls a server fn
+ *   - `onSuccess` that invalidates/removes a set of query keys
+ *   - `onError` that reports to PostHog via `captureException`
+ *   - a wrapper around `mutateAsync` that returns `null` on error
+ *   - a return object exposing the wrapper under a named key, plus
+ *     `isLoading` (from `isPending`) and `error` (normalized message)
+ *
+ * The factory is intentionally thin: it preserves the exact behavior of the
+ * hand-written hooks, just without the per-hook boilerplate. `onSuccess`
+ * receives the live `QueryClient` so callers reproduce their existing
+ * invalidate/remove logic verbatim.
+ */
+export interface CreateMutationHookConfig<TInput, TData, TActionKey extends string> {
+  /** Name of the action function exposed on the returned object (e.g. `update`). */
+  actionName: TActionKey;
+  /** The mutation function — typically `(input) => someServerFn({ data: input })`. */
+  mutationFn: (input: TInput) => Promise<TData>;
+  /**
+   * Side effects on success. Receives the live query client so callers can
+   * invalidate/remove queries exactly as before. Optional — some mutations
+   * (e.g. validate-only) have no success side effects.
+   */
+  onSuccess?: (queryClient: QueryClient, data: TData, variables: TInput) => void;
+  /**
+   * Builds the additional-properties context passed to `captureException` on
+   * error. Receives the variables so callers can include ids, etc.
+   */
+  errorContext: (variables: TInput) => Record<string, unknown>;
+}
+
+export type MutationHookResult<TInput, TData, TActionKey extends string> = {
+  isLoading: boolean;
+  error: string | null;
+} & {
+  [K in TActionKey]: (input: TInput) => Promise<TData | null>;
+};
+
+export function createMutationHook<TInput, TData, TActionKey extends string>(
+  config: CreateMutationHookConfig<TInput, TData, TActionKey>
+): () => MutationHookResult<TInput, TData, TActionKey> {
+  const { actionName, mutationFn, onSuccess, errorContext } = config;
+
+  return function useGeneratedMutationHook(): MutationHookResult<TInput, TData, TActionKey> {
+    const queryClient = useQueryClient();
+    const mutation = useMutation({
+      mutationFn: async (input: TInput) => mutationFn(input),
+      onSuccess: (data, variables) => {
+        onSuccess?.(queryClient, data, variables);
+      },
+      onError: (e, variables) => {
+        captureException(e, errorContext(variables));
+      },
+    });
+
+    const action = async (input: TInput): Promise<TData | null> => {
+      try {
+        return await mutation.mutateAsync(input);
+      } catch {
+        return null;
+      }
+    };
+
+    return {
+      [actionName]: action,
+      isLoading: mutation.isPending,
+      error: extractErrorMessage(mutation.error),
+    } as MutationHookResult<TInput, TData, TActionKey>;
+  };
+}

--- a/app/hooks/useCharacters.ts
+++ b/app/hooks/useCharacters.ts
@@ -1,8 +1,9 @@
 import { createServerFn } from '@tanstack/react-start';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import type { CharacterData, CharacterListItem } from '~/types/character';
-import { captureException } from '~/providers/PostHogProvider';
 import { queryKeys } from '~/utils/queryKeys';
+import { extractErrorMessage } from '~/utils/errors';
+import { createMutationHook } from '~/hooks/createMutationHook';
 import {
   listCharactersSchema,
   getCharacterSchema,
@@ -122,7 +123,7 @@ export function useCharacters(campaignId: string, filters?: ListCharactersFilter
   return {
     characters: characters as CharacterListItem[],
     isLoading,
-    error: error instanceof Error ? error.message : error ? String(error) : null,
+    error: extractErrorMessage(error),
   };
 }
 
@@ -140,7 +141,7 @@ export function useCharacter(id: string, campaignId: string) {
   return {
     character: character as CharacterData | null,
     isLoading,
-    error: error instanceof Error ? error.message : error ? String(error) : null,
+    error: extractErrorMessage(error),
   };
 }
 
@@ -163,38 +164,15 @@ interface CreateCharacterInput {
   sessions?: string[];
 }
 
-export function useCreateCharacter() {
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: async (input: CreateCharacterInput) => createCharacterFn({ data: input }),
-    onSuccess: (_data, { campaignId }) => {
-      queryClient.invalidateQueries({ queryKey: ['characters', 'list', campaignId], exact: false });
-      queryClient.invalidateQueries({ queryKey: queryKeys.tags.list(campaignId) });
-    },
-    onError: (e) => {
-      captureException(e, { action: 'createCharacter' });
-    },
-  });
-
-  const create = async (input: CreateCharacterInput) => {
-    try {
-      return await mutation.mutateAsync(input);
-    } catch {
-      return null;
-    }
-  };
-
-  return {
-    create,
-    isLoading: mutation.isPending,
-    error:
-      mutation.error instanceof Error
-        ? mutation.error.message
-        : mutation.error
-          ? String(mutation.error)
-          : null,
-  };
-}
+export const useCreateCharacter = createMutationHook({
+  actionName: 'create',
+  mutationFn: async (input: CreateCharacterInput) => createCharacterFn({ data: input }),
+  onSuccess: (queryClient, _data, { campaignId }) => {
+    queryClient.invalidateQueries({ queryKey: ['characters', 'list', campaignId], exact: false });
+    queryClient.invalidateQueries({ queryKey: queryKeys.tags.list(campaignId) });
+  },
+  errorContext: () => ({ action: 'createCharacter' }),
+});
 
 interface UpdateCharacterInput {
   id: string;
@@ -216,91 +194,45 @@ interface UpdateCharacterInput {
   sessions?: string[];
 }
 
-export function useUpdateCharacter() {
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: async (input: UpdateCharacterInput) => updateCharacterFn({ data: input }),
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: ['characters', 'list', variables.campaignId],
-        exact: false,
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.characters.detail(variables.id, variables.campaignId),
-      });
-      queryClient.invalidateQueries({ queryKey: queryKeys.tags.list(variables.campaignId) });
-      // Refresh GM screen windows that may display this character's content
-      queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
-    },
-    onError: (e, variables) => {
-      captureException(e, { action: 'updateCharacter', characterId: variables.id });
-    },
-  });
-
-  const update = async (input: UpdateCharacterInput) => {
-    try {
-      return await mutation.mutateAsync(input);
-    } catch {
-      return null;
-    }
-  };
-
-  return {
-    update,
-    isLoading: mutation.isPending,
-    error:
-      mutation.error instanceof Error
-        ? mutation.error.message
-        : mutation.error
-          ? String(mutation.error)
-          : null,
-  };
-}
+export const useUpdateCharacter = createMutationHook({
+  actionName: 'update',
+  mutationFn: async (input: UpdateCharacterInput) => updateCharacterFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    queryClient.invalidateQueries({
+      queryKey: ['characters', 'list', variables.campaignId],
+      exact: false,
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.characters.detail(variables.id, variables.campaignId),
+    });
+    queryClient.invalidateQueries({ queryKey: queryKeys.tags.list(variables.campaignId) });
+    // Refresh GM screen windows that may display this character's content
+    queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+  },
+  errorContext: (variables) => ({ action: 'updateCharacter', characterId: variables.id }),
+});
 
 interface DeleteCharacterInput {
   id: string;
   campaignId: string;
 }
 
-export function useDeleteCharacter() {
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: async (input: DeleteCharacterInput) => deleteCharacterFn({ data: input }),
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: ['characters', 'list', variables.campaignId],
-        exact: false,
-      });
-      queryClient.removeQueries({
-        queryKey: queryKeys.characters.detail(variables.id, variables.campaignId),
-      });
-      // Refresh GM screen windows — server removes refs for deleted characters
-      queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
-    },
-    onError: (e, variables) => {
-      captureException(e, { action: 'deleteCharacter', characterId: variables.id });
-    },
-  });
-
-  const remove = async (input: DeleteCharacterInput) => {
-    try {
-      return await mutation.mutateAsync(input);
-    } catch {
-      return null;
-    }
-  };
-
-  return {
-    remove,
-    isLoading: mutation.isPending,
-    error:
-      mutation.error instanceof Error
-        ? mutation.error.message
-        : mutation.error
-          ? String(mutation.error)
-          : null,
-  };
-}
+export const useDeleteCharacter = createMutationHook({
+  actionName: 'remove',
+  mutationFn: async (input: DeleteCharacterInput) => deleteCharacterFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    queryClient.invalidateQueries({
+      queryKey: ['characters', 'list', variables.campaignId],
+      exact: false,
+    });
+    queryClient.removeQueries({
+      queryKey: queryKeys.characters.detail(variables.id, variables.campaignId),
+    });
+    // Refresh GM screen windows — server removes refs for deleted characters
+    queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+  },
+  errorContext: (variables) => ({ action: 'deleteCharacter', characterId: variables.id }),
+});
 
 // ---------------------------------------------------------------------------
 // useUpdateCharacterStatus
@@ -312,44 +244,20 @@ interface UpdateCharacterStatusInput {
   value: 'alive' | 'deceased';
 }
 
-export function useUpdateCharacterStatus() {
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: async (input: UpdateCharacterStatusInput) =>
-      updateCharacterStatusFn({ data: input }),
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: ['characters', 'list', variables.campaignId],
-        exact: false,
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.characters.detail(variables.id, variables.campaignId),
-      });
-    },
-    onError: (e, variables) => {
-      captureException(e, { action: 'updateCharacterStatus', characterId: variables.id });
-    },
-  });
-
-  const updateStatus = async (input: UpdateCharacterStatusInput) => {
-    try {
-      return await mutation.mutateAsync(input);
-    } catch {
-      return null;
-    }
-  };
-
-  return {
-    updateStatus,
-    isLoading: mutation.isPending,
-    error:
-      mutation.error instanceof Error
-        ? mutation.error.message
-        : mutation.error
-          ? String(mutation.error)
-          : null,
-  };
-}
+export const useUpdateCharacterStatus = createMutationHook({
+  actionName: 'updateStatus',
+  mutationFn: async (input: UpdateCharacterStatusInput) => updateCharacterStatusFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    queryClient.invalidateQueries({
+      queryKey: ['characters', 'list', variables.campaignId],
+      exact: false,
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.characters.detail(variables.id, variables.campaignId),
+    });
+  },
+  errorContext: (variables) => ({ action: 'updateCharacterStatus', characterId: variables.id }),
+});
 
 // ---------------------------------------------------------------------------
 // useAddCharacterRelationship
@@ -364,50 +272,27 @@ interface AddCharacterRelationshipInput {
   isPublic?: boolean;
 }
 
-export function useAddCharacterRelationship() {
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: async (input: AddCharacterRelationshipInput) =>
-      addCharacterRelationshipFn({ data: input }),
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: ['characters', 'list', variables.campaignId],
-        exact: false,
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.characters.detail(variables.characterId, variables.campaignId),
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.characters.detail(variables.targetCharacterId, variables.campaignId),
-      });
-    },
-    onError: (e, variables) => {
-      captureException(e, {
-        action: 'addCharacterRelationship',
-        characterId: variables.characterId,
-      });
-    },
-  });
-
-  const addRelationship = async (input: AddCharacterRelationshipInput) => {
-    try {
-      return await mutation.mutateAsync(input);
-    } catch {
-      return null;
-    }
-  };
-
-  return {
-    addRelationship,
-    isLoading: mutation.isPending,
-    error:
-      mutation.error instanceof Error
-        ? mutation.error.message
-        : mutation.error
-          ? String(mutation.error)
-          : null,
-  };
-}
+export const useAddCharacterRelationship = createMutationHook({
+  actionName: 'addRelationship',
+  mutationFn: async (input: AddCharacterRelationshipInput) =>
+    addCharacterRelationshipFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    queryClient.invalidateQueries({
+      queryKey: ['characters', 'list', variables.campaignId],
+      exact: false,
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.characters.detail(variables.characterId, variables.campaignId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.characters.detail(variables.targetCharacterId, variables.campaignId),
+    });
+  },
+  errorContext: (variables) => ({
+    action: 'addCharacterRelationship',
+    characterId: variables.characterId,
+  }),
+});
 
 // ---------------------------------------------------------------------------
 // useUpdateCharacterRelationship
@@ -422,50 +307,27 @@ interface UpdateCharacterRelationshipInput {
   isPublic?: boolean;
 }
 
-export function useUpdateCharacterRelationship() {
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: async (input: UpdateCharacterRelationshipInput) =>
-      updateCharacterRelationshipFn({ data: input }),
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: ['characters', 'list', variables.campaignId],
-        exact: false,
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.characters.detail(variables.characterId, variables.campaignId),
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.characters.detail(variables.targetCharacterId, variables.campaignId),
-      });
-    },
-    onError: (e, variables) => {
-      captureException(e, {
-        action: 'updateCharacterRelationship',
-        characterId: variables.characterId,
-      });
-    },
-  });
-
-  const updateRelationship = async (input: UpdateCharacterRelationshipInput) => {
-    try {
-      return await mutation.mutateAsync(input);
-    } catch {
-      return null;
-    }
-  };
-
-  return {
-    updateRelationship,
-    isLoading: mutation.isPending,
-    error:
-      mutation.error instanceof Error
-        ? mutation.error.message
-        : mutation.error
-          ? String(mutation.error)
-          : null,
-  };
-}
+export const useUpdateCharacterRelationship = createMutationHook({
+  actionName: 'updateRelationship',
+  mutationFn: async (input: UpdateCharacterRelationshipInput) =>
+    updateCharacterRelationshipFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    queryClient.invalidateQueries({
+      queryKey: ['characters', 'list', variables.campaignId],
+      exact: false,
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.characters.detail(variables.characterId, variables.campaignId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.characters.detail(variables.targetCharacterId, variables.campaignId),
+    });
+  },
+  errorContext: (variables) => ({
+    action: 'updateCharacterRelationship',
+    characterId: variables.characterId,
+  }),
+});
 
 // ---------------------------------------------------------------------------
 // useRemoveCharacterRelationship
@@ -477,47 +339,24 @@ interface RemoveCharacterRelationshipInput {
   targetCharacterId: string;
 }
 
-export function useRemoveCharacterRelationship() {
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: async (input: RemoveCharacterRelationshipInput) =>
-      removeCharacterRelationshipFn({ data: input }),
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: ['characters', 'list', variables.campaignId],
-        exact: false,
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.characters.detail(variables.characterId, variables.campaignId),
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.characters.detail(variables.targetCharacterId, variables.campaignId),
-      });
-    },
-    onError: (e, variables) => {
-      captureException(e, {
-        action: 'removeCharacterRelationship',
-        characterId: variables.characterId,
-      });
-    },
-  });
-
-  const removeRelationship = async (input: RemoveCharacterRelationshipInput) => {
-    try {
-      return await mutation.mutateAsync(input);
-    } catch {
-      return null;
-    }
-  };
-
-  return {
-    removeRelationship,
-    isLoading: mutation.isPending,
-    error:
-      mutation.error instanceof Error
-        ? mutation.error.message
-        : mutation.error
-          ? String(mutation.error)
-          : null,
-  };
-}
+export const useRemoveCharacterRelationship = createMutationHook({
+  actionName: 'removeRelationship',
+  mutationFn: async (input: RemoveCharacterRelationshipInput) =>
+    removeCharacterRelationshipFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    queryClient.invalidateQueries({
+      queryKey: ['characters', 'list', variables.campaignId],
+      exact: false,
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.characters.detail(variables.characterId, variables.campaignId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.characters.detail(variables.targetCharacterId, variables.campaignId),
+    });
+  },
+  errorContext: (variables) => ({
+    action: 'removeCharacterRelationship',
+    characterId: variables.characterId,
+  }),
+});

--- a/app/hooks/useLocations.ts
+++ b/app/hooks/useLocations.ts
@@ -1,8 +1,9 @@
 import { createServerFn } from '@tanstack/react-start';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import type { LocationData, LocationListItem } from '~/types/location';
-import { captureException } from '~/providers/PostHogProvider';
 import { queryKeys } from '~/utils/queryKeys';
+import { extractErrorMessage } from '~/utils/errors';
+import { createMutationHook } from '~/hooks/createMutationHook';
 import {
   listLocationsSchema,
   getLocationSchema,
@@ -105,7 +106,7 @@ export function useLocations(campaignId: string, filters?: ListLocationsFilters)
   return {
     locations: locations as LocationListItem[],
     isLoading,
-    error: error instanceof Error ? error.message : error ? String(error) : null,
+    error: extractErrorMessage(error),
   };
 }
 
@@ -123,7 +124,7 @@ export function useLocation(id: string, campaignId: string) {
   return {
     location: location as LocationData | null,
     isLoading,
-    error: error instanceof Error ? error.message : error ? String(error) : null,
+    error: extractErrorMessage(error),
   };
 }
 
@@ -138,41 +139,18 @@ interface CreateLocationInput {
   tags?: string[];
 }
 
-export function useCreateLocation() {
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: async (input: CreateLocationInput) => createLocationFn({ data: input }),
-    onSuccess: (_data, { campaignId }) => {
-      queryClient.invalidateQueries({
-        queryKey: ['locations', 'list', campaignId],
-        exact: false,
-      });
-      queryClient.invalidateQueries({ queryKey: queryKeys.tags.list(campaignId) });
-    },
-    onError: (e) => {
-      captureException(e, { action: 'createLocation' });
-    },
-  });
-
-  const create = async (input: CreateLocationInput) => {
-    try {
-      return await mutation.mutateAsync(input);
-    } catch {
-      return null;
-    }
-  };
-
-  return {
-    create,
-    isLoading: mutation.isPending,
-    error:
-      mutation.error instanceof Error
-        ? mutation.error.message
-        : mutation.error
-          ? String(mutation.error)
-          : null,
-  };
-}
+export const useCreateLocation = createMutationHook({
+  actionName: 'create',
+  mutationFn: async (input: CreateLocationInput) => createLocationFn({ data: input }),
+  onSuccess: (queryClient, _data, { campaignId }) => {
+    queryClient.invalidateQueries({
+      queryKey: ['locations', 'list', campaignId],
+      exact: false,
+    });
+    queryClient.invalidateQueries({ queryKey: queryKeys.tags.list(campaignId) });
+  },
+  errorContext: () => ({ action: 'createLocation' }),
+});
 
 interface UpdateLocationInput {
   id: string;
@@ -186,93 +164,47 @@ interface UpdateLocationInput {
   tags?: string[];
 }
 
-export function useUpdateLocation() {
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: async (input: UpdateLocationInput) => updateLocationFn({ data: input }),
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: ['locations', 'list', variables.campaignId],
-        exact: false,
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.locations.detail(variables.id, variables.campaignId),
-      });
-      queryClient.invalidateQueries({ queryKey: queryKeys.tags.list(variables.campaignId) });
-      // Refresh GM screen / tabletop windows that may display this location
-      queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.tabletop.all });
-    },
-    onError: (e, variables) => {
-      captureException(e, { action: 'updateLocation', locationId: variables.id });
-    },
-  });
-
-  const update = async (input: UpdateLocationInput) => {
-    try {
-      return await mutation.mutateAsync(input);
-    } catch {
-      return null;
-    }
-  };
-
-  return {
-    update,
-    isLoading: mutation.isPending,
-    error:
-      mutation.error instanceof Error
-        ? mutation.error.message
-        : mutation.error
-          ? String(mutation.error)
-          : null,
-  };
-}
+export const useUpdateLocation = createMutationHook({
+  actionName: 'update',
+  mutationFn: async (input: UpdateLocationInput) => updateLocationFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    queryClient.invalidateQueries({
+      queryKey: ['locations', 'list', variables.campaignId],
+      exact: false,
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.locations.detail(variables.id, variables.campaignId),
+    });
+    queryClient.invalidateQueries({ queryKey: queryKeys.tags.list(variables.campaignId) });
+    // Refresh GM screen / tabletop windows that may display this location
+    queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+    queryClient.invalidateQueries({ queryKey: queryKeys.tabletop.all });
+  },
+  errorContext: (variables) => ({ action: 'updateLocation', locationId: variables.id }),
+});
 
 interface DeleteLocationInput {
   id: string;
   campaignId: string;
 }
 
-export function useDeleteLocation() {
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: async (input: DeleteLocationInput) => deleteLocationFn({ data: input }),
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: ['locations', 'list', variables.campaignId],
-        exact: false,
-      });
-      queryClient.removeQueries({
-        queryKey: queryKeys.locations.detail(variables.id, variables.campaignId),
-      });
-      // Refresh GM screen / tabletop windows — server removes refs for deleted locations
-      queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.tabletop.all });
-    },
-    onError: (e, variables) => {
-      captureException(e, { action: 'deleteLocation', locationId: variables.id });
-    },
-  });
-
-  const remove = async (input: DeleteLocationInput) => {
-    try {
-      return await mutation.mutateAsync(input);
-    } catch {
-      return null;
-    }
-  };
-
-  return {
-    remove,
-    isLoading: mutation.isPending,
-    error:
-      mutation.error instanceof Error
-        ? mutation.error.message
-        : mutation.error
-          ? String(mutation.error)
-          : null,
-  };
-}
+export const useDeleteLocation = createMutationHook({
+  actionName: 'remove',
+  mutationFn: async (input: DeleteLocationInput) => deleteLocationFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    queryClient.invalidateQueries({
+      queryKey: ['locations', 'list', variables.campaignId],
+      exact: false,
+    });
+    queryClient.removeQueries({
+      queryKey: queryKeys.locations.detail(variables.id, variables.campaignId),
+    });
+    // Refresh GM screen / tabletop windows — server removes refs for deleted locations
+    queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+    queryClient.invalidateQueries({ queryKey: queryKeys.tabletop.all });
+  },
+  errorContext: (variables) => ({ action: 'deleteLocation', locationId: variables.id }),
+});
 
 // ---------------------------------------------------------------------------
 // Image hooks
@@ -286,41 +218,18 @@ interface AddLocationImageInput {
   title: string;
 }
 
-export function useAddLocationImage() {
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: async (input: AddLocationImageInput) => addLocationImageFn({ data: input }),
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.locations.detail(variables.id, variables.campaignId),
-      });
-      queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.tabletop.all });
-    },
-    onError: (e, variables) => {
-      captureException(e, { action: 'addLocationImage', locationId: variables.id });
-    },
-  });
-
-  const addImage = async (input: AddLocationImageInput) => {
-    try {
-      return await mutation.mutateAsync(input);
-    } catch {
-      return null;
-    }
-  };
-
-  return {
-    addImage,
-    isLoading: mutation.isPending,
-    error:
-      mutation.error instanceof Error
-        ? mutation.error.message
-        : mutation.error
-          ? String(mutation.error)
-          : null,
-  };
-}
+export const useAddLocationImage = createMutationHook({
+  actionName: 'addImage',
+  mutationFn: async (input: AddLocationImageInput) => addLocationImageFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.locations.detail(variables.id, variables.campaignId),
+    });
+    queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+    queryClient.invalidateQueries({ queryKey: queryKeys.tabletop.all });
+  },
+  errorContext: (variables) => ({ action: 'addLocationImage', locationId: variables.id }),
+});
 
 interface DeleteLocationImageInput {
   id: string;
@@ -328,38 +237,15 @@ interface DeleteLocationImageInput {
   imageKey: string;
 }
 
-export function useDeleteLocationImage() {
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: async (input: DeleteLocationImageInput) => deleteLocationImageFn({ data: input }),
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.locations.detail(variables.id, variables.campaignId),
-      });
-      queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.tabletop.all });
-    },
-    onError: (e, variables) => {
-      captureException(e, { action: 'deleteLocationImage', locationId: variables.id });
-    },
-  });
-
-  const deleteImage = async (input: DeleteLocationImageInput) => {
-    try {
-      return await mutation.mutateAsync(input);
-    } catch {
-      return null;
-    }
-  };
-
-  return {
-    deleteImage,
-    isLoading: mutation.isPending,
-    error:
-      mutation.error instanceof Error
-        ? mutation.error.message
-        : mutation.error
-          ? String(mutation.error)
-          : null,
-  };
-}
+export const useDeleteLocationImage = createMutationHook({
+  actionName: 'deleteImage',
+  mutationFn: async (input: DeleteLocationImageInput) => deleteLocationImageFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.locations.detail(variables.id, variables.campaignId),
+    });
+    queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+    queryClient.invalidateQueries({ queryKey: queryKeys.tabletop.all });
+  },
+  errorContext: (variables) => ({ action: 'deleteLocationImage', locationId: variables.id }),
+});

--- a/app/hooks/useModalForm.ts
+++ b/app/hooks/useModalForm.ts
@@ -1,0 +1,140 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from 'react';
+
+/**
+ * Shared form-lifecycle scaffolding for the wiki edit/create modals
+ * (characters / players / races). These modals all repeated the same
+ * mechanical lifecycle, independent of their field sets:
+ *
+ *   - reset every form field when the modal opens or the edited record's id
+ *     changes (clears stale values from a previously-edited record)
+ *   - populate the fields once the fetched record resolves in edit mode
+ *   - track `hasSubmitted` / `fieldErrors`, and re-run validation on every
+ *     change *after* the first submit attempt so errors update live
+ *   - close on the Escape key, with the listener active only while the modal
+ *     is open (so it does not interfere with other dialogs)
+ *
+ * The hook owns only that lifecycle. The fields themselves stay in the
+ * component as ordinary `useState`, because each modal has a different field
+ * set; the hook is told how to reset/populate them via callbacks. This keeps
+ * the abstraction thin and behavior-preserving — it removes the duplicated
+ * wiring, not the per-modal specifics.
+ *
+ * `reset` and `populate` are read through refs so the reset/populate effects
+ * can key off the exact same triggers as the original hand-written effects
+ * (`[recordId, isOpen]` and `[isEdit, record]`) without re-running on every
+ * render just because the caller passes fresh inline closures.
+ *
+ * @typeParam TErrors  the modal's field-error shape (e.g. `{ firstName?: string }`)
+ * @typeParam TRecord  the fetched record shape used to populate in edit mode
+ */
+export interface UseModalFormOptions<TErrors extends object, TRecord> {
+  /** Whether the modal is currently open. Gates the reset and Escape listener. */
+  isOpen: boolean;
+  /** Called to close the modal (Escape key, etc.). */
+  onClose: () => void;
+  /**
+   * Identity of the record being edited (undefined in create mode). A change
+   * to this value re-triggers the reset, exactly like the hand-written
+   * `[recordId, isOpen]` reset effects.
+   */
+  recordId?: string;
+  /** True in edit mode. Gates population. */
+  isEdit: boolean;
+  /** The fetched record, or null/undefined until it resolves. */
+  record: TRecord | null | undefined;
+  /** Clears every form field back to its create-mode default. */
+  reset: () => void;
+  /** Copies values out of the resolved record into the form fields. */
+  populate: (record: TRecord) => void;
+  /** Pure validator returning the current field-error map. */
+  validate: () => TErrors;
+}
+
+export interface UseModalFormResult<TErrors extends object> {
+  fieldErrors: TErrors;
+  setFieldErrors: Dispatch<SetStateAction<TErrors>>;
+  hasSubmitted: boolean;
+  setHasSubmitted: Dispatch<SetStateAction<boolean>>;
+  /**
+   * Marks the form as submitted, runs `validate`, stores the result in
+   * `fieldErrors`, and returns the error map. Callers check whether it is
+   * empty to decide whether to proceed.
+   */
+  runValidation: () => TErrors;
+}
+
+export function useModalForm<TErrors extends object, TRecord>({
+  isOpen,
+  onClose,
+  recordId,
+  isEdit,
+  record,
+  reset,
+  populate,
+  validate,
+}: UseModalFormOptions<TErrors, TRecord>): UseModalFormResult<TErrors> {
+  const [fieldErrors, setFieldErrors] = useState<TErrors>({} as TErrors);
+  const [hasSubmitted, setHasSubmitted] = useState(false);
+
+  // Keep the latest reset/populate callbacks without making them effect deps —
+  // they are recreated every render by callers, but the effects must only fire
+  // on the original triggers.
+  const resetRef = useRef(reset);
+  const populateRef = useRef(populate);
+  resetRef.current = reset;
+  populateRef.current = populate;
+
+  // Close on Escape key — only active when the modal is open so it does not
+  // interfere with other dialogs.
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [isOpen, onClose]);
+
+  // Reset form when opening or switching records — clears stale values and the
+  // submit/error state. Mirrors the hand-written `[recordId, isOpen]` effects.
+  useEffect(() => {
+    resetRef.current();
+    setFieldErrors({} as TErrors);
+    setHasSubmitted(false);
+  }, [recordId, isOpen]);
+
+  // Populate form once the fetched record resolves in edit mode.
+  useEffect(() => {
+    if (isEdit && record) {
+      populateRef.current(record);
+    }
+  }, [isEdit, record]);
+
+  // Re-validate on every change once the user has attempted a submit, so errors
+  // update live.
+  useEffect(() => {
+    if (hasSubmitted) setFieldErrors(validate());
+  }, [hasSubmitted, validate]);
+
+  const runValidation = useCallback((): TErrors => {
+    setHasSubmitted(true);
+    const errors = validate();
+    setFieldErrors(errors);
+    return errors;
+  }, [validate]);
+
+  return {
+    fieldErrors,
+    setFieldErrors,
+    hasSubmitted,
+    setHasSubmitted,
+    runValidation,
+  };
+}

--- a/app/hooks/usePlayers.ts
+++ b/app/hooks/usePlayers.ts
@@ -1,8 +1,9 @@
 import { createServerFn } from '@tanstack/react-start';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import type { PlayerData, PlayerListItem } from '~/types/player';
-import { captureException } from '~/providers/PostHogProvider';
 import { queryKeys } from '~/utils/queryKeys';
+import { extractErrorMessage } from '~/utils/errors';
+import { createMutationHook } from '~/hooks/createMutationHook';
 import {
   listPlayersSchema,
   getPlayerSchema,
@@ -15,16 +16,6 @@ import {
   completeJoinWizardSchema,
 } from '~/types/schemas/players';
 import { z } from 'zod';
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function extractErrorMessage(error: unknown): string | null {
-  if (!error) return null;
-  if (error instanceof Error) return error.message;
-  return String(error);
-}
 
 // ---------------------------------------------------------------------------
 // Server function wrappers — dynamic imports keep Mongoose server-only.
@@ -205,84 +196,48 @@ interface UpdatePlayerInput {
   appearance?: string;
 }
 
-export function useUpdatePlayer() {
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: async (input: UpdatePlayerInput) => updatePlayerFn({ data: input }),
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: ['players', 'list', variables.campaignId],
-        exact: false,
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.players.detail(variables.id, variables.campaignId),
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.players.active(variables.campaignId),
-      });
-      queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
-    },
-    onError: (e, variables) => {
-      captureException(e, { action: 'updatePlayer', playerId: variables.id });
-    },
-  });
-
-  const update = async (input: UpdatePlayerInput) => {
-    try {
-      return await mutation.mutateAsync(input);
-    } catch {
-      return null;
-    }
-  };
-
-  return {
-    update,
-    isLoading: mutation.isPending,
-    error: extractErrorMessage(mutation.error),
-  };
-}
+export const useUpdatePlayer = createMutationHook({
+  actionName: 'update',
+  mutationFn: async (input: UpdatePlayerInput) => updatePlayerFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    queryClient.invalidateQueries({
+      queryKey: ['players', 'list', variables.campaignId],
+      exact: false,
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.players.detail(variables.id, variables.campaignId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.players.active(variables.campaignId),
+    });
+    queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+  },
+  errorContext: (variables) => ({ action: 'updatePlayer', playerId: variables.id }),
+});
 
 interface DeletePlayerInput {
   id: string;
   campaignId: string;
 }
 
-export function useDeletePlayer() {
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: async (input: DeletePlayerInput) => deletePlayerFn({ data: input }),
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: ['players', 'list', variables.campaignId],
-        exact: false,
-      });
-      queryClient.removeQueries({
-        queryKey: queryKeys.players.detail(variables.id, variables.campaignId),
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.players.active(variables.campaignId),
-      });
-      queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
-    },
-    onError: (e, variables) => {
-      captureException(e, { action: 'deletePlayer', playerId: variables.id });
-    },
-  });
-
-  const remove = async (input: DeletePlayerInput) => {
-    try {
-      return await mutation.mutateAsync(input);
-    } catch {
-      return null;
-    }
-  };
-
-  return {
-    remove,
-    isLoading: mutation.isPending,
-    error: extractErrorMessage(mutation.error),
-  };
-}
+export const useDeletePlayer = createMutationHook({
+  actionName: 'remove',
+  mutationFn: async (input: DeletePlayerInput) => deletePlayerFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    queryClient.invalidateQueries({
+      queryKey: ['players', 'list', variables.campaignId],
+      exact: false,
+    });
+    queryClient.removeQueries({
+      queryKey: queryKeys.players.detail(variables.id, variables.campaignId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.players.active(variables.campaignId),
+    });
+    queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+  },
+  errorContext: (variables) => ({ action: 'deletePlayer', playerId: variables.id }),
+});
 
 interface UpdatePlayerStatusInput {
   id: string;
@@ -290,41 +245,23 @@ interface UpdatePlayerStatusInput {
   value: 'alive' | 'deceased';
 }
 
-export function useUpdatePlayerStatus() {
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: async (input: UpdatePlayerStatusInput) => updatePlayerStatusFn({ data: input }),
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: ['players', 'list', variables.campaignId],
-        exact: false,
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.players.detail(variables.id, variables.campaignId),
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.players.active(variables.campaignId),
-      });
-    },
-    onError: (e, variables) => {
-      captureException(e, { action: 'updatePlayerStatus', playerId: variables.id });
-    },
-  });
-
-  const updateStatus = async (input: UpdatePlayerStatusInput) => {
-    try {
-      return await mutation.mutateAsync(input);
-    } catch {
-      return null;
-    }
-  };
-
-  return {
-    updateStatus,
-    isLoading: mutation.isPending,
-    error: extractErrorMessage(mutation.error),
-  };
-}
+export const useUpdatePlayerStatus = createMutationHook({
+  actionName: 'updateStatus',
+  mutationFn: async (input: UpdatePlayerStatusInput) => updatePlayerStatusFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    queryClient.invalidateQueries({
+      queryKey: ['players', 'list', variables.campaignId],
+      exact: false,
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.players.detail(variables.id, variables.campaignId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.players.active(variables.campaignId),
+    });
+  },
+  errorContext: (variables) => ({ action: 'updatePlayerStatus', playerId: variables.id }),
+});
 
 interface AddPlayerRelationshipInput {
   playerId: string;
@@ -334,41 +271,22 @@ interface AddPlayerRelationshipInput {
   isPublic?: boolean;
 }
 
-export function useAddPlayerRelationship() {
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: async (input: AddPlayerRelationshipInput) =>
-      addPlayerRelationshipFn({ data: input }),
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.players.detail(variables.playerId, variables.campaignId),
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.players.active(variables.campaignId),
-      });
-    },
-    onError: (e, variables) => {
-      captureException(e, {
-        action: 'addPlayerRelationship',
-        playerId: variables.playerId,
-      });
-    },
-  });
-
-  const addRelationship = async (input: AddPlayerRelationshipInput) => {
-    try {
-      return await mutation.mutateAsync(input);
-    } catch {
-      return null;
-    }
-  };
-
-  return {
-    addRelationship,
-    isLoading: mutation.isPending,
-    error: extractErrorMessage(mutation.error),
-  };
-}
+export const useAddPlayerRelationship = createMutationHook({
+  actionName: 'addRelationship',
+  mutationFn: async (input: AddPlayerRelationshipInput) => addPlayerRelationshipFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.players.detail(variables.playerId, variables.campaignId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.players.active(variables.campaignId),
+    });
+  },
+  errorContext: (variables) => ({
+    action: 'addPlayerRelationship',
+    playerId: variables.playerId,
+  }),
+});
 
 interface UpdatePlayerRelationshipInput {
   playerId: string;
@@ -378,41 +296,23 @@ interface UpdatePlayerRelationshipInput {
   isPublic?: boolean;
 }
 
-export function useUpdatePlayerRelationship() {
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: async (input: UpdatePlayerRelationshipInput) =>
-      updatePlayerRelationshipFn({ data: input }),
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.players.detail(variables.playerId, variables.campaignId),
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.players.active(variables.campaignId),
-      });
-    },
-    onError: (e, variables) => {
-      captureException(e, {
-        action: 'updatePlayerRelationship',
-        playerId: variables.playerId,
-      });
-    },
-  });
-
-  const updateRelationship = async (input: UpdatePlayerRelationshipInput) => {
-    try {
-      return await mutation.mutateAsync(input);
-    } catch {
-      return null;
-    }
-  };
-
-  return {
-    updateRelationship,
-    isLoading: mutation.isPending,
-    error: extractErrorMessage(mutation.error),
-  };
-}
+export const useUpdatePlayerRelationship = createMutationHook({
+  actionName: 'updateRelationship',
+  mutationFn: async (input: UpdatePlayerRelationshipInput) =>
+    updatePlayerRelationshipFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.players.detail(variables.playerId, variables.campaignId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.players.active(variables.campaignId),
+    });
+  },
+  errorContext: (variables) => ({
+    action: 'updatePlayerRelationship',
+    playerId: variables.playerId,
+  }),
+});
 
 interface RemovePlayerRelationshipInput {
   playerId: string;
@@ -420,68 +320,33 @@ interface RemovePlayerRelationshipInput {
   characterId: string;
 }
 
-export function useRemovePlayerRelationship() {
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: async (input: RemovePlayerRelationshipInput) =>
-      removePlayerRelationshipFn({ data: input }),
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.players.detail(variables.playerId, variables.campaignId),
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.players.active(variables.campaignId),
-      });
-    },
-    onError: (e, variables) => {
-      captureException(e, {
-        action: 'removePlayerRelationship',
-        playerId: variables.playerId,
-      });
-    },
-  });
-
-  const removeRelationship = async (input: RemovePlayerRelationshipInput) => {
-    try {
-      return await mutation.mutateAsync(input);
-    } catch {
-      return null;
-    }
-  };
-
-  return {
-    removeRelationship,
-    isLoading: mutation.isPending,
-    error: extractErrorMessage(mutation.error),
-  };
-}
+export const useRemovePlayerRelationship = createMutationHook({
+  actionName: 'removeRelationship',
+  mutationFn: async (input: RemovePlayerRelationshipInput) =>
+    removePlayerRelationshipFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.players.detail(variables.playerId, variables.campaignId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.players.active(variables.campaignId),
+    });
+  },
+  errorContext: (variables) => ({
+    action: 'removePlayerRelationship',
+    playerId: variables.playerId,
+  }),
+});
 
 interface ValidateInviteCodeInput {
   inviteCode: string;
 }
 
-export function useValidateInviteCode() {
-  const mutation = useMutation({
-    mutationFn: async (input: ValidateInviteCodeInput) => validateInviteCodeFn({ data: input }),
-    onError: (e) => {
-      captureException(e, { action: 'validateInviteCode' });
-    },
-  });
-
-  const validate = async (input: ValidateInviteCodeInput) => {
-    try {
-      return await mutation.mutateAsync(input);
-    } catch {
-      return null;
-    }
-  };
-
-  return {
-    validate,
-    isLoading: mutation.isPending,
-    error: extractErrorMessage(mutation.error),
-  };
-}
+export const useValidateInviteCode = createMutationHook({
+  actionName: 'validate',
+  mutationFn: async (input: ValidateInviteCodeInput) => validateInviteCodeFn({ data: input }),
+  errorContext: () => ({ action: 'validateInviteCode' }),
+});
 
 interface CompleteJoinWizardInput {
   campaignId: string;
@@ -527,29 +392,11 @@ interface CompleteJoinWizardInput {
   }>;
 }
 
-export function useCompleteJoinWizard() {
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: async (input: CompleteJoinWizardInput) => completeJoinWizardFn({ data: input }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.campaigns.list() });
-    },
-    onError: (e) => {
-      captureException(e, { action: 'completeJoinWizard' });
-    },
-  });
-
-  const complete = async (input: CompleteJoinWizardInput) => {
-    try {
-      return await mutation.mutateAsync(input);
-    } catch {
-      return null;
-    }
-  };
-
-  return {
-    complete,
-    isLoading: mutation.isPending,
-    error: extractErrorMessage(mutation.error),
-  };
-}
+export const useCompleteJoinWizard = createMutationHook({
+  actionName: 'complete',
+  mutationFn: async (input: CompleteJoinWizardInput) => completeJoinWizardFn({ data: input }),
+  onSuccess: (queryClient) => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.campaigns.list() });
+  },
+  errorContext: () => ({ action: 'completeJoinWizard' }),
+});

--- a/app/routes/auth/$provider.tsx
+++ b/app/routes/auth/$provider.tsx
@@ -1,64 +1,77 @@
-import { createFileRoute, redirect } from '@tanstack/react-router'
-import { createServerFn } from '@tanstack/react-start'
-import { setCookie } from '@tanstack/react-start/server'
-import { z } from 'zod'
+import { createFileRoute, redirect } from '@tanstack/react-router';
+import { createServerFn } from '@tanstack/react-start';
+import { setCookie } from '@tanstack/react-start/server';
+import { z } from 'zod';
 import {
   buildGoogleOAuthUrl,
   buildGithubOAuthUrl,
   buildAppleOAuthUrl,
   providerConfigured,
-} from '~/server/utils/oauth'
+  generateCodeVerifier,
+  deriveCodeChallenge,
+} from '~/server/utils/oauth';
 
-const VALID_PROVIDERS = ['google', 'github', 'apple'] as const
+const VALID_PROVIDERS = ['google', 'github', 'apple'] as const;
 
 const initiateOAuth = createServerFn({ method: 'GET' })
   .inputValidator(z.object({ provider: z.enum(VALID_PROVIDERS) }))
   .handler(async ({ data }) => {
-    const { provider } = data
+    const { provider } = data;
 
     if (!providerConfigured(provider)) {
-      throw redirect({ to: '/', search: { reason: 'provider_not_configured' } })
+      throw redirect({ to: '/', search: { reason: 'provider_not_configured' } });
     }
 
     // Generate CSRF state token
-    const { randomBytes } = await import('node:crypto')
-    const state = randomBytes(32).toString('hex')
+    const { randomBytes } = await import('node:crypto');
+    const state = randomBytes(32).toString('hex');
 
-    // Store state in httpOnly cookie (short-lived, 10 min)
-    setCookie('oauth_state', state, {
+    // Generate PKCE verifier + S256 challenge. The verifier is the secret kept
+    // server-side (in a cookie, same lifecycle as state); the challenge travels
+    // on the authorize request and is verified by the provider at token exchange.
+    const codeVerifier = generateCodeVerifier();
+    const codeChallenge = deriveCodeChallenge(codeVerifier);
+
+    // Store state + PKCE verifier in httpOnly cookies (short-lived, 10 min).
+    // Same mechanism/lifetime: created at authorize, consumed at callback.
+    const cookieOpts = {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
+      sameSite: 'lax' as const,
       maxAge: 600,
       path: '/',
-    })
+    };
+    setCookie('oauth_state', state, cookieOpts);
+    setCookie('oauth_code_verifier', codeVerifier, cookieOpts);
 
-    let url: string
+    let url: string;
     switch (provider) {
       case 'google':
-        url = buildGoogleOAuthUrl(state)
-        break
+        url = buildGoogleOAuthUrl(state, codeChallenge);
+        break;
       case 'github':
-        url = buildGithubOAuthUrl(state)
-        break
+        url = buildGithubOAuthUrl(state, codeChallenge);
+        break;
       case 'apple':
-        url = buildAppleOAuthUrl(state)
-        break
+        url = buildAppleOAuthUrl(state, codeChallenge);
+        break;
     }
 
-    return { redirectUrl: url }
-  })
+    return { redirectUrl: url };
+  });
 
 export const Route = createFileRoute('/auth/$provider')({
   beforeLoad: async ({ params }) => {
-    const provider = params.provider as string
-    if (!VALID_PROVIDERS.includes(provider as typeof VALID_PROVIDERS[number])) {
-      throw redirect({ to: '/' })
+    const provider = params.provider as string;
+    if (!VALID_PROVIDERS.includes(provider as (typeof VALID_PROVIDERS)[number])) {
+      throw redirect({ to: '/' });
     }
-    const result = await initiateOAuth({ data: { provider: provider as typeof VALID_PROVIDERS[number] } })
+    const result = await initiateOAuth({
+      data: { provider: provider as (typeof VALID_PROVIDERS)[number] },
+    });
     if (result?.redirectUrl) {
-      throw redirect({ href: result.redirectUrl })
+      throw redirect({ href: result.redirectUrl });
     }
   },
   component: () => null,
-})
+});

--- a/app/routes/auth/callback/$provider.tsx
+++ b/app/routes/auth/callback/$provider.tsx
@@ -21,9 +21,12 @@ const handleCallback = createServerFn({ method: 'GET' })
     async ({ data }): Promise<{ redirectTo: string; redirectSearch?: Record<string, string> }> => {
       const { provider, code, state } = data;
 
-      // Verify CSRF state token
+      // Verify CSRF state token and retrieve the PKCE verifier. Both were set at
+      // authorize time with the same lifetime; consume (delete) both here.
       const storedState = getCookie('oauth_state');
+      const codeVerifier = getCookie('oauth_code_verifier');
       deleteCookie('oauth_state', { path: '/' });
+      deleteCookie('oauth_code_verifier', { path: '/' });
 
       if (!storedState || storedState !== state) {
         await serverCaptureException(new Error('CSRF state mismatch'), undefined, {
@@ -37,11 +40,11 @@ const handleCallback = createServerFn({ method: 'GET' })
       try {
         let profile;
         if (provider === 'google') {
-          profile = await exchangeGoogleCode(code);
+          profile = await exchangeGoogleCode(code, codeVerifier);
         } else if (provider === 'github') {
-          profile = await exchangeGithubCode(code);
+          profile = await exchangeGithubCode(code, codeVerifier);
         } else if (provider === 'apple') {
-          profile = await exchangeAppleCode(code);
+          profile = await exchangeAppleCode(code, codeVerifier);
         } else {
           throw new Error(`Unsupported provider: ${provider}`);
         }

--- a/app/server/db/models/User.ts
+++ b/app/server/db/models/User.ts
@@ -14,6 +14,26 @@ const userSchema = new mongoose.Schema({
     // Measurement (ruler) line color, a 6-digit hex string (e.g. '#fbbf24').
     rulerColor: { type: String },
   },
+  // Provider OAuth tokens, encrypted at rest (AES-256-GCM). Kept server-side
+  // only (never in the session cookie) and `select: false` so they are never
+  // returned by normal queries — only explicitly via `.select('+oauthTokens')`.
+  // Used at logout time to revoke the provider grant.
+  oauthTokens: {
+    type: {
+      accessToken: {
+        ciphertext: String,
+        iv: String,
+        authTag: String,
+      },
+      refreshToken: {
+        ciphertext: String,
+        iv: String,
+        authTag: String,
+      },
+    },
+    select: false,
+    _id: false,
+  },
   lastLoginAt: { type: Date, default: Date.now },
   createdAt: { type: Date, default: Date.now },
 });

--- a/app/server/functions/characters.ts
+++ b/app/server/functions/characters.ts
@@ -1,8 +1,5 @@
 import { createServerFn } from '@tanstack/react-start';
-import { getSession } from '../session';
-import { connectDB, isDBConnected } from '../db/connection';
-import { User } from '../db/models/User';
-import { Campaign } from '../db/models/Campaign';
+import { requireCampaignMember } from '../utils/requireCampaignMember';
 import { Character } from '../db/models/Character';
 import { serverCaptureException, serverCaptureEvent } from '../utils/posthog';
 import { normalizeTags } from '../utils/helpers';
@@ -141,37 +138,6 @@ function serializeCharacterListItem(c: {
       changedBy: c.status?.changedBy ? String(c.status.changedBy) : null,
     },
   };
-}
-
-/**
- * Verify the authenticated user is a member of the given campaign.
- * Returns the DB user ID string, session user ID, and whether the user is the GM.
- */
-async function requireCampaignMember(
-  campaignId: string
-): Promise<{ userId: string; sessionUserId: string; isGM: boolean }> {
-  const user = await getSession();
-  if (!user) throw new Error('Not authenticated');
-
-  await connectDB();
-  if (!isDBConnected()) throw new Error('Database not available');
-
-  const dbUser = await User.findOne({ providerId: user.id });
-  if (!dbUser) throw new Error('User not found');
-
-  const campaign = await Campaign.findById(campaignId);
-  if (!campaign) throw new Error('Campaign not found');
-
-  const userId = String(dbUser._id);
-  const members = campaign.members ?? [];
-  const member = members.find(
-    (m: { userId: unknown; role?: string }) => String(m.userId) === userId
-  );
-  const isGM = String(campaign.gameMasterId) === userId || member?.role === 'gm';
-  const isMember = !!member || isGM;
-  if (!isMember) throw new Error('Forbidden');
-
-  return { userId, sessionUserId: user.id, isGM };
 }
 
 // ---------------------------------------------------------------------------

--- a/app/server/functions/location-types.ts
+++ b/app/server/functions/location-types.ts
@@ -1,8 +1,5 @@
 import { createServerFn } from '@tanstack/react-start';
-import { getSession } from '../session';
-import { connectDB, isDBConnected } from '../db/connection';
-import { User } from '../db/models/User';
-import { Campaign } from '../db/models/Campaign';
+import { requireCampaignMember } from '../utils/requireCampaignMember';
 import { Location } from '../db/models/Location';
 import { LocationType, seedDefaultLocationTypes } from '../db/models/LocationType';
 import { serverCaptureException, serverCaptureEvent } from '../utils/posthog';
@@ -31,37 +28,6 @@ function serializeLocationType(d: {
     isDefault: d.isDefault ?? false,
     sortOrder: d.sortOrder ?? 0,
   };
-}
-
-// ---------------------------------------------------------------------------
-// Auth helpers
-// ---------------------------------------------------------------------------
-
-async function requireCampaignMember(
-  campaignId: string
-): Promise<{ userId: string; sessionUserId: string; isGM: boolean }> {
-  const user = await getSession();
-  if (!user) throw new Error('Not authenticated');
-
-  await connectDB();
-  if (!isDBConnected()) throw new Error('Database not available');
-
-  const dbUser = await User.findOne({ providerId: user.id });
-  if (!dbUser) throw new Error('User not found');
-
-  const campaign = await Campaign.findById(campaignId);
-  if (!campaign) throw new Error('Campaign not found');
-
-  const userId = String(dbUser._id);
-  const members = campaign.members ?? [];
-  const member = members.find(
-    (m: { userId: unknown; role?: string }) => String(m.userId) === userId
-  );
-  const isGM = String(campaign.gameMasterId) === userId || member?.role === 'gm';
-  const isMember = !!member || isGM;
-  if (!isMember) throw new Error('Forbidden');
-
-  return { userId, sessionUserId: user.id, isGM };
 }
 
 // ---------------------------------------------------------------------------

--- a/app/server/functions/locations.ts
+++ b/app/server/functions/locations.ts
@@ -1,8 +1,5 @@
 import { createServerFn } from '@tanstack/react-start';
-import { getSession } from '../session';
-import { connectDB, isDBConnected } from '../db/connection';
-import { User } from '../db/models/User';
-import { Campaign } from '../db/models/Campaign';
+import { requireCampaignMember } from '../utils/requireCampaignMember';
 import { Location } from '../db/models/Location';
 import { serverCaptureException, serverCaptureEvent } from '../utils/posthog';
 import { normalizeTags } from '../utils/helpers';
@@ -140,33 +137,6 @@ function createR2Client(): { client: S3Client; bucket: string } | null {
     }),
     bucket,
   };
-}
-
-async function requireCampaignMember(
-  campaignId: string
-): Promise<{ userId: string; sessionUserId: string; isGM: boolean }> {
-  const user = await getSession();
-  if (!user) throw new Error('Not authenticated');
-
-  await connectDB();
-  if (!isDBConnected()) throw new Error('Database not available');
-
-  const dbUser = await User.findOne({ providerId: user.id });
-  if (!dbUser) throw new Error('User not found');
-
-  const campaign = await Campaign.findById(campaignId);
-  if (!campaign) throw new Error('Campaign not found');
-
-  const userId = String(dbUser._id);
-  const members = campaign.members ?? [];
-  const member = members.find(
-    (m: { userId: unknown; role?: string }) => String(m.userId) === userId
-  );
-  const isGM = String(campaign.gameMasterId) === userId || member?.role === 'gm';
-  const isMember = !!member || isGM;
-  if (!isMember) throw new Error('Forbidden');
-
-  return { userId, sessionUserId: user.id, isGM };
 }
 
 // ---------------------------------------------------------------------------

--- a/app/server/functions/mapDrawings.ts
+++ b/app/server/functions/mapDrawings.ts
@@ -1,8 +1,5 @@
 import { createServerFn } from '@tanstack/react-start';
-import { getSession } from '../session';
-import { connectDB, isDBConnected } from '../db/connection';
-import { User } from '../db/models/User';
-import { Campaign } from '../db/models/Campaign';
+import { requireCampaignMember } from '../utils/requireCampaignMember';
 import { Map as MapModel } from '../db/models/Map';
 import { MapDrawing } from '../db/models/MapDrawing';
 import { serverCaptureException, serverCaptureEvent } from '../utils/posthog';
@@ -105,37 +102,6 @@ async function mapBounds(
     w: m.imageWidth ?? Number.POSITIVE_INFINITY,
     h: m.imageHeight ?? Number.POSITIVE_INFINITY,
   };
-}
-
-// ---------------------------------------------------------------------------
-// Auth helper (mirrors mapTexts.ts)
-// ---------------------------------------------------------------------------
-
-async function requireCampaignMember(
-  campaignId: string
-): Promise<{ userId: string; sessionUserId: string; isGM: boolean }> {
-  const user = await getSession();
-  if (!user) throw new Error('Not authenticated');
-
-  await connectDB();
-  if (!isDBConnected()) throw new Error('Database not available');
-
-  const dbUser = await User.findOne({ providerId: user.id });
-  if (!dbUser) throw new Error('User not found');
-
-  const campaign = await Campaign.findById(campaignId);
-  if (!campaign) throw new Error('Campaign not found');
-
-  const userId = String(dbUser._id);
-  const members = campaign.members ?? [];
-  const member = members.find(
-    (m: { userId: unknown; role?: string }) => String(m.userId) === userId
-  );
-  const isGM = String(campaign.gameMasterId) === userId || member?.role === 'gm';
-  const isMember = !!member || isGM;
-  if (!isMember) throw new Error('Forbidden');
-
-  return { userId, sessionUserId: user.id, isGM };
 }
 
 // ---------------------------------------------------------------------------

--- a/app/server/functions/mapTexts.ts
+++ b/app/server/functions/mapTexts.ts
@@ -1,8 +1,5 @@
 import { createServerFn } from '@tanstack/react-start';
-import { getSession } from '../session';
-import { connectDB, isDBConnected } from '../db/connection';
-import { User } from '../db/models/User';
-import { Campaign } from '../db/models/Campaign';
+import { requireCampaignMember } from '../utils/requireCampaignMember';
 import { Map as MapModel } from '../db/models/Map';
 import { MapText } from '../db/models/MapText';
 import { serverCaptureException, serverCaptureEvent } from '../utils/posthog';
@@ -46,37 +43,6 @@ function serializeText(t: TextDoc): MapTextData {
     createdAt: t.createdAt instanceof Date ? t.createdAt.toISOString() : '',
     updatedAt: t.updatedAt instanceof Date ? t.updatedAt.toISOString() : '',
   };
-}
-
-// ---------------------------------------------------------------------------
-// Auth helper (mirrors mapTokens.ts)
-// ---------------------------------------------------------------------------
-
-async function requireCampaignMember(
-  campaignId: string
-): Promise<{ userId: string; sessionUserId: string; isGM: boolean }> {
-  const user = await getSession();
-  if (!user) throw new Error('Not authenticated');
-
-  await connectDB();
-  if (!isDBConnected()) throw new Error('Database not available');
-
-  const dbUser = await User.findOne({ providerId: user.id });
-  if (!dbUser) throw new Error('User not found');
-
-  const campaign = await Campaign.findById(campaignId);
-  if (!campaign) throw new Error('Campaign not found');
-
-  const userId = String(dbUser._id);
-  const members = campaign.members ?? [];
-  const member = members.find(
-    (m: { userId: unknown; role?: string }) => String(m.userId) === userId
-  );
-  const isGM = String(campaign.gameMasterId) === userId || member?.role === 'gm';
-  const isMember = !!member || isGM;
-  if (!isMember) throw new Error('Forbidden');
-
-  return { userId, sessionUserId: user.id, isGM };
 }
 
 // ---------------------------------------------------------------------------

--- a/app/server/functions/mapTokens.ts
+++ b/app/server/functions/mapTokens.ts
@@ -248,6 +248,12 @@ export const listMapTokens = createServerFn({ method: 'GET' })
       const member = await requireCampaignMember(data.campaignId);
       sessionUserId = member.sessionUserId;
 
+      // Campaign membership alone does not prove the requested map belongs to
+      // this campaign. Scope the map by campaignId (like the mutating siblings)
+      // so a member of one campaign can't read tokens of another's maps.
+      const map = await MapModel.findOne({ _id: data.mapId, campaignId: data.campaignId }).lean();
+      if (!map) throw new Error('Map not found');
+
       const filter: Record<string, unknown> = { mapId: data.mapId };
       if (!member.isGM) filter.hiddenFromPlayers = { $ne: true };
       // Bound the result set; batch placement can add many tokens per map.

--- a/app/server/functions/mapTokens.ts
+++ b/app/server/functions/mapTokens.ts
@@ -1,8 +1,5 @@
 import { createServerFn } from '@tanstack/react-start';
-import { getSession } from '../session';
-import { connectDB, isDBConnected } from '../db/connection';
-import { User } from '../db/models/User';
-import { Campaign } from '../db/models/Campaign';
+import { requireCampaignMember } from '../utils/requireCampaignMember';
 import { Map as MapModel } from '../db/models/Map';
 import { MapToken } from '../db/models/MapToken';
 import { Player } from '../db/models/Player';
@@ -66,37 +63,6 @@ function serializeToken(t: TokenDoc): MapTokenData {
     createdAt: t.createdAt instanceof Date ? t.createdAt.toISOString() : '',
     updatedAt: t.updatedAt instanceof Date ? t.updatedAt.toISOString() : '',
   };
-}
-
-// ---------------------------------------------------------------------------
-// Auth helper (mirrors maps.ts)
-// ---------------------------------------------------------------------------
-
-async function requireCampaignMember(
-  campaignId: string
-): Promise<{ userId: string; sessionUserId: string; isGM: boolean }> {
-  const user = await getSession();
-  if (!user) throw new Error('Not authenticated');
-
-  await connectDB();
-  if (!isDBConnected()) throw new Error('Database not available');
-
-  const dbUser = await User.findOne({ providerId: user.id });
-  if (!dbUser) throw new Error('User not found');
-
-  const campaign = await Campaign.findById(campaignId);
-  if (!campaign) throw new Error('Campaign not found');
-
-  const userId = String(dbUser._id);
-  const members = campaign.members ?? [];
-  const member = members.find(
-    (m: { userId: unknown; role?: string }) => String(m.userId) === userId
-  );
-  const isGM = String(campaign.gameMasterId) === userId || member?.role === 'gm';
-  const isMember = !!member || isGM;
-  if (!isMember) throw new Error('Forbidden');
-
-  return { userId, sessionUserId: user.id, isGM };
 }
 
 // ---------------------------------------------------------------------------

--- a/app/server/functions/maps.ts
+++ b/app/server/functions/maps.ts
@@ -1,9 +1,6 @@
 import { createServerFn } from '@tanstack/react-start';
 import { S3Client, DeleteObjectCommand } from '@aws-sdk/client-s3';
-import { getSession } from '../session';
-import { connectDB, isDBConnected } from '../db/connection';
-import { User } from '../db/models/User';
-import { Campaign } from '../db/models/Campaign';
+import { requireCampaignMember } from '../utils/requireCampaignMember';
 import { Map as MapModel } from '../db/models/Map';
 import { TabletopScreen } from '../db/models/TabletopScreen';
 import { Location } from '../db/models/Location';
@@ -129,33 +126,6 @@ async function broadcastActiveMapChanged(
   } catch {
     // Best-effort only — clients still refetch on focus/refresh.
   }
-}
-
-async function requireCampaignMember(
-  campaignId: string
-): Promise<{ userId: string; sessionUserId: string; isGM: boolean }> {
-  const user = await getSession();
-  if (!user) throw new Error('Not authenticated');
-
-  await connectDB();
-  if (!isDBConnected()) throw new Error('Database not available');
-
-  const dbUser = await User.findOne({ providerId: user.id });
-  if (!dbUser) throw new Error('User not found');
-
-  const campaign = await Campaign.findById(campaignId);
-  if (!campaign) throw new Error('Campaign not found');
-
-  const userId = String(dbUser._id);
-  const members = campaign.members ?? [];
-  const member = members.find(
-    (m: { userId: unknown; role?: string }) => String(m.userId) === userId
-  );
-  const isGM = String(campaign.gameMasterId) === userId || member?.role === 'gm';
-  const isMember = !!member || isGM;
-  if (!isMember) throw new Error('Forbidden');
-
-  return { userId, sessionUserId: user.id, isGM };
 }
 
 // ---------------------------------------------------------------------------

--- a/app/server/functions/players.ts
+++ b/app/server/functions/players.ts
@@ -4,6 +4,7 @@ import { getSession } from '../session';
 import { connectDB, isDBConnected } from '../db/connection';
 import { User } from '../db/models/User';
 import { Campaign } from '../db/models/Campaign';
+import { requireCampaignMember } from '../utils/requireCampaignMember';
 import { Player } from '../db/models/Player';
 import { Character } from '../db/models/Character';
 import { serverCaptureException, serverCaptureEvent } from '../utils/posthog';
@@ -140,37 +141,6 @@ function serializePlayerListItem(c: {
       changedBy: c.status?.changedBy ? String(c.status.changedBy) : null,
     },
   };
-}
-
-// ---------------------------------------------------------------------------
-// requireCampaignMember
-// ---------------------------------------------------------------------------
-
-async function requireCampaignMember(
-  campaignId: string
-): Promise<{ userId: string; sessionUserId: string; isGM: boolean }> {
-  const user = await getSession();
-  if (!user) throw new Error('Not authenticated');
-
-  await connectDB();
-  if (!isDBConnected()) throw new Error('Database not available');
-
-  const dbUser = await User.findOne({ providerId: user.id });
-  if (!dbUser) throw new Error('User not found');
-
-  const campaign = await Campaign.findById(campaignId);
-  if (!campaign) throw new Error('Campaign not found');
-
-  const userId = String(dbUser._id);
-  const members = campaign.members ?? [];
-  const member = members.find(
-    (m: { userId: unknown; role?: string }) => String(m.userId) === userId
-  );
-  const isGM = String(campaign.gameMasterId) === userId || member?.role === 'gm';
-  const isMember = !!member || isGM;
-  if (!isMember) throw new Error('Forbidden');
-
-  return { userId, sessionUserId: user.id, isGM };
 }
 
 // ---------------------------------------------------------------------------

--- a/app/server/functions/races.ts
+++ b/app/server/functions/races.ts
@@ -1,8 +1,5 @@
 import { createServerFn } from '@tanstack/react-start';
-import { getSession } from '../session';
-import { connectDB, isDBConnected } from '../db/connection';
-import { User } from '../db/models/User';
-import { Campaign } from '../db/models/Campaign';
+import { requireCampaignMember } from '../utils/requireCampaignMember';
 import { Race } from '../db/models/Race';
 import { serverCaptureException, serverCaptureEvent } from '../utils/posthog';
 import { normalizeTags } from '../utils/helpers';
@@ -57,37 +54,6 @@ function serializeRaceListItem(r: {
     createdAt: r.createdAt instanceof Date ? r.createdAt.toISOString() : '',
     updatedAt: r.updatedAt instanceof Date ? r.updatedAt.toISOString() : '',
   };
-}
-
-/**
- * Verify the authenticated user is a member of the given campaign.
- * Returns the DB user ID string, session user ID, and whether the user is the GM.
- */
-async function requireCampaignMember(
-  campaignId: string
-): Promise<{ userId: string; sessionUserId: string; isGM: boolean }> {
-  const user = await getSession();
-  if (!user) throw new Error('Not authenticated');
-
-  await connectDB();
-  if (!isDBConnected()) throw new Error('Database not available');
-
-  const dbUser = await User.findOne({ providerId: user.id });
-  if (!dbUser) throw new Error('User not found');
-
-  const campaign = await Campaign.findById(campaignId);
-  if (!campaign) throw new Error('Campaign not found');
-
-  const userId = String(dbUser._id);
-  const members = campaign.members ?? [];
-  const member = members.find(
-    (m: { userId: unknown; role?: string }) => String(m.userId) === userId
-  );
-  const isGM = String(campaign.gameMasterId) === userId || member?.role === 'gm';
-  const isMember = !!member || isGM;
-  if (!isMember) throw new Error('Forbidden');
-
-  return { userId, sessionUserId: user.id, isGM };
 }
 
 // ---------------------------------------------------------------------------

--- a/app/server/functions/rules.ts
+++ b/app/server/functions/rules.ts
@@ -3,6 +3,7 @@ import { getSession } from '../session';
 import { connectDB, isDBConnected } from '../db/connection';
 import { User } from '../db/models/User';
 import { Campaign } from '../db/models/Campaign';
+import { requireCampaignMember } from '../utils/requireCampaignMember';
 import { Rule } from '../db/models/Rule';
 import { serverCaptureException, serverCaptureEvent } from '../utils/posthog';
 import { normalizeTags } from '../utils/helpers';
@@ -61,37 +62,6 @@ function serializeRuleListItem(r: {
     createdAt: r.createdAt instanceof Date ? r.createdAt.toISOString() : '',
     updatedAt: r.updatedAt instanceof Date ? r.updatedAt.toISOString() : '',
   };
-}
-
-/**
- * Verify the authenticated user is a member of the given campaign.
- * Returns the DB user ID string, session user ID, and whether the user is the GM.
- */
-async function requireCampaignMember(
-  campaignId: string
-): Promise<{ userId: string; sessionUserId: string; isGM: boolean }> {
-  const user = await getSession();
-  if (!user) throw new Error('Not authenticated');
-
-  await connectDB();
-  if (!isDBConnected()) throw new Error('Database not available');
-
-  const dbUser = await User.findOne({ providerId: user.id });
-  if (!dbUser) throw new Error('User not found');
-
-  const campaign = await Campaign.findById(campaignId);
-  if (!campaign) throw new Error('Campaign not found');
-
-  const userId = String(dbUser._id);
-  const members = campaign.members ?? [];
-  const member = members.find(
-    (m: { userId: unknown; role?: string }) => String(m.userId) === userId
-  );
-  const isGM = String(campaign.gameMasterId) === userId || member?.role === 'gm';
-  const isMember = !!member || isGM;
-  if (!isMember) throw new Error('Forbidden');
-
-  return { userId, sessionUserId: user.id, isGM };
 }
 
 /**

--- a/app/server/session.ts
+++ b/app/server/session.ts
@@ -9,8 +9,6 @@ export interface SessionUser {
   email: string | null;
   avatar: string | null;
   role: string;
-  accessToken: string | null;
-  refreshToken: string | null;
   tokenIssuedAt: number;
 }
 

--- a/app/server/utils/oauth.ts
+++ b/app/server/utils/oauth.ts
@@ -3,6 +3,7 @@ import { User } from '../db/models/User';
 import type { SessionUser } from '../session';
 import { providerConfigured } from './helpers';
 import { serverCaptureException } from './posthog';
+import { encryptToken, decryptToken } from './tokenCrypto';
 
 export { providerConfigured };
 
@@ -298,13 +299,40 @@ export async function exchangeGithubCode(code: string): Promise<OAuthProfile> {
   };
 }
 
+/** Build the SessionUser identity claims, never including provider tokens. */
+function toSessionUser(profile: OAuthProfile, role: string, stored?: UserDoc | null): SessionUser {
+  return {
+    id: profile.id,
+    provider: profile.provider,
+    email: profile.email ?? stored?.email ?? null,
+    name: profile.name ?? (`${stored?.firstName ?? ''} ${stored?.lastName ?? ''}`.trim() || null),
+    avatar: profile.avatar ?? stored?.avatarUrl ?? null,
+    role,
+    tokenIssuedAt: profile.tokenIssuedAt,
+  };
+}
+
+interface UserDoc {
+  email?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  avatarUrl?: string | null;
+  role?: string;
+}
+
 export async function upsertUser(profile: OAuthProfile): Promise<SessionUser> {
   await connectDB();
-  if (!isDBConnected()) return { ...profile, role: 'unknown' };
+  if (!isDBConnected()) return toSessionUser(profile, 'unknown');
 
   try {
     const nameParts = (profile.name ?? '').split(' ');
-    const stored = await User.findOneAndUpdate(
+    // Encrypt provider tokens for at-rest storage. They never travel in the
+    // session cookie; they're read back (decrypted) only at logout to revoke.
+    const oauthTokens = {
+      accessToken: profile.accessToken ? encryptToken(profile.accessToken) : null,
+      refreshToken: profile.refreshToken ? encryptToken(profile.refreshToken) : null,
+    };
+    const stored = (await User.findOneAndUpdate(
       { providerId: profile.id },
       {
         $set: {
@@ -316,33 +344,60 @@ export async function upsertUser(profile: OAuthProfile): Promise<SessionUser> {
             lastName: nameParts.slice(1).join(' ') ?? '',
           }),
           ...(profile.avatar && { avatarUrl: profile.avatar }),
+          oauthTokens,
           lastLoginAt: new Date(),
         },
         $setOnInsert: { createdAt: new Date(), role: 'unknown' },
       },
       { upsert: true, returnDocument: 'after', new: true }
-    );
-    return {
-      ...profile,
-      email: profile.email ?? stored?.email ?? null,
-      name: profile.name ?? (`${stored?.firstName ?? ''} ${stored?.lastName ?? ''}`.trim() || null),
-      avatar: profile.avatar ?? stored?.avatarUrl ?? null,
-      role: stored?.role ?? 'unknown',
-    };
+    )) as UserDoc | null;
+    return toSessionUser(profile, stored?.role ?? 'unknown', stored);
   } catch (e) {
     serverCaptureException(e, profile.id, { action: 'upsertUser', provider: profile.provider });
-    return { ...profile, role: 'unknown' };
+    return toSessionUser(profile, 'unknown');
   }
 }
 
+interface EncryptedTokenField {
+  ciphertext?: string;
+  iv?: string;
+  authTag?: string;
+}
+
+/**
+ * Revoke the provider grant for the given session user.
+ *
+ * The provider access token is no longer carried in the session cookie; it is
+ * loaded (encrypted) from the User document, decrypted, and used to call the
+ * provider's revoke/delete endpoint. After a successful attempt the stored
+ * tokens are cleared. Preserves the original early-return-when-no-token
+ * behavior and per-provider routing (Google revoke, GitHub token delete; Apple
+ * has no revoke path).
+ */
 export async function revokeToken(user: SessionUser): Promise<void> {
-  if (!user.accessToken) return;
   try {
+    await connectDB();
+    if (!isDBConnected()) return;
+
+    // Tokens are select:false, so they must be explicitly selected.
+    const stored = (await User.findOne({ providerId: user.id }).select('+oauthTokens').lean()) as {
+      oauthTokens?: { accessToken?: EncryptedTokenField | null };
+    } | null;
+
+    const enc = stored?.oauthTokens?.accessToken;
+    if (!enc || !enc.ciphertext || !enc.iv || !enc.authTag) return;
+
+    const accessToken = decryptToken({
+      ciphertext: enc.ciphertext,
+      iv: enc.iv,
+      authTag: enc.authTag,
+    });
+
     if (user.provider === 'google') {
-      await fetch(
-        `https://oauth2.googleapis.com/revoke?token=${encodeURIComponent(user.accessToken)}`,
-        { method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
-      );
+      await fetch(`https://oauth2.googleapis.com/revoke?token=${encodeURIComponent(accessToken)}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      });
     } else if (
       user.provider === 'github' &&
       process.env.GITHUB_CLIENT_ID &&
@@ -358,9 +413,12 @@ export async function revokeToken(user: SessionUser): Promise<void> {
           Accept: 'application/vnd.github+json',
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ access_token: user.accessToken }),
+        body: JSON.stringify({ access_token: accessToken }),
       });
     }
+
+    // Clear the stored tokens once we've attempted revocation.
+    await User.updateOne({ providerId: user.id }, { $unset: { oauthTokens: '' } });
   } catch (e) {
     serverCaptureException(e, user.id, { action: 'revokeToken', provider: user.provider });
   }

--- a/app/server/utils/oauth.ts
+++ b/app/server/utils/oauth.ts
@@ -401,10 +401,12 @@ interface EncryptedTokenField {
  *
  * The provider access token is no longer carried in the session cookie; it is
  * loaded (encrypted) from the User document, decrypted, and used to call the
- * provider's revoke/delete endpoint. After a successful attempt the stored
- * tokens are cleared. Preserves the original early-return-when-no-token
- * behavior and per-provider routing (Google revoke, GitHub token delete; Apple
- * has no revoke path).
+ * provider's revoke/delete endpoint. Revocation is best-effort: the stored
+ * tokens are cleared once the attempt is made (regardless of the provider's
+ * HTTP response), so a token the provider has already rejected can't linger
+ * and fail again on the next logout. Preserves the original
+ * early-return-when-no-token behavior and per-provider routing (Google revoke,
+ * GitHub token delete; Apple has no revoke path).
  */
 export async function revokeToken(user: SessionUser): Promise<void> {
   try {

--- a/app/server/utils/oauth.ts
+++ b/app/server/utils/oauth.ts
@@ -1,3 +1,4 @@
+import { createHash, randomBytes } from 'node:crypto';
 import { connectDB, isDBConnected } from '../db/connection';
 import { User } from '../db/models/User';
 import type { SessionUser } from '../session';
@@ -24,7 +25,23 @@ function requireBaseUrl(): string {
   return url;
 }
 
-export function buildGoogleOAuthUrl(state?: string): string {
+/**
+ * Generate a PKCE code_verifier: a high-entropy, URL-safe random string.
+ * 32 random bytes -> 43-char base64url string (well within RFC 7636's 43-128).
+ */
+export function generateCodeVerifier(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+/**
+ * Derive the PKCE code_challenge for the S256 method:
+ *   code_challenge = BASE64URL(SHA256(ASCII(code_verifier)))
+ */
+export function deriveCodeChallenge(verifier: string): string {
+  return createHash('sha256').update(verifier).digest('base64url');
+}
+
+export function buildGoogleOAuthUrl(state?: string, codeChallenge?: string): string {
   const baseUrl = requireBaseUrl();
   const params = new URLSearchParams({
     client_id: process.env.GOOGLE_CLIENT_ID!,
@@ -34,22 +51,24 @@ export function buildGoogleOAuthUrl(state?: string): string {
     access_type: 'offline',
     prompt: 'consent',
     ...(state && { state }),
+    ...(codeChallenge && { code_challenge: codeChallenge, code_challenge_method: 'S256' }),
   });
   return `https://accounts.google.com/o/oauth2/v2/auth?${params}`;
 }
 
-export function buildGithubOAuthUrl(state?: string): string {
+export function buildGithubOAuthUrl(state?: string, codeChallenge?: string): string {
   const baseUrl = requireBaseUrl();
   const params = new URLSearchParams({
     client_id: process.env.GITHUB_CLIENT_ID!,
     redirect_uri: `${baseUrl}/auth/callback/github`,
     scope: 'user:email',
     ...(state && { state }),
+    ...(codeChallenge && { code_challenge: codeChallenge, code_challenge_method: 'S256' }),
   });
   return `https://github.com/login/oauth/authorize?${params}`;
 }
 
-export function buildAppleOAuthUrl(state?: string): string {
+export function buildAppleOAuthUrl(state?: string, codeChallenge?: string): string {
   const baseUrl = requireBaseUrl();
   const params = new URLSearchParams({
     client_id: process.env.APPLE_CLIENT_ID!,
@@ -58,11 +77,15 @@ export function buildAppleOAuthUrl(state?: string): string {
     scope: 'name email',
     response_mode: 'query',
     ...(state && { state }),
+    ...(codeChallenge && { code_challenge: codeChallenge, code_challenge_method: 'S256' }),
   });
   return `https://appleid.apple.com/auth/authorize?${params}`;
 }
 
-export async function exchangeAppleCode(code: string): Promise<OAuthProfile> {
+export async function exchangeAppleCode(
+  code: string,
+  codeVerifier?: string
+): Promise<OAuthProfile> {
   const { APPLE_CLIENT_ID, APPLE_TEAM_ID, APPLE_KEY_ID, APPLE_PRIVATE_KEY_PATH } = process.env;
   const appleBaseUrl = requireBaseUrl();
   if (!APPLE_CLIENT_ID || !APPLE_TEAM_ID || !APPLE_KEY_ID || !APPLE_PRIVATE_KEY_PATH) {
@@ -94,6 +117,7 @@ export async function exchangeAppleCode(code: string): Promise<OAuthProfile> {
       code,
       grant_type: 'authorization_code',
       redirect_uri: `${appleBaseUrl}/auth/callback/apple`,
+      ...(codeVerifier && { code_verifier: codeVerifier }),
     }),
   });
 
@@ -141,7 +165,10 @@ export async function exchangeAppleCode(code: string): Promise<OAuthProfile> {
   };
 }
 
-export async function exchangeGoogleCode(code: string): Promise<OAuthProfile> {
+export async function exchangeGoogleCode(
+  code: string,
+  codeVerifier?: string
+): Promise<OAuthProfile> {
   const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -151,6 +178,7 @@ export async function exchangeGoogleCode(code: string): Promise<OAuthProfile> {
       client_secret: process.env.GOOGLE_CLIENT_SECRET!,
       redirect_uri: `${requireBaseUrl()}/auth/callback/google`,
       grant_type: 'authorization_code',
+      ...(codeVerifier && { code_verifier: codeVerifier }),
     }),
   });
   if (!tokenRes.ok) {
@@ -216,7 +244,10 @@ export async function exchangeGoogleCode(code: string): Promise<OAuthProfile> {
   };
 }
 
-export async function exchangeGithubCode(code: string): Promise<OAuthProfile> {
+export async function exchangeGithubCode(
+  code: string,
+  codeVerifier?: string
+): Promise<OAuthProfile> {
   const tokenRes = await fetch('https://github.com/login/oauth/access_token', {
     method: 'POST',
     headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
@@ -225,6 +256,7 @@ export async function exchangeGithubCode(code: string): Promise<OAuthProfile> {
       client_secret: process.env.GITHUB_CLIENT_SECRET!,
       code,
       redirect_uri: `${requireBaseUrl()}/auth/callback/github`,
+      ...(codeVerifier && { code_verifier: codeVerifier }),
     }),
   });
   if (!tokenRes.ok) {

--- a/app/server/utils/requireCampaignMember.ts
+++ b/app/server/utils/requireCampaignMember.ts
@@ -1,0 +1,38 @@
+import { getSession } from '../session';
+import { connectDB, isDBConnected } from '../db/connection';
+import { User } from '../db/models/User';
+import { Campaign } from '../db/models/Campaign';
+
+/**
+ * Verify the authenticated user is a member of the given campaign.
+ * Returns the DB user ID string, session user ID, and whether the user is the GM.
+ *
+ * Throws on any failure: not authenticated, DB unavailable, user not found,
+ * campaign not found, or the user not being a member of the campaign.
+ */
+export async function requireCampaignMember(
+  campaignId: string
+): Promise<{ userId: string; sessionUserId: string; isGM: boolean }> {
+  const user = await getSession();
+  if (!user) throw new Error('Not authenticated');
+
+  await connectDB();
+  if (!isDBConnected()) throw new Error('Database not available');
+
+  const dbUser = await User.findOne({ providerId: user.id });
+  if (!dbUser) throw new Error('User not found');
+
+  const campaign = await Campaign.findById(campaignId);
+  if (!campaign) throw new Error('Campaign not found');
+
+  const userId = String(dbUser._id);
+  const members = campaign.members ?? [];
+  const member = members.find(
+    (m: { userId: unknown; role?: string }) => String(m.userId) === userId
+  );
+  const isGM = String(campaign.gameMasterId) === userId || member?.role === 'gm';
+  const isMember = !!member || isGM;
+  if (!isMember) throw new Error('Forbidden');
+
+  return { userId, sessionUserId: user.id, isGM };
+}

--- a/app/server/utils/tokenCrypto.ts
+++ b/app/server/utils/tokenCrypto.ts
@@ -1,0 +1,70 @@
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'node:crypto';
+
+/**
+ * Encrypted OAuth provider tokens at rest.
+ *
+ * Provider access/refresh tokens are sensitive bearer credentials. We keep them
+ * OUT of the client-held session cookie and store them on the User document,
+ * encrypted with AES-256-GCM. The encryption key is derived from the existing
+ * SESSION_SECRET env var, so no new required env var is introduced.
+ *
+ * Each ciphertext carries its own random IV plus the GCM auth tag, so tampering
+ * (or a key mismatch) is detected at decrypt time and surfaces as an error.
+ */
+
+export interface EncryptedToken {
+  /** Base64 ciphertext */
+  ciphertext: string;
+  /** Base64 random IV (12 bytes, GCM standard) */
+  iv: string;
+  /** Base64 GCM authentication tag */
+  authTag: string;
+}
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12; // 96-bit nonce recommended for GCM
+const KEY_LENGTH = 32; // 256-bit key
+
+// App-specific, fixed salt so the derived key is stable across processes/deploys
+// while remaining distinct from any other use of SESSION_SECRET.
+const KEY_SALT = 'cartyx-oauth-token-encryption-v1';
+
+function getKey(): Buffer {
+  const secret = process.env.SESSION_SECRET;
+  if (!secret) throw new Error('SESSION_SECRET environment variable is not set');
+  // scrypt is intentionally slow but key derivation happens only on login/logout,
+  // which are low-frequency operations.
+  return scryptSync(secret, KEY_SALT, KEY_LENGTH);
+}
+
+/** Encrypt a plaintext provider token. Returns ciphertext + IV + auth tag. */
+export function encryptToken(plaintext: string): EncryptedToken {
+  const key = getKey();
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return {
+    ciphertext: encrypted.toString('base64'),
+    iv: iv.toString('base64'),
+    authTag: authTag.toString('base64'),
+  };
+}
+
+/**
+ * Decrypt a previously-encrypted provider token.
+ * Throws if the ciphertext, IV, or auth tag has been tampered with, or if the
+ * key (SESSION_SECRET) no longer matches what was used to encrypt.
+ */
+export function decryptToken(payload: EncryptedToken): string {
+  const key = getKey();
+  const iv = Buffer.from(payload.iv, 'base64');
+  const authTag = Buffer.from(payload.authTag, 'base64');
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+  const decrypted = Buffer.concat([
+    decipher.update(Buffer.from(payload.ciphertext, 'base64')),
+    decipher.final(),
+  ]);
+  return decrypted.toString('utf8');
+}

--- a/app/utils/errors.ts
+++ b/app/utils/errors.ts
@@ -1,0 +1,15 @@
+/**
+ * Normalize an unknown error into a user-displayable message.
+ *
+ * - `null`/`undefined` (and other falsy values) → `null` (no error)
+ * - `Error` instances → their `.message`
+ * - anything else truthy → `String(error)`
+ *
+ * This is the shared implementation used by the query/mutation hooks, which
+ * previously inlined this logic in two equivalent forms.
+ */
+export function extractErrorMessage(error: unknown): string | null {
+  if (!error) return null;
+  if (error instanceof Error) return error.message;
+  return String(error);
+}

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -1,0 +1,299 @@
+# Tabletop / Maps — Tech Debt & Refactoring Backlog
+
+Living backlog of refactors and follow-ups identified during the map-editor work
+(drawing tool, multi-token group move, GM-only gating) and a three-part code
+review (component decomposition, branch quality, PR comments). Use this to scope
+a fresh branch + session.
+
+**Status of the big one:** `ActiveMapStage.tsx` has already been reduced from
+~2,647 → ~1,679 lines by extracting cohesive modules (geometry, viewport, ruler,
+drop-target, token interactions, drawing/text layers, dialogs, map-sync). What
+remains below is the **harder, higher-risk, or off-scope** work that was
+deliberately deferred.
+
+**Proven extraction pattern (use it again):** move state + handlers + effects
+into a `useXxx` hook (or a presentational `XxxLayer` component), **destructure
+the hook's return into the same local names** so call sites stay unchanged, keep
+anything touching the shared `dragRef` in the parent, preserve every
+`data-testid`, and verify against the relevant e2e spec before committing one
+extraction at a time.
+
+**Per-item metadata convention.** Each item carries a `Status:` (OPEN/RESOLVED)
+and a `Last-verified:` date. Re-verify line counts, file paths, and var names
+against the current code before trusting any number here — they drift.
+
+---
+
+## 1. ActiveMapStage: split the text + drawing tool _state_ off the shared `dragRef` (HIGH value, HIGH risk)
+
+- **Status:** OPEN
+- **Last-verified:** 2026-06-15
+
+**Files:** `app/components/mainview/tabletop/ActiveMapStage.tsx` (1679 lines)
+(target: `useTextTool.ts`, `useDrawingTool.ts`, optionally a `useStageDrag`).
+
+**Why it needs refactoring.** The stage still owns ~1,680 lines because three
+tools (pan/token already partly extracted, **text**, **drawing**) share ONE
+mutable `dragRef` discriminated union and two large `onPointerMove`/`onPointerUp`
+switches. The text- and drawing-tool _state + handlers_ (draft/selection/brush
+state, `openTextDraft`/`commitTextDraft`/`applyTextColor`, `removeDrawing`/
+`eraseAt`/`beginDrawing*`, plus their focus/deselect/Delete effects) are
+**interleaved with each other and with the dragRef branches**, so they can't be
+lifted as cleanly as `useTokenInteractions` was.
+
+**Why it's worth it.** These are the last two big concerns keeping the component
+huge; isolating them makes each tool independently testable and readable.
+
+**Why it's risky / approach.** The `dragRef` is the coupling point. Recommended:
+keep ONE `dragRef` + the two pointer handlers in the parent (or a `useStageDrag`
+hook) and have each tool hook expose `{ onPointerDownProbe, onPointerMove,
+onPointerUp }` that the parent dispatches in the **exact current priority order**
+(ruler → text → drawing → token → pan). Preserve the throttled-broadcast cadence,
+the group-delta clamp, the `draftActiveRef` double-commit guard, and the
+`requestAnimationFrame` focus deferral. Do this last and behind the unified
+dispatch; gate every step on the drawing + text + token + measurement e2e specs.
+
+---
+
+## 2. TabletopView: extract the remaining concerns (MEDIUM value, MEDIUM risk)
+
+- **Status:** OPEN
+- **Last-verified:** 2026-06-15
+
+**File:** `app/components/mainview/tabletop/TabletopView.tsx` (783 lines).
+
+The inbound map-sync reducer is already extracted (`useTabletopMapSync`). Still
+mixed in one component:
+
+- **`useTabletopModals()`** — the `DialogState` machine plus six `editing*Id`
+  states drive a tangle of modal toggles; collapse into one reducer with
+  `openX`/`close` actions. _Why:_ the modal wiring is repetitive and easy to get
+  out of sync.
+- **`useFloatingWindows()`** — `localWindows`/`handleWindowsChange`/
+  `localScreenIdRef` and the big server→local window merge effect are a
+  self-contained concern. _Why:_ it's the densest logic in the file and unrelated
+  to tab/screen management.
+
+See also item 9 for the four `_`-prefixed dead bindings in this file.
+
+_Note:_ the earlier claim of a `react-hooks/exhaustive-deps` warning on the
+window-merge effect could **not** be confirmed in the current code — there is no
+`eslint-disable` and no inline `exhaustive-deps` annotation in this file, so that
+clause has been dropped. If a warning surfaces from `npm run lint`, re-add it
+here with the exact line.
+
+---
+
+## 3. GMScreensView decomposition (MEDIUM value, LOW/MEDIUM risk)
+
+- **Status:** OPEN
+- **Last-verified:** 2026-06-15
+
+**File:** `app/components/mainview/gmscreens/GMScreensView.tsx` (768 lines).
+
+A single exported component with ~36 hook calls and a debounced-autosave pattern.
+
+- Extract **`useDebouncedSave`** (the `DEBOUNCE_MS` autosave). _Why:_ the
+  debounce/flush logic is reusable and currently inlined.
+- Consider a **panel/list split**. _Why:_ it's the 2nd-largest tabletop-area
+  component; smaller pieces are easier to reason about and test. Skim first to
+  confirm the seams before committing.
+
+---
+
+## 4. Wiki modal field primitives + tab split (LOW value, LOW risk)
+
+- **Status:** OPEN
+- **Last-verified:** 2026-06-15
+
+**Files:** `app/components/wiki/monsters/MonsterModal.tsx` (842 lines), and the
+other 500+ line wiki modals (`CharacterModal`, `PlayerModal`, `LocationModal`).
+
+- `MonsterModal` already splits `StatsTab`/`FeaturesTab`/`LinksTab` and field
+  primitives (`NumberField`/`SelectField`/`CSVField`) **within one file** — move
+  each tab to its own file and the primitives to `app/components/shared/`.
+- **Primitives are NOT duplicated today (confirmed 2026-06-15):** a repo-wide
+  grep finds `NumberField`/`SelectField`/`CSVField` only inside `MonsterModal.tsx`
+  — no other modal references or re-implements them. So the extraction payoff is
+  **low**: it's only worthwhile if you also migrate the other modals onto the
+  shared primitives. Don't extract on the assumption of existing duplication.
+- **Modal LIFECYCLE has now been extracted** into `useModalForm`
+  (`app/hooks/useModalForm.ts`, commit `e8edafa`) and adopted by 3 of the 4
+  modals: `CharacterModal`, `PlayerModal`, `RaceModal`. The remaining work is
+  **just `LocationModal`** — and migrating it must also fix its latent
+  ungated-Escape bug (see item 10).
+
+---
+
+## 5. Minor correctness / perf / hardening follow-ups (LOW)
+
+These are small and independent — good "warm-up" tasks for the new branch.
+
+- **Optimistic drawing create.** (Status: OPEN, Last-verified: 2026-06-15)
+  `ActiveMapStage` commits a new drawing only in the mutation's `onSuccess`
+  (preview is cleared on pointerup), so on a slow link the shape briefly vanishes
+  before reappearing. _Fix:_ keep the preview until the create resolves, or insert
+  an optimistic temp entry reconciled on success. (Tokens/text share this
+  pattern — consider fixing all three together.)
+- **Batch group-move cache writes.** (Status: OPEN, Last-verified: 2026-06-15)
+  The token-move drag calls `applyTokenMoveToCache` once per token per frame
+  (O(selection) `setQueryData` per mousemove). _Fix:_ batch into a single
+  `setQueryData` pass for large selections. Minor perf only.
+
+---
+
+## 6. MapUploadModal cleanup (LOW value, LOW risk)
+
+- **Status:** OPEN
+- **Last-verified:** 2026-06-15
+
+**File:** `app/components/wiki/maps/MapUploadModal.tsx` (519 lines).
+
+A sibling candidate to the wiki modal cleanup in item 4. Large single-file modal;
+once `useModalForm` (item 4) and any shared field primitives land, this modal is
+a natural next adopter. Skim for the same modal-lifecycle boilerplate before
+committing.
+
+---
+
+## 7. TabletopView dead-code cleanup (LOW value, LOW risk)
+
+- **Status:** OPEN
+- **Last-verified:** 2026-06-15
+
+**File:** `app/components/mainview/tabletop/TabletopView.tsx`.
+
+There are **four** `_`-prefixed bindings that are declared but unused (confirmed
+2026-06-15):
+
+- `_toWindowState` — module-level helper function (line ~59).
+- `_sessionId` — destructured but unread (line ~90).
+- `_pings` — `const [_pings, setPings] = useState<PingData[]>([])` (line ~107);
+  only the setter is used.
+- `_handlePingExpired` — `useCallback` that is never wired up (line ~159).
+
+Decide per binding: delete if truly dead, or wire up if a feature (ping display)
+was left half-finished. Do this alongside item 2's extraction so the file shrinks
+in one pass.
+
+---
+
+## 8. OAuth pre-existing-session one-time revocation gap (LOW, transitional, self-healing)
+
+- **Status:** OPEN (transitional — expected to age out)
+- **Last-verified:** 2026-06-15
+
+Commit `81dfa1c` moved OAuth provider tokens out of the `cartyx_session` cookie
+into an encrypted (AES-256-GCM) server-side store on the User doc
+(`app/server/utils/tokenCrypto.ts`); logout revocation now reads from there.
+
+**Gap:** a user who was already logged in _before_ this change has no provider
+token in the new store yet. At their **next logout**, provider-grant revocation
+is silently skipped **once**. It self-heals on their next login (which writes the
+encrypted token). Low severity, no action strictly required — track only so it
+isn't mistaken for a regression. Can be closed once the active-session population
+has fully cycled through a login.
+
+---
+
+## 9. Remaining `requireCampaignMember` variants left intentionally un-consolidated (INFO / LOW)
+
+- **Status:** OPEN (intentional — documents a deliberate non-consolidation)
+- **Last-verified:** 2026-06-15
+
+Commits `ad8545f` + `d950031` centralized the duplicated `requireCampaignMember`
+helper into `app/server/utils/requireCampaignMember.ts` and migrated 10
+server-function files. **Three files keep their own local copy on purpose**
+because they have different contracts:
+
+- `app/server/functions/notes.ts` (local `requireCampaignMember`, ~line 74)
+- `app/server/functions/tags.ts` (local `requireCampaignMember`, ~line 12)
+- `app/server/functions/tabletop.ts` (local `requireCampaignMember` ~line 170 and
+  a `requireCampaignGM` ~line 204)
+
+They differ in return shape and/or GM semantics (e.g. no `isGM` in the return),
+so folding them into the shared helper would change behavior. Only consolidate if
+the shared helper is first generalized to cover these contracts without
+broadening its surface for the 10 already-migrated callers.
+
+---
+
+## 10. LocationModal: ungated Escape handler + not migrated to `useModalForm` (LOW, latent bug)
+
+- **Status:** OPEN
+- **Last-verified:** 2026-06-15
+
+**File:** `app/components/wiki/locations/LocationModal.tsx`.
+
+`LocationModal` was **left unmigrated** from item 4's `useModalForm` extraction
+because (a) it has extra non-lifecycle state and (b) its Escape handler is
+**ungated** — a latent bug. Confirmed 2026-06-15: the `keydown` listener is
+registered in a `useEffect` with deps `[onClose]` and is **not gated on
+`isOpen`** (lines ~62–68), even though the component early-returns `null` when
+`!isOpen` (line ~161). So while the modal is mounted-but-closed, a global Escape
+press still fires `onClose()`.
+
+_Fix as part of migrating it:_ gate the handler on `isOpen` (or only attach the
+listener while open), then move the shared lifecycle onto `useModalForm` like the
+other three modals. Verify the location wiki e2e flow afterward.
+
+---
+
+## Resolved
+
+Items closed on the `update-tech-debt` branch (on top of `origin/dev`) and
+earlier map-editor work. Kept for traceability.
+
+- **`tabletop-map` party `onRequest` auth — RESOLVED (earlier, commit `1f8871b`).**
+  The HTTP broadcast endpoint is no longer unauthenticated. `onRequest` now
+  requires a signed **`tabletop-broadcast`** JWT (HS256, verified against
+  `SESSION_SECRET`, `scope === 'tabletop-broadcast'`) before accepting a
+  `map:active-changed` POST — see `party/tabletop-map.ts` (~lines 130–142).
+  Confirmed 2026-06-15.
+- **`listMapTokens` IDOR — RESOLVED (commit `7887a43`).** `listMapTokens` is now
+  scoped by `campaignId`, closing the cross-campaign read.
+- **`requireCampaignMember` duplication — RESOLVED (commits `ad8545f`,
+  `d950031`).** Centralized into `app/server/utils/requireCampaignMember.ts`; 10
+  server-function files migrated. (Three intentionally retained — see open item 9.)
+- **OAuth provider tokens hardening — RESOLVED (commits `81dfa1c`, `b469bcb`).**
+  Provider tokens moved out of the `cartyx_session` cookie into an encrypted
+  (AES-256-GCM) server-side store on the User doc
+  (`app/server/utils/tokenCrypto.ts`); logout revocation reads from there.
+  (One transitional gap remains — see open item 8.)
+- **OAuth PKCE — RESOLVED (commit `af4f13d`).** Added PKCE (S256) to the
+  authorization-code flow for all three providers.
+- **Mutation-hook duplication — RESOLVED (commit `0613a24`).** Extracted a
+  `createMutationHook` factory + shared `extractErrorMessage`
+  (`app/utils/errors.ts`); ~20 mutation hooks migrated.
+- **Shared wiki modal lifecycle — RESOLVED for 3 of 4 (commit `e8edafa`).**
+  Extracted `useModalForm` (`app/hooks/useModalForm.ts`); Character/Player/Race
+  modals migrated. (LocationModal remains — see open item 10.)
+- **e2e now runs in CI + supply-chain guard now enforcing — RESOLVED (commits
+  `dba040e`, `1de2a26`, `5e677be`).** Added a Playwright e2e job (mongo:8 service)
+  to `.github/workflows/ci.yml`; removed `continue-on-error` from the
+  `check:deps-age` step so it is now blocking (its sunset window has passed); and
+  fixed `scripts/seed-gm.cjs` so the fresh-DB e2e bootstrap produces a queryable
+  GM user.
+
+---
+
+## Verification checklist (per the repo conventions)
+
+For every change in the new session. **Establish the baseline first** by running
+each command on a clean checkout, then ensure your change doesn't regress it
+(numbers drift — capture them at the start of the session rather than trusting any
+hardcoded count here):
+
+- `npm run typecheck` — clean (no errors).
+- `npm run lint` — record the starting error/warning counts; keep errors at 0 and
+  do not introduce new warnings. (Run it once up front to get today's baseline.)
+- `npm test` (`vitest run --project unit`) — record the starting passing-test
+  count from the run summary, then keep it green and non-decreasing.
+- Relevant + full `e2e/tabletop` and `e2e/gmscreens` suites green, run serially:
+  `--project=chromium --reporter=line --workers=1`. Run new/changed specs 2–3×
+  for flake.
+- Server-side model/server-fn changes require restarting the dev server
+  (`lsof -ti tcp:3000 | xargs kill`, then `npm run dev`); party changes require
+  restarting `npm run party:dev`.
+- Commit one extraction at a time, conventional-commit style, ending with the
+  `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>` line.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,5 +24,8 @@ export default defineConfig({
     command: 'npm run dev',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
+    // The dev server's first cold route compile can exceed Playwright's default
+    // 60s webServer boot window in CI; give it longer so cold starts don't flake.
+    timeout: 180_000,
   },
 });

--- a/scripts/seed-gm.cjs
+++ b/scripts/seed-gm.cjs
@@ -3,29 +3,46 @@ const mongoose = require('mongoose');
 const uri = process.env.MONGODB_URI;
 if (!uri) { console.error('No MONGODB_URI'); process.exit(1); }
 
-const gmSchema = new mongoose.Schema({
+// Must match the real app's User schema (app/server/db/models/User.ts) so the
+// GM lands in the `users` collection with a `role: 'gm'` field — that's what
+// both `scripts/dev_seed.py` and `e2e/globalSetup.ts` look up via
+// `db.users.findOne({ role: 'gm' })`. (A prior version wrote a `GameMaster`
+// model → `gamemasters` collection with no `role`, so a fresh DB never had a
+// queryable GM and `dev:seed` / e2e bootstrap failed with "No GM user found".)
+const userSchema = new mongoose.Schema({
   email:       { type: String, required: true, unique: true },
+  role:        { type: String, enum: ['gm', 'player', 'unknown'], default: 'unknown', index: true },
   firstName:   String,
   lastName:    String,
+  provider:    String,
+  providerId:  { type: String, unique: true, sparse: true },
   avatarPath:  String,
+  avatarUrl:   String,
+  campaigns:   [{ campaignId: mongoose.Schema.Types.ObjectId, joinedAt: Date, status: String }],
   lastLoginAt: Date,
   createdAt:   { type: Date, default: Date.now }
 });
-const GM = mongoose.model('GameMaster', gmSchema);
+const User = mongoose.model('User', userSchema);
 
 async function seed() {
-  await mongoose.connect(uri);
-  const gm = await GM.findOneAndUpdate(
+  // Honor MONGODB_DB the same way dev_seed.py and globalSetup.ts do, so all
+  // three target the same database (e.g. cartyx_e2e in CI). Without this the
+  // GM would be written to the URI's default database instead.
+  await mongoose.connect(uri, { dbName: process.env.MONGODB_DB });
+  const gm = await User.findOneAndUpdate(
     { email: 'alabeau@gmail.com' },
     {
       email: 'alabeau@gmail.com',
+      role: 'gm',
       firstName: 'Aaron',
       lastName: 'LaBeau',
-      createdAt: new Date()
+      provider: 'google',
+      // Needed by e2e/globalSetup.ts to mint the test session JWT.
+      providerId: 'seed-gm-alabeau',
     },
-    { upsert: true, new: true }
+    { upsert: true, returnDocument: 'after' }
   );
-  console.log('✅ GM seeded:', gm.email, gm._id.toString());
+  console.log('✅ GM seeded:', gm.email, '| role:', gm.role, '|', gm._id.toString());
   await mongoose.disconnect();
 }
 seed().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/seed-gm.cjs
+++ b/scripts/seed-gm.cjs
@@ -40,7 +40,10 @@ async function seed() {
       // Needed by e2e/globalSetup.ts to mint the test session JWT.
       providerId: 'seed-gm-alabeau',
     },
-    { upsert: true, returnDocument: 'after' }
+    // `new: true` alongside `returnDocument: 'after'` matches the repo
+    // convention (and upsertUser) so the post-update doc is returned reliably
+    // across Mongoose versions — otherwise `gm` could be the pre-upsert null.
+    { upsert: true, returnDocument: 'after', new: true }
   );
   console.log('✅ GM seeded:', gm.email, '| role:', gm.role, '|', gm._id.toString());
   await mongoose.disconnect();

--- a/tests/hooks/createMutationHook.test.tsx
+++ b/tests/hooks/createMutationHook.test.tsx
@@ -1,0 +1,122 @@
+import React, { type ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const captureException = vi.fn();
+vi.mock('~/providers/PostHogProvider', () => ({
+  captureException: (...args: unknown[]) => captureException(...args),
+}));
+
+import { createMutationHook } from '~/hooks/createMutationHook';
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+}
+
+interface Input {
+  id: string;
+  campaignId: string;
+}
+
+describe('createMutationHook', () => {
+  beforeEach(() => {
+    captureException.mockClear();
+  });
+
+  it('exposes the action under the configured name plus isLoading/error', () => {
+    const useThing = createMutationHook({
+      actionName: 'doThing',
+      mutationFn: async (_input: Input) => ({ ok: true }),
+      errorContext: () => ({ action: 'doThing' }),
+    });
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useThing(), { wrapper });
+
+    expect(typeof (result.current as Record<string, unknown>).doThing).toBe('function');
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns the resolved data on success and runs onSuccess with the query client + data + variables', async () => {
+    const onSuccess = vi.fn();
+    const useThing = createMutationHook({
+      actionName: 'doThing',
+      mutationFn: async (input: Input) => ({ saved: input.id }),
+      onSuccess,
+      errorContext: () => ({ action: 'doThing' }),
+    });
+    const { queryClient, wrapper } = makeWrapper();
+    const { result } = renderHook(() => useThing(), { wrapper });
+
+    let returned: unknown;
+    await act(async () => {
+      returned = await (result.current as { doThing: (i: Input) => Promise<unknown> }).doThing({
+        id: 'x',
+        campaignId: 'c',
+      });
+    });
+
+    expect(returned).toEqual({ saved: 'x' });
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledWith(
+      queryClient,
+      { saved: 'x' },
+      { id: 'x', campaignId: 'c' }
+    );
+  });
+
+  it('returns null on error, reports via captureException with built context, and exposes the message', async () => {
+    const useThing = createMutationHook({
+      actionName: 'doThing',
+      mutationFn: async (_input: Input) => {
+        throw new Error('kaboom');
+      },
+      errorContext: (vars: Input) => ({ action: 'doThing', id: vars.id }),
+    });
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useThing(), { wrapper });
+
+    let returned: unknown = 'sentinel';
+    await act(async () => {
+      returned = await (result.current as { doThing: (i: Input) => Promise<unknown> }).doThing({
+        id: 'y',
+        campaignId: 'c',
+      });
+    });
+
+    expect(returned).toBeNull();
+    expect(captureException).toHaveBeenCalledTimes(1);
+    const [err, ctx] = captureException.mock.calls[0];
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe('kaboom');
+    expect(ctx).toEqual({ action: 'doThing', id: 'y' });
+
+    await waitFor(() => expect(result.current.error).toBe('kaboom'));
+  });
+
+  it('does not throw when onSuccess is omitted', async () => {
+    const useThing = createMutationHook({
+      actionName: 'validate',
+      mutationFn: async (_input: Input) => ({ valid: true }),
+      errorContext: () => ({ action: 'validate' }),
+    });
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useThing(), { wrapper });
+
+    let returned: unknown;
+    await act(async () => {
+      returned = await (result.current as { validate: (i: Input) => Promise<unknown> }).validate({
+        id: 'z',
+        campaignId: 'c',
+      });
+    });
+    expect(returned).toEqual({ valid: true });
+  });
+});

--- a/tests/hooks/useModalForm.test.tsx
+++ b/tests/hooks/useModalForm.test.tsx
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useModalForm, type UseModalFormOptions } from '~/hooks/useModalForm';
+
+interface Errors {
+  name?: string;
+}
+
+interface Record {
+  id: string;
+  name: string;
+}
+
+/**
+ * Builds a complete options object with sensible spies, overridable per test.
+ */
+function makeOptions(overrides: Partial<UseModalFormOptions<Errors, Record>> = {}) {
+  return {
+    isOpen: true,
+    onClose: vi.fn(),
+    recordId: undefined,
+    isEdit: false,
+    record: null,
+    reset: vi.fn(),
+    populate: vi.fn(),
+    validate: vi.fn((): Errors => ({})),
+    ...overrides,
+  } satisfies UseModalFormOptions<Errors, Record>;
+}
+
+describe('useModalForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('reset', () => {
+    it('calls reset and clears submit/error state on initial open', () => {
+      const opts = makeOptions();
+      renderHook(() => useModalForm(opts));
+      expect(opts.reset).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-runs reset when recordId changes', () => {
+      const opts = makeOptions({ recordId: 'a' });
+      const { rerender } = renderHook((p) => useModalForm(p), { initialProps: opts });
+      expect(opts.reset).toHaveBeenCalledTimes(1);
+
+      rerender({ ...opts, recordId: 'b' });
+      expect(opts.reset).toHaveBeenCalledTimes(2);
+    });
+
+    it('re-runs reset when isOpen toggles', () => {
+      const opts = makeOptions({ isOpen: false });
+      const { rerender } = renderHook((p) => useModalForm(p), { initialProps: opts });
+      expect(opts.reset).toHaveBeenCalledTimes(1);
+
+      rerender({ ...opts, isOpen: true });
+      expect(opts.reset).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not reset on an unrelated re-render', () => {
+      const opts = makeOptions({ recordId: 'a' });
+      const { rerender } = renderHook((p) => useModalForm(p), { initialProps: opts });
+      expect(opts.reset).toHaveBeenCalledTimes(1);
+
+      // Same recordId/isOpen, but a fresh inline reset closure (as a real
+      // component would pass). Must NOT trigger another reset.
+      rerender({ ...opts, reset: vi.fn() });
+      expect(opts.reset).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears prior fieldErrors and hasSubmitted when recordId changes', () => {
+      const opts = makeOptions({ recordId: 'a', validate: () => ({ name: 'Required' }) });
+      const { result, rerender } = renderHook((p) => useModalForm(p), { initialProps: opts });
+
+      act(() => {
+        result.current.runValidation();
+      });
+      expect(result.current.hasSubmitted).toBe(true);
+      expect(result.current.fieldErrors).toEqual({ name: 'Required' });
+
+      rerender({ ...opts, recordId: 'b' });
+      expect(result.current.hasSubmitted).toBe(false);
+      expect(result.current.fieldErrors).toEqual({});
+    });
+  });
+
+  describe('populate', () => {
+    it('populates when in edit mode and the record resolves', () => {
+      const record = { id: '1', name: 'Gandalf' };
+      const opts = makeOptions({ isEdit: true, recordId: '1', record: null });
+      const { rerender } = renderHook((p) => useModalForm(p), { initialProps: opts });
+      expect(opts.populate).not.toHaveBeenCalled();
+
+      rerender({ ...opts, record });
+      expect(opts.populate).toHaveBeenCalledWith(record);
+    });
+
+    it('does not populate in create mode', () => {
+      const record = { id: '1', name: 'Gandalf' };
+      const opts = makeOptions({ isEdit: false, record });
+      renderHook(() => useModalForm(opts));
+      expect(opts.populate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validate', () => {
+    it('runValidation sets hasSubmitted, stores errors, and returns them', () => {
+      const errors = { name: 'Name is required' };
+      const opts = makeOptions({ validate: () => errors });
+      const { result } = renderHook(() => useModalForm(opts));
+
+      let returned: Errors = {};
+      act(() => {
+        returned = result.current.runValidation();
+      });
+
+      expect(returned).toEqual(errors);
+      expect(result.current.hasSubmitted).toBe(true);
+      expect(result.current.fieldErrors).toEqual(errors);
+    });
+
+    it('re-validates on change after the first submit attempt', () => {
+      let errors: Errors = { name: 'Name is required' };
+      const validate = vi.fn(() => errors);
+      const opts = makeOptions({ validate });
+      const { result, rerender } = renderHook((p) => useModalForm(p), { initialProps: opts });
+
+      // No live validation before first submit.
+      rerender({ ...opts, validate });
+      expect(result.current.fieldErrors).toEqual({});
+
+      act(() => {
+        result.current.runValidation();
+      });
+      expect(result.current.fieldErrors).toEqual({ name: 'Name is required' });
+
+      // User fixes the field: validate now returns no errors. A re-render with
+      // a new validate closure should refresh fieldErrors live.
+      errors = {};
+      rerender({ ...opts, validate: () => ({}) });
+      expect(result.current.fieldErrors).toEqual({});
+    });
+
+    it('does not validate live before any submit', () => {
+      const validate = vi.fn(() => ({ name: 'x' }));
+      const opts = makeOptions({ validate });
+      const { rerender } = renderHook((p) => useModalForm(p), { initialProps: opts });
+      validate.mockClear();
+      rerender({ ...opts, validate });
+      expect(validate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Escape', () => {
+    it('calls onClose when Escape is pressed while open', () => {
+      const opts = makeOptions({ isOpen: true });
+      renderHook(() => useModalForm(opts));
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      });
+      expect(opts.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClose for other keys', () => {
+      const opts = makeOptions({ isOpen: true });
+      renderHook(() => useModalForm(opts));
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      });
+      expect(opts.onClose).not.toHaveBeenCalled();
+    });
+
+    it('does not listen for Escape while closed', () => {
+      const opts = makeOptions({ isOpen: false });
+      renderHook(() => useModalForm(opts));
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      });
+      expect(opts.onClose).not.toHaveBeenCalled();
+    });
+
+    it('removes the listener on unmount', () => {
+      const opts = makeOptions({ isOpen: true });
+      const { unmount } = renderHook(() => useModalForm(opts));
+      unmount();
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      });
+      expect(opts.onClose).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/server/functions/auth.test.ts
+++ b/tests/server/functions/auth.test.ts
@@ -1,166 +1,211 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { SignJWT } from 'jose'
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SignJWT } from 'jose';
 
 // Mock PostHog server capture for testing exception logging
-const mockServerCaptureException = vi.fn()
+const mockServerCaptureException = vi.fn();
 vi.mock('~/server/utils/posthog', () => ({
   serverCaptureException: (...args: unknown[]) => mockServerCaptureException(...args),
   serverCaptureEvent: vi.fn(),
   shutdownPostHog: vi.fn(),
-}))
+}));
 
 // Test the session module in isolation
 describe('session', () => {
-  let getCookieMock: ReturnType<typeof vi.fn>
-  let setCookieMock: ReturnType<typeof vi.fn>
-  let deleteCookieMock: ReturnType<typeof vi.fn>
+  let getCookieMock: ReturnType<typeof vi.fn>;
+  let setCookieMock: ReturnType<typeof vi.fn>;
+  let deleteCookieMock: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
-    vi.resetModules()
-    mockServerCaptureException.mockClear()
-    process.env.SESSION_SECRET = 'test-secret-for-unit-tests-at-least-32-chars'
+    vi.resetModules();
+    mockServerCaptureException.mockClear();
+    process.env.SESSION_SECRET = 'test-secret-for-unit-tests-at-least-32-chars';
 
-    const startServer = await import('@tanstack/react-start/server')
-    getCookieMock = vi.mocked(startServer.getCookie)
-    setCookieMock = vi.mocked(startServer.setCookie)
-    deleteCookieMock = vi.mocked(startServer.deleteCookie)
-  })
+    const startServer = await import('@tanstack/react-start/server');
+    getCookieMock = vi.mocked(startServer.getCookie);
+    setCookieMock = vi.mocked(startServer.setCookie);
+    deleteCookieMock = vi.mocked(startServer.deleteCookie);
+  });
 
   it('getSession returns null when no cookie', async () => {
-    getCookieMock.mockReturnValue(undefined)
-    const { getSession } = await import('~/server/session')
-    const result = await getSession()
-    expect(result).toBeNull()
-  })
+    getCookieMock.mockReturnValue(undefined);
+    const { getSession } = await import('~/server/session');
+    const result = await getSession();
+    expect(result).toBeNull();
+  });
 
   it('getSession returns null for invalid token', async () => {
-    getCookieMock.mockReturnValue('invalid.token.here')
-    const { getSession } = await import('~/server/session')
-    const result = await getSession()
-    expect(result).toBeNull()
-  })
+    getCookieMock.mockReturnValue('invalid.token.here');
+    const { getSession } = await import('~/server/session');
+    const result = await getSession();
+    expect(result).toBeNull();
+  });
 
   it('getSession captures exception to PostHog on invalid token', async () => {
-    getCookieMock.mockReturnValue('invalid.token.here')
-    const { getSession } = await import('~/server/session')
-    await getSession()
+    getCookieMock.mockReturnValue('invalid.token.here');
+    const { getSession } = await import('~/server/session');
+    await getSession();
     expect(mockServerCaptureException).toHaveBeenCalledWith(
       expect.anything(),
       undefined,
-      expect.objectContaining({ action: 'getSession', step: 'jwtVerify' }),
-    )
-  })
+      expect.objectContaining({ action: 'getSession', step: 'jwtVerify' })
+    );
+  });
 
   it('getSession tags expected JWT errors as handled', async () => {
-    getCookieMock.mockReturnValue('invalid.token.here')
-    const { getSession } = await import('~/server/session')
-    await getSession()
+    getCookieMock.mockReturnValue('invalid.token.here');
+    const { getSession } = await import('~/server/session');
+    await getSession();
     expect(mockServerCaptureException).toHaveBeenCalledWith(
       expect.anything(),
       undefined,
-      expect.objectContaining({ handled: expect.any(Boolean) }),
-    )
-  })
+      expect.objectContaining({ handled: expect.any(Boolean) })
+    );
+  });
 
   it('getSession does not capture exception when no cookie', async () => {
-    getCookieMock.mockReturnValue(undefined)
-    const { getSession } = await import('~/server/session')
-    await getSession()
-    expect(mockServerCaptureException).not.toHaveBeenCalled()
-  })
+    getCookieMock.mockReturnValue(undefined);
+    const { getSession } = await import('~/server/session');
+    await getSession();
+    expect(mockServerCaptureException).not.toHaveBeenCalled();
+  });
 
   it('getSession returns user for valid token', async () => {
-    const secret = new TextEncoder().encode('test-secret-for-unit-tests-at-least-32-chars')
-    const user = { id: 'google_123', provider: 'google', name: 'Test User', email: 'test@example.com', avatar: null, role: 'gm', accessToken: null, refreshToken: null, tokenIssuedAt: Date.now() }
-    const token = await new SignJWT({ user }).setProtectedHeader({ alg: 'HS256' }).setExpirationTime('1h').sign(secret)
-    getCookieMock.mockReturnValue(token)
+    const secret = new TextEncoder().encode('test-secret-for-unit-tests-at-least-32-chars');
+    const user = {
+      id: 'google_123',
+      provider: 'google',
+      name: 'Test User',
+      email: 'test@example.com',
+      avatar: null,
+      role: 'gm',
+      tokenIssuedAt: Date.now(),
+    };
+    const token = await new SignJWT({ user })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setExpirationTime('1h')
+      .sign(secret);
+    getCookieMock.mockReturnValue(token);
 
-    const { getSession } = await import('~/server/session')
-    const result = await getSession()
-    expect(result).toMatchObject({ id: 'google_123', provider: 'google', role: 'gm' })
-  })
+    const { getSession } = await import('~/server/session');
+    const result = await getSession();
+    expect(result).toMatchObject({ id: 'google_123', provider: 'google', role: 'gm' });
+  });
 
   it('setSession calls setCookie with httpOnly token', async () => {
-    const { setSession } = await import('~/server/session')
-    const user = { id: 'github_456', provider: 'github', name: 'Dev User', email: null, avatar: null, role: 'player', accessToken: 'tok', refreshToken: null, tokenIssuedAt: Date.now() }
-    await setSession(user)
+    const { setSession } = await import('~/server/session');
+    const user = {
+      id: 'github_456',
+      provider: 'github',
+      name: 'Dev User',
+      email: null,
+      avatar: null,
+      role: 'player',
+      tokenIssuedAt: Date.now(),
+    };
+    await setSession(user);
     expect(setCookieMock).toHaveBeenCalledWith(
       'cartyx_session',
       expect.any(String),
       expect.objectContaining({ httpOnly: true, sameSite: 'lax' })
-    )
-  })
+    );
+  });
+
+  it('session cookie payload never contains provider tokens', async () => {
+    const { jwtVerify } = await import('jose');
+    const { setSession } = await import('~/server/session');
+    const user = {
+      id: 'google_999',
+      provider: 'google',
+      name: 'Tok User',
+      email: null,
+      avatar: null,
+      role: 'gm',
+      tokenIssuedAt: Date.now(),
+    };
+    await setSession(user);
+
+    const signedToken = setCookieMock.mock.calls[0][1] as string;
+    // Decode + verify the signed cookie payload.
+    const secret = new TextEncoder().encode('test-secret-for-unit-tests-at-least-32-chars');
+    const { payload } = await jwtVerify(signedToken, secret, { algorithms: ['HS256'] });
+    const sessionUser = (payload as { user: Record<string, unknown> }).user;
+    expect(sessionUser).not.toHaveProperty('accessToken');
+    expect(sessionUser).not.toHaveProperty('refreshToken');
+    // The raw signed token string must not embed any token material either.
+    expect(JSON.stringify(payload)).not.toContain('accessToken');
+    expect(JSON.stringify(payload)).not.toContain('refreshToken');
+  });
 
   it('clearSession calls deleteCookie', async () => {
-    const { clearSession } = await import('~/server/session')
-    await clearSession()
-    expect(deleteCookieMock).toHaveBeenCalledWith('cartyx_session', { path: '/' })
-  })
-})
+    const { clearSession } = await import('~/server/session');
+    await clearSession();
+    expect(deleteCookieMock).toHaveBeenCalledWith('cartyx_session', { path: '/' });
+  });
+});
 
 describe('OAuth URL builders', () => {
   beforeEach(() => {
-    process.env.GOOGLE_CLIENT_ID = 'test-google-client-id'
-    process.env.GOOGLE_CLIENT_SECRET = 'test-google-secret'
-    process.env.GITHUB_CLIENT_ID = 'test-github-client-id'
-    process.env.GITHUB_CLIENT_SECRET = 'test-github-secret'
-    process.env.BASE_URL = 'https://example.com'
-  })
+    process.env.GOOGLE_CLIENT_ID = 'test-google-client-id';
+    process.env.GOOGLE_CLIENT_SECRET = 'test-google-secret';
+    process.env.GITHUB_CLIENT_ID = 'test-github-client-id';
+    process.env.GITHUB_CLIENT_SECRET = 'test-github-secret';
+    process.env.BASE_URL = 'https://example.com';
+  });
 
   it('buildGoogleOAuthUrl returns valid URL with state', async () => {
-    const { buildGoogleOAuthUrl } = await import('~/server/utils/oauth')
-    const url = buildGoogleOAuthUrl('test-state-123')
-    expect(url).toContain('accounts.google.com')
-    expect(url).toContain('client_id=test-google-client-id')
-    expect(url).toContain('scope=openid+profile+email')
-    expect(url).toContain('state=test-state-123')
-  })
+    const { buildGoogleOAuthUrl } = await import('~/server/utils/oauth');
+    const url = buildGoogleOAuthUrl('test-state-123');
+    expect(url).toContain('accounts.google.com');
+    expect(url).toContain('client_id=test-google-client-id');
+    expect(url).toContain('scope=openid+profile+email');
+    expect(url).toContain('state=test-state-123');
+  });
 
   it('buildGoogleOAuthUrl works without state', async () => {
-    const { buildGoogleOAuthUrl } = await import('~/server/utils/oauth')
-    const url = buildGoogleOAuthUrl()
-    expect(url).toContain('accounts.google.com')
-    expect(url).not.toContain('state=')
-  })
+    const { buildGoogleOAuthUrl } = await import('~/server/utils/oauth');
+    const url = buildGoogleOAuthUrl();
+    expect(url).toContain('accounts.google.com');
+    expect(url).not.toContain('state=');
+  });
 
   it('buildGithubOAuthUrl returns valid URL with state', async () => {
-    const { buildGithubOAuthUrl } = await import('~/server/utils/oauth')
-    const url = buildGithubOAuthUrl('csrf-token')
-    expect(url).toContain('github.com/login/oauth/authorize')
-    expect(url).toContain('client_id=test-github-client-id')
-    expect(url).toContain('state=csrf-token')
-  })
-})
+    const { buildGithubOAuthUrl } = await import('~/server/utils/oauth');
+    const url = buildGithubOAuthUrl('csrf-token');
+    expect(url).toContain('github.com/login/oauth/authorize');
+    expect(url).toContain('client_id=test-github-client-id');
+    expect(url).toContain('state=csrf-token');
+  });
+});
 
 describe('providerConfigured', () => {
   beforeEach(() => {
-    process.env.BASE_URL = 'https://example.com'
-  })
+    process.env.BASE_URL = 'https://example.com';
+  });
 
   it('returns false when env vars missing', async () => {
-    delete process.env.GOOGLE_CLIENT_ID
-    delete process.env.GOOGLE_CLIENT_SECRET
-    const { providerConfigured } = await import('~/server/utils/helpers')
-    expect(providerConfigured('google')).toBe(false)
-  })
+    delete process.env.GOOGLE_CLIENT_ID;
+    delete process.env.GOOGLE_CLIENT_SECRET;
+    const { providerConfigured } = await import('~/server/utils/helpers');
+    expect(providerConfigured('google')).toBe(false);
+  });
 
   it('returns true when both env vars present', async () => {
-    process.env.GOOGLE_CLIENT_ID = 'test-id'
-    process.env.GOOGLE_CLIENT_SECRET = 'test-secret'
-    const { providerConfigured } = await import('~/server/utils/helpers')
-    expect(providerConfigured('google')).toBe(true)
-  })
+    process.env.GOOGLE_CLIENT_ID = 'test-id';
+    process.env.GOOGLE_CLIENT_SECRET = 'test-secret';
+    const { providerConfigured } = await import('~/server/utils/helpers');
+    expect(providerConfigured('google')).toBe(true);
+  });
 
   it('returns false for unknown provider', async () => {
-    const { providerConfigured } = await import('~/server/utils/helpers')
-    expect(providerConfigured('facebook')).toBe(false)
-  })
+    const { providerConfigured } = await import('~/server/utils/helpers');
+    expect(providerConfigured('facebook')).toBe(false);
+  });
 
   it('returns false when BASE_URL is missing', async () => {
-    delete process.env.BASE_URL
-    process.env.GOOGLE_CLIENT_ID = 'test-id'
-    process.env.GOOGLE_CLIENT_SECRET = 'test-secret'
-    const { providerConfigured } = await import('~/server/utils/helpers')
-    expect(providerConfigured('google')).toBe(false)
-  })
-})
+    delete process.env.BASE_URL;
+    process.env.GOOGLE_CLIENT_ID = 'test-id';
+    process.env.GOOGLE_CLIENT_SECRET = 'test-secret';
+    const { providerConfigured } = await import('~/server/utils/helpers');
+    expect(providerConfigured('google')).toBe(false);
+  });
+});

--- a/tests/server/functions/mapTokens.test.ts
+++ b/tests/server/functions/mapTokens.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tanstack/react-start', () => ({
+  createServerFn: () => ({
+    inputValidator: () => ({
+      handler: (fn: unknown) => fn,
+    }),
+    handler: (fn: unknown) => fn,
+  }),
+}));
+
+vi.mock('~/server/session', () => ({ getSession: vi.fn() }));
+vi.mock('~/server/db/connection', () => ({
+  connectDB: vi.fn(),
+  isDBConnected: vi.fn(() => true),
+}));
+vi.mock('~/server/db/models/User', () => ({
+  User: { findOne: vi.fn() },
+}));
+vi.mock('~/server/db/models/Campaign', () => ({
+  Campaign: { findById: vi.fn() },
+}));
+vi.mock('~/server/db/models/Map', () => ({
+  Map: { findOne: vi.fn() },
+}));
+vi.mock('~/server/db/models/MapToken', () => ({
+  MapToken: { find: vi.fn() },
+}));
+vi.mock('~/server/db/models/Player', () => ({ Player: { findOne: vi.fn() } }));
+vi.mock('~/server/db/models/Character', () => ({ Character: { findOne: vi.fn() } }));
+vi.mock('~/server/db/models/Monster', () => ({ Monster: { findOne: vi.fn() } }));
+vi.mock('~/server/utils/posthog', () => ({
+  serverCaptureException: vi.fn(),
+  serverCaptureEvent: vi.fn(),
+}));
+
+import { getSession } from '~/server/session';
+import { User } from '~/server/db/models/User';
+import { Campaign } from '~/server/db/models/Campaign';
+import { Map as MapModel } from '~/server/db/models/Map';
+import { MapToken } from '~/server/db/models/MapToken';
+import { listMapTokens } from '~/server/functions/mapTokens';
+
+const mockSession = {
+  id: 'session-user-1',
+  provider: 'google',
+  name: 'Test User',
+  email: 'test@example.com',
+  avatar: null,
+  role: 'gm',
+  accessToken: null,
+  refreshToken: null,
+  tokenIssuedAt: 0,
+};
+const mockDbUser = { _id: 'dbuser-1', firstName: 'Test', lastName: 'User' };
+// User is a member (GM) of campaign A only.
+const campaignA = {
+  _id: 'camp-A',
+  gameMasterId: 'dbuser-1',
+  members: [{ userId: 'dbuser-1', role: 'gm' }],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getSession).mockResolvedValue(mockSession);
+  vi.mocked(User.findOne).mockResolvedValue(mockDbUser);
+  vi.mocked(Campaign.findById).mockResolvedValue(campaignA);
+});
+
+const _listMapTokens = listMapTokens as unknown as (args: {
+  data: { campaignId: string; mapId: string };
+}) => Promise<{ tokens: unknown[] }>;
+
+function mockMapTokenFind(docs: unknown[]) {
+  vi.mocked(MapToken.find).mockReturnValue({
+    sort: vi.fn().mockReturnValue({
+      limit: vi.fn().mockReturnValue({
+        lean: vi.fn().mockResolvedValue(docs),
+      }),
+    }),
+  } as never);
+}
+
+describe('listMapTokens — IDOR / campaign scoping', () => {
+  it('rejects reading tokens of a map that does not belong to the campaign', async () => {
+    // Map belongs to campaign B, so a scoped lookup within campaign A finds nothing.
+    vi.mocked(MapModel.findOne).mockReturnValue({
+      lean: vi.fn().mockResolvedValue(null),
+    } as never);
+    mockMapTokenFind([]);
+
+    await expect(
+      _listMapTokens({ data: { campaignId: 'camp-A', mapId: 'map-from-camp-B' } })
+    ).rejects.toThrow('Map not found');
+
+    // Critically, tokens must never be queried for a foreign map.
+    expect(MapToken.find).not.toHaveBeenCalled();
+    // The scoping lookup must constrain by both _id and campaignId.
+    expect(MapModel.findOne).toHaveBeenCalledWith({
+      _id: 'map-from-camp-B',
+      campaignId: 'camp-A',
+    });
+  });
+
+  it('returns tokens for a legitimate same-campaign read', async () => {
+    const tokenDoc = {
+      _id: 't1',
+      mapId: 'map-A',
+      campaignId: 'camp-A',
+      sourceCollection: 'monster',
+      sourceDocumentId: 'mon-1',
+      ownerUserId: null,
+      x: 10,
+      y: 20,
+      sizeSquares: 1,
+      instanceNumber: 1,
+      color: '#fff',
+      label: 'Goblin A',
+      imageUrl: '',
+      hiddenFromPlayers: false,
+      zIndex: 0,
+      createdAt: new Date(0),
+    };
+    // Map belongs to campaign A.
+    vi.mocked(MapModel.findOne).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({ _id: 'map-A', campaignId: 'camp-A' }),
+    } as never);
+    mockMapTokenFind([tokenDoc]);
+
+    const result = await _listMapTokens({
+      data: { campaignId: 'camp-A', mapId: 'map-A' },
+    });
+
+    expect(MapToken.find).toHaveBeenCalledWith(expect.objectContaining({ mapId: 'map-A' }));
+    expect(result.tokens).toHaveLength(1);
+  });
+});

--- a/tests/server/utils/oauth.test.ts
+++ b/tests/server/utils/oauth.test.ts
@@ -40,6 +40,164 @@ function mockFindOneReturning(value: unknown) {
   });
 }
 
+describe('PKCE: generateCodeVerifier / deriveCodeChallenge', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('generates a URL-safe (base64url) verifier of the expected length, unique per call', async () => {
+    const { generateCodeVerifier } = await import('~/server/utils/oauth');
+    const a = generateCodeVerifier();
+    const b = generateCodeVerifier();
+
+    // base64url charset only: A-Z a-z 0-9 - _ (no +, /, or = padding)
+    expect(a).toMatch(/^[A-Za-z0-9_-]+$/);
+    // 32 random bytes -> 43-char base64url string (within RFC 7636's 43-128).
+    expect(a).toHaveLength(43);
+    expect(b).toHaveLength(43);
+    // Cryptographically random => different each call.
+    expect(a).not.toBe(b);
+  });
+
+  it('derives code_challenge = base64url(sha256(verifier)) for S256', async () => {
+    const { deriveCodeChallenge } = await import('~/server/utils/oauth');
+    const { createHash } = await import('node:crypto');
+
+    const verifier = 'test-verifier-fixed-value';
+    const expected = createHash('sha256').update(verifier).digest('base64url');
+
+    const challenge = deriveCodeChallenge(verifier);
+    expect(challenge).toBe(expected);
+    // SHA-256 -> 32 bytes -> 43-char base64url, URL-safe charset, no padding.
+    expect(challenge).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(challenge).toHaveLength(43);
+    expect(challenge).not.toContain('=');
+  });
+
+  it('RFC 7636 vector: known verifier maps to the known challenge', async () => {
+    const { deriveCodeChallenge } = await import('~/server/utils/oauth');
+    // From RFC 7636 Appendix B.
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    expect(deriveCodeChallenge(verifier)).toBe('E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM');
+  });
+});
+
+describe('PKCE: authorize URLs include code_challenge + S256', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.BASE_URL = 'https://example.com';
+    process.env.GOOGLE_CLIENT_ID = 'g-client';
+    process.env.GITHUB_CLIENT_ID = 'gh-client';
+    process.env.APPLE_CLIENT_ID = 'apple-client';
+  });
+
+  it('Google authorize URL includes code_challenge and S256 when challenge provided', async () => {
+    const { buildGoogleOAuthUrl } = await import('~/server/utils/oauth');
+    const url = buildGoogleOAuthUrl('state-1', 'challenge-abc');
+    expect(url).toContain('code_challenge=challenge-abc');
+    expect(url).toContain('code_challenge_method=S256');
+    expect(url).toContain('state=state-1');
+  });
+
+  it('GitHub authorize URL includes code_challenge and S256 when challenge provided', async () => {
+    const { buildGithubOAuthUrl } = await import('~/server/utils/oauth');
+    const url = buildGithubOAuthUrl('state-2', 'challenge-def');
+    expect(url).toContain('code_challenge=challenge-def');
+    expect(url).toContain('code_challenge_method=S256');
+  });
+
+  it('Apple authorize URL includes code_challenge and S256 when challenge provided', async () => {
+    const { buildAppleOAuthUrl } = await import('~/server/utils/oauth');
+    const url = buildAppleOAuthUrl('state-3', 'challenge-ghi');
+    expect(url).toContain('code_challenge=challenge-ghi');
+    expect(url).toContain('code_challenge_method=S256');
+  });
+
+  it('omits code_challenge params when no challenge is provided (behavior-preserving)', async () => {
+    const { buildGoogleOAuthUrl, buildGithubOAuthUrl, buildAppleOAuthUrl } =
+      await import('~/server/utils/oauth');
+    for (const url of [
+      buildGoogleOAuthUrl('s'),
+      buildGithubOAuthUrl('s'),
+      buildAppleOAuthUrl('s'),
+    ]) {
+      expect(url).not.toContain('code_challenge');
+      expect(url).not.toContain('S256');
+    }
+  });
+});
+
+describe('PKCE: token exchange includes code_verifier', () => {
+  const originalFetchLocal = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.BASE_URL = 'https://example.com';
+    process.env.GOOGLE_CLIENT_ID = 'g-client';
+    process.env.GOOGLE_CLIENT_SECRET = 'g-secret';
+    process.env.GITHUB_CLIENT_ID = 'gh-client';
+    process.env.GITHUB_CLIENT_SECRET = 'gh-secret';
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetchLocal;
+  });
+
+  it('Google token exchange request body includes code_verifier', async () => {
+    const fetchMock = vi
+      .fn()
+      // token endpoint
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ access_token: 'g-access' }) })
+      // userinfo endpoint
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: '42', name: 'X', email: 'x@y.z' }),
+      });
+    globalThis.fetch = fetchMock;
+
+    const { exchangeGoogleCode } = await import('~/server/utils/oauth');
+    await exchangeGoogleCode('the-code', 'verifier-123');
+
+    const [, init] = fetchMock.mock.calls[0] as [string, { body: URLSearchParams }];
+    const body = init.body.toString();
+    expect(body).toContain('code_verifier=verifier-123');
+    expect(body).toContain('code=the-code');
+  });
+
+  it('GitHub token exchange request body includes code_verifier', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ access_token: 'gh-access' }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 7, name: 'X', email: 'x@y.z', avatar_url: null }),
+      });
+    globalThis.fetch = fetchMock;
+
+    const { exchangeGithubCode } = await import('~/server/utils/oauth');
+    await exchangeGithubCode('gh-code', 'verifier-456');
+
+    const [, init] = fetchMock.mock.calls[0] as [string, { body: string }];
+    const body = JSON.parse(init.body) as { code_verifier?: string; code?: string };
+    expect(body.code_verifier).toBe('verifier-456');
+    expect(body.code).toBe('gh-code');
+  });
+
+  it('exchange omits code_verifier when none is supplied (behavior-preserving)', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ access_token: 'g-access' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: '42' }) });
+    globalThis.fetch = fetchMock;
+
+    const { exchangeGoogleCode } = await import('~/server/utils/oauth');
+    await exchangeGoogleCode('the-code');
+
+    const [, init] = fetchMock.mock.calls[0] as [string, { body: URLSearchParams }];
+    expect(init.body.toString()).not.toContain('code_verifier');
+  });
+});
+
 describe('upsertUser', () => {
   beforeEach(() => {
     vi.resetModules();

--- a/tests/server/utils/oauth.test.ts
+++ b/tests/server/utils/oauth.test.ts
@@ -275,4 +275,30 @@ describe('revokeToken (reads from encrypted server-side store)', () => {
       provider: 'google',
     });
   });
+
+  it('does not throw and captures exception when the stored token cannot be decrypted (e.g. rotated SESSION_SECRET)', async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+    // A well-formed encrypted token whose ciphertext/auth tag have been tampered
+    // with: the GCM auth check fails at decrypt time, so decryptToken throws.
+    // This simulates the stored ciphertext no longer being decryptable (e.g. the
+    // SESSION_SECRET was rotated since the token was persisted).
+    const valid = await storedToken('google-access-xyz');
+    const tampered = { ...valid, ciphertext: Buffer.from('garbage-ciphertext').toString('base64') };
+    mockFindOneReturning({ oauthTokens: { accessToken: tampered } });
+
+    const { revokeToken } = await import('~/server/utils/oauth');
+    // Logout must proceed gracefully: revokeToken must not throw to its caller.
+    await expect(revokeToken(sessionUser('google', 'google_123'))).resolves.toBeUndefined();
+
+    // Decryption failed before any provider call or token clear could happen.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mockUpdateOne).not.toHaveBeenCalled();
+    // The decrypt failure is captured rather than crashing.
+    expect(mockServerCaptureException).toHaveBeenCalledTimes(1);
+    expect(mockServerCaptureException).toHaveBeenCalledWith(expect.any(Error), 'google_123', {
+      action: 'revokeToken',
+      provider: 'google',
+    });
+  });
 });

--- a/tests/server/utils/oauth.test.ts
+++ b/tests/server/utils/oauth.test.ts
@@ -1,40 +1,59 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const mockServerCaptureException = vi.fn()
+const mockServerCaptureException = vi.fn();
 vi.mock('~/server/utils/posthog', () => ({
   serverCaptureException: (...args: unknown[]) => mockServerCaptureException(...args),
   serverCaptureEvent: vi.fn(),
   shutdownPostHog: vi.fn(),
-}))
+}));
 
-const mockFindOneAndUpdate = vi.fn()
+const mockFindOneAndUpdate = vi.fn();
+const mockFindOne = vi.fn();
+const mockUpdateOne = vi.fn();
 vi.mock('~/server/db/models/User', () => ({
-  User: { findOneAndUpdate: (...args: unknown[]) => mockFindOneAndUpdate(...args) },
-}))
+  User: {
+    findOneAndUpdate: (...args: unknown[]) => mockFindOneAndUpdate(...args),
+    findOne: (...args: unknown[]) => mockFindOne(...args),
+    updateOne: (...args: unknown[]) => mockUpdateOne(...args),
+  },
+}));
 
-const mockConnectDB = vi.fn()
-const mockIsDBConnected = vi.fn(() => true)
+const mockConnectDB = vi.fn();
+const mockIsDBConnected = vi.fn(() => true);
 vi.mock('~/server/db/connection', () => ({
   connectDB: (...args: unknown[]) => mockConnectDB(...args),
   isDBConnected: () => mockIsDBConnected(),
-}))
+}));
 
 // Mock fetch globally for revokeToken tests
-const originalFetch = globalThis.fetch
+const originalFetch = globalThis.fetch;
 
-describe('upsertUser PostHog logging', () => {
+// SESSION_SECRET drives the token-encryption key derivation.
+process.env.SESSION_SECRET = 'test-secret-for-unit-tests-at-least-32-chars';
+
+/** Helper: build the `findOne(...).select(...).lean()` chain used by revokeToken. */
+function mockFindOneReturning(value: unknown) {
+  mockFindOne.mockReturnValue({
+    select: vi.fn().mockReturnValue({
+      lean: vi.fn().mockResolvedValue(value),
+    }),
+  });
+}
+
+describe('upsertUser', () => {
   beforeEach(() => {
-    vi.resetModules()
-    mockServerCaptureException.mockClear()
-    mockFindOneAndUpdate.mockClear()
-    mockConnectDB.mockClear()
-  })
+    vi.resetModules();
+    mockServerCaptureException.mockClear();
+    mockFindOneAndUpdate.mockClear();
+    mockConnectDB.mockClear();
+    mockIsDBConnected.mockReturnValue(true);
+  });
 
   it('captures exception to PostHog when DB upsert fails', async () => {
-    const dbError = new Error('MongoDB connection lost')
-    mockFindOneAndUpdate.mockRejectedValue(dbError)
+    const dbError = new Error('MongoDB connection lost');
+    mockFindOneAndUpdate.mockRejectedValue(dbError);
 
-    const { upsertUser } = await import('~/server/utils/oauth')
+    const { upsertUser } = await import('~/server/utils/oauth');
     const profile = {
       id: 'google_123',
       provider: 'google' as const,
@@ -44,18 +63,17 @@ describe('upsertUser PostHog logging', () => {
       accessToken: 'tok',
       refreshToken: null,
       tokenIssuedAt: Date.now(),
-    }
+    };
 
-    const result = await upsertUser(profile)
+    const result = await upsertUser(profile);
 
-    expect(mockServerCaptureException).toHaveBeenCalledWith(
-      dbError,
-      'google_123',
-      { action: 'upsertUser', provider: 'google' },
-    )
-    // Should still return fallback profile with role 'unknown'
-    expect(result.role).toBe('unknown')
-  })
+    expect(mockServerCaptureException).toHaveBeenCalledWith(dbError, 'google_123', {
+      action: 'upsertUser',
+      provider: 'google',
+    });
+    // Should still return fallback session user with role 'unknown'
+    expect(result.role).toBe('unknown');
+  });
 
   it('does not capture exception on successful upsert', async () => {
     mockFindOneAndUpdate.mockResolvedValue({
@@ -64,9 +82,9 @@ describe('upsertUser PostHog logging', () => {
       lastName: 'User',
       avatarUrl: null,
       role: 'gm',
-    })
+    });
 
-    const { upsertUser } = await import('~/server/utils/oauth')
+    const { upsertUser } = await import('~/server/utils/oauth');
     const profile = {
       id: 'github_456',
       provider: 'github' as const,
@@ -76,92 +94,185 @@ describe('upsertUser PostHog logging', () => {
       accessToken: 'tok',
       refreshToken: null,
       tokenIssuedAt: Date.now(),
-    }
+    };
 
-    await upsertUser(profile)
-    expect(mockServerCaptureException).not.toHaveBeenCalled()
-  })
-})
+    await upsertUser(profile);
+    expect(mockServerCaptureException).not.toHaveBeenCalled();
+  });
 
-describe('revokeToken PostHog logging', () => {
-  beforeEach(() => {
-    mockServerCaptureException.mockClear()
-  })
+  it('persists provider tokens ENCRYPTED (not plaintext) and never returns them in the session user', async () => {
+    mockFindOneAndUpdate.mockResolvedValue({ role: 'gm' });
 
-  afterEach(() => {
-    globalThis.fetch = originalFetch
-  })
-
-  it('captures exception to PostHog when Google token revocation fails', async () => {
-    const fetchError = new Error('Network timeout')
-    globalThis.fetch = vi.fn().mockRejectedValue(fetchError)
-
-    const { revokeToken } = await import('~/server/utils/oauth')
-    await revokeToken({
-      id: 'google_123',
-      provider: 'google',
-      name: null,
-      email: null,
+    const { upsertUser } = await import('~/server/utils/oauth');
+    const profile = {
+      id: 'google_789',
+      provider: 'google' as const,
+      name: 'Token User',
+      email: 'tok@example.com',
       avatar: null,
-      role: 'gm',
-      accessToken: 'some-token',
-      refreshToken: null,
+      accessToken: 'super-secret-access-token',
+      refreshToken: 'super-secret-refresh-token',
       tokenIssuedAt: Date.now(),
-    })
+    };
 
-    expect(mockServerCaptureException).toHaveBeenCalledWith(
-      fetchError,
-      'google_123',
-      { action: 'revokeToken', provider: 'google' },
-    )
-  })
+    const sessionUser = await upsertUser(profile);
 
-  it('does not capture exception when no access token', async () => {
-    globalThis.fetch = vi.fn()
+    // The returned SessionUser must NOT carry the provider tokens.
+    expect(sessionUser).not.toHaveProperty('accessToken');
+    expect(sessionUser).not.toHaveProperty('refreshToken');
+    expect(JSON.stringify(sessionUser)).not.toContain('super-secret-access-token');
+    expect(JSON.stringify(sessionUser)).not.toContain('super-secret-refresh-token');
+    // Identity claims preserved.
+    expect(sessionUser).toMatchObject({ id: 'google_789', provider: 'google', role: 'gm' });
 
-    const { revokeToken } = await import('~/server/utils/oauth')
-    await revokeToken({
-      id: 'google_123',
-      provider: 'google',
+    // The persisted document must store encrypted tokens (ciphertext/iv/authTag),
+    // never the plaintext.
+    const update = mockFindOneAndUpdate.mock.calls[0][1] as {
+      $set: {
+        oauthTokens: { accessToken: Record<string, string>; refreshToken: Record<string, string> };
+      };
+    };
+    const persisted = JSON.stringify(update.$set.oauthTokens);
+    expect(persisted).not.toContain('super-secret-access-token');
+    expect(persisted).not.toContain('super-secret-refresh-token');
+    expect(update.$set.oauthTokens.accessToken).toHaveProperty('ciphertext');
+    expect(update.$set.oauthTokens.accessToken).toHaveProperty('iv');
+    expect(update.$set.oauthTokens.accessToken).toHaveProperty('authTag');
+    expect(update.$set.oauthTokens.refreshToken).toHaveProperty('ciphertext');
+  });
+
+  it('stores null token slots when the provider returned no token', async () => {
+    mockFindOneAndUpdate.mockResolvedValue({ role: 'player' });
+
+    const { upsertUser } = await import('~/server/utils/oauth');
+    await upsertUser({
+      id: 'apple_001',
+      provider: 'apple' as const,
       name: null,
       email: null,
       avatar: null,
-      role: 'gm',
       accessToken: null,
       refreshToken: null,
       tokenIssuedAt: Date.now(),
-    })
+    });
 
-    expect(mockServerCaptureException).not.toHaveBeenCalled()
-    expect(globalThis.fetch).not.toHaveBeenCalled()
-  })
+    const update = mockFindOneAndUpdate.mock.calls[0][1] as {
+      $set: { oauthTokens: { accessToken: unknown; refreshToken: unknown } };
+    };
+    expect(update.$set.oauthTokens.accessToken).toBeNull();
+    expect(update.$set.oauthTokens.refreshToken).toBeNull();
+  });
+});
 
-  it('captures exception to PostHog when GitHub token revocation fails', async () => {
-    process.env.GITHUB_CLIENT_ID = 'test-client-id'
-    process.env.GITHUB_CLIENT_SECRET = 'test-client-secret'
-    const fetchError = new Error('502 Bad Gateway')
-    globalThis.fetch = vi.fn().mockRejectedValue(fetchError)
+describe('revokeToken (reads from encrypted server-side store)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockServerCaptureException.mockClear();
+    mockFindOne.mockReset();
+    mockUpdateOne.mockReset();
+    mockConnectDB.mockClear();
+    mockIsDBConnected.mockReturnValue(true);
+    mockUpdateOne.mockResolvedValue(undefined);
+  });
 
-    const { revokeToken } = await import('~/server/utils/oauth')
-    await revokeToken({
-      id: 'github_456',
-      provider: 'github',
-      name: null,
-      email: null,
-      avatar: null,
-      role: 'player',
-      accessToken: 'gh-token',
-      refreshToken: null,
-      tokenIssuedAt: Date.now(),
-    })
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
 
-    expect(mockServerCaptureException).toHaveBeenCalledWith(
-      fetchError,
-      'github_456',
-      { action: 'revokeToken', provider: 'github' },
-    )
+  const sessionUser = (provider: string, id = `${provider}_1`) => ({
+    id,
+    provider,
+    name: null,
+    email: null,
+    avatar: null,
+    role: 'gm',
+    tokenIssuedAt: Date.now(),
+  });
 
-    delete process.env.GITHUB_CLIENT_ID
-    delete process.env.GITHUB_CLIENT_SECRET
-  })
-})
+  /** Encrypt a token the same way upsertUser does, for use as stored fixture. */
+  async function storedToken(plaintext: string) {
+    const { encryptToken } = await import('~/server/utils/tokenCrypto');
+    return encryptToken(plaintext);
+  }
+
+  it('decrypts the stored Google token and calls the Google revoke endpoint, then clears tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    globalThis.fetch = fetchMock;
+    mockFindOneReturning({ oauthTokens: { accessToken: await storedToken('google-access-xyz') } });
+
+    const { revokeToken } = await import('~/server/utils/oauth');
+    await revokeToken(sessionUser('google', 'google_123'));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('oauth2.googleapis.com/revoke');
+    // The decrypted plaintext token is sent to the provider.
+    expect(url).toContain(encodeURIComponent('google-access-xyz'));
+    // Tokens cleared after revocation.
+    expect(mockUpdateOne).toHaveBeenCalledWith(
+      { providerId: 'google_123' },
+      { $unset: { oauthTokens: '' } }
+    );
+    expect(mockServerCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('decrypts the stored GitHub token and calls the GitHub token-delete endpoint', async () => {
+    process.env.GITHUB_CLIENT_ID = 'test-client-id';
+    process.env.GITHUB_CLIENT_SECRET = 'test-client-secret';
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    globalThis.fetch = fetchMock;
+    mockFindOneReturning({ oauthTokens: { accessToken: await storedToken('gh-access-abc') } });
+
+    const { revokeToken } = await import('~/server/utils/oauth');
+    await revokeToken(sessionUser('github', 'github_456'));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, { method?: string; body?: string }];
+    expect(url).toContain('api.github.com/applications/test-client-id/token');
+    expect(init.method).toBe('DELETE');
+    expect(init.body).toContain('gh-access-abc');
+    expect(mockUpdateOne).toHaveBeenCalled();
+
+    delete process.env.GITHUB_CLIENT_ID;
+    delete process.env.GITHUB_CLIENT_SECRET;
+  });
+
+  it('early-returns without fetch when no token is stored', async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+    mockFindOneReturning({ oauthTokens: undefined });
+
+    const { revokeToken } = await import('~/server/utils/oauth');
+    await revokeToken(sessionUser('google'));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mockUpdateOne).not.toHaveBeenCalled();
+    expect(mockServerCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('early-returns when the user document is not found', async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+    mockFindOneReturning(null);
+
+    const { revokeToken } = await import('~/server/utils/oauth');
+    await revokeToken(sessionUser('google'));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mockServerCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('captures exception to PostHog when Google token revocation fetch fails', async () => {
+    const fetchError = new Error('Network timeout');
+    globalThis.fetch = vi.fn().mockRejectedValue(fetchError);
+    mockFindOneReturning({ oauthTokens: { accessToken: await storedToken('google-access-xyz') } });
+
+    const { revokeToken } = await import('~/server/utils/oauth');
+    await revokeToken(sessionUser('google', 'google_123'));
+
+    expect(mockServerCaptureException).toHaveBeenCalledWith(fetchError, 'google_123', {
+      action: 'revokeToken',
+      provider: 'google',
+    });
+  });
+});

--- a/tests/server/utils/requireCampaignMember.test.ts
+++ b/tests/server/utils/requireCampaignMember.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('~/server/session', () => ({ getSession: vi.fn() }));
+vi.mock('~/server/db/connection', () => ({
+  connectDB: vi.fn(),
+  isDBConnected: vi.fn(() => true),
+}));
+vi.mock('~/server/db/models/User', () => ({
+  User: { findOne: vi.fn() },
+}));
+vi.mock('~/server/db/models/Campaign', () => ({
+  Campaign: { findById: vi.fn() },
+}));
+
+import { getSession } from '~/server/session';
+import { connectDB, isDBConnected } from '~/server/db/connection';
+import { User } from '~/server/db/models/User';
+import { Campaign } from '~/server/db/models/Campaign';
+import { requireCampaignMember } from '~/server/utils/requireCampaignMember';
+
+const mockSession = {
+  id: 'session-user-1',
+  provider: 'google',
+  name: 'Test User',
+  email: 'test@example.com',
+  avatar: null,
+  role: 'gm',
+  accessToken: null,
+  refreshToken: null,
+  tokenIssuedAt: 0,
+};
+const mockDbUser = { _id: 'dbuser-1', firstName: 'Test', lastName: 'User' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getSession).mockResolvedValue(mockSession);
+  vi.mocked(isDBConnected).mockReturnValue(true);
+  vi.mocked(User.findOne).mockResolvedValue(mockDbUser);
+});
+
+describe('requireCampaignMember', () => {
+  it('allows the GM (gameMasterId match) and reports isGM', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue({
+      _id: 'camp-A',
+      gameMasterId: 'dbuser-1',
+      members: [{ userId: 'dbuser-1', role: 'gm' }],
+    } as never);
+
+    const result = await requireCampaignMember('camp-A');
+
+    expect(result).toEqual({
+      userId: 'dbuser-1',
+      sessionUserId: 'session-user-1',
+      isGM: true,
+    });
+  });
+
+  it('allows a non-GM member and reports isGM false', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue({
+      _id: 'camp-A',
+      gameMasterId: 'someone-else',
+      members: [{ userId: 'dbuser-1', role: 'player' }],
+    } as never);
+
+    const result = await requireCampaignMember('camp-A');
+
+    expect(result).toEqual({
+      userId: 'dbuser-1',
+      sessionUserId: 'session-user-1',
+      isGM: false,
+    });
+  });
+
+  it('rejects a user who is not a member of the campaign', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue({
+      _id: 'camp-A',
+      gameMasterId: 'someone-else',
+      members: [{ userId: 'another-member', role: 'player' }],
+    } as never);
+
+    await expect(requireCampaignMember('camp-A')).rejects.toThrow('Forbidden');
+  });
+
+  it('rejects when not authenticated', async () => {
+    vi.mocked(getSession).mockResolvedValue(null as never);
+
+    await expect(requireCampaignMember('camp-A')).rejects.toThrow('Not authenticated');
+    expect(connectDB).not.toHaveBeenCalled();
+  });
+
+  it('throws when the database is unavailable', async () => {
+    vi.mocked(isDBConnected).mockReturnValue(false);
+
+    await expect(requireCampaignMember('camp-A')).rejects.toThrow('Database not available');
+  });
+
+  it('throws when the DB user is not found', async () => {
+    vi.mocked(User.findOne).mockResolvedValue(null);
+
+    await expect(requireCampaignMember('camp-A')).rejects.toThrow('User not found');
+  });
+
+  it('throws when the campaign is not found', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(null as never);
+
+    await expect(requireCampaignMember('camp-A')).rejects.toThrow('Campaign not found');
+  });
+});

--- a/tests/server/utils/tokenCrypto.test.ts
+++ b/tests/server/utils/tokenCrypto.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { encryptToken, decryptToken } from '~/server/utils/tokenCrypto';
+
+describe('tokenCrypto (AES-256-GCM)', () => {
+  beforeEach(() => {
+    process.env.SESSION_SECRET = 'test-secret-for-unit-tests-at-least-32-chars';
+  });
+
+  it('round-trips a token through encrypt/decrypt', () => {
+    const plaintext = 'ya29.a0Af-some-provider-access-token';
+    const enc = encryptToken(plaintext);
+    expect(decryptToken(enc)).toBe(plaintext);
+  });
+
+  it('produces ciphertext-only output (no plaintext leakage) with iv + authTag', () => {
+    const plaintext = 'sensitive-bearer-token';
+    const enc = encryptToken(plaintext);
+    expect(enc.ciphertext).not.toContain(plaintext);
+    expect(enc.iv).toBeTruthy();
+    expect(enc.authTag).toBeTruthy();
+    // Base64 fields decode to non-empty buffers.
+    expect(Buffer.from(enc.iv, 'base64').length).toBe(12);
+    expect(Buffer.from(enc.authTag, 'base64').length).toBe(16);
+  });
+
+  it('uses a fresh IV each call (different ciphertext for same plaintext)', () => {
+    const a = encryptToken('same-token');
+    const b = encryptToken('same-token');
+    expect(a.ciphertext).not.toBe(b.ciphertext);
+    expect(a.iv).not.toBe(b.iv);
+    // Both still decrypt back to the original.
+    expect(decryptToken(a)).toBe('same-token');
+    expect(decryptToken(b)).toBe('same-token');
+  });
+
+  it('fails to decrypt when the ciphertext is tampered with', () => {
+    const enc = encryptToken('original-token');
+    const tampered = { ...enc, ciphertext: Buffer.from('garbage-bytes').toString('base64') };
+    expect(() => decryptToken(tampered)).toThrow();
+  });
+
+  it('fails to decrypt when the auth tag is tampered with', () => {
+    const enc = encryptToken('original-token');
+    const flipped = Buffer.from(enc.authTag, 'base64');
+    flipped[0] = flipped[0] ^ 0xff;
+    const tampered = { ...enc, authTag: flipped.toString('base64') };
+    expect(() => decryptToken(tampered)).toThrow();
+  });
+
+  it('fails to decrypt when the key (SESSION_SECRET) differs from encrypt time', () => {
+    const enc = encryptToken('original-token');
+    process.env.SESSION_SECRET = 'a-completely-different-secret-thats-32-chars!';
+    expect(() => decryptToken(enc)).toThrow();
+  });
+
+  it('throws when SESSION_SECRET is missing', () => {
+    delete process.env.SESSION_SECRET;
+    expect(() => encryptToken('x')).toThrow(/SESSION_SECRET/);
+  });
+});

--- a/tests/utils/errors.test.ts
+++ b/tests/utils/errors.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { extractErrorMessage } from '~/utils/errors';
+
+describe('extractErrorMessage', () => {
+  it('returns null for null/undefined', () => {
+    expect(extractErrorMessage(null)).toBeNull();
+    expect(extractErrorMessage(undefined)).toBeNull();
+  });
+
+  it('returns null for other falsy values', () => {
+    expect(extractErrorMessage('')).toBeNull();
+    expect(extractErrorMessage(0)).toBeNull();
+    expect(extractErrorMessage(false)).toBeNull();
+  });
+
+  it('returns the message for Error instances', () => {
+    expect(extractErrorMessage(new Error('boom'))).toBe('boom');
+    expect(extractErrorMessage(new TypeError('bad type'))).toBe('bad type');
+  });
+
+  it('stringifies truthy non-Error values', () => {
+    expect(extractErrorMessage('plain string')).toBe('plain string');
+    expect(extractErrorMessage(42)).toBe('42');
+    expect(extractErrorMessage({ toString: () => 'custom' })).toBe('custom');
+  });
+});


### PR DESCRIPTION
## Summary

Addresses a batch of tech-debt and security findings surfaced by a project review. Each change landed as its own reviewed commit; all are behavior-preserving except the intentional security/CI hardening noted below.

**Security**
- **Fix `listMapTokens` IDOR** (`7887a43`): the token read path was scoped by `mapId` only, letting a member of any campaign read another campaign's map tokens. Now scoped by `{ _id, campaignId }`, matching its mutating siblings.
- **OAuth tokens out of the session cookie** (`81dfa1c`, `b469bcb`): provider `accessToken`/`refreshToken` were signed into the `cartyx_session` cookie. They now live in an AES-256-GCM encrypted, `select:false` store on the User doc; logout revocation reads/decrypts from there and clears after. Resilient to a rotated `SESSION_SECRET` (logout never crashes).
- **PKCE (S256)** added to the OAuth authorization-code flow for all three providers (`af4f13d`); the `code_verifier` round-trips like the existing CSRF `state` cookie.

**Refactors (behavior-preserving)**
- Centralized the duplicated `requireCampaignMember` into `app/server/utils/` across 10 server-function files; 3 files with genuinely different auth contracts were intentionally left alone (`ad8545f`, `d950031`).
- Extracted `createMutationHook` + shared `extractErrorMessage`; migrated ~20 mutation hooks (`0613a24`).
- Extracted `useModalForm` for the shared modal lifecycle; migrated 3/4 wiki modals (LocationModal left — latent ungated-Escape bug) (`e8edafa`).

**CI / tooling**
- Added a Playwright **e2e job** to CI (mongo:8 service container) so the e2e suite finally runs on PRs (`dba040e`, `1de2a26`).
- Re-enabled the `check:deps-age` supply-chain guard (removed `continue-on-error`; sunset date passed) — enforces our "only update npm packages published ≥1 week" policy.
- Fixed `seed-gm.cjs` so the fresh-DB e2e bootstrap produces a queryable GM user (`5e677be`).

**Docs**
- Reconciled `docs/tech-debt.md` with reality: a Resolved section, corrected counts, refreshed line numbers, run-the-command baselines, and new tracked items (`00e0053`).

## Heads-up for reviewers
- **`check:deps-age` is now blocking.** The first CI run can legitimately fail if any direct dependency in the lockfile was published <10 days ago — that's the guard working as intended. Emergency bypass: `SKIP_AGE_CHECK=1`.
- **e2e in CI is unproven until this PR runs Actions.** The seed→globalSetup chain was validated empirically against a throwaway in-memory Mongo, but the live mongo service + Playwright pass are first exercised here.
- **One-time OAuth revocation gap:** users with a session minted before this change have no `oauthTokens` stored, so their next logout skips provider-grant revocation once, then self-heals on next login. Tracked in `docs/tech-debt.md`.

## Test Plan
- [x] `npm run typecheck` clean
- [x] `npm run test` — 1225/1225 unit tests pass
- [x] `npm run lint` — 0 errors / 29 warnings (baseline preserved)
- [ ] CI e2e job goes green on this PR (first real run)
- [ ] `check:deps-age` passes (or is consciously bypassed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)