### PR TITLE
feat: Lore — history/stories linkable to any entity

### DIFF
--- a/app/components/join-wizard/JoinWizard.tsx
+++ b/app/components/join-wizard/JoinWizard.tsx
@@ -7,6 +7,7 @@ import { StepInviteCode } from './StepInviteCode';
 import { StepPlayerInfo } from './StepPlayerInfo';
 import { StepBackstory } from './StepBackstory';
 import { StepRelatedCharacters } from './StepRelatedCharacters';
+import { StepLore } from './StepLore';
 import { StepReview } from './StepReview';
 import type { PictureCrop } from '~/types/character';
 
@@ -36,6 +37,12 @@ export interface WizardPlayerState {
   appearance: string;
 }
 
+export interface WizardLore {
+  title: string;
+  content: string;
+  isPublic: boolean;
+}
+
 export interface WizardCharacter {
   firstName: string;
   lastName: string;
@@ -56,6 +63,7 @@ export interface WizardState {
   campaignName: string;
   player: WizardPlayerState;
   characters: WizardCharacter[];
+  lore: WizardLore[];
 }
 
 // ---------------------------------------------------------------------------
@@ -92,6 +100,7 @@ function defaultState(): WizardState {
     campaignName: '',
     player: defaultPlayer(),
     characters: [],
+    lore: [],
   };
 }
 
@@ -136,7 +145,7 @@ export function clearStorage(campaignId: string) {
 // Step labels
 // ---------------------------------------------------------------------------
 
-const STEPS = ['INVITE', 'PLAYER', 'BACKSTORY', 'CHARACTERS', 'REVIEW'];
+const STEPS = ['INVITE', 'PLAYER', 'BACKSTORY', 'CHARACTERS', 'LORE', 'REVIEW'];
 
 // ---------------------------------------------------------------------------
 // JoinWizard component
@@ -212,6 +221,10 @@ export function JoinWizard() {
     setWizardState((prev) => ({ ...prev, characters }));
   }, []);
 
+  const setLore = useCallback((lore: WizardLore[]) => {
+    setWizardState((prev) => ({ ...prev, lore }));
+  }, []);
+
   // Only allow step navigation to already-visited steps
   const handleStepClick = useCallback(
     (s: number) => {
@@ -282,7 +295,16 @@ export function JoinWizard() {
           />
         )}
 
-        {step === 5 && <StepReview wizardState={wizardState} onBack={() => goToStep(4)} />}
+        {step === 5 && (
+          <StepLore
+            lore={wizardState.lore}
+            onUpdate={setLore}
+            onNext={() => goToStep(6)}
+            onBack={() => goToStep(4)}
+          />
+        )}
+
+        {step === 6 && <StepReview wizardState={wizardState} onBack={() => goToStep(5)} />}
       </main>
     </div>
   );

--- a/app/components/join-wizard/StepLore.tsx
+++ b/app/components/join-wizard/StepLore.tsx
@@ -1,0 +1,151 @@
+import { PixelButton } from '~/components/PixelButton';
+import { MarkdownEditor } from '~/components/shared/MarkdownEditor';
+import { SectionHeader } from '~/components/SectionHeader';
+import { BookOpen, Plus, Trash2, Globe, Lock } from 'lucide-react';
+import type { WizardLore } from './JoinWizard';
+
+interface StepLoreProps {
+  lore: WizardLore[];
+  onUpdate: (lore: WizardLore[]) => void;
+  onNext: () => void;
+  onBack: () => void;
+}
+
+export function StepLore({ lore, onUpdate, onNext, onBack }: StepLoreProps) {
+  function addEntry() {
+    onUpdate([...lore, { title: '', content: '', isPublic: false }]);
+  }
+
+  function removeEntry(index: number) {
+    onUpdate(lore.filter((_, i) => i !== index));
+  }
+
+  function updateEntry(index: number, patch: Partial<WizardLore>) {
+    onUpdate(lore.map((entry, i) => (i === index ? { ...entry, ...patch } : entry)));
+  }
+
+  return (
+    <div className="bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden">
+      <div className="p-8 pb-6 space-y-5">
+        <SectionHeader size="xs" tracking="tracking-[3px]" className="mb-7">
+          LORE ENTRIES
+        </SectionHeader>
+
+        {/* Info banner */}
+        <div className="flex items-start gap-3 p-4 bg-indigo-500/5 border border-indigo-500/20 rounded-xl">
+          <BookOpen className="h-5 w-5 text-indigo-400 mt-0.5 shrink-0" />
+          <p className="text-xs text-indigo-300/80 leading-relaxed">
+            Add lore entries about your character — legends, secrets, journal entries, or world
+            knowledge. Mark entries public to share them with other players.
+          </p>
+        </div>
+
+        {/* Lore entry list */}
+        {lore.length > 0 && (
+          <div className="space-y-4">
+            {lore.map((entry, index) => (
+              <div
+                key={index}
+                data-testid={`lore-entry-${index}`}
+                className="border border-white/[0.07] rounded-xl overflow-hidden"
+              >
+                <div className="p-4 space-y-3 bg-white/[0.02]">
+                  {/* Title row */}
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="text"
+                      value={entry.title}
+                      onChange={(e) => updateEntry(index, { title: e.target.value })}
+                      placeholder="Entry title..."
+                      data-testid={`lore-title-${index}`}
+                      className="flex-1 bg-transparent border border-white/[0.1] rounded-lg px-3 py-1.5 text-sm text-white placeholder-slate-600 focus:outline-none focus:border-white/30 transition-colors"
+                    />
+                    {/* Public/private toggle */}
+                    <button
+                      type="button"
+                      onClick={() => updateEntry(index, { isPublic: !entry.isPublic })}
+                      data-testid={`lore-visibility-${index}`}
+                      title={
+                        entry.isPublic
+                          ? 'Public — visible to all players'
+                          : 'Private — only you and the GM'
+                      }
+                      className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+                        entry.isPublic
+                          ? 'bg-emerald-500/10 border-emerald-500/30 text-emerald-400 hover:bg-emerald-500/20'
+                          : 'bg-white/[0.03] border-white/[0.1] text-slate-500 hover:text-slate-400'
+                      }`}
+                    >
+                      {entry.isPublic ? (
+                        <>
+                          <Globe className="h-3 w-3" />
+                          Public
+                        </>
+                      ) : (
+                        <>
+                          <Lock className="h-3 w-3" />
+                          Private
+                        </>
+                      )}
+                    </button>
+                    {/* Remove button */}
+                    <button
+                      type="button"
+                      onClick={() => removeEntry(index)}
+                      data-testid={`lore-remove-${index}`}
+                      title="Remove entry"
+                      className="p-1.5 text-slate-600 hover:text-red-400 transition-colors rounded-lg hover:bg-red-500/10"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </div>
+
+                  {/* Content */}
+                  <MarkdownEditor
+                    label=""
+                    value={entry.content}
+                    onChange={(content) => updateEntry(index, { content })}
+                    placeholder="Write the lore entry content here..."
+                    minHeight="120px"
+                    id={`lore-content-${index}`}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Add button */}
+        <button
+          type="button"
+          onClick={addEntry}
+          data-testid="lore-add-entry"
+          className="flex items-center gap-2 text-xs text-slate-500 hover:text-slate-300 transition-colors font-medium py-1"
+        >
+          <Plus className="h-4 w-4" />
+          Add lore entry
+        </button>
+
+        {lore.length === 0 && (
+          <button
+            type="button"
+            onClick={onNext}
+            className="text-xs text-slate-500 hover:text-slate-400 transition-colors font-medium"
+          >
+            Skip for now &rarr;
+          </button>
+        )}
+      </div>
+
+      {/* Footer nav */}
+      <div className="flex items-center justify-between px-8 py-5 border-t border-white/[0.06]">
+        <PixelButton variant="secondary" size="sm" onClick={onBack} type="button">
+          &larr; Back
+        </PixelButton>
+        <PixelButton variant="primary" size="sm" onClick={onNext} type="button">
+          Next: Review &rarr;
+        </PixelButton>
+      </div>
+    </div>
+  );
+}

--- a/app/components/join-wizard/StepReview.tsx
+++ b/app/components/join-wizard/StepReview.tsx
@@ -6,7 +6,7 @@ import { StatusBanner } from '~/components/StatusBanner';
 import { useCompleteJoinWizard } from '~/hooks/usePlayers';
 import { clearStorage } from './JoinWizard';
 import type { WizardState } from './JoinWizard';
-import { Swords, CheckCircle2 } from 'lucide-react';
+import { Swords, CheckCircle2, BookOpen } from 'lucide-react';
 
 interface StepReviewProps {
   wizardState: WizardState;
@@ -18,7 +18,7 @@ export function StepReview({ wizardState, onBack }: StepReviewProps) {
   const { complete, isLoading, error } = useCompleteJoinWizard();
   const [submitError, setSubmitError] = useState<string | null>(null);
 
-  const { player, characters, campaignId, campaignName } = wizardState;
+  const { player, characters, lore, campaignId, campaignName } = wizardState;
 
   async function handleJoin() {
     setSubmitError(null);
@@ -76,6 +76,11 @@ export function StepReview({ wizardState, onBack }: StepReviewProps) {
           descriptor: c.relationship.descriptor.trim(),
           isPublic: c.relationship.isPublic,
         },
+      })),
+      lore: (wizardState.lore ?? []).map((l) => ({
+        title: l.title.trim(),
+        content: l.content,
+        isPublic: l.isPublic,
       })),
     });
 
@@ -212,6 +217,29 @@ export function StepReview({ wizardState, onBack }: StepReviewProps) {
               </span>
             </div>
           )}
+        </div>
+
+        {/* Lore entries */}
+        <div>
+          <SectionHeader color="muted" tracking="tracking-widest" className="mb-2">
+            LORE ENTRIES ({(lore ?? []).length})
+          </SectionHeader>
+          <div className="bg-white/[0.03] border border-white/[0.07] rounded-xl px-4 py-3 flex items-center gap-2">
+            {(lore ?? []).length > 0 ? (
+              <>
+                <BookOpen className="h-4 w-4 text-indigo-400 shrink-0" />
+                <span className="text-xs text-slate-400">
+                  {(lore ?? []).length} {(lore ?? []).length === 1 ? 'entry' : 'entries'} —{' '}
+                  {(lore ?? []).filter((l) => l.isPublic).length} public,{' '}
+                  {(lore ?? []).filter((l) => !l.isPublic).length} private
+                </span>
+              </>
+            ) : (
+              <span className="text-xs text-slate-600 italic">
+                No lore entries — can be added later
+              </span>
+            )}
+          </div>
         </div>
       </div>
 

--- a/app/components/mainview/gmscreens/EventWindowWrapper.tsx
+++ b/app/components/mainview/gmscreens/EventWindowWrapper.tsx
@@ -1,0 +1,35 @@
+import { EventWindow } from '~/components/wiki/calendar/EventWindow';
+import { useEvent } from '~/hooks/useEvents';
+import { useCalendar } from '~/hooks/useCalendar';
+import { calendarConfigFromData } from '~/types/calendar';
+
+export function EventWindowWrapper({
+  eventId,
+  campaignId,
+}: {
+  eventId: string;
+  campaignId: string;
+}) {
+  const { event, isLoading } = useEvent(eventId, campaignId);
+  const { calendar } = useCalendar(campaignId);
+
+  const cfg = calendar ? calendarConfigFromData(calendar) : null;
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-xs text-slate-500 animate-pulse">Loading event...</p>
+      </div>
+    );
+  }
+
+  if (!event) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-xs text-slate-500">Event not found</p>
+      </div>
+    );
+  }
+
+  return <EventWindow event={event} cfg={cfg} />;
+}

--- a/app/components/mainview/gmscreens/GMScreensView.tsx
+++ b/app/components/mainview/gmscreens/GMScreensView.tsx
@@ -12,6 +12,7 @@ import type { WindowState } from '~/types/gmscreen';
 import { MARKDOWN_PROSE_CLASSES } from '~/utils/markdownProseClasses';
 import { CharacterWindowWrapper, EditCharacterModalWrapper } from './CharacterWindowWrapper';
 import { LoreWindowWrapper, EditLoreModalWrapper } from './LoreWindowWrapper';
+import { EventWindowWrapper } from './EventWindowWrapper';
 import { RaceWindowWrapper, EditRaceModalWrapper } from '~/components/wiki/races/RaceWindowWrapper';
 import { RuleWindowWrapper, EditRuleModalWrapper } from './RuleWindowWrapper';
 import {
@@ -471,6 +472,8 @@ export function GMScreensView({ campaignId, isGM = true }: GMScreensViewProps) {
               onEdit={() => setEditingLoreId(w.documentId)}
             />
           );
+        } else if (w.collection === 'events') {
+          windowContent = <EventWindowWrapper eventId={w.documentId} campaignId={campaignId} />;
         } else {
           windowContent = (
             <div className="p-4 overflow-auto h-full">

--- a/app/components/mainview/gmscreens/GMScreensView.tsx
+++ b/app/components/mainview/gmscreens/GMScreensView.tsx
@@ -11,6 +11,7 @@ import type { FloatingWindowState } from '~/components/mainview/FloatingWindow';
 import type { WindowState } from '~/types/gmscreen';
 import { MARKDOWN_PROSE_CLASSES } from '~/utils/markdownProseClasses';
 import { CharacterWindowWrapper, EditCharacterModalWrapper } from './CharacterWindowWrapper';
+import { LoreWindowWrapper, EditLoreModalWrapper } from './LoreWindowWrapper';
 import { RaceWindowWrapper, EditRaceModalWrapper } from '~/components/wiki/races/RaceWindowWrapper';
 import { RuleWindowWrapper, EditRuleModalWrapper } from './RuleWindowWrapper';
 import {
@@ -60,6 +61,7 @@ export function GMScreensView({ campaignId, isGM = true }: GMScreensViewProps) {
   const [editingPlayerId, setEditingPlayerId] = useState<string | null>(null);
   const [editingLocationId, setEditingLocationId] = useState<string | null>(null);
   const [editingMonsterId, setEditingMonsterId] = useState<string | null>(null);
+  const [editingLoreId, setEditingLoreId] = useState<string | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
   const [flashWindowId, setFlashWindowId] = useState<string | null>(null);
   const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -461,6 +463,14 @@ export function GMScreensView({ campaignId, isGM = true }: GMScreensViewProps) {
               onEdit={() => setEditingMonsterId(w.documentId)}
             />
           );
+        } else if (w.collection === 'lore') {
+          windowContent = (
+            <LoreWindowWrapper
+              loreId={w.documentId}
+              campaignId={campaignId}
+              onEdit={() => setEditingLoreId(w.documentId)}
+            />
+          );
         } else {
           windowContent = (
             <div className="p-4 overflow-auto h-full">
@@ -478,7 +488,8 @@ export function GMScreensView({ campaignId, isGM = true }: GMScreensViewProps) {
         if (
           w.collection === 'rule' ||
           w.collection === 'character' ||
-          w.collection === 'location'
+          w.collection === 'location' ||
+          w.collection === 'lore'
         ) {
           if (doc?.isPublic === true) {
             titleIcon = (
@@ -761,6 +772,13 @@ export function GMScreensView({ campaignId, isGM = true }: GMScreensViewProps) {
           campaignId={campaignId}
           monsterId={editingMonsterId}
           onClose={() => setEditingMonsterId(null)}
+        />
+      )}
+      {editingLoreId !== null && (
+        <EditLoreModalWrapper
+          campaignId={campaignId}
+          loreId={editingLoreId}
+          onClose={() => setEditingLoreId(null)}
         />
       )}
     </div>

--- a/app/components/mainview/gmscreens/LoreWindowWrapper.tsx
+++ b/app/components/mainview/gmscreens/LoreWindowWrapper.tsx
@@ -1,0 +1,45 @@
+import { LoreWindow } from '~/components/wiki/lore/LoreWindow';
+import { LoreModal } from '~/components/wiki/lore/LoreModal';
+import { useLoreEntry } from '~/hooks/useLore';
+
+export function EditLoreModalWrapper({
+  campaignId,
+  loreId,
+  onClose,
+}: {
+  campaignId: string;
+  loreId: string;
+  onClose: () => void;
+}) {
+  return <LoreModal isOpen onClose={onClose} campaignId={campaignId} loreId={loreId} />;
+}
+
+export function LoreWindowWrapper({
+  loreId,
+  campaignId,
+  onEdit,
+}: {
+  loreId: string;
+  campaignId: string;
+  onEdit: () => void;
+}) {
+  const { lore, isLoading } = useLoreEntry(loreId, campaignId);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-xs text-slate-500 animate-pulse">Loading lore...</p>
+      </div>
+    );
+  }
+
+  if (!lore) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-xs text-slate-500">Lore entry not found</p>
+      </div>
+    );
+  }
+
+  return <LoreWindow lore={lore} onEdit={onEdit} />;
+}

--- a/app/components/mainview/tabletop/TabletopView.tsx
+++ b/app/components/mainview/tabletop/TabletopView.tsx
@@ -24,6 +24,10 @@ import {
   CharacterWindowWrapper,
   EditCharacterModalWrapper,
 } from '~/components/mainview/gmscreens/CharacterWindowWrapper';
+import {
+  LoreWindowWrapper,
+  EditLoreModalWrapper,
+} from '~/components/mainview/gmscreens/LoreWindowWrapper';
 import { RaceWindowWrapper, EditRaceModalWrapper } from '~/components/wiki/races/RaceWindowWrapper';
 import {
   RuleWindowWrapper,
@@ -112,6 +116,7 @@ export function TabletopView({
   const [editingPlayerId, setEditingPlayerId] = useState<string | null>(null);
   const [editingLocationId, setEditingLocationId] = useState<string | null>(null);
   const [editingMonsterId, setEditingMonsterId] = useState<string | null>(null);
+  const [editingLoreId, setEditingLoreId] = useState<string | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
   const [localWindows, setLocalWindows] = useState<ManagedWindow[]>([]);
   const localScreenIdRef = useRef<string | null>(null);
@@ -348,6 +353,14 @@ export function TabletopView({
               onEdit={() => setEditingMonsterId(w.documentId)}
             />
           );
+        } else if (w.collection === 'lore') {
+          windowContent = (
+            <LoreWindowWrapper
+              loreId={w.documentId}
+              campaignId={campaignId}
+              onEdit={() => setEditingLoreId(w.documentId)}
+            />
+          );
         } else {
           windowContent = (
             <div className="p-4 overflow-auto h-full">
@@ -365,7 +378,8 @@ export function TabletopView({
         if (
           w.collection === 'rule' ||
           w.collection === 'character' ||
-          w.collection === 'location'
+          w.collection === 'location' ||
+          w.collection === 'lore'
         ) {
           if (doc?.isPublic === true) {
             titleIcon = (
@@ -661,6 +675,13 @@ export function TabletopView({
           campaignId={campaignId}
           monsterId={editingMonsterId}
           onClose={() => setEditingMonsterId(null)}
+        />
+      )}
+      {editingLoreId !== null && (
+        <EditLoreModalWrapper
+          campaignId={campaignId}
+          loreId={editingLoreId}
+          onClose={() => setEditingLoreId(null)}
         />
       )}
     </div>

--- a/app/components/mainview/tabletop/TabletopView.tsx
+++ b/app/components/mainview/tabletop/TabletopView.tsx
@@ -28,6 +28,7 @@ import {
   LoreWindowWrapper,
   EditLoreModalWrapper,
 } from '~/components/mainview/gmscreens/LoreWindowWrapper';
+import { EventWindowWrapper } from '~/components/mainview/gmscreens/EventWindowWrapper';
 import { RaceWindowWrapper, EditRaceModalWrapper } from '~/components/wiki/races/RaceWindowWrapper';
 import {
   RuleWindowWrapper,
@@ -361,6 +362,8 @@ export function TabletopView({
               onEdit={() => setEditingLoreId(w.documentId)}
             />
           );
+        } else if (w.collection === 'events') {
+          windowContent = <EventWindowWrapper eventId={w.documentId} campaignId={campaignId} />;
         } else {
           windowContent = (
             <div className="p-4 overflow-auto h-full">

--- a/app/components/wiki/WikiPanel.tsx
+++ b/app/components/wiki/WikiPanel.tsx
@@ -9,6 +9,8 @@ import {
   Map as MapIcon,
   Skull,
   BookOpen,
+  CalendarDays,
+  CalendarClock,
 } from 'lucide-react';
 import { CharactersPanel } from './characters/CharactersPanel';
 import { RacesPanel } from './races/RacesPanel';
@@ -18,6 +20,8 @@ import { LocationsPanel } from './locations/LocationsPanel';
 import { MapsPanel } from './maps/MapsPanel';
 import { MonstersPanel } from './monsters/MonstersPanel';
 import { LorePanel } from './lore/LorePanel';
+import { CalendarPanel } from './calendar/CalendarPanel';
+import { EventsPanel } from './calendar/EventsPanel';
 import { useCampaign } from '~/hooks/useCampaigns';
 
 type WikiCategoryId =
@@ -28,7 +32,9 @@ type WikiCategoryId =
   | 'locations'
   | 'lore'
   | 'maps'
-  | 'monsters';
+  | 'monsters'
+  | 'calendar'
+  | 'events';
 
 interface WikiCategory {
   id: WikiCategoryId;
@@ -47,6 +53,8 @@ const WIKI_CATEGORIES: WikiCategory[] = [
   { id: 'lore', label: 'Lore', icon: BookOpen },
   { id: 'maps', label: 'Maps', icon: MapIcon, gmOnly: true },
   { id: 'monsters', label: 'Monsters', icon: Skull, gmOnly: true },
+  { id: 'calendar', label: 'Calendar', icon: CalendarDays },
+  { id: 'events', label: 'Events', icon: CalendarClock, gmOnly: true },
 ];
 
 export function WikiPanel() {
@@ -97,6 +105,10 @@ export function WikiPanel() {
         <MapsPanel onBack={() => setSelectedCategory(null)} />
       ) : selectedCategory === 'monsters' && isGM ? (
         <MonstersPanel onBack={() => setSelectedCategory(null)} />
+      ) : selectedCategory === 'calendar' ? (
+        <CalendarPanel onBack={() => setSelectedCategory(null)} />
+      ) : selectedCategory === 'events' && isGM ? (
+        <EventsPanel onBack={() => setSelectedCategory(null)} />
       ) : null}
     </div>
   );

--- a/app/components/wiki/WikiPanel.tsx
+++ b/app/components/wiki/WikiPanel.tsx
@@ -1,6 +1,15 @@
 import React, { useState } from 'react';
 import { useParams } from '@tanstack/react-router';
-import { Users, Dna, ScrollText, UserCircle, MapPin, Map as MapIcon, Skull } from 'lucide-react';
+import {
+  Users,
+  Dna,
+  ScrollText,
+  UserCircle,
+  MapPin,
+  Map as MapIcon,
+  Skull,
+  BookOpen,
+} from 'lucide-react';
 import { CharactersPanel } from './characters/CharactersPanel';
 import { RacesPanel } from './races/RacesPanel';
 import { RulesPanel } from './rules/RulesPanel';
@@ -8,6 +17,7 @@ import { PlayersPanel } from './players/PlayersPanel';
 import { LocationsPanel } from './locations/LocationsPanel';
 import { MapsPanel } from './maps/MapsPanel';
 import { MonstersPanel } from './monsters/MonstersPanel';
+import { LorePanel } from './lore/LorePanel';
 import { useCampaign } from '~/hooks/useCampaigns';
 
 type WikiCategoryId =
@@ -16,6 +26,7 @@ type WikiCategoryId =
   | 'races'
   | 'rules'
   | 'locations'
+  | 'lore'
   | 'maps'
   | 'monsters';
 
@@ -33,6 +44,7 @@ const WIKI_CATEGORIES: WikiCategory[] = [
   { id: 'races', label: 'Races', icon: Dna },
   { id: 'rules', label: 'Rules', icon: ScrollText },
   { id: 'locations', label: 'Locations', icon: MapPin },
+  { id: 'lore', label: 'Lore', icon: BookOpen },
   { id: 'maps', label: 'Maps', icon: MapIcon, gmOnly: true },
   { id: 'monsters', label: 'Monsters', icon: Skull, gmOnly: true },
 ];
@@ -79,6 +91,8 @@ export function WikiPanel() {
         <RulesPanel onBack={() => setSelectedCategory(null)} />
       ) : selectedCategory === 'locations' ? (
         <LocationsPanel onBack={() => setSelectedCategory(null)} />
+      ) : selectedCategory === 'lore' ? (
+        <LorePanel onBack={() => setSelectedCategory(null)} />
       ) : selectedCategory === 'maps' && isGM ? (
         <MapsPanel onBack={() => setSelectedCategory(null)} />
       ) : selectedCategory === 'monsters' && isGM ? (

--- a/app/components/wiki/calendar/CalDatePicker.tsx
+++ b/app/components/wiki/calendar/CalDatePicker.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import type { CalendarConfig, CalDate } from '~/utils/calendarEngine';
+import { daysInMonth } from '~/utils/calendarEngine';
+
+interface CalDatePickerProps {
+  cfg: CalendarConfig;
+  value: CalDate;
+  onChange: (d: CalDate) => void;
+  disabled?: boolean;
+  idPrefix: string;
+}
+
+export function CalDatePicker({
+  cfg,
+  value,
+  onChange,
+  disabled = false,
+  idPrefix,
+}: CalDatePickerProps) {
+  const maxDay = daysInMonth(cfg, value.year, value.monthIndex);
+  const isZeroLengthMonth = maxDay === 0;
+
+  function handleYearChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const year = parseInt(e.target.value, 10);
+    if (!Number.isFinite(year)) return;
+    const newMax = daysInMonth(cfg, year, value.monthIndex);
+    const clampedDay = newMax === 0 ? 1 : Math.min(value.day, newMax);
+    onChange({ year, monthIndex: value.monthIndex, day: clampedDay });
+  }
+
+  function handleMonthChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const monthIndex = parseInt(e.target.value, 10);
+    const newMax = daysInMonth(cfg, value.year, monthIndex);
+    const clampedDay = newMax === 0 ? 1 : Math.min(value.day, newMax);
+    onChange({ year: value.year, monthIndex, day: clampedDay });
+  }
+
+  function handleDayChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const day = parseInt(e.target.value, 10);
+    onChange({ year: value.year, monthIndex: value.monthIndex, day });
+  }
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      {/* Year */}
+      <input
+        type="number"
+        data-testid={`${idPrefix}-year`}
+        value={value.year}
+        onChange={handleYearChange}
+        disabled={disabled}
+        className="w-20 rounded-md border border-white/[0.1] bg-white/[0.04] px-2 py-1.5 text-xs font-sans text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500/50 disabled:opacity-40 disabled:cursor-not-allowed"
+      />
+
+      {/* Month */}
+      <select
+        data-testid={`${idPrefix}-month`}
+        value={value.monthIndex}
+        onChange={handleMonthChange}
+        disabled={disabled}
+        className="rounded-md border border-white/[0.1] bg-[#0d1117] px-2 py-1.5 text-xs font-sans text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500/50 disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        {cfg.months.map((m, i) => (
+          <option key={i} value={i}>
+            {m.name}
+          </option>
+        ))}
+      </select>
+
+      {/* Day */}
+      {isZeroLengthMonth ? (
+        <span className="text-xs text-amber-400/80 italic">no days this year</span>
+      ) : (
+        <select
+          data-testid={`${idPrefix}-day`}
+          value={value.day}
+          onChange={handleDayChange}
+          disabled={disabled}
+          className="rounded-md border border-white/[0.1] bg-[#0d1117] px-2 py-1.5 text-xs font-sans text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500/50 disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {Array.from({ length: maxDay }, (_, i) => i + 1).map((d) => (
+            <option key={d} value={d}>
+              {d}
+            </option>
+          ))}
+        </select>
+      )}
+    </div>
+  );
+}

--- a/app/components/wiki/calendar/CalendarEditorModal.tsx
+++ b/app/components/wiki/calendar/CalendarEditorModal.tsx
@@ -1,0 +1,13 @@
+// TODO(Task 16): real CalendarEditorModal
+import type { CalendarData } from '~/types/calendar';
+
+interface CalendarEditorModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  campaignId: string;
+  calendar: CalendarData | null;
+}
+
+export function CalendarEditorModal(_props: CalendarEditorModalProps) {
+  return null;
+}

--- a/app/components/wiki/calendar/CalendarEditorModal.tsx
+++ b/app/components/wiki/calendar/CalendarEditorModal.tsx
@@ -1,5 +1,27 @@
-// TODO(Task 16): real CalendarEditorModal
+import React, { useState, useCallback, useMemo } from 'react';
+import { createPortal } from 'react-dom';
+import { X, Plus, Trash2 } from 'lucide-react';
+import { FormInput } from '~/components/FormInput';
+import { PixelButton } from '~/components/PixelButton';
+import { CalDatePicker } from '~/components/wiki/calendar/CalDatePicker';
+import { useUpsertCalendar } from '~/hooks/useCalendar';
+import type { UpsertCalendarInput } from '~/hooks/useCalendar';
+import { HARPTOS_CONFIG } from '~/utils/harptos';
+import { validateDate } from '~/utils/calendarEngine';
+import type {
+  CalendarConfig,
+  CalMonth,
+  CalLeapRule,
+  CalMoon,
+  CalSeason,
+  CalHoliday,
+  CalDate,
+} from '~/utils/calendarEngine';
 import type { CalendarData } from '~/types/calendar';
+
+// ---------------------------------------------------------------------------
+// Prop interface (kept as-is from stub)
+// ---------------------------------------------------------------------------
 
 interface CalendarEditorModalProps {
   isOpen: boolean;
@@ -8,6 +30,1286 @@ interface CalendarEditorModalProps {
   calendar: CalendarData | null;
 }
 
-export function CalendarEditorModal(_props: CalendarEditorModalProps) {
-  return null;
+// ---------------------------------------------------------------------------
+// Small helper types for row editors (no as-any)
+// ---------------------------------------------------------------------------
+
+type MonthRow = { name: string; days: number; isIntercalary: boolean };
+type LeapRow = {
+  name: string;
+  monthIndex: number;
+  interval: number;
+  offset: number;
+  addDays: number;
+};
+type MoonRow = { name: string; cycleLength: number; offsetDays: number; color: string };
+type SeasonRow = { name: string; startMonthIndex: number; startDay: number; color: string };
+type HolidayRow = { name: string; monthIndex: number; day: number; color: string };
+type NamedYearRow = { year: number; name: string };
+
+// ---------------------------------------------------------------------------
+// Default / empty values
+// ---------------------------------------------------------------------------
+
+const DEFAULT_CURRENT_DATE: CalDate = { year: 1, monthIndex: 0, day: 1 };
+const DEFAULT_MONTH: MonthRow = { name: 'Month 1', days: 30, isIntercalary: false };
+
+function defaultFromCalendar(calendar: CalendarData | null): {
+  name: string;
+  description: string;
+  yearSuffix: string;
+  weekdayMode: 'continuous' | 'resetEachMonth';
+  weekdays: string[];
+  months: MonthRow[];
+  leapDays: LeapRow[];
+  moons: MoonRow[];
+  seasons: SeasonRow[];
+  holidays: HolidayRow[];
+  namedYears: NamedYearRow[];
+  currentDate: CalDate;
+  epochYear: number;
+  epochWeekdayIndex: number;
+} {
+  if (!calendar) {
+    return {
+      name: '',
+      description: '',
+      yearSuffix: '',
+      weekdayMode: 'resetEachMonth',
+      weekdays: ['First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth', 'Seventh'],
+      months: [DEFAULT_MONTH],
+      leapDays: [],
+      moons: [],
+      seasons: [],
+      holidays: [],
+      namedYears: [],
+      currentDate: DEFAULT_CURRENT_DATE,
+      epochYear: 1,
+      epochWeekdayIndex: 0,
+    };
+  }
+  return {
+    name: calendar.name,
+    description: calendar.description,
+    yearSuffix: calendar.yearSuffix,
+    weekdayMode: calendar.weekdayMode,
+    weekdays: calendar.weekdays.slice(),
+    months: calendar.months.map((m) => ({
+      name: m.name,
+      days: m.days,
+      isIntercalary: !!m.isIntercalary,
+    })),
+    leapDays: calendar.leapDays.map((l) => ({
+      name: l.name,
+      monthIndex: l.monthIndex,
+      interval: l.interval,
+      offset: l.offset,
+      addDays: l.addDays,
+    })),
+    moons: (calendar.moons ?? []).map((m) => ({
+      name: m.name,
+      cycleLength: m.cycleLength,
+      offsetDays: m.offsetDays,
+      color: m.color ?? '',
+    })),
+    seasons: (calendar.seasons ?? []).map((s) => ({
+      name: s.name,
+      startMonthIndex: s.startMonthIndex,
+      startDay: s.startDay,
+      color: s.color ?? '',
+    })),
+    holidays: (calendar.holidays ?? []).map((h) => ({
+      name: h.name,
+      monthIndex: h.monthIndex,
+      day: h.day,
+      color: h.color ?? '',
+    })),
+    namedYears: calendar.namedYears.map((ny) => ({ year: ny.year, name: ny.name })),
+    currentDate: { ...calendar.currentDate },
+    epochYear: calendar.epoch.year,
+    epochWeekdayIndex: calendar.epoch.weekdayIndex,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Shared sub-component styling helpers
+// ---------------------------------------------------------------------------
+
+const sectionLabelCls = 'block text-xs font-semibold text-slate-400 mb-2 tracking-wide';
+const inputCls =
+  'bg-white/[0.04] border border-white/10 rounded-lg px-2 py-1.5 text-xs text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500/50 placeholder-slate-600';
+const smallInputCls = inputCls + ' w-20';
+const rowBtnCls =
+  'p-1 rounded text-slate-500 hover:text-rose-400 hover:bg-rose-500/10 transition-colors';
+const addBtnCls =
+  'inline-flex items-center gap-1 px-2 py-1 rounded-lg border border-dashed border-white/10 text-xs text-slate-500 hover:text-slate-300 hover:border-white/20 transition-colors';
+
+// ---------------------------------------------------------------------------
+// Generic "string list" editor (weekdays)
+// ---------------------------------------------------------------------------
+
+function WeekdayEditor({
+  weekdays,
+  onChange,
+  disabled,
+}: {
+  weekdays: string[];
+  onChange: (days: string[]) => void;
+  disabled: boolean;
+}) {
+  const update = (idx: number, val: string) => {
+    const next = weekdays.slice();
+    next[idx] = val;
+    onChange(next);
+  };
+  const remove = (idx: number) => onChange(weekdays.filter((_, i) => i !== idx));
+  const add = () => onChange([...weekdays, `Day ${weekdays.length + 1}`]);
+
+  return (
+    <div className="space-y-1.5">
+      {weekdays.map((day, idx) => (
+        <div key={idx} className="flex items-center gap-2">
+          <span className="text-xs text-slate-600 w-5 shrink-0">{idx + 1}.</span>
+          <input
+            className={inputCls + ' flex-1'}
+            value={day}
+            onChange={(e) => update(idx, e.target.value)}
+            disabled={disabled}
+            placeholder={`Day ${idx + 1}`}
+          />
+          <button
+            type="button"
+            onClick={() => remove(idx)}
+            disabled={disabled || weekdays.length <= 1}
+            className={rowBtnCls + (weekdays.length <= 1 ? ' opacity-30 cursor-not-allowed' : '')}
+            aria-label={`Remove weekday ${idx + 1}`}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      ))}
+      <button type="button" onClick={add} disabled={disabled} className={addBtnCls}>
+        <Plus className="h-3 w-3" />
+        Add weekday
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Month rows editor
+// ---------------------------------------------------------------------------
+
+function MonthsEditor({
+  months,
+  onChange,
+  disabled,
+}: {
+  months: MonthRow[];
+  onChange: (m: MonthRow[]) => void;
+  disabled: boolean;
+}) {
+  const update = (idx: number, patch: Partial<MonthRow>) => {
+    const next = months.slice();
+    next[idx] = { ...next[idx]!, ...patch };
+    onChange(next);
+  };
+  const remove = (idx: number) => onChange(months.filter((_, i) => i !== idx));
+  const add = () =>
+    onChange([...months, { name: `Month ${months.length + 1}`, days: 30, isIntercalary: false }]);
+
+  return (
+    <div className="space-y-1.5">
+      <div className="grid grid-cols-[1fr_64px_80px_28px] gap-2 text-[10px] text-slate-600 font-semibold uppercase tracking-wide px-1 mb-1">
+        <span>Name</span>
+        <span>Days</span>
+        <span>Intercalary</span>
+        <span />
+      </div>
+      {months.map((m, idx) => (
+        <div key={idx} className="grid grid-cols-[1fr_64px_80px_28px] gap-2 items-center">
+          <input
+            className={inputCls + ' w-full'}
+            value={m.name}
+            onChange={(e) => update(idx, { name: e.target.value })}
+            disabled={disabled}
+            placeholder={`Month ${idx + 1}`}
+          />
+          <input
+            type="number"
+            className={inputCls + ' w-full'}
+            value={m.days}
+            min={0}
+            onChange={(e) => update(idx, { days: Math.max(0, parseInt(e.target.value, 10) || 0) })}
+            disabled={disabled}
+          />
+          <label className="flex items-center gap-1.5 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={m.isIntercalary}
+              onChange={(e) => update(idx, { isIntercalary: e.target.checked })}
+              disabled={disabled}
+              className="rounded"
+            />
+            <span className="text-xs text-slate-500">Intercalary</span>
+          </label>
+          <button
+            type="button"
+            onClick={() => remove(idx)}
+            disabled={disabled || months.length <= 1}
+            className={rowBtnCls + (months.length <= 1 ? ' opacity-30 cursor-not-allowed' : '')}
+            aria-label={`Remove month ${idx + 1}`}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      ))}
+      <button type="button" onClick={add} disabled={disabled} className={addBtnCls}>
+        <Plus className="h-3 w-3" />
+        Add month
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Leap days editor
+// ---------------------------------------------------------------------------
+
+function LeapDaysEditor({
+  leapDays,
+  months,
+  onChange,
+  disabled,
+}: {
+  leapDays: LeapRow[];
+  months: MonthRow[];
+  onChange: (l: LeapRow[]) => void;
+  disabled: boolean;
+}) {
+  const update = (idx: number, patch: Partial<LeapRow>) => {
+    const next = leapDays.slice();
+    next[idx] = { ...next[idx]!, ...patch };
+    onChange(next);
+  };
+  const remove = (idx: number) => onChange(leapDays.filter((_, i) => i !== idx));
+  const add = () =>
+    onChange([...leapDays, { name: '', monthIndex: 0, interval: 4, offset: 0, addDays: 1 }]);
+
+  return (
+    <div className="space-y-2">
+      {leapDays.map((l, idx) => (
+        <div
+          key={idx}
+          className="flex flex-wrap items-end gap-2 p-2 rounded-lg bg-white/[0.02] border border-white/[0.05]"
+        >
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-slate-600">Name</span>
+            <input
+              className={inputCls + ' w-32'}
+              value={l.name}
+              onChange={(e) => update(idx, { name: e.target.value })}
+              disabled={disabled}
+              placeholder="Leap day name"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-slate-600">Month</span>
+            <select
+              className={inputCls}
+              value={l.monthIndex}
+              onChange={(e) => update(idx, { monthIndex: parseInt(e.target.value, 10) })}
+              disabled={disabled}
+            >
+              {months.map((m, mi) => (
+                <option key={mi} value={mi}>
+                  {m.name || `Month ${mi + 1}`}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-slate-600">Interval</span>
+            <input
+              type="number"
+              className={smallInputCls}
+              value={l.interval}
+              min={1}
+              onChange={(e) =>
+                update(idx, { interval: Math.max(1, parseInt(e.target.value, 10) || 1) })
+              }
+              disabled={disabled}
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-slate-600">Offset</span>
+            <input
+              type="number"
+              className={smallInputCls}
+              value={l.offset}
+              onChange={(e) => update(idx, { offset: parseInt(e.target.value, 10) || 0 })}
+              disabled={disabled}
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-slate-600">Add days</span>
+            <input
+              type="number"
+              className={smallInputCls}
+              value={l.addDays}
+              min={1}
+              onChange={(e) =>
+                update(idx, { addDays: Math.max(1, parseInt(e.target.value, 10) || 1) })
+              }
+              disabled={disabled}
+            />
+          </div>
+          <button
+            type="button"
+            onClick={() => remove(idx)}
+            disabled={disabled}
+            className={rowBtnCls}
+            aria-label="Remove leap rule"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      ))}
+      <button type="button" onClick={add} disabled={disabled} className={addBtnCls}>
+        <Plus className="h-3 w-3" />
+        Add leap rule
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Moons editor
+// ---------------------------------------------------------------------------
+
+function MoonsEditor({
+  moons,
+  onChange,
+  disabled,
+}: {
+  moons: MoonRow[];
+  onChange: (m: MoonRow[]) => void;
+  disabled: boolean;
+}) {
+  const update = (idx: number, patch: Partial<MoonRow>) => {
+    const next = moons.slice();
+    next[idx] = { ...next[idx]!, ...patch };
+    onChange(next);
+  };
+  const remove = (idx: number) => onChange(moons.filter((_, i) => i !== idx));
+  const add = () => onChange([...moons, { name: '', cycleLength: 30, offsetDays: 0, color: '' }]);
+
+  return (
+    <div className="space-y-2">
+      {moons.map((m, idx) => (
+        <div
+          key={idx}
+          className="flex flex-wrap items-end gap-2 p-2 rounded-lg bg-white/[0.02] border border-white/[0.05]"
+        >
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-slate-600">Name</span>
+            <input
+              className={inputCls + ' w-28'}
+              value={m.name}
+              onChange={(e) => update(idx, { name: e.target.value })}
+              disabled={disabled}
+              placeholder="Moon name"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-slate-600">Cycle (days)</span>
+            <input
+              type="number"
+              className={smallInputCls}
+              value={m.cycleLength}
+              min={1}
+              onChange={(e) =>
+                update(idx, { cycleLength: Math.max(1, parseInt(e.target.value, 10) || 1) })
+              }
+              disabled={disabled}
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-slate-600">Offset days</span>
+            <input
+              type="number"
+              className={smallInputCls}
+              value={m.offsetDays}
+              onChange={(e) => update(idx, { offsetDays: parseInt(e.target.value, 10) || 0 })}
+              disabled={disabled}
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-slate-600">Color</span>
+            <input
+              className={inputCls + ' w-20'}
+              value={m.color}
+              onChange={(e) => update(idx, { color: e.target.value })}
+              disabled={disabled}
+              placeholder="#hex"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={() => remove(idx)}
+            disabled={disabled}
+            className={rowBtnCls}
+            aria-label="Remove moon"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      ))}
+      <button type="button" onClick={add} disabled={disabled} className={addBtnCls}>
+        <Plus className="h-3 w-3" />
+        Add moon
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Seasons editor
+// ---------------------------------------------------------------------------
+
+function SeasonsEditor({
+  seasons,
+  months,
+  onChange,
+  disabled,
+}: {
+  seasons: SeasonRow[];
+  months: MonthRow[];
+  onChange: (s: SeasonRow[]) => void;
+  disabled: boolean;
+}) {
+  const update = (idx: number, patch: Partial<SeasonRow>) => {
+    const next = seasons.slice();
+    next[idx] = { ...next[idx]!, ...patch };
+    onChange(next);
+  };
+  const remove = (idx: number) => onChange(seasons.filter((_, i) => i !== idx));
+  const add = () =>
+    onChange([...seasons, { name: '', startMonthIndex: 0, startDay: 1, color: '' }]);
+
+  return (
+    <div className="space-y-2">
+      {seasons.map((s, idx) => (
+        <div
+          key={idx}
+          className="flex flex-wrap items-end gap-2 p-2 rounded-lg bg-white/[0.02] border border-white/[0.05]"
+        >
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-slate-600">Name</span>
+            <input
+              className={inputCls + ' w-28'}
+              value={s.name}
+              onChange={(e) => update(idx, { name: e.target.value })}
+              disabled={disabled}
+              placeholder="Season name"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-slate-600">Start month</span>
+            <select
+              className={inputCls}
+              value={s.startMonthIndex}
+              onChange={(e) => update(idx, { startMonthIndex: parseInt(e.target.value, 10) })}
+              disabled={disabled}
+            >
+              {months.map((m, mi) => (
+                <option key={mi} value={mi}>
+                  {m.name || `Month ${mi + 1}`}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-slate-600">Start day</span>
+            <input
+              type="number"
+              className={smallInputCls}
+              value={s.startDay}
+              min={1}
+              onChange={(e) =>
+                update(idx, { startDay: Math.max(1, parseInt(e.target.value, 10) || 1) })
+              }
+              disabled={disabled}
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-slate-600">Color</span>
+            <input
+              className={inputCls + ' w-20'}
+              value={s.color}
+              onChange={(e) => update(idx, { color: e.target.value })}
+              disabled={disabled}
+              placeholder="#hex"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={() => remove(idx)}
+            disabled={disabled}
+            className={rowBtnCls}
+            aria-label="Remove season"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      ))}
+      <button type="button" onClick={add} disabled={disabled} className={addBtnCls}>
+        <Plus className="h-3 w-3" />
+        Add season
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Holidays editor
+// ---------------------------------------------------------------------------
+
+function HolidaysEditor({
+  holidays,
+  months,
+  onChange,
+  disabled,
+}: {
+  holidays: HolidayRow[];
+  months: MonthRow[];
+  onChange: (h: HolidayRow[]) => void;
+  disabled: boolean;
+}) {
+  const update = (idx: number, patch: Partial<HolidayRow>) => {
+    const next = holidays.slice();
+    next[idx] = { ...next[idx]!, ...patch };
+    onChange(next);
+  };
+  const remove = (idx: number) => onChange(holidays.filter((_, i) => i !== idx));
+  const add = () => onChange([...holidays, { name: '', monthIndex: 0, day: 1, color: '' }]);
+
+  return (
+    <div className="space-y-2">
+      {holidays.map((h, idx) => (
+        <div
+          key={idx}
+          className="flex flex-wrap items-end gap-2 p-2 rounded-lg bg-white/[0.02] border border-white/[0.05]"
+        >
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-slate-600">Name</span>
+            <input
+              className={inputCls + ' w-28'}
+              value={h.name}
+              onChange={(e) => update(idx, { name: e.target.value })}
+              disabled={disabled}
+              placeholder="Holiday name"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-slate-600">Month</span>
+            <select
+              className={inputCls}
+              value={h.monthIndex}
+              onChange={(e) => update(idx, { monthIndex: parseInt(e.target.value, 10) })}
+              disabled={disabled}
+            >
+              {months.map((m, mi) => (
+                <option key={mi} value={mi}>
+                  {m.name || `Month ${mi + 1}`}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-slate-600">Day</span>
+            <input
+              type="number"
+              className={smallInputCls}
+              value={h.day}
+              min={1}
+              onChange={(e) => update(idx, { day: Math.max(1, parseInt(e.target.value, 10) || 1) })}
+              disabled={disabled}
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-slate-600">Color</span>
+            <input
+              className={inputCls + ' w-20'}
+              value={h.color}
+              onChange={(e) => update(idx, { color: e.target.value })}
+              disabled={disabled}
+              placeholder="#hex"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={() => remove(idx)}
+            disabled={disabled}
+            className={rowBtnCls}
+            aria-label="Remove holiday"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      ))}
+      <button type="button" onClick={add} disabled={disabled} className={addBtnCls}>
+        <Plus className="h-3 w-3" />
+        Add holiday
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Named years editor
+// ---------------------------------------------------------------------------
+
+function NamedYearsEditor({
+  namedYears,
+  onChange,
+  disabled,
+}: {
+  namedYears: NamedYearRow[];
+  onChange: (ny: NamedYearRow[]) => void;
+  disabled: boolean;
+}) {
+  const update = (idx: number, patch: Partial<NamedYearRow>) => {
+    const next = namedYears.slice();
+    next[idx] = { ...next[idx]!, ...patch };
+    onChange(next);
+  };
+  const remove = (idx: number) => onChange(namedYears.filter((_, i) => i !== idx));
+  const add = () => onChange([...namedYears, { year: 1, name: '' }]);
+
+  return (
+    <div className="space-y-1.5">
+      {namedYears.map((ny, idx) => (
+        <div key={idx} className="flex items-center gap-2">
+          <input
+            type="number"
+            className={smallInputCls}
+            value={ny.year}
+            onChange={(e) => update(idx, { year: parseInt(e.target.value, 10) || 0 })}
+            disabled={disabled}
+          />
+          <input
+            className={inputCls + ' flex-1'}
+            value={ny.name}
+            onChange={(e) => update(idx, { name: e.target.value })}
+            disabled={disabled}
+            placeholder="Year name"
+          />
+          <button
+            type="button"
+            onClick={() => remove(idx)}
+            disabled={disabled}
+            className={rowBtnCls}
+            aria-label="Remove named year"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      ))}
+      <button type="button" onClick={add} disabled={disabled} className={addBtnCls}>
+        <Plus className="h-3 w-3" />
+        Add named year
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section wrapper
+// ---------------------------------------------------------------------------
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-2">
+      <h3 className={sectionLabelCls}>{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function CalendarEditorModal({
+  isOpen,
+  onClose,
+  campaignId,
+  calendar,
+}: CalendarEditorModalProps) {
+  const isEdit = calendar !== null;
+  const { save, isLoading: isSaving } = useUpsertCalendar();
+
+  // ---- Form state ----
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [yearSuffix, setYearSuffix] = useState('');
+  const [weekdayMode, setWeekdayMode] = useState<'continuous' | 'resetEachMonth'>('resetEachMonth');
+  const [weekdays, setWeekdays] = useState<string[]>(['First']);
+  const [months, setMonths] = useState<MonthRow[]>([DEFAULT_MONTH]);
+  const [leapDays, setLeapDays] = useState<LeapRow[]>([]);
+  const [moons, setMoons] = useState<MoonRow[]>([]);
+  const [seasons, setSeasons] = useState<SeasonRow[]>([]);
+  const [holidays, setHolidays] = useState<HolidayRow[]>([]);
+  const [namedYears, setNamedYears] = useState<NamedYearRow[]>([]);
+  const [currentDate, setCurrentDate] = useState<CalDate>(DEFAULT_CURRENT_DATE);
+  const [epochYear, setEpochYear] = useState(1);
+  const [epochWeekdayIndex, setEpochWeekdayIndex] = useState(0);
+
+  // ---- Error / warning state ----
+  const [error, setError] = useState<string | null>(null);
+  const [fieldError, setFieldError] = useState<{ name?: string; currentDate?: string }>({});
+  const [warningBanner, setWarningBanner] = useState<string | null>(null);
+
+  // ---- Populate / reset when modal opens ----
+  // We use a ref-free approach: populate on each open, using isOpen as the trigger.
+  // (useModalForm is LoreModal-specific; we inline equivalent logic.)
+  const [lastOpenKey, setLastOpenKey] = useState<string | null>(null);
+  const openKey = isOpen ? (calendar?.id ?? '__new__') : null;
+
+  if (openKey !== lastOpenKey) {
+    // Synchronous state update during render (React's prescribed pattern for
+    // "derived from props" — keeps all state in sync without useEffect).
+    setLastOpenKey(openKey);
+    if (openKey !== null) {
+      const d = defaultFromCalendar(calendar);
+      setName(d.name);
+      setDescription(d.description);
+      setYearSuffix(d.yearSuffix);
+      setWeekdayMode(d.weekdayMode);
+      setWeekdays(d.weekdays);
+      setMonths(d.months);
+      setLeapDays(d.leapDays);
+      setMoons(d.moons);
+      setSeasons(d.seasons);
+      setHolidays(d.holidays);
+      setNamedYears(d.namedYears);
+      setCurrentDate(d.currentDate);
+      setEpochYear(d.epochYear);
+      setEpochWeekdayIndex(d.epochWeekdayIndex);
+      setError(null);
+      setFieldError({});
+      setWarningBanner(null);
+    }
+  }
+
+  // ---- In-progress CalendarConfig (built from current form state) ----
+  const cfgInProgress = useMemo((): CalendarConfig => {
+    return {
+      months: months.map(
+        (m): CalMonth => ({
+          name: m.name,
+          days: m.days,
+          ...(m.isIntercalary ? { isIntercalary: true } : {}),
+        })
+      ),
+      weekdays: weekdays.length > 0 ? weekdays : ['Day'],
+      weekdayMode,
+      epoch: { year: epochYear, weekdayIndex: epochWeekdayIndex },
+      yearSuffix,
+      leapDays: leapDays.map(
+        (l): CalLeapRule => ({
+          name: l.name,
+          monthIndex: l.monthIndex,
+          interval: l.interval,
+          offset: l.offset,
+          addDays: l.addDays,
+        })
+      ),
+      moons: moons.map(
+        (m): CalMoon => ({
+          name: m.name,
+          cycleLength: m.cycleLength,
+          offsetDays: m.offsetDays,
+          ...(m.color ? { color: m.color } : {}),
+        })
+      ),
+      seasons: seasons.map(
+        (s): CalSeason => ({
+          name: s.name,
+          startMonthIndex: s.startMonthIndex,
+          startDay: s.startDay,
+          ...(s.color ? { color: s.color } : {}),
+        })
+      ),
+      holidays: holidays.map(
+        (h): CalHoliday => ({
+          name: h.name,
+          monthIndex: h.monthIndex,
+          day: h.day,
+          ...(h.color ? { color: h.color } : {}),
+        })
+      ),
+    };
+  }, [
+    months,
+    weekdays,
+    weekdayMode,
+    epochYear,
+    epochWeekdayIndex,
+    yearSuffix,
+    leapDays,
+    moons,
+    seasons,
+    holidays,
+  ]);
+
+  // Clamp currentDate monthIndex if months changed and it's now out of bounds.
+  const safeCurrentDate = useMemo((): CalDate => {
+    if (currentDate.monthIndex >= months.length) {
+      return { year: currentDate.year, monthIndex: 0, day: 1 };
+    }
+    return currentDate;
+  }, [currentDate, months.length]);
+
+  // ---- Harptos preset ----
+  const handleLoadHarptos = useCallback(() => {
+    setName('Calendar of Harptos');
+    setDescription('The official calendar of Faerûn, used throughout the Forgotten Realms.');
+    setYearSuffix(HARPTOS_CONFIG.yearSuffix ?? 'DR');
+    setWeekdayMode(HARPTOS_CONFIG.weekdayMode);
+    setWeekdays(HARPTOS_CONFIG.weekdays.slice());
+    setMonths(
+      HARPTOS_CONFIG.months.map((m) => ({
+        name: m.name,
+        days: m.days,
+        isIntercalary: !!m.isIntercalary,
+      }))
+    );
+    setLeapDays(
+      HARPTOS_CONFIG.leapDays.map((l) => ({
+        name: l.name,
+        monthIndex: l.monthIndex,
+        interval: l.interval,
+        offset: l.offset,
+        addDays: l.addDays,
+      }))
+    );
+    setMoons(
+      (HARPTOS_CONFIG.moons ?? []).map((m) => ({
+        name: m.name,
+        cycleLength: m.cycleLength,
+        offsetDays: m.offsetDays,
+        color: m.color ?? '',
+      }))
+    );
+    setSeasons(
+      (HARPTOS_CONFIG.seasons ?? []).map((s) => ({
+        name: s.name,
+        startMonthIndex: s.startMonthIndex,
+        startDay: s.startDay,
+        color: s.color ?? '',
+      }))
+    );
+    setHolidays(
+      (HARPTOS_CONFIG.holidays ?? []).map((h) => ({
+        name: h.name,
+        monthIndex: h.monthIndex,
+        day: h.day,
+        color: h.color ?? '',
+      }))
+    );
+    setNamedYears([]);
+    setEpochYear(HARPTOS_CONFIG.epoch.year);
+    setEpochWeekdayIndex(HARPTOS_CONFIG.epoch.weekdayIndex);
+    setCurrentDate({ year: 1491, monthIndex: 6, day: 15 });
+    setFieldError({});
+    setError(null);
+    setWarningBanner(null);
+  }, []);
+
+  // ---- Save ----
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      setError(null);
+      setWarningBanner(null);
+
+      const errors: { name?: string; currentDate?: string } = {};
+      if (!name.trim()) errors.name = 'Name is required';
+      if (months.length < 1) errors.name = errors.name ?? 'At least one month is required';
+      if (weekdays.length < 1) errors.name = errors.name ?? 'At least one weekday is required';
+
+      // Validate currentDate against in-progress config
+      const dateCheck = validateDate(cfgInProgress, safeCurrentDate);
+      if (!dateCheck.ok) {
+        errors.currentDate = dateCheck.error ?? 'Current date is invalid for this calendar';
+      }
+
+      setFieldError(errors);
+      if (Object.keys(errors).length > 0) return;
+
+      const input: UpsertCalendarInput = {
+        campaignId,
+        name: name.trim(),
+        description,
+        yearSuffix,
+        weekdayMode,
+        weekdays,
+        months: months.map(
+          (m): CalMonth => ({
+            name: m.name,
+            days: m.days,
+            ...(m.isIntercalary ? { isIntercalary: true } : {}),
+          })
+        ),
+        leapDays: leapDays.map(
+          (l): CalLeapRule => ({
+            name: l.name,
+            monthIndex: l.monthIndex,
+            interval: l.interval,
+            offset: l.offset,
+            addDays: l.addDays,
+          })
+        ),
+        moons: moons.map(
+          (m): CalMoon => ({
+            name: m.name,
+            cycleLength: m.cycleLength,
+            offsetDays: m.offsetDays,
+            ...(m.color ? { color: m.color } : {}),
+          })
+        ),
+        seasons: seasons.map(
+          (s): CalSeason => ({
+            name: s.name,
+            startMonthIndex: s.startMonthIndex,
+            startDay: s.startDay,
+            ...(s.color ? { color: s.color } : {}),
+          })
+        ),
+        holidays: holidays.map(
+          (h): CalHoliday => ({
+            name: h.name,
+            monthIndex: h.monthIndex,
+            day: h.day,
+            ...(h.color ? { color: h.color } : {}),
+          })
+        ),
+        namedYears,
+        currentDate: safeCurrentDate,
+        epoch: { year: epochYear, weekdayIndex: epochWeekdayIndex },
+      };
+
+      const result = await save(input);
+
+      if (result === null) {
+        setError(`Failed to ${isEdit ? 'update' : 'create'} calendar. Please try again.`);
+        return;
+      }
+
+      // Non-blocking warning if events now have out-of-range dates
+      const invalidCount = result.invalidEventIds?.length ?? 0;
+      if (invalidCount > 0) {
+        setWarningBanner(
+          `${invalidCount} event${invalidCount === 1 ? '' : 's'} now ${invalidCount === 1 ? 'has a date' : 'have dates'} outside the new calendar and need${invalidCount === 1 ? 's' : ''} fixing`
+        );
+        // Keep modal open to show the warning; user can close manually
+        return;
+      }
+
+      onClose();
+    },
+    [
+      name,
+      description,
+      yearSuffix,
+      weekdayMode,
+      weekdays,
+      months,
+      leapDays,
+      moons,
+      seasons,
+      holidays,
+      namedYears,
+      safeCurrentDate,
+      cfgInProgress,
+      epochYear,
+      epochWeekdayIndex,
+      campaignId,
+      isEdit,
+      save,
+      onClose,
+    ]
+  );
+
+  // Rules of Hooks: all hooks above, `if (!isOpen) return null` is AFTER all hooks.
+  if (!isOpen) return null;
+
+  const isDisabled = isSaving;
+
+  return createPortal(
+    <div
+      role="presentation"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-2 sm:p-4 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <form
+        data-testid="calendar-editor"
+        onSubmit={handleSubmit}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="calendar-editor-title"
+        className="w-full h-full max-w-[90vw] max-h-[90vh] sm:max-w-[90vw] sm:max-h-[90vh] bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col"
+      >
+        {/* Header */}
+        <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
+          <h2
+            id="calendar-editor-title"
+            className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest"
+          >
+            {isEdit ? 'Edit Calendar' : 'Create Calendar'}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-slate-500 hover:text-white transition-colors"
+            aria-label="Close modal"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </header>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto p-4 sm:p-6 space-y-6 min-h-0">
+          {/* Error banner */}
+          {error && (
+            <div className="p-3 bg-rose-500/10 border border-rose-500/20 rounded-lg text-rose-400 text-xs font-semibold">
+              {error}
+            </div>
+          )}
+
+          {/* Warning banner (non-blocking) */}
+          {warningBanner && (
+            <div className="p-3 bg-amber-500/10 border border-amber-500/20 rounded-lg text-amber-400 text-xs font-semibold flex items-start justify-between gap-2">
+              <span>{warningBanner}</span>
+              <button
+                type="button"
+                onClick={() => setWarningBanner(null)}
+                className="text-amber-400/70 hover:text-amber-300 shrink-0"
+                aria-label="Dismiss warning"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+          )}
+
+          {/* Harptos preset */}
+          <div>
+            <button
+              type="button"
+              data-testid="calendar-harptos-button"
+              onClick={handleLoadHarptos}
+              disabled={isDisabled}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-amber-600/20 border border-amber-500/30 text-amber-400 hover:bg-amber-600/30 text-xs font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Load Calendar of Harptos
+            </button>
+            <p className="text-[10px] text-slate-600 mt-1.5">
+              Fills all fields with the Faerûnian calendar (DR reckoning).
+            </p>
+          </div>
+
+          {/* Name */}
+          <FormInput
+            label="Calendar name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            error={fieldError.name}
+            required
+            disabled={isDisabled}
+            placeholder="e.g. Calendar of Harptos"
+            data-testid="calendar-name-input"
+          />
+
+          {/* Description */}
+          <div>
+            <label className={sectionLabelCls} htmlFor="calendar-description">
+              Description
+            </label>
+            <textarea
+              id="calendar-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              disabled={isDisabled}
+              placeholder="Optional description…"
+              rows={3}
+              className="w-full bg-white/[0.04] border border-white/10 rounded-xl px-4 py-3 text-slate-200 text-sm placeholder-slate-700 focus:outline-none focus:bg-white/[0.06] transition-all resize-none disabled:opacity-50 disabled:cursor-not-allowed"
+            />
+          </div>
+
+          {/* Year suffix */}
+          <FormInput
+            label="Year suffix"
+            value={yearSuffix}
+            onChange={(e) => setYearSuffix(e.target.value)}
+            disabled={isDisabled}
+            placeholder="e.g. DR, CE, AE"
+          />
+
+          {/* Weekday mode */}
+          <Section title="Weekday mode">
+            <div className="flex items-center gap-6">
+              {(['continuous', 'resetEachMonth'] as const).map((mode) => (
+                <label key={mode} className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="weekday-mode"
+                    value={mode}
+                    checked={weekdayMode === mode}
+                    onChange={() => setWeekdayMode(mode)}
+                    disabled={isDisabled}
+                    className="accent-blue-500"
+                  />
+                  <span className="text-xs text-slate-300">
+                    {mode === 'continuous' ? 'Continuous (weeks span months)' : 'Reset each month'}
+                  </span>
+                </label>
+              ))}
+            </div>
+          </Section>
+
+          {/* Epoch */}
+          <Section title="Epoch (for continuous weekday mode)">
+            <div className="flex items-end gap-4 flex-wrap">
+              <div className="flex flex-col gap-1">
+                <label className="text-[10px] text-slate-600" htmlFor="epoch-year">
+                  Epoch year
+                </label>
+                <input
+                  id="epoch-year"
+                  type="number"
+                  className={smallInputCls}
+                  value={epochYear}
+                  onChange={(e) => setEpochYear(parseInt(e.target.value, 10) || 0)}
+                  disabled={isDisabled}
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className="text-[10px] text-slate-600" htmlFor="epoch-weekday">
+                  Starting weekday index (0 = first weekday)
+                </label>
+                <input
+                  id="epoch-weekday"
+                  type="number"
+                  className={smallInputCls}
+                  value={epochWeekdayIndex}
+                  min={0}
+                  onChange={(e) =>
+                    setEpochWeekdayIndex(Math.max(0, parseInt(e.target.value, 10) || 0))
+                  }
+                  disabled={isDisabled}
+                />
+              </div>
+            </div>
+          </Section>
+
+          {/* Weekdays */}
+          <Section title="Weekdays (at least 1 required)">
+            <WeekdayEditor weekdays={weekdays} onChange={setWeekdays} disabled={isDisabled} />
+          </Section>
+
+          {/* Months */}
+          <Section title="Months (at least 1 required)">
+            <MonthsEditor months={months} onChange={setMonths} disabled={isDisabled} />
+          </Section>
+
+          {/* Leap days */}
+          <Section title="Leap day rules">
+            <LeapDaysEditor
+              leapDays={leapDays}
+              months={months}
+              onChange={setLeapDays}
+              disabled={isDisabled}
+            />
+          </Section>
+
+          {/* Moons */}
+          <Section title="Moons">
+            <MoonsEditor moons={moons} onChange={setMoons} disabled={isDisabled} />
+          </Section>
+
+          {/* Seasons */}
+          <Section title="Seasons">
+            <SeasonsEditor
+              seasons={seasons}
+              months={months}
+              onChange={setSeasons}
+              disabled={isDisabled}
+            />
+          </Section>
+
+          {/* Holidays */}
+          <Section title="Holidays">
+            <HolidaysEditor
+              holidays={holidays}
+              months={months}
+              onChange={setHolidays}
+              disabled={isDisabled}
+            />
+          </Section>
+
+          {/* Named years */}
+          <Section title="Named years">
+            <NamedYearsEditor
+              namedYears={namedYears}
+              onChange={setNamedYears}
+              disabled={isDisabled}
+            />
+          </Section>
+
+          {/* Current date */}
+          <Section title="Current date">
+            {fieldError.currentDate && (
+              <p className="text-xs text-red-400 mb-1" role="alert">
+                {fieldError.currentDate}
+              </p>
+            )}
+            <CalDatePicker
+              cfg={cfgInProgress}
+              value={safeCurrentDate}
+              onChange={setCurrentDate}
+              disabled={isDisabled}
+              idPrefix="calendar-current-date"
+            />
+          </Section>
+        </div>
+
+        {/* Footer */}
+        <footer className="flex items-center justify-end px-4 sm:px-6 py-4 border-t border-white/[0.07] bg-white/[0.01] shrink-0 gap-3">
+          <PixelButton
+            variant="secondary"
+            size="sm"
+            onClick={onClose}
+            disabled={isSaving}
+            type="button"
+          >
+            Cancel
+          </PixelButton>
+          <PixelButton
+            variant="primary"
+            size="sm"
+            disabled={isDisabled}
+            type="submit"
+            data-testid="calendar-save-button"
+          >
+            {isSaving ? 'Saving…' : isEdit ? 'Update calendar' : 'Create calendar'}
+          </PixelButton>
+        </footer>
+      </form>
+    </div>,
+    document.body
+  );
 }

--- a/app/components/wiki/calendar/CalendarEditorModal.tsx
+++ b/app/components/wiki/calendar/CalendarEditorModal.tsx
@@ -20,7 +20,7 @@ import type {
 import type { CalendarData } from '~/types/calendar';
 
 // ---------------------------------------------------------------------------
-// Prop interface (kept as-is from stub)
+// Prop interface
 // ---------------------------------------------------------------------------
 
 interface CalendarEditorModalProps {

--- a/app/components/wiki/calendar/CalendarGridView.tsx
+++ b/app/components/wiki/calendar/CalendarGridView.tsx
@@ -1,0 +1,268 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import type { CalendarConfig, CalDate } from '~/utils/calendarEngine';
+import {
+  monthGrid,
+  toOrdinal,
+  compareDates,
+  holidaysOn,
+  moonPhase,
+  seasonOf,
+} from '~/utils/calendarEngine';
+import type { EventListItem } from '~/types/event';
+
+interface CalendarGridViewProps {
+  cfg: CalendarConfig;
+  year: number;
+  monthIndex: number;
+  events: EventListItem[];
+  currentDate: CalDate;
+  onPrev(): void;
+  onNext(): void;
+  onSelectDay(date: CalDate): void;
+}
+
+/** Moon phase fraction → a compact unicode symbol. */
+function moonSymbol(phase: number): string {
+  if (phase < 0.0625) return '🌑';
+  if (phase < 0.1875) return '🌒';
+  if (phase < 0.3125) return '🌓';
+  if (phase < 0.4375) return '🌔';
+  if (phase < 0.5625) return '🌕';
+  if (phase < 0.6875) return '🌖';
+  if (phase < 0.8125) return '🌗';
+  if (phase < 0.9375) return '🌘';
+  return '🌑';
+}
+
+export function CalendarGridView({
+  cfg,
+  year,
+  monthIndex,
+  events,
+  currentDate,
+  onPrev,
+  onNext,
+  onSelectDay,
+}: CalendarGridViewProps) {
+  const month = cfg.months[monthIndex];
+  const yearLabel = `${year}${cfg.yearSuffix ? ` ${cfg.yearSuffix}` : ''}`;
+  const monthName = month?.name ?? '';
+
+  // --- Navigation header (shared by both views) ---
+  const header = (
+    <div className="flex items-center justify-between px-4 py-2 border-b border-white/[0.07]">
+      <button
+        type="button"
+        onClick={onPrev}
+        className="p-1.5 rounded-md text-slate-400 hover:text-slate-200 hover:bg-white/[0.05] transition-colors"
+        aria-label="Previous month"
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </button>
+      <span className="text-sm font-semibold text-slate-200">
+        {monthName} <span className="text-slate-400 font-normal">{yearLabel}</span>
+      </span>
+      <button
+        type="button"
+        onClick={onNext}
+        className="p-1.5 rounded-md text-slate-400 hover:text-slate-200 hover:bg-white/[0.05] transition-colors"
+        aria-label="Next month"
+      >
+        <ChevronRight className="h-4 w-4" />
+      </button>
+    </div>
+  );
+
+  // --- Intercalary: festival banner ---
+  if (month?.isIntercalary) {
+    const festivalEvents = events.filter(
+      (ev) => ev.start.year === year && ev.start.monthIndex === monthIndex && ev.start.day === 1
+    );
+    return (
+      <div
+        data-testid="calendar-grid"
+        className="flex flex-col bg-[#080A12] rounded-lg overflow-hidden border border-white/[0.07]"
+      >
+        {header}
+        <div className="flex flex-col items-center justify-center gap-3 p-8 text-center">
+          <div className="h-16 w-16 rounded-full bg-amber-500/10 border border-amber-500/20 flex items-center justify-center mb-1">
+            <span className="text-2xl">✨</span>
+          </div>
+          <p className="text-base font-bold text-amber-300">{monthName}</p>
+          <p className="text-xs text-slate-500">Festival day — {yearLabel}</p>
+          {festivalEvents.length > 0 && (
+            <div className="mt-2 flex flex-col gap-1.5 w-full max-w-xs">
+              {festivalEvents.map((ev) => (
+                <div
+                  key={ev.id}
+                  className="px-3 py-1.5 rounded-md bg-white/[0.04] border border-white/[0.08] text-xs text-slate-300 truncate"
+                  style={ev.color ? { borderLeftColor: ev.color, borderLeftWidth: 3 } : undefined}
+                >
+                  {ev.title}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // --- Regular grid ---
+  const rows = monthGrid(cfg, year, monthIndex);
+
+  // Footer info: use first day of month's ordinal
+  const firstOrdinal = toOrdinal(cfg, { year, monthIndex, day: 1 });
+  const season = seasonOf(cfg, firstOrdinal);
+  const moons = cfg.moons ?? [];
+
+  return (
+    <div
+      data-testid="calendar-grid"
+      className="flex flex-col bg-[#080A12] rounded-lg overflow-hidden border border-white/[0.07]"
+    >
+      {header}
+
+      {/* Weekday header row */}
+      <div
+        className="grid border-b border-white/[0.07]"
+        style={{ gridTemplateColumns: `repeat(${cfg.weekdays.length}, minmax(0, 1fr))` }}
+      >
+        {cfg.weekdays.map((wd) => (
+          <div
+            key={wd}
+            className="py-1.5 text-center text-[10px] font-semibold text-slate-500 uppercase tracking-wider"
+          >
+            {wd.slice(0, 3)}
+          </div>
+        ))}
+      </div>
+
+      {/* Day cells */}
+      <div className="flex-1">
+        {rows.map((row, rowIdx) => (
+          <div
+            key={rowIdx}
+            className="grid border-b border-white/[0.04] last:border-0"
+            style={{ gridTemplateColumns: `repeat(${cfg.weekdays.length}, minmax(0, 1fr))` }}
+          >
+            {row.map((cell, colIdx) => {
+              if (cell === null) {
+                return (
+                  <div
+                    key={colIdx}
+                    className="min-h-[56px] border-r border-white/[0.04] last:border-0 bg-black/[0.15]"
+                  />
+                );
+              }
+
+              const day = cell;
+              const cellDate: CalDate = { year, monthIndex, day };
+              const ord = toOrdinal(cfg, cellDate);
+              const isToday = compareDates(cfg, cellDate, currentDate) === 0;
+              const holidays = holidaysOn(cfg, year, monthIndex, day);
+              const hasHoliday = holidays.length > 0;
+              const holidayColor = holidays[0]?.color ?? null;
+
+              const dayEvents = events.filter(
+                (ev) => ev.startOrdinal <= ord && ord <= ev.endOrdinal
+              );
+
+              return (
+                <button
+                  key={colIdx}
+                  type="button"
+                  onClick={() => onSelectDay(cellDate)}
+                  className={[
+                    'min-h-[56px] p-1 border-r border-white/[0.04] last:border-0 text-left align-top transition-colors',
+                    'hover:bg-white/[0.04] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500/50',
+                    isToday ? 'bg-blue-500/10' : '',
+                    hasHoliday && !isToday ? 'bg-amber-500/5' : '',
+                  ]
+                    .filter(Boolean)
+                    .join(' ')}
+                  style={
+                    hasHoliday && holidayColor
+                      ? { boxShadow: `inset 0 2px 0 0 ${holidayColor}40` }
+                      : undefined
+                  }
+                >
+                  {/* Day number */}
+                  <div className="flex items-center justify-between mb-0.5">
+                    <span
+                      className={[
+                        'inline-flex items-center justify-center h-5 w-5 rounded-full text-[11px] font-semibold',
+                        isToday ? 'bg-blue-500 text-white' : 'text-slate-300',
+                      ].join(' ')}
+                    >
+                      {day}
+                    </span>
+                    {hasHoliday && (
+                      <span
+                        className="h-1.5 w-1.5 rounded-full shrink-0"
+                        style={{ backgroundColor: holidayColor ?? '#f59e0b' }}
+                        title={holidays.map((h) => h.name).join(', ')}
+                      />
+                    )}
+                  </div>
+
+                  {/* Event chips */}
+                  <div className="flex flex-col gap-px">
+                    {dayEvents.slice(0, 3).map((ev) => {
+                      const isMultiDay = ev.startOrdinal !== ev.endOrdinal;
+                      return (
+                        <div
+                          key={ev.id}
+                          className={[
+                            'truncate text-[9px] leading-tight px-1 py-px rounded font-medium',
+                            isMultiDay ? 'rounded-none px-1' : 'rounded',
+                          ].join(' ')}
+                          style={{
+                            backgroundColor: ev.color ? `${ev.color}33` : 'rgba(59,130,246,0.2)',
+                            color: ev.color ?? '#93c5fd',
+                            borderLeft: isMultiDay ? `2px solid ${ev.color ?? '#3b82f6'}` : 'none',
+                          }}
+                          title={ev.title}
+                        >
+                          {ev.title}
+                        </div>
+                      );
+                    })}
+                    {dayEvents.length > 3 && (
+                      <span className="text-[9px] text-slate-500 px-1">
+                        +{dayEvents.length - 3}
+                      </span>
+                    )}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+
+      {/* Footer: season + moons */}
+      {(season !== null || moons.length > 0) && (
+        <div className="flex items-center gap-3 px-4 py-2 border-t border-white/[0.07] text-[11px] text-slate-500">
+          {season !== null && (
+            <span
+              className="font-medium"
+              style={season.color ? { color: season.color } : undefined}
+            >
+              {season.name}
+            </span>
+          )}
+          {moons.map((moon) => {
+            const phase = moonPhase(cfg, moon, firstOrdinal);
+            return (
+              <span key={moon.name} className="flex items-center gap-1" title={moon.name}>
+                <span className="text-sm leading-none">{moonSymbol(phase)}</span>
+                <span>{moon.name}</span>
+              </span>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/wiki/calendar/CalendarPanel.tsx
+++ b/app/components/wiki/calendar/CalendarPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useParams } from '@tanstack/react-router';
 import { CalendarDays, List, LayoutGrid } from 'lucide-react';
 import { WikiCategoryHeader } from '~/components/wiki/shared/WikiCategoryHeader';
@@ -12,6 +12,7 @@ import { useCampaign } from '~/hooks/useCampaigns';
 import { HARPTOS_CONFIG } from '~/utils/harptos';
 import type { CalendarConfig } from '~/utils/calendarEngine';
 import type { CalDate } from '~/types/calendar';
+import { calendarConfigFromData } from '~/types/calendar';
 
 interface CalendarPanelProps {
   onBack: () => void;
@@ -31,20 +32,14 @@ export function CalendarPanel({ onBack }: CalendarPanelProps) {
   const [viewEventId, setViewEventId] = useState<string | undefined>();
   const [editorOpen, setEditorOpen] = useState(false);
 
+  // Reset cursor when the calendar identity or month count changes so a stale
+  // cursor can't point past the end of the month array.
+  useEffect(() => {
+    setCursor(null);
+  }, [calendar?.id, calendar?.months.length]);
+
   // Build CalendarConfig from CalendarData when available.
-  const cfg: CalendarConfig | null = calendar
-    ? {
-        months: calendar.months,
-        weekdays: calendar.weekdays,
-        weekdayMode: calendar.weekdayMode,
-        epoch: calendar.epoch,
-        leapDays: calendar.leapDays,
-        yearSuffix: calendar.yearSuffix,
-        moons: calendar.moons,
-        seasons: calendar.seasons,
-        holidays: calendar.holidays,
-      }
-    : null;
+  const cfg: CalendarConfig | null = calendar ? calendarConfigFromData(calendar) : null;
 
   const handleHarptos = () => {
     const harptosCurrentDate: CalDate = { year: 1491, monthIndex: 6, day: 15 };
@@ -185,7 +180,7 @@ export function CalendarPanel({ onBack }: CalendarPanelProps) {
               <CalendarGridView
                 cfg={cfg}
                 year={currentYear}
-                monthIndex={currentMonthIndex}
+                monthIndex={Math.min(Math.max(currentMonthIndex, 0), cfg.months.length - 1)}
                 events={events}
                 currentDate={calendar.currentDate}
                 onPrev={handlePrev}

--- a/app/components/wiki/calendar/CalendarPanel.tsx
+++ b/app/components/wiki/calendar/CalendarPanel.tsx
@@ -1,8 +1,221 @@
-// TODO(Task 14): replace stub with real panel
+import { useState } from 'react';
+import { useParams } from '@tanstack/react-router';
+import { CalendarDays, List, LayoutGrid } from 'lucide-react';
+import { WikiCategoryHeader } from '~/components/wiki/shared/WikiCategoryHeader';
+import { CalendarGridView } from './CalendarGridView';
+import { EventListView } from './EventListView';
+import { EventViewModal } from './EventViewModal';
+import { CalendarEditorModal } from './CalendarEditorModal';
+import { useCalendar, useUpsertCalendar } from '~/hooks/useCalendar';
+import { useEvents } from '~/hooks/useEvents';
+import { useCampaign } from '~/hooks/useCampaigns';
+import { HARPTOS_CONFIG } from '~/utils/harptos';
+import type { CalendarConfig } from '~/utils/calendarEngine';
+import type { CalDate } from '~/types/calendar';
+
 interface CalendarPanelProps {
   onBack: () => void;
 }
 
-export function CalendarPanel(_props: CalendarPanelProps) {
-  return <div data-testid="calendar-panel-stub">Calendar (coming soon)</div>;
+export function CalendarPanel({ onBack }: CalendarPanelProps) {
+  const { campaignId } = useParams({ from: '/campaigns/$campaignId/play' });
+  const { campaign } = useCampaign(campaignId);
+  const isGM = campaign?.isGM ?? false;
+
+  const { calendar, isLoading } = useCalendar(campaignId);
+  const { events } = useEvents(campaignId);
+  const { save: saveCalendar, isLoading: isSaving } = useUpsertCalendar();
+
+  const [view, setView] = useState<'list' | 'grid'>('list');
+  const [cursor, setCursor] = useState<{ year: number; monthIndex: number } | null>(null);
+  const [viewEventId, setViewEventId] = useState<string | undefined>();
+  const [editorOpen, setEditorOpen] = useState(false);
+
+  // Build CalendarConfig from CalendarData when available.
+  const cfg: CalendarConfig | null = calendar
+    ? {
+        months: calendar.months,
+        weekdays: calendar.weekdays,
+        weekdayMode: calendar.weekdayMode,
+        epoch: calendar.epoch,
+        leapDays: calendar.leapDays,
+        yearSuffix: calendar.yearSuffix,
+        moons: calendar.moons,
+        seasons: calendar.seasons,
+        holidays: calendar.holidays,
+      }
+    : null;
+
+  const handleHarptos = () => {
+    const harptosCurrentDate: CalDate = { year: 1491, monthIndex: 6, day: 15 };
+    saveCalendar({
+      campaignId,
+      name: 'Calendar of Harptos',
+      description: '',
+      namedYears: [],
+      currentDate: harptosCurrentDate,
+      months: HARPTOS_CONFIG.months,
+      weekdays: HARPTOS_CONFIG.weekdays,
+      weekdayMode: HARPTOS_CONFIG.weekdayMode,
+      epoch: HARPTOS_CONFIG.epoch,
+      yearSuffix: HARPTOS_CONFIG.yearSuffix ?? '',
+      leapDays: HARPTOS_CONFIG.leapDays,
+      moons: HARPTOS_CONFIG.moons ?? [],
+      seasons: HARPTOS_CONFIG.seasons ?? [],
+      holidays: HARPTOS_CONFIG.holidays ?? [],
+    });
+  };
+
+  // Month navigation (index stepping only, no date arithmetic).
+  const currentYear = cursor?.year ?? calendar?.currentDate.year ?? 1;
+  const currentMonthIndex = cursor?.monthIndex ?? calendar?.currentDate.monthIndex ?? 0;
+  const totalMonths = cfg?.months.length ?? 1;
+
+  const handlePrev = () => {
+    if (currentMonthIndex === 0) {
+      setCursor({ year: currentYear - 1, monthIndex: totalMonths - 1 });
+    } else {
+      setCursor({ year: currentYear, monthIndex: currentMonthIndex - 1 });
+    }
+  };
+
+  const handleNext = () => {
+    if (currentMonthIndex >= totalMonths - 1) {
+      setCursor({ year: currentYear + 1, monthIndex: 0 });
+    } else {
+      setCursor({ year: currentYear, monthIndex: currentMonthIndex + 1 });
+    }
+  };
+
+  return (
+    <div data-testid="calendar-panel" className="flex flex-col h-full w-full bg-[#080A12]">
+      <WikiCategoryHeader title="Calendar" onBack={onBack} />
+
+      {/* View toggle + configure button row */}
+      {calendar && (
+        <div className="flex items-center justify-between px-4 py-2 border-b border-white/[0.07]">
+          <button
+            type="button"
+            data-testid="calendar-view-toggle"
+            onClick={() => setView((v) => (v === 'list' ? 'grid' : 'list'))}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold text-slate-400 hover:text-slate-200 hover:bg-white/[0.05] transition-colors border border-white/[0.07]"
+            aria-label={view === 'list' ? 'Switch to grid view' : 'Switch to list view'}
+          >
+            {view === 'list' ? (
+              <>
+                <LayoutGrid className="h-3.5 w-3.5" />
+                Grid
+              </>
+            ) : (
+              <>
+                <List className="h-3.5 w-3.5" />
+                List
+              </>
+            )}
+          </button>
+
+          {isGM && (
+            <button
+              type="button"
+              data-testid="calendar-configure-button"
+              onClick={() => setEditorOpen(true)}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold text-slate-400 hover:text-slate-200 hover:bg-white/[0.05] transition-colors border border-white/[0.07]"
+            >
+              Configure calendar
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Main content area */}
+      {isLoading ? (
+        <div className="flex flex-1 items-center justify-center p-8">
+          <p className="font-sans font-semibold text-xs text-slate-500 animate-pulse">
+            Loading calendar...
+          </p>
+        </div>
+      ) : calendar === null ? (
+        /* No calendar exists */
+        <div className="flex flex-1 flex-col items-center justify-center p-8 text-center gap-4">
+          <div className="h-12 w-12 rounded-full bg-white/[0.03] flex items-center justify-center">
+            <CalendarDays className="h-6 w-6 text-slate-600" />
+          </div>
+          {isGM ? (
+            <>
+              <p className="font-sans font-semibold text-xs text-slate-500">
+                No calendar has been set up yet.
+              </p>
+              <div className="flex flex-col gap-2 w-full max-w-xs">
+                <button
+                  type="button"
+                  onClick={() => setEditorOpen(true)}
+                  className="w-full px-4 py-2 rounded-xl bg-blue-600/20 border border-blue-500/30 text-blue-400 hover:bg-blue-600/30 text-xs font-semibold transition-colors"
+                >
+                  Set up calendar
+                </button>
+                <button
+                  type="button"
+                  data-testid="calendar-harptos-button"
+                  onClick={handleHarptos}
+                  disabled={isSaving}
+                  className="w-full px-4 py-2 rounded-xl bg-amber-600/20 border border-amber-500/30 text-amber-400 hover:bg-amber-600/30 text-xs font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {isSaving ? 'Saving...' : 'Use Calendar of Harptos'}
+                </button>
+              </div>
+            </>
+          ) : (
+            <p className="font-sans font-semibold text-xs text-slate-500">
+              The GM hasn't set up a calendar yet.
+            </p>
+          )}
+        </div>
+      ) : cfg ? (
+        /* Calendar exists */
+        <div className="flex-1 overflow-y-auto min-h-0">
+          {view === 'list' ? (
+            <EventListView
+              cfg={cfg}
+              events={events}
+              isGM={isGM}
+              onSelect={(e) => setViewEventId(e.id)}
+            />
+          ) : (
+            <div className="p-3">
+              <CalendarGridView
+                cfg={cfg}
+                year={currentYear}
+                monthIndex={currentMonthIndex}
+                events={events}
+                currentDate={calendar.currentDate}
+                onPrev={handlePrev}
+                onNext={handleNext}
+                onSelectDay={() => {
+                  /* no-op: day selection is a future enhancement */
+                }}
+              />
+            </div>
+          )}
+        </div>
+      ) : null}
+
+      {/* Event view modal */}
+      {viewEventId && (
+        <EventViewModal
+          isOpen={!!viewEventId}
+          onClose={() => setViewEventId(undefined)}
+          eventId={viewEventId}
+          campaignId={campaignId}
+        />
+      )}
+
+      {/* Calendar editor modal (stub until Task 16) */}
+      <CalendarEditorModal
+        isOpen={editorOpen}
+        onClose={() => setEditorOpen(false)}
+        campaignId={campaignId}
+        calendar={calendar}
+      />
+    </div>
+  );
 }

--- a/app/components/wiki/calendar/CalendarPanel.tsx
+++ b/app/components/wiki/calendar/CalendarPanel.tsx
@@ -1,0 +1,8 @@
+// TODO(Task 14): replace stub with real panel
+interface CalendarPanelProps {
+  onBack: () => void;
+}
+
+export function CalendarPanel(_props: CalendarPanelProps) {
+  return <div data-testid="calendar-panel-stub">Calendar (coming soon)</div>;
+}

--- a/app/components/wiki/calendar/CalendarPanel.tsx
+++ b/app/components/wiki/calendar/CalendarPanel.tsx
@@ -204,7 +204,7 @@ export function CalendarPanel({ onBack }: CalendarPanelProps) {
         />
       )}
 
-      {/* Calendar editor modal (stub until Task 16) */}
+      {/* Calendar editor modal */}
       <CalendarEditorModal
         isOpen={editorOpen}
         onClose={() => setEditorOpen(false)}

--- a/app/components/wiki/calendar/EventCard.tsx
+++ b/app/components/wiki/calendar/EventCard.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { Globe, Lock } from 'lucide-react';
+import type { EventListItem } from '~/types/event';
+import type { CalendarConfig } from '~/utils/calendarEngine';
+import { formatDate } from '~/utils/calendarEngine';
+import { setTokenDragImage } from '~/utils/setTokenDragImage';
+
+const GRADIENT_PAIRS = [
+  ['#3b82f6', '#8b5cf6'],
+  ['#f59e0b', '#ef4444'],
+  ['#10b981', '#06b6d4'],
+  ['#ec4899', '#8b5cf6'],
+  ['#f97316', '#eab308'],
+  ['#14b8a6', '#3b82f6'],
+];
+
+function hashName(name: string): number {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash << 5) - hash + name.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+
+interface EventCardProps {
+  event: EventListItem;
+  cfg: CalendarConfig;
+  onClick: (event: EventListItem) => void;
+}
+
+export function EventCard({ event, cfg, onClick }: EventCardProps) {
+  const gradientIndex = hashName(event.title) % GRADIENT_PAIRS.length;
+  const [gradFrom] = GRADIENT_PAIRS[gradientIndex]!;
+  const firstImageUrl = event.images[0]?.url ?? null;
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      draggable="true"
+      data-testid="event-card"
+      data-event-id={event.id}
+      onDragStart={(e) => {
+        e.dataTransfer.setData(
+          'application/x-cartyx-document',
+          JSON.stringify({
+            collection: 'events',
+            documentId: event.id,
+            title: event.title,
+          })
+        );
+        e.dataTransfer.effectAllowed = 'copy';
+        setTokenDragImage(e, {
+          pictureUrl: firstImageUrl,
+          initial: event.title,
+          color: gradFrom,
+        });
+        e.currentTarget.style.opacity = '0.4';
+      }}
+      onDragEnd={(e) => {
+        e.currentTarget.style.opacity = '';
+      }}
+      onClick={() => onClick(event)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick(event);
+        }
+      }}
+      className="flex items-start gap-3 px-4 py-3 border-b border-white/[0.05] hover:bg-white/[0.03] transition-colors group cursor-grab active:cursor-grabbing"
+    >
+      {/* Avatar / first image thumbnail */}
+      <div
+        className="w-10 h-10 rounded-lg flex-shrink-0 flex items-center justify-center overflow-hidden mt-0.5"
+        style={
+          firstImageUrl
+            ? undefined
+            : {
+                background: `linear-gradient(135deg, ${gradFrom}, ${GRADIENT_PAIRS[gradientIndex]![1]})`,
+              }
+        }
+      >
+        {firstImageUrl ? (
+          <img src={firstImageUrl} alt="" loading="lazy" className="w-full h-full object-cover" />
+        ) : (
+          <span className="text-sm text-white font-semibold uppercase">
+            {event.title.charAt(0)}
+          </span>
+        )}
+      </div>
+
+      {/* Details */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-0.5">
+          <span
+            data-testid="event-card-title"
+            className="text-sm font-semibold text-slate-200 group-hover:text-blue-400 transition-colors truncate"
+          >
+            {event.title}
+          </span>
+          {event.isEpic && (
+            <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-amber-500/15 border border-amber-500/25 text-amber-400 font-bold text-[9px] uppercase tracking-tight shrink-0">
+              EPIC
+            </span>
+          )}
+          {event.isPublic ? (
+            <Globe className="h-3.5 w-3.5 text-emerald-500 shrink-0" aria-label="Public" />
+          ) : (
+            <Lock className="h-3.5 w-3.5 text-amber-500 shrink-0" aria-label="Private" />
+          )}
+        </div>
+
+        <p className="text-[11px] text-slate-500">{formatDate(cfg, event.start)}</p>
+
+        {event.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1 mt-1">
+            {event.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[9px] tracking-tight"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/wiki/calendar/EventLinksEditor.tsx
+++ b/app/components/wiki/calendar/EventLinksEditor.tsx
@@ -1,0 +1,199 @@
+import { useState, useMemo, useId } from 'react';
+import { X } from 'lucide-react';
+import { useCharacters } from '~/hooks/useCharacters';
+import { usePlayers } from '~/hooks/usePlayers';
+import { useLocations } from '~/hooks/useLocations';
+import { useRaces } from '~/hooks/useRaces';
+import { useLore } from '~/hooks/useLore';
+import type { EventLink, EventLinkKind } from '~/types/event';
+
+interface Candidate {
+  id: string;
+  label: string;
+}
+
+const KIND_LABELS: Record<EventLinkKind, string> = {
+  character: 'Character',
+  player: 'Player',
+  location: 'Location',
+  race: 'Race',
+  lore: 'Lore',
+};
+
+const KIND_BADGE_COLORS: Record<EventLinkKind, string> = {
+  character: 'bg-blue-500/20 text-blue-300',
+  player: 'bg-green-500/20 text-green-300',
+  location: 'bg-amber-500/20 text-amber-300',
+  race: 'bg-purple-500/20 text-purple-300',
+  lore: 'bg-sky-500/20 text-sky-300',
+};
+
+interface Props {
+  campaignId: string;
+  links: EventLink[];
+  onChange: (links: EventLink[]) => void;
+  disabled?: boolean;
+}
+
+export function EventLinksEditor({ campaignId, links, onChange, disabled }: Props) {
+  const uid = useId();
+  const kindSelectId = `event-links-kind-${uid}`;
+  const entitySelectId = `event-links-entity-${uid}`;
+
+  const [kind, setKind] = useState<EventLinkKind>('character');
+  const [selectedId, setSelectedId] = useState('');
+
+  // Fetch all five entity lists — always enabled so the selects populate quickly
+  const { characters } = useCharacters(campaignId);
+  const { players } = usePlayers(campaignId);
+  const { locations } = useLocations(campaignId);
+  const { races } = useRaces(campaignId);
+  const { lore } = useLore(campaignId);
+
+  // Build the candidate list for the currently chosen kind
+  const candidates: Candidate[] = useMemo(() => {
+    switch (kind) {
+      case 'character':
+        return characters.map((c) => ({
+          id: c.id,
+          label: `${c.firstName} ${c.lastName}`.trim(),
+        }));
+      case 'player':
+        return players.map((p) => ({
+          id: p.id,
+          label: `${p.firstName} ${p.lastName}`.trim(),
+        }));
+      case 'location':
+        return locations.map((l) => ({ id: l.id, label: l.name }));
+      case 'race':
+        return races.map((r) => ({ id: r.id, label: r.title }));
+      case 'lore':
+        return lore.map((l) => ({ id: l.id, label: l.title }));
+    }
+  }, [kind, characters, players, locations, races, lore]);
+
+  // Reset entity selection when kind changes
+  const handleKindChange = (newKind: EventLinkKind) => {
+    setKind(newKind);
+    setSelectedId('');
+  };
+
+  const handleAddLink = () => {
+    if (!selectedId) return;
+
+    // Deduplicate: same kind + id already present
+    const alreadyLinked = links.some((l) => l.kind === kind && l.id === selectedId);
+    if (alreadyLinked) return;
+
+    const candidate = candidates.find((c) => c.id === selectedId);
+    if (!candidate) return;
+
+    const newLink: EventLink = { kind, id: selectedId, label: candidate.label };
+    onChange([...links, newLink]);
+    setSelectedId('');
+  };
+
+  const handleRemoveLink = (removeKind: EventLinkKind, removeId: string) => {
+    onChange(links.filter((l) => !(l.kind === removeKind && l.id === removeId)));
+  };
+
+  return (
+    <div data-testid="event-links-editor" className="space-y-3">
+      <span className="block text-xs font-semibold text-slate-400 tracking-wide">
+        Linked Entities
+      </span>
+
+      {/* Existing link chips */}
+      {links.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {links.map((link) => {
+            const label = link.label ?? link.id;
+            return (
+              <span
+                key={`${link.kind}-${link.id}`}
+                className="inline-flex items-center gap-1.5 bg-white/[0.06] border border-white/10 rounded-full pl-2.5 pr-1.5 py-1 text-xs text-slate-200"
+              >
+                {label}
+                <span
+                  className={`rounded-full px-1.5 py-0.5 text-[10px] font-semibold ${KIND_BADGE_COLORS[link.kind]}`}
+                >
+                  {KIND_LABELS[link.kind]}
+                </span>
+                {!disabled && (
+                  <button
+                    type="button"
+                    aria-label={`Remove ${label}`}
+                    onClick={() => handleRemoveLink(link.kind, link.id)}
+                    className="text-slate-500 hover:text-white transition-colors ml-0.5 rounded-full p-0.5 focus:outline-none focus:ring-1 focus:ring-white/30"
+                  >
+                    <X size={11} strokeWidth={2.5} />
+                  </button>
+                )}
+              </span>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Add link controls */}
+      {!disabled && (
+        <div className="flex items-end gap-2">
+          {/* Kind selector */}
+          <div className="flex-shrink-0">
+            <label htmlFor={kindSelectId} className="block text-[11px] text-slate-500 mb-1">
+              Type
+            </label>
+            <select
+              id={kindSelectId}
+              value={kind}
+              onChange={(e) => handleKindChange(e.target.value as EventLinkKind)}
+              className="bg-white/[0.04] border border-white/10 rounded-xl px-3 py-2.5 text-slate-200 text-sm focus:outline-none focus:border-blue-500/50 transition-all appearance-none cursor-pointer"
+            >
+              {(Object.keys(KIND_LABELS) as EventLinkKind[]).map((k) => (
+                <option key={k} value={k} className="bg-[#0D1117]">
+                  {KIND_LABELS[k]}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Entity selector */}
+          <div className="flex-1 min-w-0">
+            <label htmlFor={entitySelectId} className="block text-[11px] text-slate-500 mb-1">
+              Entity
+            </label>
+            <select
+              id={entitySelectId}
+              aria-label="Entity to link"
+              value={selectedId}
+              onChange={(e) => setSelectedId(e.target.value)}
+              disabled={candidates.length === 0}
+              className="w-full bg-white/[0.04] border border-white/10 rounded-xl px-3 py-2.5 text-slate-200 text-sm focus:outline-none focus:border-blue-500/50 transition-all appearance-none cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <option value="" className="bg-[#0D1117]">
+                {candidates.length === 0
+                  ? `No ${KIND_LABELS[kind].toLowerCase()}s`
+                  : `Select ${KIND_LABELS[kind].toLowerCase()}…`}
+              </option>
+              {candidates.map((c) => (
+                <option key={c.id} value={c.id} className="bg-[#0D1117]">
+                  {c.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Add button */}
+          <button
+            type="button"
+            onClick={handleAddLink}
+            disabled={!selectedId}
+            className="flex-shrink-0 px-3 py-2.5 rounded-xl text-sm font-semibold bg-blue-600 hover:bg-blue-500 disabled:bg-white/[0.06] disabled:text-slate-500 disabled:cursor-not-allowed text-white transition-colors"
+          >
+            Add link
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/wiki/calendar/EventListView.tsx
+++ b/app/components/wiki/calendar/EventListView.tsx
@@ -1,0 +1,155 @@
+import { Globe, Lock, Link2 } from 'lucide-react';
+import type { CalendarConfig } from '~/utils/calendarEngine';
+import { formatDate } from '~/utils/calendarEngine';
+import type { EventListItem } from '~/types/event';
+
+interface EventListViewProps {
+  cfg: CalendarConfig;
+  events: EventListItem[];
+  isGM: boolean;
+  onSelect(e: EventListItem): void;
+}
+
+/** Group a sorted-by-startOrdinal list into year → monthIndex buckets
+ *  without performing any date arithmetic — we preserve the incoming
+ *  order and just read start.year / start.monthIndex. */
+function groupEvents(events: EventListItem[]): Map<number, Map<number, EventListItem[]>> {
+  const byYear = new Map<number, Map<number, EventListItem[]>>();
+  for (const ev of events) {
+    const { year, monthIndex } = ev.start;
+    if (!byYear.has(year)) byYear.set(year, new Map());
+    const byMonth = byYear.get(year)!;
+    if (!byMonth.has(monthIndex)) byMonth.set(monthIndex, []);
+    byMonth.get(monthIndex)!.push(ev);
+  }
+  return byYear;
+}
+
+export function EventListView({ cfg, events, isGM, onSelect }: EventListViewProps) {
+  if (events.length === 0) {
+    return (
+      <div
+        data-testid="event-list"
+        className="flex flex-1 flex-col items-center justify-center p-8 text-center"
+      >
+        <p className="font-sans font-semibold text-xs text-slate-500">No events</p>
+      </div>
+    );
+  }
+
+  const grouped = groupEvents(events);
+  // Preserve insertion order (which reflects startOrdinal sort from server)
+  const years = Array.from(grouped.keys());
+
+  return (
+    <div data-testid="event-list" className="flex flex-col">
+      {years.map((year) => {
+        const byMonth = grouped.get(year)!;
+        const monthIndices = Array.from(byMonth.keys());
+
+        return (
+          <div key={year}>
+            {/* Year heading */}
+            <div className="sticky top-0 z-10 px-4 py-1.5 bg-[#080A12] border-b border-white/[0.07]">
+              <span className="text-[10px] font-bold text-slate-500 uppercase tracking-wider">
+                {year}
+                {cfg.yearSuffix ? ` ${cfg.yearSuffix}` : ''}
+              </span>
+            </div>
+
+            {monthIndices.map((monthIndex) => {
+              const monthEvents = byMonth.get(monthIndex)!;
+              const monthName = cfg.months[monthIndex]?.name ?? '';
+
+              return (
+                <div key={monthIndex}>
+                  {/* Month sub-heading */}
+                  <div className="px-4 py-1 border-b border-white/[0.04] bg-white/[0.01]">
+                    <span className="text-[10px] font-semibold text-slate-600 uppercase tracking-wider">
+                      {monthName}
+                    </span>
+                  </div>
+
+                  {/* Event rows */}
+                  {monthEvents.map((ev) => (
+                    <button
+                      key={ev.id}
+                      type="button"
+                      data-testid="event-row"
+                      data-event-id={ev.id}
+                      onClick={() => onSelect(ev)}
+                      className="flex items-start gap-3 w-full px-4 py-3 border-b border-white/[0.05] hover:bg-white/[0.03] transition-colors text-left group"
+                    >
+                      {/* Color stripe */}
+                      <div
+                        className="w-1 self-stretch rounded-full shrink-0 mt-0.5"
+                        style={{ backgroundColor: ev.color ?? '#3b82f6' }}
+                      />
+
+                      {/* Main content */}
+                      <div className="flex-1 min-w-0">
+                        {/* Date range */}
+                        <p className="text-[10px] text-slate-500 mb-0.5">
+                          {formatDate(cfg, ev.start)}
+                          {ev.end !== null && ` – ${formatDate(cfg, ev.end)}`}
+                        </p>
+
+                        {/* Title + badges row */}
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <span className="text-sm font-semibold text-slate-200 group-hover:text-blue-400 transition-colors truncate">
+                            {ev.title}
+                          </span>
+
+                          {ev.isEpic && (
+                            <span className="inline-flex items-center px-1.5 py-px rounded bg-amber-500/15 border border-amber-500/25 text-amber-400 font-bold text-[9px] uppercase tracking-tight shrink-0">
+                              EPIC
+                            </span>
+                          )}
+
+                          {isGM &&
+                            (ev.isPublic ? (
+                              <span className="inline-flex items-center gap-1 px-1.5 py-px rounded bg-emerald-500/15 border border-emerald-500/20 text-emerald-400 font-semibold text-[9px] shrink-0">
+                                <Globe className="h-2.5 w-2.5" />
+                                Public
+                              </span>
+                            ) : (
+                              <span className="inline-flex items-center gap-1 px-1.5 py-px rounded bg-red-500/15 border border-red-500/20 text-red-400 font-semibold text-[9px] shrink-0">
+                                <Lock className="h-2.5 w-2.5" />
+                                Private
+                              </span>
+                            ))}
+                        </div>
+
+                        {/* Tags */}
+                        {ev.tags.length > 0 && (
+                          <div className="flex flex-wrap gap-1 mt-1">
+                            {ev.tags.map((tag) => (
+                              <span
+                                key={tag}
+                                className="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[9px] tracking-tight"
+                              >
+                                #{tag}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+
+                      {/* Link count */}
+                      {ev.links.length > 0 && (
+                        <span className="inline-flex items-center gap-1 shrink-0 text-[10px] text-slate-500 mt-0.5">
+                          <Link2 className="h-3 w-3" />
+                          {ev.links.length}
+                        </span>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              );
+            })}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/components/wiki/calendar/EventModal.tsx
+++ b/app/components/wiki/calendar/EventModal.tsx
@@ -9,7 +9,9 @@ import { EventLinksEditor } from '~/components/wiki/calendar/EventLinksEditor';
 import { CalDatePicker } from '~/components/wiki/calendar/CalDatePicker';
 import { useEvent, useCreateEvent, useUpdateEvent, useDeleteEvent } from '~/hooks/useEvents';
 import { useCalendar } from '~/hooks/useCalendar';
+import { useSessions } from '~/hooks/useSessions';
 import { useModalForm } from '~/hooks/useModalForm';
+import { FormSelect } from '~/components/FormSelect';
 import { uploadToR2 } from '~/utils/uploadToR2';
 import { compressImage } from '~/utils/compressImage';
 import { validateDate } from '~/utils/calendarEngine';
@@ -38,6 +40,7 @@ export function EventModal({ isOpen, onClose, campaignId, eventId }: EventModalP
   const { update, isLoading: isUpdating } = useUpdateEvent();
   const { remove, isLoading: isDeleting } = useDeleteEvent();
   const { calendar } = useCalendar(campaignId);
+  const { sessions } = useSessions(campaignId, true);
 
   const cfg = calendar ? calendarConfigFromData(calendar) : null;
   const defaultDate: CalDate = calendar ? calendar.currentDate : { year: 1, monthIndex: 0, day: 1 };
@@ -51,7 +54,7 @@ export function EventModal({ isOpen, onClose, campaignId, eventId }: EventModalP
   const [isMultiDay, setIsMultiDay] = useState(false);
   const [end, setEnd] = useState<CalDate | null>(null);
   const [links, setLinks] = useState<EventLink[]>([]);
-  const [sessionId] = useState<string | null>(null);
+  const [sessionId, setSessionId] = useState<string | null>(null);
   const [images, setImages] = useState<EventImage[]>([]);
   const [tags, setTags] = useState<string[]>([]);
   const [color] = useState<string | null>(null);
@@ -89,6 +92,7 @@ export function EventModal({ isOpen, onClose, campaignId, eventId }: EventModalP
       setIsMultiDay(false);
       setEnd(null);
       setLinks([]);
+      setSessionId(null);
       setImages([]);
       setTags([]);
       setError(null);
@@ -109,6 +113,7 @@ export function EventModal({ isOpen, onClose, campaignId, eventId }: EventModalP
         setEnd(null);
       }
       setLinks(ev.links);
+      setSessionId(ev.sessionId ?? null);
       setImages(ev.images);
       setTags(ev.tags);
     },
@@ -486,6 +491,28 @@ export function EventModal({ isOpen, onClose, campaignId, eventId }: EventModalP
                 onChange={setLinks}
                 disabled={isBusy}
               />
+
+              {/* Session (optional) */}
+              <div data-testid="event-session-select">
+                <FormSelect
+                  label={
+                    <span>
+                      Session{' '}
+                      <span className="text-slate-600 text-[10px] font-normal">(optional)</span>
+                    </span>
+                  }
+                  value={sessionId ?? ''}
+                  onChange={(e) => setSessionId(e.target.value || null)}
+                  disabled={isBusy}
+                  options={[
+                    { value: '', label: 'None' },
+                    ...sessions.map((s) => ({
+                      value: s.id,
+                      label: `Session ${s.number}: ${s.name}`,
+                    })),
+                  ]}
+                />
+              </div>
             </>
           )}
         </div>

--- a/app/components/wiki/calendar/EventModal.tsx
+++ b/app/components/wiki/calendar/EventModal.tsx
@@ -1,5 +1,21 @@
-// TODO(Task 15): real EventModal
-// Mirroring LoreModal props: isOpen, onClose, campaignId, eventId? (create vs edit)
+import React, { useState, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { X, Globe, Lock } from 'lucide-react';
+import { FormInput } from '~/components/FormInput';
+import { PixelButton } from '~/components/PixelButton';
+import { MarkdownEditor } from '~/components/shared/MarkdownEditor';
+import { TagAutocompleteInput } from '~/components/shared/TagAutocompleteInput';
+import { EventLinksEditor } from '~/components/wiki/calendar/EventLinksEditor';
+import { CalDatePicker } from '~/components/wiki/calendar/CalDatePicker';
+import { useEvent, useCreateEvent, useUpdateEvent, useDeleteEvent } from '~/hooks/useEvents';
+import { useCalendar } from '~/hooks/useCalendar';
+import { useModalForm } from '~/hooks/useModalForm';
+import { uploadToR2 } from '~/utils/uploadToR2';
+import { compressImage } from '~/utils/compressImage';
+import { validateDate } from '~/utils/calendarEngine';
+import { calendarConfigFromData } from '~/types/calendar';
+import type { EventLink, EventImage } from '~/types/event';
+import type { CalDate } from '~/types/calendar';
 
 interface EventModalProps {
   isOpen: boolean;
@@ -8,6 +24,532 @@ interface EventModalProps {
   eventId?: string;
 }
 
-export function EventModal(_props: EventModalProps) {
-  return null;
+interface FieldErrors {
+  title?: string;
+  start?: string;
+  end?: string;
+}
+
+export function EventModal({ isOpen, onClose, campaignId, eventId }: EventModalProps) {
+  const isEdit = !!eventId;
+
+  const { event: existingEvent, isLoading: isFetchingEvent } = useEvent(eventId ?? '', campaignId);
+  const { create, isLoading: isCreating } = useCreateEvent();
+  const { update, isLoading: isUpdating } = useUpdateEvent();
+  const { remove, isLoading: isDeleting } = useDeleteEvent();
+  const { calendar } = useCalendar(campaignId);
+
+  const cfg = calendar ? calendarConfigFromData(calendar) : null;
+  const defaultDate: CalDate = calendar ? calendar.currentDate : { year: 1, monthIndex: 0, day: 1 };
+
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [gmContent, setGmContent] = useState('');
+  const [isPublic, setIsPublic] = useState(false);
+  const [isEpic, setIsEpic] = useState(false);
+  const [start, setStart] = useState<CalDate>(defaultDate);
+  const [isMultiDay, setIsMultiDay] = useState(false);
+  const [end, setEnd] = useState<CalDate | null>(null);
+  const [links, setLinks] = useState<EventLink[]>([]);
+  const [sessionId] = useState<string | null>(null);
+  const [images, setImages] = useState<EventImage[]>([]);
+  const [tags, setTags] = useState<string[]>([]);
+  const [color] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isUploadingImage, setIsUploadingImage] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const validate = useCallback((): FieldErrors => {
+    const errors: FieldErrors = {};
+    if (!title.trim()) errors.title = 'Title is required';
+    if (cfg) {
+      const startResult = validateDate(cfg, start);
+      if (!startResult.ok) errors.start = startResult.error ?? 'Invalid start date';
+      if (isMultiDay && end !== null) {
+        const endResult = validateDate(cfg, end);
+        if (!endResult.ok) errors.end = endResult.error ?? 'Invalid end date';
+      }
+    }
+    return errors;
+  }, [title, cfg, start, isMultiDay, end]);
+
+  const { fieldErrors, runValidation } = useModalForm({
+    isOpen,
+    onClose,
+    recordId: eventId,
+    isEdit,
+    record: existingEvent,
+    reset: () => {
+      setTitle('');
+      setContent('');
+      setGmContent('');
+      setIsPublic(false);
+      setIsEpic(false);
+      setStart(defaultDate);
+      setIsMultiDay(false);
+      setEnd(null);
+      setLinks([]);
+      setImages([]);
+      setTags([]);
+      setError(null);
+      setShowDeleteConfirm(false);
+    },
+    populate: (ev) => {
+      setTitle(ev.title);
+      setContent(ev.content);
+      setGmContent(ev.gmContent);
+      setIsPublic(ev.isPublic);
+      setIsEpic(ev.isEpic);
+      setStart(ev.start);
+      if (ev.end !== null) {
+        setIsMultiDay(true);
+        setEnd(ev.end);
+      } else {
+        setIsMultiDay(false);
+        setEnd(null);
+      }
+      setLinks(ev.links);
+      setImages(ev.images);
+      setTags(ev.tags);
+    },
+    validate,
+  });
+
+  const handleAddImage = useCallback(async (file: File) => {
+    setIsUploadingImage(true);
+    setError(null);
+    try {
+      const compressed = await compressImage(file);
+      const { publicUrl } = await uploadToR2(compressed, 'uploads/events');
+      const newImage: EventImage = { url: publicUrl, caption: '', crop: null };
+      setImages((prev) => [...prev, newImage]);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Image upload failed');
+    } finally {
+      setIsUploadingImage(false);
+    }
+  }, []);
+
+  const handleRemoveImage = useCallback((index: number) => {
+    setImages((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const handleImageFileChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      await handleAddImage(file);
+      e.target.value = '';
+    },
+    [handleAddImage]
+  );
+
+  const handleMultiDayChange = (checked: boolean) => {
+    setIsMultiDay(checked);
+    if (checked && end === null) {
+      setEnd(start);
+    } else if (!checked) {
+      setEnd(null);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const errors = runValidation();
+    if (Object.keys(errors).length > 0) return;
+
+    const input = {
+      campaignId,
+      title: title.trim(),
+      content,
+      gmContent,
+      isPublic,
+      isEpic,
+      start,
+      end: isMultiDay ? end : null,
+      links: links.map((l) => ({ kind: l.kind, id: l.id })),
+      sessionId,
+      images: images.map((img) => ({
+        url: img.url,
+        caption: img.caption,
+        crop: img.crop,
+      })),
+      tags,
+      color,
+    };
+
+    let success = false;
+    if (isEdit && eventId) {
+      const result = await update({ ...input, id: eventId });
+      success = !!result;
+    } else {
+      const result = await create(input);
+      success = !!result;
+    }
+
+    if (success) {
+      onClose();
+    } else {
+      setError(`Failed to ${isEdit ? 'update' : 'create'} event. Please try again.`);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!eventId) return;
+    const result = await remove({ id: eventId, campaignId });
+    if (result !== undefined) {
+      onClose();
+    } else {
+      setError('Failed to delete event. Please try again.');
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const isLoadingEvent = !!(isEdit && isFetchingEvent);
+  const isSaving = isCreating || isUpdating;
+  const isBusy = isLoadingEvent || isSaving || isUploadingImage || isDeleting;
+
+  return createPortal(
+    <div
+      role="presentation"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-2 sm:p-4 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="event-modal-title"
+        className="w-full h-full max-w-[90vw] max-h-[90vh] sm:max-w-[90vw] sm:max-h-[90vh] bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col"
+      >
+        <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
+          <h2
+            id="event-modal-title"
+            className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest"
+          >
+            {isEdit ? 'Edit Event' : 'Create Event'}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-slate-500 hover:text-white transition-colors"
+            aria-label="Close modal"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto p-4 sm:p-6 space-y-5 min-h-0">
+          {error && (
+            <div className="p-3 bg-rose-500/10 border border-rose-500/20 rounded-lg text-rose-400 text-xs font-semibold">
+              {error}
+            </div>
+          )}
+
+          {isLoadingEvent ? (
+            <div className="flex items-center justify-center py-12">
+              <p className="text-xs text-slate-500 animate-pulse">Loading event...</p>
+            </div>
+          ) : (
+            <>
+              {/* Title */}
+              <FormInput
+                label="Title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                error={fieldErrors.title}
+                required
+                disabled={isBusy}
+                placeholder="Event title"
+                data-testid="event-title-input"
+              />
+
+              {/* Epic toggle */}
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  data-testid="event-epic-toggle"
+                  disabled={isBusy}
+                  onClick={() => setIsEpic((v) => !v)}
+                  className={`h-9 px-4 rounded-xl border flex items-center gap-2 transition-all text-xs font-semibold ${
+                    isEpic
+                      ? 'bg-amber-500/15 border-amber-500/30 text-amber-400'
+                      : 'bg-white/[0.03] border-white/[0.07] text-slate-500 hover:border-white/20'
+                  }`}
+                >
+                  {isEpic ? 'Epic event' : 'Mark as epic'}
+                </button>
+              </div>
+
+              {/* Start date */}
+              <div>
+                <span className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide">
+                  Start date
+                </span>
+                {cfg ? (
+                  <>
+                    <CalDatePicker
+                      cfg={cfg}
+                      value={start}
+                      onChange={setStart}
+                      disabled={isBusy}
+                      idPrefix="event-start"
+                    />
+                    {fieldErrors.start && (
+                      <p className="text-xs text-rose-400 mt-1">{fieldErrors.start}</p>
+                    )}
+                  </>
+                ) : (
+                  <p className="text-xs text-slate-500">No calendar configured.</p>
+                )}
+              </div>
+
+              {/* Multi-day toggle + end date */}
+              <div>
+                <label className="flex items-center gap-2 cursor-pointer mb-3">
+                  <input
+                    type="checkbox"
+                    checked={isMultiDay}
+                    onChange={(e) => handleMultiDayChange(e.target.checked)}
+                    disabled={isBusy}
+                    className="rounded border-white/20 bg-white/[0.04] text-blue-500 focus:ring-blue-500/30"
+                  />
+                  <span className="text-xs font-semibold text-slate-400">Multi-day event</span>
+                </label>
+
+                {isMultiDay && end !== null && cfg && (
+                  <div>
+                    <span className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide">
+                      End date
+                    </span>
+                    <CalDatePicker
+                      cfg={cfg}
+                      value={end}
+                      onChange={setEnd}
+                      disabled={isBusy}
+                      idPrefix="event-end"
+                    />
+                    {fieldErrors.end && (
+                      <p className="text-xs text-rose-400 mt-1">{fieldErrors.end}</p>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              {/* Content */}
+              <MarkdownEditor
+                label="Content"
+                value={content}
+                onChange={setContent}
+                placeholder="Public event content..."
+                disabled={isBusy}
+                minHeight="120px"
+                id="event-content-editor"
+              />
+
+              {/* GM Notes — always shown (only GMs reach EventModal) */}
+              <MarkdownEditor
+                label={
+                  <span>
+                    GM Notes{' '}
+                    <span className="text-amber-500 text-[10px] font-normal">
+                      (only visible to GM)
+                    </span>
+                  </span>
+                }
+                value={gmContent}
+                onChange={setGmContent}
+                placeholder="GM-only event notes..."
+                disabled={isBusy}
+                minHeight="120px"
+                id="event-gmcontent-editor"
+              />
+
+              {/* Images */}
+              <div>
+                <span className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide">
+                  Images
+                </span>
+                {images.length > 0 && (
+                  <div className="flex flex-wrap gap-3 mb-3">
+                    {images.map((img, idx) => (
+                      <div key={idx} className="relative group">
+                        <img
+                          src={img.url}
+                          alt={img.caption || `Event image ${idx + 1}`}
+                          className="w-20 h-20 object-cover rounded-lg border border-white/10"
+                        />
+                        {!isBusy && (
+                          <button
+                            type="button"
+                            onClick={() => handleRemoveImage(idx)}
+                            className="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-rose-600 flex items-center justify-center hover:bg-rose-500 transition-colors"
+                            aria-label={`Remove image ${idx + 1}`}
+                          >
+                            <X className="h-3 w-3 text-white" />
+                          </button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <label
+                  className={`inline-flex items-center gap-2 px-3 py-2 rounded-xl text-xs font-semibold border transition-colors cursor-pointer ${isBusy || isUploadingImage ? 'opacity-50 cursor-not-allowed border-white/10 text-slate-500' : 'border-white/10 text-slate-300 hover:border-blue-500/50 hover:text-blue-300'}`}
+                >
+                  <input
+                    type="file"
+                    accept=".jpg,.jpeg,.png,.webp"
+                    onChange={handleImageFileChange}
+                    disabled={isBusy || isUploadingImage}
+                    className="hidden"
+                  />
+                  {isUploadingImage ? 'Uploading...' : 'Add image'}
+                </label>
+                <p className="text-xs text-slate-700 mt-1.5">JPG, PNG, or WebP. Max 5MB.</p>
+              </div>
+
+              {/* Tags */}
+              <div>
+                <label
+                  htmlFor="event-tags-input"
+                  className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide"
+                >
+                  Tags
+                </label>
+                <TagAutocompleteInput
+                  campaignId={campaignId}
+                  selectedTags={tags}
+                  onTagsChange={setTags}
+                  placeholder="Type a tag and press Enter"
+                  disabled={isBusy}
+                  id="event-tags-input"
+                />
+                <p className="text-xs text-slate-700 mt-1.5">
+                  Press Enter or comma to add. Suggestions appear as you type.
+                </p>
+              </div>
+
+              {/* Visibility */}
+              <div className="flex items-center gap-6 pt-2">
+                <label className="flex items-center gap-3 cursor-pointer group">
+                  <input
+                    type="radio"
+                    name="event-visibility"
+                    checked={!isPublic}
+                    onChange={() => setIsPublic(false)}
+                    className="sr-only"
+                    disabled={isBusy}
+                  />
+                  <div
+                    className={`h-10 px-4 rounded-xl border flex items-center gap-2.5 transition-all ${
+                      !isPublic
+                        ? 'bg-blue-600/10 border-blue-500/50 text-blue-300 shadow-sm shadow-blue-500/10'
+                        : 'bg-white/[0.03] border-white/[0.07] text-slate-500 hover:border-white/20'
+                    }`}
+                  >
+                    <Lock className="h-3.5 w-3.5" />
+                    <span className="font-sans font-bold text-xs">Private</span>
+                  </div>
+                </label>
+
+                <label className="flex items-center gap-3 cursor-pointer group">
+                  <input
+                    type="radio"
+                    name="event-visibility"
+                    checked={isPublic}
+                    onChange={() => setIsPublic(true)}
+                    className="sr-only"
+                    disabled={isBusy}
+                  />
+                  <div
+                    className={`h-10 px-4 rounded-xl border flex items-center gap-2.5 transition-all ${
+                      isPublic
+                        ? 'bg-emerald-600/10 border-emerald-500/50 text-emerald-300 shadow-sm shadow-emerald-500/10'
+                        : 'bg-white/[0.03] border-white/[0.07] text-slate-500 hover:border-white/20'
+                    }`}
+                  >
+                    <Globe className="h-3.5 w-3.5" />
+                    <span className="font-sans font-bold text-xs">Public</span>
+                  </div>
+                </label>
+              </div>
+
+              {/* Linked Entities */}
+              <EventLinksEditor
+                campaignId={campaignId}
+                links={links}
+                onChange={setLinks}
+                disabled={isBusy}
+              />
+            </>
+          )}
+        </div>
+
+        <footer className="flex items-center justify-between px-4 sm:px-6 py-4 border-t border-white/[0.07] bg-white/[0.01] shrink-0">
+          {/* Delete side */}
+          <div>
+            {isEdit && !showDeleteConfirm && (
+              <button
+                type="button"
+                onClick={() => setShowDeleteConfirm(true)}
+                disabled={isBusy}
+                className="px-3 py-2 rounded-xl text-xs font-semibold text-rose-400 border border-rose-500/20 hover:bg-rose-500/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Delete
+              </button>
+            )}
+            {isEdit && showDeleteConfirm && (
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-rose-400 font-semibold">Delete this event?</span>
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  disabled={isBusy}
+                  className="px-3 py-2 rounded-xl text-xs font-semibold bg-rose-600 hover:bg-rose-500 text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {isDeleting ? 'Deleting...' : 'Confirm'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowDeleteConfirm(false)}
+                  disabled={isBusy}
+                  className="px-3 py-2 rounded-xl text-xs font-semibold text-slate-400 hover:text-white transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            )}
+          </div>
+
+          {/* Save/Cancel side */}
+          <div className="flex items-center gap-3">
+            <PixelButton
+              variant="secondary"
+              size="sm"
+              onClick={onClose}
+              disabled={isSaving}
+              type="button"
+            >
+              Cancel
+            </PixelButton>
+            <PixelButton variant="primary" size="sm" disabled={isBusy} type="submit">
+              {isSaving
+                ? 'Saving...'
+                : isLoadingEvent
+                  ? 'Loading...'
+                  : isEdit
+                    ? 'Update Event'
+                    : 'Create Event'}
+            </PixelButton>
+          </div>
+        </footer>
+      </form>
+    </div>,
+    document.body
+  );
 }

--- a/app/components/wiki/calendar/EventModal.tsx
+++ b/app/components/wiki/calendar/EventModal.tsx
@@ -1,0 +1,13 @@
+// TODO(Task 15): real EventModal
+// Mirroring LoreModal props: isOpen, onClose, campaignId, eventId? (create vs edit)
+
+interface EventModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  campaignId: string;
+  eventId?: string;
+}
+
+export function EventModal(_props: EventModalProps) {
+  return null;
+}

--- a/app/components/wiki/calendar/EventViewModal.tsx
+++ b/app/components/wiki/calendar/EventViewModal.tsx
@@ -6,6 +6,7 @@ import { EventModal } from './EventModal';
 import { useEvent } from '~/hooks/useEvents';
 import { useCalendar } from '~/hooks/useCalendar';
 import type { CalendarConfig } from '~/utils/calendarEngine';
+import { calendarConfigFromData } from '~/types/calendar';
 
 interface EventViewModalProps {
   isOpen: boolean;
@@ -16,10 +17,8 @@ interface EventViewModalProps {
 
 export function EventViewModal({ isOpen, onClose, eventId, campaignId }: EventViewModalProps) {
   const { event, isLoading: isLoadingEvent } = useEvent(eventId, campaignId);
-  const { calendar, isLoading: isLoadingCalendar } = useCalendar(campaignId);
+  const { calendar } = useCalendar(campaignId);
   const [isEditOpen, setIsEditOpen] = useState(false);
-
-  const isLoading = isLoadingEvent || isLoadingCalendar;
 
   useEffect(() => {
     if (!isOpen) return;
@@ -34,19 +33,7 @@ export function EventViewModal({ isOpen, onClose, eventId, campaignId }: EventVi
   if (!isOpen) return null;
 
   // Build a CalendarConfig from the calendar data when available.
-  const cfg: CalendarConfig | null = calendar
-    ? {
-        months: calendar.months,
-        weekdays: calendar.weekdays,
-        weekdayMode: calendar.weekdayMode,
-        epoch: calendar.epoch,
-        leapDays: calendar.leapDays,
-        yearSuffix: calendar.yearSuffix,
-        moons: calendar.moons,
-        seasons: calendar.seasons,
-        holidays: calendar.holidays,
-      }
-    : null;
+  const cfg: CalendarConfig | null = calendar ? calendarConfigFromData(calendar) : null;
 
   return createPortal(
     <>
@@ -94,20 +81,20 @@ export function EventViewModal({ isOpen, onClose, eventId, campaignId }: EventVi
           </header>
 
           <div className="flex-1 overflow-y-auto min-h-0">
-            {isLoading ? (
+            {isLoadingEvent ? (
               <div className="flex items-center justify-center py-12">
                 <p className="text-xs text-slate-500 animate-pulse">Loading event...</p>
               </div>
-            ) : event && cfg ? (
+            ) : !event ? (
+              <div className="flex items-center justify-center py-12">
+                <p className="text-xs text-slate-500">Event not found</p>
+              </div>
+            ) : (
               <EventWindow
                 event={event}
                 cfg={cfg}
                 onEdit={event.canEdit ? () => setIsEditOpen(true) : undefined}
               />
-            ) : (
-              <div className="flex items-center justify-center py-12">
-                <p className="text-xs text-slate-500">Event not found</p>
-              </div>
             )}
           </div>
         </div>

--- a/app/components/wiki/calendar/EventViewModal.tsx
+++ b/app/components/wiki/calendar/EventViewModal.tsx
@@ -1,0 +1,125 @@
+import { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { Globe, Lock, X } from 'lucide-react';
+import { EventWindow } from './EventWindow';
+import { EventModal } from './EventModal';
+import { useEvent } from '~/hooks/useEvents';
+import { useCalendar } from '~/hooks/useCalendar';
+import type { CalendarConfig } from '~/utils/calendarEngine';
+
+interface EventViewModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  eventId: string;
+  campaignId: string;
+}
+
+export function EventViewModal({ isOpen, onClose, eventId, campaignId }: EventViewModalProps) {
+  const { event, isLoading: isLoadingEvent } = useEvent(eventId, campaignId);
+  const { calendar, isLoading: isLoadingCalendar } = useCalendar(campaignId);
+  const [isEditOpen, setIsEditOpen] = useState(false);
+
+  const isLoading = isLoadingEvent || isLoadingCalendar;
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  // Build a CalendarConfig from the calendar data when available.
+  const cfg: CalendarConfig | null = calendar
+    ? {
+        months: calendar.months,
+        weekdays: calendar.weekdays,
+        weekdayMode: calendar.weekdayMode,
+        epoch: calendar.epoch,
+        leapDays: calendar.leapDays,
+        yearSuffix: calendar.yearSuffix,
+        moons: calendar.moons,
+        seasons: calendar.seasons,
+        holidays: calendar.holidays,
+      }
+    : null;
+
+  return createPortal(
+    <>
+      <div
+        role="presentation"
+        className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-2 sm:p-4 backdrop-blur-sm"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) onClose();
+        }}
+      >
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="event-view-modal-title"
+          className="w-full max-w-lg max-h-[90vh] bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col"
+        >
+          <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
+            <div className="flex items-center gap-2 min-w-0">
+              {event &&
+                (event.isPublic ? (
+                  <Globe className="h-3.5 w-3.5 text-emerald-400 shrink-0" aria-hidden="true" />
+                ) : (
+                  <Lock className="h-3.5 w-3.5 text-amber-400 shrink-0" aria-hidden="true" />
+                ))}
+              <h2
+                id="event-view-modal-title"
+                className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest truncate"
+              >
+                {event ? event.title : 'Event'}
+                {event && (
+                  <span className="sr-only">{event.isPublic ? ' (Public)' : ' (Private)'}</span>
+                )}
+              </h2>
+            </div>
+            <div className="flex items-center gap-1 shrink-0">
+              <button
+                type="button"
+                onClick={onClose}
+                className="text-slate-500 hover:text-white transition-colors"
+                aria-label="Close modal"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+          </header>
+
+          <div className="flex-1 overflow-y-auto min-h-0">
+            {isLoading ? (
+              <div className="flex items-center justify-center py-12">
+                <p className="text-xs text-slate-500 animate-pulse">Loading event...</p>
+              </div>
+            ) : event && cfg ? (
+              <EventWindow
+                event={event}
+                cfg={cfg}
+                onEdit={event.canEdit ? () => setIsEditOpen(true) : undefined}
+              />
+            ) : (
+              <div className="flex items-center justify-center py-12">
+                <p className="text-xs text-slate-500">Event not found</p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <EventModal
+        isOpen={isEditOpen}
+        onClose={() => setIsEditOpen(false)}
+        campaignId={campaignId}
+        eventId={eventId}
+      />
+    </>,
+    document.body
+  );
+}

--- a/app/components/wiki/calendar/EventWindow.tsx
+++ b/app/components/wiki/calendar/EventWindow.tsx
@@ -53,7 +53,7 @@ function LinkChip({ link }: { link: EventLink }) {
 
 interface EventWindowProps {
   event: EventData;
-  cfg: CalendarConfig;
+  cfg: CalendarConfig | null;
   onEdit?: () => void;
 }
 
@@ -63,8 +63,8 @@ export function EventWindow({ event, cfg, onEdit }: EventWindowProps) {
   const hasGmContent = !!event.gmContent;
   const hasLinks = event.links.length > 0;
 
-  const startLabel = formatDate(cfg, event.start);
-  const endLabel = event.end !== null ? formatDate(cfg, event.end) : null;
+  const startLabel = cfg ? formatDate(cfg, event.start) : null;
+  const endLabel = cfg && event.end !== null ? formatDate(cfg, event.end) : null;
 
   return (
     <div data-testid="event-window" className="flex flex-col gap-4 p-4">
@@ -99,11 +99,13 @@ export function EventWindow({ event, cfg, onEdit }: EventWindowProps) {
         </div>
       )}
 
-      {/* Date range */}
-      <p className="text-xs text-slate-500">
-        {startLabel}
-        {endLabel && ` – ${endLabel}`}
-      </p>
+      {/* Date range (only rendered when cfg is available) */}
+      {startLabel !== null && (
+        <p className="text-xs text-slate-500">
+          {startLabel}
+          {endLabel && ` – ${endLabel}`}
+        </p>
+      )}
 
       {/* Tags */}
       {event.tags.length > 0 && (

--- a/app/components/wiki/calendar/EventWindow.tsx
+++ b/app/components/wiki/calendar/EventWindow.tsx
@@ -1,0 +1,184 @@
+import React from 'react';
+import { Globe, Lock, Pencil } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { EventData, EventLink } from '~/types/event';
+import type { PictureCrop } from '~/types/character';
+import type { CalendarConfig } from '~/utils/calendarEngine';
+import { formatDate } from '~/utils/calendarEngine';
+import { MARKDOWN_PROSE_CLASSES } from '~/utils/markdownProseClasses';
+
+function getCropStyle(crop: PictureCrop): React.CSSProperties {
+  const centerX = (crop.x + crop.width / 2) * 100;
+  const centerY = (crop.y + crop.height / 2) * 100;
+  const scale = 1 / crop.width;
+  return {
+    objectPosition: `${centerX}% ${centerY}%`,
+    transform: `scale(${scale})`,
+  };
+}
+
+/** Maps event link kind → a colour scheme for the chip badge. */
+const KIND_BADGE_COLORS: Record<string, string> = {
+  character: 'bg-violet-500/10 border-violet-500/20 text-violet-400',
+  player: 'bg-sky-500/10 border-sky-500/20 text-sky-400',
+  race: 'bg-teal-500/10 border-teal-500/20 text-teal-400',
+  location: 'bg-amber-500/10 border-amber-500/20 text-amber-400',
+  lore: 'bg-blue-500/10 border-blue-500/20 text-blue-400',
+};
+
+const KIND_LABELS: Record<string, string> = {
+  character: 'Character',
+  player: 'Player',
+  race: 'Race',
+  location: 'Location',
+  lore: 'Lore',
+};
+
+function LinkChip({ link }: { link: EventLink }) {
+  const kindLabel = KIND_LABELS[link.kind] ?? link.kind;
+  const colorClass =
+    KIND_BADGE_COLORS[link.kind] ?? 'bg-white/[0.05] border-white/[0.08] text-slate-300';
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs ${colorClass}`}
+    >
+      <span className="text-[10px] font-bold uppercase tracking-wider opacity-70 shrink-0">
+        {kindLabel}
+      </span>
+      <span>{link.label ?? link.id}</span>
+    </span>
+  );
+}
+
+interface EventWindowProps {
+  event: EventData;
+  cfg: CalendarConfig;
+  onEdit?: () => void;
+}
+
+export function EventWindow({ event, cfg, onEdit }: EventWindowProps) {
+  const hasImages = event.images.length > 0;
+  const hasContent = !!event.content;
+  const hasGmContent = !!event.gmContent;
+  const hasLinks = event.links.length > 0;
+
+  const startLabel = formatDate(cfg, event.start);
+  const endLabel = event.end !== null ? formatDate(cfg, event.end) : null;
+
+  return (
+    <div data-testid="event-window" className="flex flex-col gap-4 p-4">
+      {/* Header: title, visibility, edit */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          {event.isPublic ? (
+            <Globe className="h-3.5 w-3.5 text-emerald-400 shrink-0" aria-label="Public" />
+          ) : (
+            <Lock className="h-3.5 w-3.5 text-amber-400 shrink-0" aria-label="Private" />
+          )}
+          <h3 className="font-sans font-bold text-sm text-slate-100 truncate">{event.title}</h3>
+        </div>
+        {event.canEdit && onEdit && (
+          <button
+            type="button"
+            onClick={onEdit}
+            className="shrink-0 p-1 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors"
+            aria-label="Edit event"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+
+      {/* Epic badge */}
+      {event.isEpic && (
+        <div>
+          <span className="inline-flex items-center px-2 py-0.5 rounded bg-amber-500/15 border border-amber-500/25 text-amber-400 font-bold text-[9px] uppercase tracking-tight">
+            EPIC
+          </span>
+        </div>
+      )}
+
+      {/* Date range */}
+      <p className="text-xs text-slate-500">
+        {startLabel}
+        {endLabel && ` – ${endLabel}`}
+      </p>
+
+      {/* Tags */}
+      {event.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {event.tags.map((tag) => (
+            <span
+              key={tag}
+              className="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[9px] tracking-tight"
+            >
+              #{tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Images gallery */}
+      {hasImages && (
+        <div className="flex flex-col gap-3">
+          <p className="text-[10px] uppercase tracking-wider text-slate-500">Images</p>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            {event.images.map((image, idx) => (
+              <div key={idx} className="flex flex-col gap-1">
+                <div className="w-full aspect-square overflow-hidden rounded-lg border border-white/[0.08]">
+                  <img
+                    src={image.url}
+                    alt={image.caption || `Event image ${idx + 1}`}
+                    className="w-full h-full object-cover"
+                    style={image.crop ? getCropStyle(image.crop) : undefined}
+                  />
+                </div>
+                {image.caption && (
+                  <p className="text-[10px] text-slate-500 text-center leading-tight">
+                    {image.caption}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Content */}
+      {hasContent ? (
+        <div className={MARKDOWN_PROSE_CLASSES}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{event.content}</ReactMarkdown>
+        </div>
+      ) : (
+        !hasImages &&
+        !hasLinks &&
+        !hasGmContent && <p className="text-xs text-slate-500">No event details yet.</p>
+      )}
+
+      {/* GM Content */}
+      {hasGmContent && (
+        <div>
+          <div className="mb-2 rounded-md bg-amber-500/10 border border-amber-500/20 px-3 py-2">
+            <p className="text-[10px] text-amber-400">GM Notes — only visible to the GM.</p>
+          </div>
+          <div className={MARKDOWN_PROSE_CLASSES}>
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{event.gmContent}</ReactMarkdown>
+          </div>
+        </div>
+      )}
+
+      {/* Linked entities */}
+      {hasLinks && (
+        <div className="flex flex-col gap-2">
+          <p className="text-[10px] uppercase tracking-wider text-slate-500">Linked to</p>
+          <div className="flex flex-wrap gap-2">
+            {event.links.map((link, idx) => (
+              <LinkChip key={`${link.kind}-${link.id}-${idx}`} link={link} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/wiki/calendar/EventsPanel.tsx
+++ b/app/components/wiki/calendar/EventsPanel.tsx
@@ -1,0 +1,8 @@
+// TODO(Task 15): replace stub with real panel
+interface EventsPanelProps {
+  onBack: () => void;
+}
+
+export function EventsPanel(_props: EventsPanelProps) {
+  return <div data-testid="events-panel-stub">Events (coming soon)</div>;
+}

--- a/app/components/wiki/calendar/EventsPanel.tsx
+++ b/app/components/wiki/calendar/EventsPanel.tsx
@@ -1,8 +1,146 @@
-// TODO(Task 15): replace stub with real panel
+import { useState } from 'react';
+import { useParams } from '@tanstack/react-router';
+import { CalendarDays } from 'lucide-react';
+import { WikiCategoryHeader } from '~/components/wiki/shared/WikiCategoryHeader';
+import { WikiFilterBar } from '~/components/wiki/shared/WikiFilterBar';
+import { EventCard } from './EventCard';
+import { EventModal } from './EventModal';
+import { useEvents } from '~/hooks/useEvents';
+import { useCalendar } from '~/hooks/useCalendar';
+import { useCampaign } from '~/hooks/useCampaigns';
+import { calendarConfigFromData } from '~/types/calendar';
+import type { EventListItem } from '~/types/event';
+
 interface EventsPanelProps {
   onBack: () => void;
 }
 
-export function EventsPanel(_props: EventsPanelProps) {
-  return <div data-testid="events-panel-stub">Events (coming soon)</div>;
+export function EventsPanel({ onBack }: EventsPanelProps) {
+  const { campaignId } = useParams({ from: '/campaigns/$campaignId/play' });
+  const { campaign } = useCampaign(campaignId);
+  const isGM = campaign?.isGM ?? false;
+
+  const [search, setSearch] = useState('');
+  const [visibility, setVisibility] = useState<'all' | 'public' | 'private'>('all');
+  const [filterTags, setFilterTags] = useState<string[]>([]);
+  const [epicOnly, setEpicOnly] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedEventId, setSelectedEventId] = useState<string | undefined>();
+
+  const { calendar, isLoading: isLoadingCalendar } = useCalendar(campaignId);
+  const cfg = calendar ? calendarConfigFromData(calendar) : null;
+
+  const { events, isLoading, error } = useEvents(campaignId, {
+    search: search || undefined,
+    visibility,
+    tags: filterTags.length > 0 ? filterTags : undefined,
+    epicOnly: epicOnly || undefined,
+  });
+
+  const handleCreateClick = () => {
+    setSelectedEventId(undefined);
+    setIsModalOpen(true);
+  };
+
+  const handleEventClick = (item: EventListItem) => {
+    if (item.canEdit) {
+      setSelectedEventId(item.id);
+      setIsModalOpen(true);
+    }
+  };
+
+  const handleModalClose = () => {
+    setIsModalOpen(false);
+    setSelectedEventId(undefined);
+  };
+
+  return (
+    <div className="flex flex-col h-full w-full bg-[#080A12]">
+      <WikiCategoryHeader title="Events" onBack={onBack} />
+      <WikiFilterBar
+        search={search}
+        onSearchChange={setSearch}
+        visibility={visibility}
+        onVisibilityChange={setVisibility}
+        onCreateClick={handleCreateClick}
+        createButtonTestId="event-create-button"
+        campaignId={campaignId}
+        filterTags={filterTags}
+        onFilterTagsChange={setFilterTags}
+        searchPlaceholder="Search events..."
+        showSessionFilter={false}
+        showVisibilityFilter={isGM}
+      />
+
+      {/* Epic-only toggle — adjacent to the filter bar */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-white/[0.07] bg-[#0D1117]">
+        <button
+          type="button"
+          onClick={() => setEpicOnly((v) => !v)}
+          className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold border transition-all ${
+            epicOnly
+              ? 'bg-amber-500/15 border-amber-500/30 text-amber-400'
+              : 'bg-white/[0.03] border-white/[0.07] text-slate-500 hover:border-white/20 hover:text-slate-300'
+          }`}
+          aria-pressed={epicOnly}
+        >
+          Epic only
+        </button>
+      </div>
+
+      {isLoadingCalendar ? (
+        <div className="flex flex-1 items-center justify-center p-8">
+          <p className="font-sans font-semibold text-xs text-slate-500 animate-pulse">
+            Loading calendar...
+          </p>
+        </div>
+      ) : !calendar ? (
+        <div className="flex flex-1 flex-col items-center justify-center p-8 text-center">
+          <div className="h-12 w-12 rounded-full bg-white/[0.03] flex items-center justify-center mb-3">
+            <CalendarDays className="h-6 w-6 text-slate-600" />
+          </div>
+          <p className="font-sans font-semibold text-xs text-slate-500 mb-1">
+            No calendar configured.
+          </p>
+          <p className="font-sans text-xs text-slate-600">
+            Create a calendar first in the Calendar category.
+          </p>
+        </div>
+      ) : isLoading ? (
+        <div className="flex flex-1 items-center justify-center p-8">
+          <p className="font-sans font-semibold text-xs text-slate-500 animate-pulse">
+            Loading events...
+          </p>
+        </div>
+      ) : error ? (
+        <div className="flex flex-1 items-center justify-center p-8 text-center">
+          <p className="font-sans font-semibold text-xs text-rose-400">{error}</p>
+        </div>
+      ) : events.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center p-8 text-center">
+          <div className="h-12 w-12 rounded-full bg-white/[0.03] flex items-center justify-center mb-3">
+            <CalendarDays className="h-6 w-6 text-slate-600" />
+          </div>
+          <p className="font-sans font-semibold text-xs text-slate-500">
+            No events found matching your filters.
+          </p>
+        </div>
+      ) : (
+        <div className="flex-1 overflow-y-auto min-h-0">
+          <div className="flex flex-col">
+            {events.map((item) => (
+              <EventCard key={item.id} event={item} cfg={cfg!} onClick={handleEventClick} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      <EventModal
+        isOpen={isModalOpen}
+        onClose={handleModalClose}
+        campaignId={campaignId}
+        eventId={selectedEventId}
+      />
+    </div>
+  );
 }

--- a/app/components/wiki/calendar/EventsPanel.tsx
+++ b/app/components/wiki/calendar/EventsPanel.tsx
@@ -54,6 +54,40 @@ export function EventsPanel({ onBack }: EventsPanelProps) {
     setSelectedEventId(undefined);
   };
 
+  // When there's no calendar configured, show only the header + empty state.
+  // Do NOT render the WikiFilterBar or EventModal—those require a calendar.
+  if (isLoadingCalendar) {
+    return (
+      <div className="flex flex-col h-full w-full bg-[#080A12]">
+        <WikiCategoryHeader title="Events" onBack={onBack} />
+        <div className="flex flex-1 items-center justify-center p-8">
+          <p className="font-sans font-semibold text-xs text-slate-500 animate-pulse">
+            Loading calendar...
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!calendar) {
+    return (
+      <div className="flex flex-col h-full w-full bg-[#080A12]">
+        <WikiCategoryHeader title="Events" onBack={onBack} />
+        <div className="flex flex-1 flex-col items-center justify-center p-8 text-center">
+          <div className="h-12 w-12 rounded-full bg-white/[0.03] flex items-center justify-center mb-3">
+            <CalendarDays className="h-6 w-6 text-slate-600" />
+          </div>
+          <p className="font-sans font-semibold text-xs text-slate-500 mb-1">
+            No calendar configured.
+          </p>
+          <p className="font-sans text-xs text-slate-600">
+            Create a calendar first in the Calendar category.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col h-full w-full bg-[#080A12]">
       <WikiCategoryHeader title="Events" onBack={onBack} />
@@ -88,25 +122,7 @@ export function EventsPanel({ onBack }: EventsPanelProps) {
         </button>
       </div>
 
-      {isLoadingCalendar ? (
-        <div className="flex flex-1 items-center justify-center p-8">
-          <p className="font-sans font-semibold text-xs text-slate-500 animate-pulse">
-            Loading calendar...
-          </p>
-        </div>
-      ) : !calendar ? (
-        <div className="flex flex-1 flex-col items-center justify-center p-8 text-center">
-          <div className="h-12 w-12 rounded-full bg-white/[0.03] flex items-center justify-center mb-3">
-            <CalendarDays className="h-6 w-6 text-slate-600" />
-          </div>
-          <p className="font-sans font-semibold text-xs text-slate-500 mb-1">
-            No calendar configured.
-          </p>
-          <p className="font-sans text-xs text-slate-600">
-            Create a calendar first in the Calendar category.
-          </p>
-        </div>
-      ) : isLoading ? (
+      {isLoading ? (
         <div className="flex flex-1 items-center justify-center p-8">
           <p className="font-sans font-semibold text-xs text-slate-500 animate-pulse">
             Loading events...

--- a/app/components/wiki/lore/LoreCard.tsx
+++ b/app/components/wiki/lore/LoreCard.tsx
@@ -37,6 +37,7 @@ export function LoreCard({ lore, onClick }: LoreCardProps) {
       tabIndex={0}
       draggable="true"
       data-testid="lore-card"
+      data-lore-id={lore.id}
       onDragStart={(e) => {
         e.dataTransfer.setData(
           'application/x-cartyx-document',
@@ -87,7 +88,10 @@ export function LoreCard({ lore, onClick }: LoreCardProps) {
       {/* Details */}
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 mb-0.5">
-          <span className="text-sm font-semibold text-slate-200 group-hover:text-blue-400 transition-colors truncate">
+          <span
+            data-testid="lore-card-title"
+            className="text-sm font-semibold text-slate-200 group-hover:text-blue-400 transition-colors truncate"
+          >
             {lore.title}
           </span>
           {lore.isPublic ? (

--- a/app/components/wiki/lore/LoreCard.tsx
+++ b/app/components/wiki/lore/LoreCard.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { Globe, Lock } from 'lucide-react';
+import type { LoreListItem } from '~/types/lore';
+import { setTokenDragImage } from '~/utils/setTokenDragImage';
+
+const GRADIENT_PAIRS = [
+  ['#3b82f6', '#8b5cf6'],
+  ['#f59e0b', '#ef4444'],
+  ['#10b981', '#06b6d4'],
+  ['#ec4899', '#8b5cf6'],
+  ['#f97316', '#eab308'],
+  ['#14b8a6', '#3b82f6'],
+];
+
+function hashName(name: string): number {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash << 5) - hash + name.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+
+interface LoreCardProps {
+  lore: LoreListItem;
+  onClick: (lore: LoreListItem) => void;
+}
+
+export function LoreCard({ lore, onClick }: LoreCardProps) {
+  const gradientIndex = hashName(lore.title) % GRADIENT_PAIRS.length;
+  const [gradFrom] = GRADIENT_PAIRS[gradientIndex]!;
+  const firstImageUrl = lore.images[0]?.url ?? null;
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      draggable="true"
+      data-testid="lore-card"
+      onDragStart={(e) => {
+        e.dataTransfer.setData(
+          'application/x-cartyx-document',
+          JSON.stringify({
+            collection: 'lore',
+            documentId: lore.id,
+            title: lore.title,
+          })
+        );
+        e.dataTransfer.effectAllowed = 'copy';
+        setTokenDragImage(e, {
+          pictureUrl: firstImageUrl,
+          initial: lore.title,
+          color: gradFrom,
+        });
+        e.currentTarget.style.opacity = '0.4';
+      }}
+      onDragEnd={(e) => {
+        e.currentTarget.style.opacity = '';
+      }}
+      onClick={() => onClick(lore)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick(lore);
+        }
+      }}
+      className="flex items-start gap-3 px-4 py-3 border-b border-white/[0.05] hover:bg-white/[0.03] transition-colors group cursor-grab active:cursor-grabbing"
+    >
+      {/* Avatar / first image thumbnail */}
+      <div
+        className="w-10 h-10 rounded-lg flex-shrink-0 flex items-center justify-center overflow-hidden mt-0.5"
+        style={
+          firstImageUrl
+            ? undefined
+            : {
+                background: `linear-gradient(135deg, ${gradFrom}, ${GRADIENT_PAIRS[gradientIndex]![1]})`,
+              }
+        }
+      >
+        {firstImageUrl ? (
+          <img src={firstImageUrl} alt="" loading="lazy" className="w-full h-full object-cover" />
+        ) : (
+          <span className="text-sm text-white font-semibold uppercase">{lore.title.charAt(0)}</span>
+        )}
+      </div>
+
+      {/* Details */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-0.5">
+          <span className="text-sm font-semibold text-slate-200 group-hover:text-blue-400 transition-colors truncate">
+            {lore.title}
+          </span>
+          {lore.isPublic ? (
+            <Globe className="h-3.5 w-3.5 text-emerald-500 shrink-0" aria-label="Public" />
+          ) : (
+            <Lock className="h-3.5 w-3.5 text-amber-500 shrink-0" aria-label="Private" />
+          )}
+        </div>
+
+        {lore.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1 mb-1">
+            {lore.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[9px] tracking-tight"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {lore.links.length > 0 && (
+          <p className="text-[11px] text-slate-500">
+            {lore.links.length === 1
+              ? (lore.links[0]?.label ?? '1 link')
+              : `${lore.links.length} links`}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/wiki/lore/LoreLinksEditor.tsx
+++ b/app/components/wiki/lore/LoreLinksEditor.tsx
@@ -1,0 +1,193 @@
+import { useState, useMemo, useId } from 'react';
+import { X } from 'lucide-react';
+import { useCharacters } from '~/hooks/useCharacters';
+import { usePlayers } from '~/hooks/usePlayers';
+import { useLocations } from '~/hooks/useLocations';
+import { useRaces } from '~/hooks/useRaces';
+import type { LoreLink, LoreLinkKind } from '~/types/lore';
+
+interface Candidate {
+  id: string;
+  label: string;
+}
+
+const KIND_LABELS: Record<LoreLinkKind, string> = {
+  character: 'Character',
+  player: 'Player',
+  location: 'Location',
+  race: 'Race',
+};
+
+const KIND_BADGE_COLORS: Record<LoreLinkKind, string> = {
+  character: 'bg-blue-500/20 text-blue-300',
+  player: 'bg-green-500/20 text-green-300',
+  location: 'bg-amber-500/20 text-amber-300',
+  race: 'bg-purple-500/20 text-purple-300',
+};
+
+interface Props {
+  campaignId: string;
+  links: LoreLink[];
+  onChange: (links: LoreLink[]) => void;
+  disabled?: boolean;
+}
+
+export function LoreLinksEditor({ campaignId, links, onChange, disabled }: Props) {
+  const uid = useId();
+  const kindSelectId = `lore-links-kind-${uid}`;
+  const entitySelectId = `lore-links-entity-${uid}`;
+
+  const [kind, setKind] = useState<LoreLinkKind>('character');
+  const [selectedId, setSelectedId] = useState('');
+
+  // Fetch all four entity lists — always enabled so the selects populate quickly
+  const { characters } = useCharacters(campaignId);
+  const { players } = usePlayers(campaignId);
+  const { locations } = useLocations(campaignId);
+  const { races } = useRaces(campaignId);
+
+  // Build the candidate list for the currently chosen kind
+  const candidates: Candidate[] = useMemo(() => {
+    switch (kind) {
+      case 'character':
+        return characters.map((c) => ({
+          id: c.id,
+          label: `${c.firstName} ${c.lastName}`.trim(),
+        }));
+      case 'player':
+        return players.map((p) => ({
+          id: p.id,
+          label: `${p.firstName} ${p.lastName}`.trim(),
+        }));
+      case 'location':
+        return locations.map((l) => ({ id: l.id, label: l.name }));
+      case 'race':
+        return races.map((r) => ({ id: r.id, label: r.title }));
+    }
+  }, [kind, characters, players, locations, races]);
+
+  // Reset entity selection when kind changes
+  const handleKindChange = (newKind: LoreLinkKind) => {
+    setKind(newKind);
+    setSelectedId('');
+  };
+
+  const handleAddLink = () => {
+    if (!selectedId) return;
+
+    // Deduplicate: same kind + id already present
+    const alreadyLinked = links.some((l) => l.kind === kind && l.id === selectedId);
+    if (alreadyLinked) return;
+
+    const candidate = candidates.find((c) => c.id === selectedId);
+    if (!candidate) return;
+
+    const newLink: LoreLink = { kind, id: selectedId, label: candidate.label };
+    onChange([...links, newLink]);
+    setSelectedId('');
+  };
+
+  const handleRemoveLink = (removeKind: LoreLinkKind, removeId: string) => {
+    onChange(links.filter((l) => !(l.kind === removeKind && l.id === removeId)));
+  };
+
+  return (
+    <div data-testid="lore-links-editor" className="space-y-3">
+      <span className="block text-xs font-semibold text-slate-400 tracking-wide">
+        Linked Entities
+      </span>
+
+      {/* Existing link chips */}
+      {links.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {links.map((link) => {
+            const label = link.label ?? link.id;
+            return (
+              <span
+                key={`${link.kind}-${link.id}`}
+                className="inline-flex items-center gap-1.5 bg-white/[0.06] border border-white/10 rounded-full pl-2.5 pr-1.5 py-1 text-xs text-slate-200"
+              >
+                {label}
+                <span
+                  className={`rounded-full px-1.5 py-0.5 text-[10px] font-semibold ${KIND_BADGE_COLORS[link.kind]}`}
+                >
+                  {KIND_LABELS[link.kind]}
+                </span>
+                {!disabled && (
+                  <button
+                    type="button"
+                    aria-label={`Remove ${label}`}
+                    onClick={() => handleRemoveLink(link.kind, link.id)}
+                    className="text-slate-500 hover:text-white transition-colors ml-0.5 rounded-full p-0.5 focus:outline-none focus:ring-1 focus:ring-white/30"
+                  >
+                    <X size={11} strokeWidth={2.5} />
+                  </button>
+                )}
+              </span>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Add link controls */}
+      {!disabled && (
+        <div className="flex items-end gap-2">
+          {/* Kind selector */}
+          <div className="flex-shrink-0">
+            <label htmlFor={kindSelectId} className="block text-[11px] text-slate-500 mb-1">
+              Type
+            </label>
+            <select
+              id={kindSelectId}
+              value={kind}
+              onChange={(e) => handleKindChange(e.target.value as LoreLinkKind)}
+              className="bg-white/[0.04] border border-white/10 rounded-xl px-3 py-2.5 text-slate-200 text-sm focus:outline-none focus:border-blue-500/50 transition-all appearance-none cursor-pointer"
+            >
+              {(Object.keys(KIND_LABELS) as LoreLinkKind[]).map((k) => (
+                <option key={k} value={k} className="bg-[#0D1117]">
+                  {KIND_LABELS[k]}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Entity selector */}
+          <div className="flex-1 min-w-0">
+            <label htmlFor={entitySelectId} className="block text-[11px] text-slate-500 mb-1">
+              Entity
+            </label>
+            <select
+              id={entitySelectId}
+              aria-label="Entity to link"
+              value={selectedId}
+              onChange={(e) => setSelectedId(e.target.value)}
+              disabled={candidates.length === 0}
+              className="w-full bg-white/[0.04] border border-white/10 rounded-xl px-3 py-2.5 text-slate-200 text-sm focus:outline-none focus:border-blue-500/50 transition-all appearance-none cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <option value="" className="bg-[#0D1117]">
+                {candidates.length === 0
+                  ? `No ${KIND_LABELS[kind].toLowerCase()}s`
+                  : `Select ${KIND_LABELS[kind].toLowerCase()}…`}
+              </option>
+              {candidates.map((c) => (
+                <option key={c.id} value={c.id} className="bg-[#0D1117]">
+                  {c.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Add button */}
+          <button
+            type="button"
+            onClick={handleAddLink}
+            disabled={!selectedId}
+            className="flex-shrink-0 px-3 py-2.5 rounded-xl text-sm font-semibold bg-blue-600 hover:bg-blue-500 disabled:bg-white/[0.06] disabled:text-slate-500 disabled:cursor-not-allowed text-white transition-colors"
+          >
+            Add link
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/wiki/lore/LoreList.tsx
+++ b/app/components/wiki/lore/LoreList.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { Globe, Lock, Pencil, Trash2, Plus } from 'lucide-react';
+import type { LoreListItem } from '~/types/lore';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface LoreListProps {
+  lore: LoreListItem[];
+  canManage: boolean;
+  onAdd: () => void;
+  onOpen: (id: string) => void;
+  onEdit: (id: string) => void;
+  onRemove: (id: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function LoreList({ lore, canManage, onAdd, onOpen, onEdit, onRemove }: LoreListProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      {canManage && (
+        <button
+          type="button"
+          onClick={onAdd}
+          className="flex items-center gap-1.5 text-xs text-blue-400 hover:text-blue-300 transition-colors mb-1"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Add lore
+        </button>
+      )}
+
+      {lore.length === 0 && <p className="text-xs text-slate-500">No lore yet.</p>}
+
+      {lore.map((entry) => (
+        <div
+          key={entry.id}
+          role="button"
+          tabIndex={0}
+          onClick={() => onOpen(entry.id)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              onOpen(entry.id);
+            }
+          }}
+          className="flex items-center gap-3 rounded-md border border-white/[0.06] bg-white/[0.02] px-3 py-2 hover:bg-white/[0.04] transition-colors cursor-pointer"
+        >
+          {/* Title */}
+          <div className="flex-1 min-w-0">
+            <p className="text-xs font-bold text-slate-200 truncate">{entry.title}</p>
+          </div>
+
+          {/* Public / Private badge */}
+          {entry.isPublic ? (
+            <span className="shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[9px] font-semibold bg-emerald-500/15 text-emerald-400 border border-emerald-500/20">
+              <Globe className="h-2.5 w-2.5" />
+              Public
+            </span>
+          ) : (
+            <span className="shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[9px] font-semibold bg-red-500/15 text-red-400 border border-red-500/20">
+              <Lock className="h-2.5 w-2.5" />
+              Private
+            </span>
+          )}
+
+          {/* Action buttons */}
+          {canManage && (
+            <div className="flex items-center gap-1 shrink-0">
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onEdit(entry.id);
+                }}
+                className="p-1 rounded text-slate-500 hover:text-slate-300 hover:bg-white/[0.05] transition-colors"
+                aria-label={`Edit ${entry.title}`}
+              >
+                <Pencil className="h-3 w-3" />
+              </button>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRemove(entry.id);
+                }}
+                className="p-1 rounded text-slate-500 hover:text-red-400 hover:bg-white/[0.05] transition-colors"
+                aria-label={`Remove ${entry.title}`}
+              >
+                <Trash2 className="h-3 w-3" />
+              </button>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/components/wiki/lore/LoreModal.tsx
+++ b/app/components/wiki/lore/LoreModal.tsx
@@ -217,6 +217,7 @@ export function LoreModal({ isOpen, onClose, campaignId, loreId, initialLinks }:
                 required
                 disabled={isDisabled}
                 placeholder="Lore entry title"
+                data-testid="lore-title-input"
               />
 
               {/* Content */}

--- a/app/components/wiki/lore/LoreModal.tsx
+++ b/app/components/wiki/lore/LoreModal.tsx
@@ -1,0 +1,397 @@
+import React, { useState, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { X, Globe, Lock } from 'lucide-react';
+import { FormInput } from '~/components/FormInput';
+import { PixelButton } from '~/components/PixelButton';
+import { MarkdownEditor } from '~/components/shared/MarkdownEditor';
+import { TagAutocompleteInput } from '~/components/shared/TagAutocompleteInput';
+import { LoreLinksEditor } from '~/components/wiki/lore/LoreLinksEditor';
+import { ShowOnTabletopButton } from '~/components/wiki/shared/ShowOnTabletopButton';
+import { useLoreEntry, useCreateLore, useUpdateLore } from '~/hooks/useLore';
+import { useCampaign } from '~/hooks/useCampaigns';
+import { useModalForm } from '~/hooks/useModalForm';
+import { uploadToR2 } from '~/utils/uploadToR2';
+import { compressImage } from '~/utils/compressImage';
+import type { LoreLink, LoreImage } from '~/types/lore';
+
+interface LoreModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  campaignId: string;
+  loreId?: string;
+  initialLinks?: LoreLink[];
+}
+
+interface FieldErrors {
+  title?: string;
+}
+
+export function LoreModal({ isOpen, onClose, campaignId, loreId, initialLinks }: LoreModalProps) {
+  const isEdit = !!loreId;
+
+  const { lore: existingLore, isLoading: isFetchingLore } = useLoreEntry(loreId ?? '', campaignId);
+  const { create, isLoading: isCreating } = useCreateLore();
+  const { update, isLoading: isUpdating } = useUpdateLore();
+  const { campaign } = useCampaign(campaignId);
+  const isGM = campaign?.isGM ?? false;
+
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [gmContent, setGmContent] = useState('');
+  const [isPublic, setIsPublic] = useState(false);
+  const [images, setImages] = useState<LoreImage[]>([]);
+  const [links, setLinks] = useState<LoreLink[]>(initialLinks ?? []);
+  const [tags, setTags] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isUploadingImage, setIsUploadingImage] = useState(false);
+
+  const validate = useCallback((): FieldErrors => {
+    const errors: FieldErrors = {};
+    if (!title.trim()) errors.title = 'Title is required';
+    return errors;
+  }, [title]);
+
+  const { fieldErrors, runValidation } = useModalForm({
+    isOpen,
+    onClose,
+    recordId: loreId,
+    isEdit,
+    record: existingLore,
+    reset: () => {
+      setTitle('');
+      setContent('');
+      setGmContent('');
+      setIsPublic(false);
+      setImages([]);
+      setLinks(initialLinks ?? []);
+      setTags([]);
+      setError(null);
+    },
+    populate: (l) => {
+      setTitle(l.title);
+      setContent(l.content);
+      setGmContent(l.gmContent);
+      setIsPublic(l.isPublic);
+      setImages(l.images);
+      setLinks(l.links);
+      setTags(l.tags);
+    },
+    validate,
+  });
+
+  const handleAddImage = useCallback(async (file: File) => {
+    setIsUploadingImage(true);
+    setError(null);
+    try {
+      const compressed = await compressImage(file);
+      const { publicUrl } = await uploadToR2(compressed, 'uploads/lore');
+      const newImage: LoreImage = { url: publicUrl, caption: '', crop: null };
+      setImages((prev) => [...prev, newImage]);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Image upload failed');
+    } finally {
+      setIsUploadingImage(false);
+    }
+  }, []);
+
+  const handleRemoveImage = useCallback((index: number) => {
+    setImages((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const handleImageFileChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      await handleAddImage(file);
+      // Reset input so same file can be re-selected
+      e.target.value = '';
+    },
+    [handleAddImage]
+  );
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const errors = runValidation();
+    if (Object.keys(errors).length > 0) return;
+
+    const input = {
+      campaignId,
+      title: title.trim(),
+      content,
+      gmContent: isGM ? gmContent : undefined,
+      isPublic,
+      images: images.map((img) => ({
+        url: img.url,
+        caption: img.caption,
+        crop: img.crop,
+      })),
+      links: links.map((l) => ({ kind: l.kind, id: l.id })),
+      tags,
+    };
+
+    let success = false;
+    if (isEdit && loreId) {
+      const result = await update({ ...input, id: loreId });
+      success = !!result;
+    } else {
+      const result = await create(input);
+      success = !!result;
+    }
+
+    if (success) {
+      onClose();
+    } else {
+      setError(`Failed to ${isEdit ? 'update' : 'create'} lore. Please try again.`);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const isLoadingLore = !!(isEdit && isFetchingLore);
+  const isSaving = isCreating || isUpdating;
+  const isDisabled = isLoadingLore || isSaving || isUploadingImage;
+
+  return createPortal(
+    <div
+      role="presentation"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-2 sm:p-4 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="lore-modal-title"
+        className="w-full h-full max-w-[90vw] max-h-[90vh] sm:max-w-[90vw] sm:max-h-[90vh] bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col"
+      >
+        <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
+          <h2
+            id="lore-modal-title"
+            className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest"
+          >
+            {isEdit ? 'Edit Lore' : 'Create Lore'}
+          </h2>
+          <div className="flex items-center gap-1 shrink-0">
+            {isEdit && loreId && (
+              <ShowOnTabletopButton
+                campaignId={campaignId}
+                collection="lore"
+                documentId={loreId}
+                isGM={isGM}
+              />
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-slate-500 hover:text-white transition-colors"
+              aria-label="Close modal"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+        </header>
+
+        <div className="flex-1 overflow-y-auto p-4 sm:p-6 space-y-5 min-h-0">
+          {error && (
+            <div className="p-3 bg-rose-500/10 border border-rose-500/20 rounded-lg text-rose-400 text-xs font-semibold">
+              {error}
+            </div>
+          )}
+
+          {isLoadingLore ? (
+            <div className="flex items-center justify-center py-12">
+              <p className="text-xs text-slate-500 animate-pulse">Loading lore...</p>
+            </div>
+          ) : (
+            <>
+              {/* Title */}
+              <FormInput
+                label="Title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                error={fieldErrors.title}
+                required
+                disabled={isDisabled}
+                placeholder="Lore entry title"
+              />
+
+              {/* Content */}
+              <MarkdownEditor
+                label="Content"
+                value={content}
+                onChange={setContent}
+                placeholder="Public lore content..."
+                disabled={isDisabled}
+                minHeight="120px"
+                id="lore-content-editor"
+              />
+
+              {/* GM Notes — only visible to GM */}
+              {isGM && (
+                <MarkdownEditor
+                  label={
+                    <span>
+                      GM Notes{' '}
+                      <span className="text-amber-500 text-[10px] font-normal">
+                        (only visible to GM)
+                      </span>
+                    </span>
+                  }
+                  value={gmContent}
+                  onChange={setGmContent}
+                  placeholder="GM-only lore notes..."
+                  disabled={isDisabled}
+                  minHeight="120px"
+                  id="lore-gmcontent-editor"
+                />
+              )}
+
+              {/* Images */}
+              <div>
+                <span className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide">
+                  Images
+                </span>
+                {images.length > 0 && (
+                  <div className="flex flex-wrap gap-3 mb-3">
+                    {images.map((img, idx) => (
+                      <div key={idx} className="relative group">
+                        <img
+                          src={img.url}
+                          alt={img.caption || `Lore image ${idx + 1}`}
+                          className="w-20 h-20 object-cover rounded-lg border border-white/10"
+                        />
+                        {!isDisabled && (
+                          <button
+                            type="button"
+                            onClick={() => handleRemoveImage(idx)}
+                            className="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-rose-600 flex items-center justify-center hover:bg-rose-500 transition-colors"
+                            aria-label={`Remove image ${idx + 1}`}
+                          >
+                            <X className="h-3 w-3 text-white" />
+                          </button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <label
+                  className={`inline-flex items-center gap-2 px-3 py-2 rounded-xl text-xs font-semibold border transition-colors cursor-pointer ${isDisabled || isUploadingImage ? 'opacity-50 cursor-not-allowed border-white/10 text-slate-500' : 'border-white/10 text-slate-300 hover:border-blue-500/50 hover:text-blue-300'}`}
+                >
+                  <input
+                    type="file"
+                    accept=".jpg,.jpeg,.png,.webp"
+                    onChange={handleImageFileChange}
+                    disabled={isDisabled || isUploadingImage}
+                    className="hidden"
+                  />
+                  {isUploadingImage ? 'Uploading...' : 'Add image'}
+                </label>
+                <p className="text-xs text-slate-700 mt-1.5">JPG, PNG, or WebP. Max 5MB.</p>
+              </div>
+
+              {/* Tags */}
+              <div>
+                <label
+                  htmlFor="lore-tags-input"
+                  className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide"
+                >
+                  Tags
+                </label>
+                <TagAutocompleteInput
+                  campaignId={campaignId}
+                  selectedTags={tags}
+                  onTagsChange={setTags}
+                  placeholder="Type a tag and press Enter"
+                  disabled={isDisabled}
+                  id="lore-tags-input"
+                />
+                <p className="text-xs text-slate-700 mt-1.5">
+                  Press Enter or comma to add. Suggestions appear as you type.
+                </p>
+              </div>
+
+              {/* Visibility */}
+              <div className="flex items-center gap-6 pt-2">
+                <label className="flex items-center gap-3 cursor-pointer group">
+                  <input
+                    type="radio"
+                    name="lore-visibility"
+                    checked={!isPublic}
+                    onChange={() => setIsPublic(false)}
+                    className="sr-only"
+                    disabled={isDisabled}
+                  />
+                  <div
+                    className={`h-10 px-4 rounded-xl border flex items-center gap-2.5 transition-all ${
+                      !isPublic
+                        ? 'bg-blue-600/10 border-blue-500/50 text-blue-300 shadow-sm shadow-blue-500/10'
+                        : 'bg-white/[0.03] border-white/[0.07] text-slate-500 hover:border-white/20'
+                    }`}
+                  >
+                    <Lock className="h-3.5 w-3.5" />
+                    <span className="font-sans font-bold text-xs">Private</span>
+                  </div>
+                </label>
+
+                <label className="flex items-center gap-3 cursor-pointer group">
+                  <input
+                    type="radio"
+                    name="lore-visibility"
+                    checked={isPublic}
+                    onChange={() => setIsPublic(true)}
+                    className="sr-only"
+                    disabled={isDisabled}
+                  />
+                  <div
+                    className={`h-10 px-4 rounded-xl border flex items-center gap-2.5 transition-all ${
+                      isPublic
+                        ? 'bg-emerald-600/10 border-emerald-500/50 text-emerald-300 shadow-sm shadow-emerald-500/10'
+                        : 'bg-white/[0.03] border-white/[0.07] text-slate-500 hover:border-white/20'
+                    }`}
+                  >
+                    <Globe className="h-3.5 w-3.5" />
+                    <span className="font-sans font-bold text-xs">Public</span>
+                  </div>
+                </label>
+              </div>
+
+              {/* Linked Entities */}
+              <LoreLinksEditor
+                campaignId={campaignId}
+                links={links}
+                onChange={setLinks}
+                disabled={isDisabled}
+              />
+            </>
+          )}
+        </div>
+
+        <footer className="flex items-center justify-end px-4 sm:px-6 py-4 border-t border-white/[0.07] bg-white/[0.01] shrink-0 gap-3">
+          <PixelButton
+            variant="secondary"
+            size="sm"
+            onClick={onClose}
+            disabled={isSaving}
+            type="button"
+          >
+            Cancel
+          </PixelButton>
+          <PixelButton variant="primary" size="sm" disabled={isDisabled} type="submit">
+            {isSaving
+              ? 'Saving...'
+              : isLoadingLore
+                ? 'Loading...'
+                : isEdit
+                  ? 'Update Lore'
+                  : 'Create Lore'}
+          </PixelButton>
+        </footer>
+      </form>
+    </div>,
+    document.body
+  );
+}

--- a/app/components/wiki/lore/LorePanel.tsx
+++ b/app/components/wiki/lore/LorePanel.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+import { useParams } from '@tanstack/react-router';
+import { BookOpen } from 'lucide-react';
+import { WikiCategoryHeader } from '~/components/wiki/shared/WikiCategoryHeader';
+import { WikiFilterBar } from '~/components/wiki/shared/WikiFilterBar';
+import { LoreCard } from './LoreCard';
+import { LoreModal } from './LoreModal';
+import { LoreViewModal } from './LoreViewModal';
+import { useLore } from '~/hooks/useLore';
+import { useCampaign } from '~/hooks/useCampaigns';
+import type { LoreListItem } from '~/types/lore';
+
+interface LorePanelProps {
+  onBack: () => void;
+}
+
+export function LorePanel({ onBack }: LorePanelProps) {
+  const { campaignId } = useParams({ from: '/campaigns/$campaignId/play' });
+  const { campaign } = useCampaign(campaignId);
+  const isGM = campaign?.isGM ?? false;
+
+  const [search, setSearch] = useState('');
+  const [visibility, setVisibility] = useState<'all' | 'public' | 'private'>('all');
+  const [filterTags, setFilterTags] = useState<string[]>([]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedLoreId, setSelectedLoreId] = useState<string | undefined>();
+  const [viewLoreId, setViewLoreId] = useState<string | undefined>();
+
+  const { lore, isLoading, error } = useLore(campaignId, {
+    search: search || undefined,
+    visibility,
+    tags: filterTags.length > 0 ? filterTags : undefined,
+  });
+
+  const handleCreateClick = () => {
+    setSelectedLoreId(undefined);
+    setIsModalOpen(true);
+  };
+
+  const handleLoreClick = (item: LoreListItem) => {
+    if (item.canEdit) {
+      setSelectedLoreId(item.id);
+      setIsModalOpen(true);
+    } else {
+      setViewLoreId(item.id);
+    }
+  };
+
+  const handleModalClose = () => {
+    setIsModalOpen(false);
+    setSelectedLoreId(undefined);
+  };
+
+  const handleViewModalClose = () => {
+    setViewLoreId(undefined);
+  };
+
+  return (
+    <div className="flex flex-col h-full w-full bg-[#080A12]">
+      <WikiCategoryHeader title="Lore" onBack={onBack} />
+      <WikiFilterBar
+        search={search}
+        onSearchChange={setSearch}
+        visibility={visibility}
+        onVisibilityChange={setVisibility}
+        onCreateClick={isGM ? handleCreateClick : undefined}
+        createButtonTestId="lore-create-button"
+        campaignId={campaignId}
+        filterTags={filterTags}
+        onFilterTagsChange={setFilterTags}
+        searchPlaceholder="Search lore..."
+        showSessionFilter={false}
+        showVisibilityFilter={isGM}
+      />
+
+      {isLoading ? (
+        <div className="flex flex-1 items-center justify-center p-8">
+          <p className="font-sans font-semibold text-xs text-slate-500 animate-pulse">
+            Loading lore...
+          </p>
+        </div>
+      ) : error ? (
+        <div className="flex flex-1 items-center justify-center p-8 text-center">
+          <p className="font-sans font-semibold text-xs text-rose-400">{error}</p>
+        </div>
+      ) : lore.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center p-8 text-center">
+          <div className="h-12 w-12 rounded-full bg-white/[0.03] flex items-center justify-center mb-3">
+            <BookOpen className="h-6 w-6 text-slate-600" />
+          </div>
+          <p className="font-sans font-semibold text-xs text-slate-500">
+            No lore found matching your filters.
+          </p>
+        </div>
+      ) : (
+        <div className="flex-1 overflow-y-auto min-h-0">
+          <div className="flex flex-col">
+            {lore.map((item) => (
+              <LoreCard key={item.id} lore={item} onClick={handleLoreClick} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {isGM && (
+        <LoreModal
+          isOpen={isModalOpen}
+          onClose={handleModalClose}
+          campaignId={campaignId}
+          loreId={selectedLoreId}
+        />
+      )}
+      {viewLoreId && (
+        <LoreViewModal
+          isOpen={!!viewLoreId}
+          onClose={handleViewModalClose}
+          loreId={viewLoreId}
+          campaignId={campaignId}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/components/wiki/lore/LorePanel.tsx
+++ b/app/components/wiki/lore/LorePanel.tsx
@@ -63,7 +63,7 @@ export function LorePanel({ onBack }: LorePanelProps) {
         onSearchChange={setSearch}
         visibility={visibility}
         onVisibilityChange={setVisibility}
-        onCreateClick={isGM ? handleCreateClick : undefined}
+        onCreateClick={handleCreateClick}
         createButtonTestId="lore-create-button"
         campaignId={campaignId}
         filterTags={filterTags}
@@ -102,14 +102,12 @@ export function LorePanel({ onBack }: LorePanelProps) {
         </div>
       )}
 
-      {isGM && (
-        <LoreModal
-          isOpen={isModalOpen}
-          onClose={handleModalClose}
-          campaignId={campaignId}
-          loreId={selectedLoreId}
-        />
-      )}
+      <LoreModal
+        isOpen={isModalOpen}
+        onClose={handleModalClose}
+        campaignId={campaignId}
+        loreId={selectedLoreId}
+      />
       {viewLoreId && (
         <LoreViewModal
           isOpen={!!viewLoreId}

--- a/app/components/wiki/lore/LoreViewModal.tsx
+++ b/app/components/wiki/lore/LoreViewModal.tsx
@@ -1,0 +1,100 @@
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { Globe, Lock, X } from 'lucide-react';
+import { LoreWindow } from './LoreWindow';
+import { useLoreEntry } from '~/hooks/useLore';
+import { useCampaign } from '~/hooks/useCampaigns';
+import { ShowOnTabletopButton } from '~/components/wiki/shared/ShowOnTabletopButton';
+
+interface LoreViewModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  loreId: string;
+  campaignId: string;
+}
+
+export function LoreViewModal({ isOpen, onClose, loreId, campaignId }: LoreViewModalProps) {
+  const { lore, isLoading } = useLoreEntry(loreId, campaignId);
+  const { campaign } = useCampaign(campaignId);
+  const isGM = campaign?.isGM ?? false;
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div
+      role="presentation"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-2 sm:p-4 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="lore-view-modal-title"
+        className="w-full max-w-lg max-h-[90vh] bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col"
+      >
+        <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
+          <div className="flex items-center gap-2 min-w-0">
+            {lore &&
+              (lore.isPublic ? (
+                <Globe className="h-3.5 w-3.5 text-emerald-400 shrink-0" aria-hidden="true" />
+              ) : (
+                <Lock className="h-3.5 w-3.5 text-amber-400 shrink-0" aria-hidden="true" />
+              ))}
+            <h2
+              id="lore-view-modal-title"
+              className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest truncate"
+            >
+              {lore ? lore.title : 'Lore'}
+              {lore && (
+                <span className="sr-only">{lore.isPublic ? ' (Public)' : ' (Private)'}</span>
+              )}
+            </h2>
+          </div>
+          <div className="flex items-center gap-1 shrink-0">
+            <ShowOnTabletopButton
+              campaignId={campaignId}
+              collection="lore"
+              documentId={loreId}
+              isGM={isGM}
+            />
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-slate-500 hover:text-white transition-colors"
+              aria-label="Close modal"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+        </header>
+
+        <div className="flex-1 overflow-y-auto min-h-0">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <p className="text-xs text-slate-500 animate-pulse">Loading lore...</p>
+            </div>
+          ) : lore ? (
+            <LoreWindow lore={lore} />
+          ) : (
+            <div className="flex items-center justify-center py-12">
+              <p className="text-xs text-slate-500">Lore entry not found</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/app/components/wiki/lore/LoreWindow.tsx
+++ b/app/components/wiki/lore/LoreWindow.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { Globe, Lock, Pencil } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { LoreData, LoreLink } from '~/types/lore';
+import type { PictureCrop } from '~/types/character';
+import { MARKDOWN_PROSE_CLASSES } from '~/utils/markdownProseClasses';
+
+function getCropStyle(crop: PictureCrop): React.CSSProperties {
+  const centerX = (crop.x + crop.width / 2) * 100;
+  const centerY = (crop.y + crop.height / 2) * 100;
+  const scale = 1 / crop.width;
+  return {
+    objectPosition: `${centerX}% ${centerY}%`,
+    transform: `scale(${scale})`,
+  };
+}
+
+const KIND_LABELS: Record<string, string> = {
+  race: 'Race',
+  character: 'Character',
+  player: 'Player',
+  location: 'Location',
+};
+
+function LinkChip({ link }: { link: LoreLink }) {
+  const kindLabel = KIND_LABELS[link.kind] ?? link.kind;
+  return (
+    <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-white/[0.05] border border-white/[0.08] text-slate-300 text-xs">
+      <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500 shrink-0">
+        {kindLabel}
+      </span>
+      <span>{link.label ?? link.id}</span>
+    </span>
+  );
+}
+
+interface LoreWindowProps {
+  lore: LoreData;
+  onEdit?: () => void;
+}
+
+export function LoreWindow({ lore, onEdit }: LoreWindowProps) {
+  const hasImages = lore.images.length > 0;
+  const hasContent = !!lore.content;
+  const hasGmContent = !!lore.gmContent;
+  const hasLinks = lore.links.length > 0;
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      {/* Header: title, visibility, edit */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          {lore.isPublic ? (
+            <Globe className="h-3.5 w-3.5 text-emerald-400 shrink-0" aria-label="Public" />
+          ) : (
+            <Lock className="h-3.5 w-3.5 text-amber-400 shrink-0" aria-label="Private" />
+          )}
+          <h3 className="font-sans font-bold text-sm text-slate-100 truncate">{lore.title}</h3>
+        </div>
+        {lore.canEdit && onEdit && (
+          <button
+            type="button"
+            onClick={onEdit}
+            className="shrink-0 p-1 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors"
+            aria-label="Edit lore entry"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+
+      {/* Tags */}
+      {lore.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {lore.tags.map((tag) => (
+            <span
+              key={tag}
+              className="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[9px] tracking-tight"
+            >
+              #{tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Images gallery */}
+      {hasImages && (
+        <div className="flex flex-col gap-3">
+          <p className="text-[10px] uppercase tracking-wider text-slate-500">Images</p>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            {lore.images.map((image, idx) => (
+              <div key={idx} className="flex flex-col gap-1">
+                <div className="w-full aspect-square overflow-hidden rounded-lg border border-white/[0.08]">
+                  <img
+                    src={image.url}
+                    alt={image.caption || `Lore image ${idx + 1}`}
+                    className="w-full h-full object-cover"
+                    style={image.crop ? getCropStyle(image.crop) : undefined}
+                  />
+                </div>
+                {image.caption && (
+                  <p className="text-[10px] text-slate-500 text-center leading-tight">
+                    {image.caption}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Content */}
+      {hasContent ? (
+        <div className={MARKDOWN_PROSE_CLASSES}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{lore.content}</ReactMarkdown>
+        </div>
+      ) : (
+        !hasImages &&
+        !hasLinks &&
+        !hasGmContent && <p className="text-xs text-slate-500">No lore details yet.</p>
+      )}
+
+      {/* GM Content */}
+      {hasGmContent && (
+        <div>
+          <div className="mb-2 rounded-md bg-amber-500/10 border border-amber-500/20 px-3 py-2">
+            <p className="text-[10px] text-amber-400">GM Notes — only visible to the GM.</p>
+          </div>
+          <div className={MARKDOWN_PROSE_CLASSES}>
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{lore.gmContent}</ReactMarkdown>
+          </div>
+        </div>
+      )}
+
+      {/* Linked entities */}
+      {hasLinks && (
+        <div className="flex flex-col gap-2">
+          <p className="text-[10px] uppercase tracking-wider text-slate-500">Linked to</p>
+          <div className="flex flex-wrap gap-2">
+            {lore.links.map((link, idx) => (
+              <LinkChip key={`${link.kind}-${link.id}-${idx}`} link={link} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/wiki/lore/LoreWindow.tsx
+++ b/app/components/wiki/lore/LoreWindow.tsx
@@ -47,7 +47,7 @@ export function LoreWindow({ lore, onEdit }: LoreWindowProps) {
   const hasLinks = lore.links.length > 0;
 
   return (
-    <div className="flex flex-col gap-4 p-4">
+    <div data-testid="lore-window" className="flex flex-col gap-4 p-4">
       {/* Header: title, visibility, edit */}
       <div className="flex items-start justify-between gap-2">
         <div className="flex items-center gap-2 min-w-0">

--- a/app/components/wiki/players/PlayerLoreTab.tsx
+++ b/app/components/wiki/players/PlayerLoreTab.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { useLinkedLore, useDeleteLore } from '~/hooks/useLore';
+import { LoreList } from '~/components/wiki/lore/LoreList';
+import { LoreModal } from '~/components/wiki/lore/LoreModal';
+import { LoreViewModal } from '~/components/wiki/lore/LoreViewModal';
+
+interface PlayerLoreTabProps {
+  campaignId: string;
+  playerId: string;
+  canManage: boolean;
+}
+
+export function PlayerLoreTab({ campaignId, playerId, canManage }: PlayerLoreTabProps) {
+  const { lore } = useLinkedLore(campaignId, 'player', playerId);
+  const { remove } = useDeleteLore();
+
+  const [addOpen, setAddOpen] = useState(false);
+  const [editId, setEditId] = useState<string | null>(null);
+  const [viewId, setViewId] = useState<string | null>(null);
+
+  return (
+    <>
+      <LoreList
+        lore={lore}
+        canManage={canManage}
+        onAdd={() => setAddOpen(true)}
+        onOpen={setViewId}
+        onEdit={setEditId}
+        onRemove={(id) => remove({ id, campaignId })}
+      />
+
+      {addOpen && (
+        <LoreModal
+          isOpen
+          onClose={() => setAddOpen(false)}
+          campaignId={campaignId}
+          initialLinks={[{ kind: 'player', id: playerId }]}
+        />
+      )}
+
+      {editId && (
+        <LoreModal isOpen onClose={() => setEditId(null)} campaignId={campaignId} loreId={editId} />
+      )}
+
+      {viewId && (
+        <LoreViewModal
+          isOpen
+          onClose={() => setViewId(null)}
+          loreId={viewId}
+          campaignId={campaignId}
+        />
+      )}
+    </>
+  );
+}

--- a/app/components/wiki/players/PlayerModal.tsx
+++ b/app/components/wiki/players/PlayerModal.tsx
@@ -13,6 +13,7 @@ import { useModalForm } from '~/hooks/useModalForm';
 import type { PictureCrop } from '~/types/character';
 import { uploadToR2 } from '~/utils/uploadToR2';
 import { compressImage } from '~/utils/compressImage';
+import { PlayerLoreTab } from './PlayerLoreTab';
 
 interface PlayerModalProps {
   campaignId: string;
@@ -456,6 +457,16 @@ export function PlayerModal({ campaignId, playerId, onClose }: PlayerModalProps)
                   minHeight="120px"
                   id="player-gmnotes-editor"
                 />
+              )}
+
+              {/* Lore — only shown when editing an existing player */}
+              {isEdit && playerId && (
+                <div className="space-y-2">
+                  <p className="text-xs font-semibold text-slate-400 uppercase tracking-widest">
+                    Lore
+                  </p>
+                  <PlayerLoreTab campaignId={campaignId} playerId={playerId} canManage={true} />
+                </div>
               )}
             </>
           )}

--- a/app/components/wiki/players/PlayerWindow.tsx
+++ b/app/components/wiki/players/PlayerWindow.tsx
@@ -13,6 +13,7 @@ import {
   useUpdatePlayerRelationship,
   useRemovePlayerRelationship,
 } from '~/hooks/usePlayers';
+import { PlayerLoreTab } from '~/components/wiki/players/PlayerLoreTab';
 
 function getCropStyle(crop: PictureCrop): React.CSSProperties {
   const centerX = (crop.x + crop.width / 2) * 100;
@@ -99,6 +100,7 @@ export function PlayerWindow({ player, onEdit }: PlayerWindowProps) {
     { id: 'backstory', label: 'Backstory', hidden: player.backstory === '' },
     { id: 'gmnotes', label: 'GM Notes', hidden: player.gmNotes === '' },
     { id: 'relationships', label: 'Relationships' },
+    { id: 'lore', label: 'Lore' },
   ];
 
   return (
@@ -297,6 +299,14 @@ export function PlayerWindow({ player, onEdit }: PlayerWindowProps) {
               />
             )}
           </>
+        )}
+
+        {activeTab === 'lore' && (
+          <PlayerLoreTab
+            campaignId={player.campaignId}
+            playerId={player.id}
+            canManage={player.canEdit}
+          />
         )}
       </div>
     </div>

--- a/app/components/wiki/shared/WikiFilterBar.tsx
+++ b/app/components/wiki/shared/WikiFilterBar.tsx
@@ -11,6 +11,7 @@ interface WikiFilterBarProps {
   onVisibilityChange: (value: 'all' | 'public' | 'private') => void;
   sessions?: CampaignData['sessions'];
   onCreateClick?: () => void;
+  createButtonTestId?: string;
   campaignId: string;
   filterTags: string[];
   onFilterTagsChange: (tags: string[]) => void;
@@ -28,6 +29,7 @@ export function WikiFilterBar({
   onVisibilityChange,
   sessions = [],
   onCreateClick,
+  createButtonTestId,
   campaignId,
   filterTags,
   onFilterTagsChange,
@@ -55,6 +57,7 @@ export function WikiFilterBar({
             onClick={onCreateClick}
             className="flex items-center justify-center h-8 w-8 rounded bg-blue-600 hover:bg-blue-500 text-white transition-colors"
             aria-label="Create new item"
+            data-testid={createButtonTestId}
           >
             <Plus className="h-4 w-4" />
           </button>

--- a/app/hooks/useCalendar.ts
+++ b/app/hooks/useCalendar.ts
@@ -1,0 +1,110 @@
+import { createServerFn } from '@tanstack/react-start';
+import { useQuery } from '@tanstack/react-query';
+import type { CalendarData, CalDate } from '~/types/calendar';
+import { queryKeys } from '~/utils/queryKeys';
+import { extractErrorMessage } from '~/utils/errors';
+import { createMutationHook } from '~/hooks/createMutationHook';
+import {
+  getCalendarSchema,
+  upsertCalendarSchema,
+  setCurrentDateSchema,
+  deleteCalendarSchema,
+} from '~/types/schemas/calendars';
+
+// ---------------------------------------------------------------------------
+// Server function wrappers — dynamic imports keep Mongoose server-only.
+// TanStack Start compiles these to RPC stubs on the client.
+// ---------------------------------------------------------------------------
+
+const getCalendarFn = createServerFn({ method: 'GET' })
+  .inputValidator(getCalendarSchema)
+  .handler(async ({ data }) => {
+    const { getCalendar } = await import('~/server/functions/calendars');
+    return getCalendar({ data });
+  });
+
+const upsertCalendarFn = createServerFn({ method: 'POST' })
+  .inputValidator(upsertCalendarSchema)
+  .handler(async ({ data }) => {
+    const { upsertCalendar } = await import('~/server/functions/calendars');
+    return upsertCalendar({ data });
+  });
+
+const setCurrentDateFn = createServerFn({ method: 'POST' })
+  .inputValidator(setCurrentDateSchema)
+  .handler(async ({ data }) => {
+    const { setCurrentDate } = await import('~/server/functions/calendars');
+    return setCurrentDate({ data });
+  });
+
+const deleteCalendarFn = createServerFn({ method: 'POST' })
+  .inputValidator(deleteCalendarSchema)
+  .handler(async ({ data }) => {
+    const { deleteCalendar } = await import('~/server/functions/calendars');
+    return deleteCalendar({ data });
+  });
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+export function useCalendar(campaignId: string) {
+  const {
+    data: calendar = null,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.calendar.detail(campaignId),
+    queryFn: () => getCalendarFn({ data: { campaignId } }),
+    enabled: !!campaignId,
+  });
+
+  return {
+    calendar: calendar as CalendarData | null,
+    isLoading,
+    error: extractErrorMessage(error),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mutation hooks
+// ---------------------------------------------------------------------------
+
+export type UpsertCalendarInput = { campaignId: string } & Omit<
+  CalendarData,
+  'id' | 'createdBy' | 'createdAt' | 'updatedAt' | 'canEdit'
+>;
+
+export const useUpsertCalendar = createMutationHook({
+  actionName: 'save',
+  mutationFn: async (input: UpsertCalendarInput) => upsertCalendarFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.calendar.detail(variables.campaignId) });
+    queryClient.invalidateQueries({
+      queryKey: ['events', 'list', variables.campaignId],
+      exact: false,
+    });
+    queryClient.invalidateQueries({ queryKey: queryKeys.events.epic(variables.campaignId) });
+  },
+  errorContext: () => ({ action: 'upsertCalendar' }),
+});
+
+export const useSetCurrentDate = createMutationHook({
+  actionName: 'setCurrentDate',
+  mutationFn: async (input: { campaignId: string; currentDate: CalDate }) =>
+    setCurrentDateFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.calendar.detail(variables.campaignId) });
+    queryClient.invalidateQueries({ queryKey: queryKeys.events.epic(variables.campaignId) });
+  },
+  errorContext: () => ({ action: 'setCurrentDate' }),
+});
+
+export const useDeleteCalendar = createMutationHook({
+  actionName: 'remove',
+  mutationFn: async (input: { campaignId: string }) => deleteCalendarFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.calendar.detail(variables.campaignId) });
+  },
+  errorContext: () => ({ action: 'deleteCalendar' }),
+});

--- a/app/hooks/useCalendar.ts
+++ b/app/hooks/useCalendar.ts
@@ -104,7 +104,8 @@ export const useDeleteCalendar = createMutationHook({
   actionName: 'remove',
   mutationFn: async (input: { campaignId: string }) => deleteCalendarFn({ data: input }),
   onSuccess: (queryClient, _data, variables) => {
-    queryClient.invalidateQueries({ queryKey: queryKeys.calendar.detail(variables.campaignId) });
+    // The calendar is gone; drop its cached detail rather than invalidating (which would refetch a null). Mirrors useDeleteLore.
+    queryClient.removeQueries({ queryKey: queryKeys.calendar.detail(variables.campaignId) });
   },
   errorContext: () => ({ action: 'deleteCalendar' }),
 });

--- a/app/hooks/useEvents.ts
+++ b/app/hooks/useEvents.ts
@@ -1,0 +1,225 @@
+import { createServerFn } from '@tanstack/react-start';
+import { useQuery } from '@tanstack/react-query';
+import type { EventData, EventListItem, EventLinkKind } from '~/types/event';
+import type { CalDate } from '~/types/calendar';
+import { queryKeys } from '~/utils/queryKeys';
+import { extractErrorMessage } from '~/utils/errors';
+import { createMutationHook } from '~/hooks/createMutationHook';
+import {
+  listEventsSchema,
+  getEventSchema,
+  createEventSchema,
+  updateEventSchema,
+  deleteEventSchema,
+} from '~/types/schemas/events';
+
+// ---------------------------------------------------------------------------
+// Server function wrappers — dynamic imports keep Mongoose server-only.
+// TanStack Start compiles these to RPC stubs on the client.
+// ---------------------------------------------------------------------------
+
+const listEventsFn = createServerFn({ method: 'GET' })
+  .inputValidator(listEventsSchema)
+  .handler(async ({ data }) => {
+    const { listEvents } = await import('~/server/functions/events');
+    return listEvents({ data });
+  });
+
+const getEventFn = createServerFn({ method: 'GET' })
+  .inputValidator(getEventSchema)
+  .handler(async ({ data }) => {
+    const { getEvent } = await import('~/server/functions/events');
+    return getEvent({ data });
+  });
+
+const createEventFn = createServerFn({ method: 'POST' })
+  .inputValidator(createEventSchema)
+  .handler(async ({ data }) => {
+    const { createEvent } = await import('~/server/functions/events');
+    return createEvent({ data });
+  });
+
+const updateEventFn = createServerFn({ method: 'POST' })
+  .inputValidator(updateEventSchema)
+  .handler(async ({ data }) => {
+    const { updateEvent } = await import('~/server/functions/events');
+    return updateEvent({ data });
+  });
+
+const deleteEventFn = createServerFn({ method: 'POST' })
+  .inputValidator(deleteEventSchema)
+  .handler(async ({ data }) => {
+    const { deleteEvent } = await import('~/server/functions/events');
+    return deleteEvent({ data });
+  });
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+export interface EventFilters {
+  search?: string;
+  tags?: string[];
+  visibility?: 'all' | 'public' | 'private';
+  epicOnly?: boolean;
+  linkedKind?: EventLinkKind;
+  linkedId?: string;
+}
+
+export function useEvents(campaignId: string, filters?: EventFilters) {
+  const {
+    data: events = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.events.list(campaignId, JSON.stringify(filters ?? {})),
+    queryFn: () =>
+      listEventsFn({
+        data: {
+          campaignId,
+          search: filters?.search,
+          tags: filters?.tags,
+          visibility: filters?.visibility,
+          epicOnly: filters?.epicOnly,
+          linkedKind: filters?.linkedKind,
+          linkedId: filters?.linkedId,
+        },
+      }),
+    enabled: !!campaignId,
+  });
+
+  return {
+    events: events as EventListItem[],
+    isLoading,
+    error: extractErrorMessage(error),
+  };
+}
+
+export function useEpicEvents(campaignId: string) {
+  const {
+    data: events = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.events.epic(campaignId),
+    queryFn: () => listEventsFn({ data: { campaignId, epicOnly: true } }),
+    enabled: !!campaignId,
+  });
+
+  return {
+    events: events as EventListItem[],
+    isLoading,
+    error: extractErrorMessage(error),
+  };
+}
+
+export function useEvent(id: string, campaignId: string) {
+  const {
+    data: event = null,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.events.detail(id, campaignId),
+    queryFn: () => getEventFn({ data: { id, campaignId } }),
+    enabled: !!id && !!campaignId,
+  });
+
+  return {
+    event: event as EventData | null,
+    isLoading,
+    error: extractErrorMessage(error),
+  };
+}
+
+export function useLinkedEvents(campaignId: string, kind: string, id: string) {
+  const {
+    data: events = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.events.linked(campaignId, kind, id),
+    queryFn: () =>
+      listEventsFn({
+        data: {
+          campaignId,
+          linkedKind: kind as EventLinkKind,
+          linkedId: id,
+        },
+      }),
+    enabled: !!campaignId && !!kind && !!id,
+  });
+
+  return {
+    events: events as EventListItem[],
+    isLoading,
+    error: extractErrorMessage(error),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mutation hooks
+// ---------------------------------------------------------------------------
+
+export interface EventMutationInput {
+  id?: string;
+  campaignId: string;
+  title: string;
+  content?: string;
+  gmContent?: string;
+  isPublic?: boolean;
+  isEpic?: boolean;
+  start: CalDate;
+  end?: CalDate | null;
+  links?: { kind: EventLinkKind; id: string }[];
+  sessionId?: string | null;
+  images?: {
+    url: string;
+    caption: string;
+    crop: { x: number; y: number; width: number; height: number } | null;
+  }[];
+  tags?: string[];
+  color?: string | null;
+}
+
+function invalidateEvents(
+  queryClient: import('@tanstack/react-query').QueryClient,
+  campaignId: string
+) {
+  queryClient.invalidateQueries({ queryKey: ['events', 'list', campaignId], exact: false });
+  queryClient.invalidateQueries({ queryKey: ['events', 'linked', campaignId], exact: false });
+  queryClient.invalidateQueries({ queryKey: queryKeys.events.epic(campaignId) });
+  queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+}
+
+export const useCreateEvent = createMutationHook({
+  actionName: 'create',
+  mutationFn: async (input: EventMutationInput) => createEventFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    invalidateEvents(queryClient, variables.campaignId);
+  },
+  errorContext: () => ({ action: 'createEvent' }),
+});
+
+export const useUpdateEvent = createMutationHook({
+  actionName: 'update',
+  mutationFn: async (input: EventMutationInput & { id: string }) => updateEventFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    invalidateEvents(queryClient, variables.campaignId);
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.events.detail(variables.id, variables.campaignId),
+    });
+  },
+  errorContext: (variables) => ({ action: 'updateEvent', eventId: variables.id }),
+});
+
+export const useDeleteEvent = createMutationHook({
+  actionName: 'remove',
+  mutationFn: async (input: { id: string; campaignId: string }) => deleteEventFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    invalidateEvents(queryClient, variables.campaignId);
+    queryClient.removeQueries({
+      queryKey: queryKeys.events.detail(variables.id, variables.campaignId),
+    });
+  },
+  errorContext: (variables) => ({ action: 'deleteEvent', eventId: variables.id }),
+});

--- a/app/hooks/useLore.ts
+++ b/app/hooks/useLore.ts
@@ -1,0 +1,227 @@
+import { createServerFn } from '@tanstack/react-start';
+import { useQuery } from '@tanstack/react-query';
+import type { LoreData, LoreListItem, LoreLinkKind } from '~/types/lore';
+import { queryKeys } from '~/utils/queryKeys';
+import { extractErrorMessage } from '~/utils/errors';
+import { createMutationHook } from '~/hooks/createMutationHook';
+import {
+  listLoreSchema,
+  getLoreSchema,
+  createLoreSchema,
+  updateLoreSchema,
+  deleteLoreSchema,
+} from '~/types/schemas/lore';
+
+// ---------------------------------------------------------------------------
+// Server function wrappers — dynamic imports keep Mongoose server-only.
+// TanStack Start compiles these to RPC stubs on the client.
+// ---------------------------------------------------------------------------
+
+const listLoreFn = createServerFn({ method: 'GET' })
+  .inputValidator(listLoreSchema)
+  .handler(async ({ data }) => {
+    const { listLore } = await import('~/server/functions/lore');
+    return listLore({ data });
+  });
+
+const getLoreFn = createServerFn({ method: 'GET' })
+  .inputValidator(getLoreSchema)
+  .handler(async ({ data }) => {
+    const { getLore } = await import('~/server/functions/lore');
+    return getLore({ data });
+  });
+
+const createLoreFn = createServerFn({ method: 'POST' })
+  .inputValidator(createLoreSchema)
+  .handler(async ({ data }) => {
+    const { createLore } = await import('~/server/functions/lore');
+    return createLore({ data });
+  });
+
+const updateLoreFn = createServerFn({ method: 'POST' })
+  .inputValidator(updateLoreSchema)
+  .handler(async ({ data }) => {
+    const { updateLore } = await import('~/server/functions/lore');
+    return updateLore({ data });
+  });
+
+const deleteLoreFn = createServerFn({ method: 'POST' })
+  .inputValidator(deleteLoreSchema)
+  .handler(async ({ data }) => {
+    const { deleteLore } = await import('~/server/functions/lore');
+    return deleteLore({ data });
+  });
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+export interface LoreFilters {
+  search?: string;
+  tags?: string[];
+  visibility?: 'all' | 'public' | 'private';
+  linkedKind?: LoreLinkKind;
+  linkedId?: string;
+}
+
+export function useLore(campaignId: string, filters?: LoreFilters) {
+  const {
+    data: lore = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.lore.list(campaignId, JSON.stringify(filters ?? {})),
+    queryFn: () =>
+      listLoreFn({
+        data: {
+          campaignId,
+          search: filters?.search,
+          tags: filters?.tags,
+          visibility: filters?.visibility,
+          linkedKind: filters?.linkedKind,
+          linkedId: filters?.linkedId,
+        },
+      }),
+    enabled: !!campaignId,
+  });
+
+  return {
+    lore: lore as LoreListItem[],
+    isLoading,
+    error: extractErrorMessage(error),
+  };
+}
+
+export function useLoreEntry(id: string, campaignId: string) {
+  const {
+    data: lore = null,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.lore.detail(id, campaignId),
+    queryFn: () => getLoreFn({ data: { id, campaignId } }),
+    enabled: !!id && !!campaignId,
+  });
+
+  return {
+    lore: lore as LoreData | null,
+    isLoading,
+    error: extractErrorMessage(error),
+  };
+}
+
+export function useLinkedLore(campaignId: string, kind: string, id: string) {
+  const {
+    data: lore = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.lore.linked(campaignId, kind, id),
+    queryFn: () =>
+      listLoreFn({
+        data: {
+          campaignId,
+          linkedKind: kind as LoreLinkKind,
+          linkedId: id,
+        },
+      }),
+    enabled: !!campaignId && !!kind && !!id,
+  });
+
+  return {
+    lore: lore as LoreListItem[],
+    isLoading,
+    error: extractErrorMessage(error),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mutation hooks
+// ---------------------------------------------------------------------------
+
+export interface CreateLoreInput {
+  campaignId: string;
+  title: string;
+  content?: string;
+  gmContent?: string;
+  isPublic?: boolean;
+  images?: {
+    url: string;
+    caption: string;
+    crop: { x: number; y: number; width: number; height: number } | null;
+  }[];
+  links?: { kind: LoreLinkKind; id: string }[];
+  tags?: string[];
+}
+
+export const useCreateLore = createMutationHook({
+  actionName: 'create',
+  mutationFn: async (input: CreateLoreInput) => createLoreFn({ data: input }),
+  onSuccess: (queryClient, _data, { campaignId }) => {
+    queryClient.invalidateQueries({ queryKey: ['lore', 'list', campaignId], exact: false });
+    queryClient.invalidateQueries({ queryKey: ['lore', 'linked', campaignId], exact: false });
+    queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+  },
+  errorContext: () => ({ action: 'createLore' }),
+});
+
+export interface UpdateLoreInput {
+  id: string;
+  campaignId: string;
+  title: string;
+  content?: string;
+  gmContent?: string;
+  isPublic?: boolean;
+  images?: {
+    url: string;
+    caption: string;
+    crop: { x: number; y: number; width: number; height: number } | null;
+  }[];
+  links?: { kind: LoreLinkKind; id: string }[];
+  tags?: string[];
+}
+
+export const useUpdateLore = createMutationHook({
+  actionName: 'update',
+  mutationFn: async (input: UpdateLoreInput) => updateLoreFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    queryClient.invalidateQueries({
+      queryKey: ['lore', 'list', variables.campaignId],
+      exact: false,
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.lore.detail(variables.id, variables.campaignId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: ['lore', 'linked', variables.campaignId],
+      exact: false,
+    });
+    queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+  },
+  errorContext: (variables) => ({ action: 'updateLore', loreId: variables.id }),
+});
+
+export interface DeleteLoreInput {
+  id: string;
+  campaignId: string;
+}
+
+export const useDeleteLore = createMutationHook({
+  actionName: 'remove',
+  mutationFn: async (input: DeleteLoreInput) => deleteLoreFn({ data: input }),
+  onSuccess: (queryClient, _data, variables) => {
+    queryClient.invalidateQueries({
+      queryKey: ['lore', 'list', variables.campaignId],
+      exact: false,
+    });
+    queryClient.removeQueries({
+      queryKey: queryKeys.lore.detail(variables.id, variables.campaignId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: ['lore', 'linked', variables.campaignId],
+      exact: false,
+    });
+    queryClient.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+  },
+  errorContext: (variables) => ({ action: 'deleteLore', loreId: variables.id }),
+});

--- a/app/hooks/usePlayers.ts
+++ b/app/hooks/usePlayers.ts
@@ -390,6 +390,11 @@ interface CompleteJoinWizardInput {
       isPublic?: boolean;
     };
   }>;
+  lore?: Array<{
+    title: string;
+    content?: string;
+    isPublic?: boolean;
+  }>;
 }
 
 export const useCompleteJoinWizard = createMutationHook({

--- a/app/routes/campaign/join.tsx
+++ b/app/routes/campaign/join.tsx
@@ -5,7 +5,7 @@ import { JoinWizard } from '~/components/join-wizard/JoinWizard';
 
 export const joinSearchSchema = z.object({
   code: z.string().optional(),
-  step: z.coerce.number().min(1).max(5).catch(1),
+  step: z.coerce.number().min(1).max(6).catch(1),
   campaignId: z.string().optional(),
 });
 

--- a/app/routes/campaigns/$campaignId/play.tsx
+++ b/app/routes/campaigns/$campaignId/play.tsx
@@ -15,6 +15,10 @@ import type { TabId } from '~/components/mainview/TabNavigation';
 import type { ToolType } from '~/components/mainview/ToolBar';
 import { CatchUpWidget } from '~/components/mainview/widgets/CatchUpWidget';
 import { CampaignTimelineWidget } from '~/components/mainview/widgets/CampaignTimelineWidget';
+import { useCalendar } from '~/hooks/useCalendar';
+import { useEpicEvents } from '~/hooks/useEvents';
+import { eventsToTimeline } from '~/services/eventsTimeline';
+import { calendarConfigFromData } from '~/types/calendar';
 import { KeyAlliesWidget } from '~/components/mainview/widgets/KeyAlliesWidget';
 import { PartyMembersWidget } from '~/components/mainview/widgets/PartyMembersWidget';
 import { SessionsListWidget } from '~/components/mainview/widgets/SessionsListWidget';
@@ -97,6 +101,12 @@ function PlayPageContent() {
 
   const needsNewPlayer = !isCampaignLoading && !isPlayerLoading && !activePlayer && !campaign?.isGM;
 
+  const { calendar } = useCalendar(campaignId);
+  const { events: epicEvents } = useEpicEvents(campaignId);
+  const timelineEvents = calendar
+    ? eventsToTimeline(calendarConfigFromData(calendar), epicEvents, calendar.currentDate)
+    : undefined;
+
   // Coerce non-GMs away from the GM-only tab
   const effectiveTab =
     activeTab === 'gmscreens' && !campaign?.isGM ? ('dashboard' as const) : activeTab;
@@ -158,7 +168,7 @@ function PlayPageContent() {
               <PartyMembersWidget campaignId={campaignId} />
               <KeyAlliesWidget campaignId={campaignId} />
               <SessionsListWidget campaignId={campaignId} className="col-span-full" />
-              <CampaignTimelineWidget className="xl:col-span-2" />
+              <CampaignTimelineWidget events={timelineEvents} className="xl:col-span-2" />
             </DashboardView>
           </div>
           <div

--- a/app/server/db/models/Calendar.ts
+++ b/app/server/db/models/Calendar.ts
@@ -1,0 +1,59 @@
+import mongoose from 'mongoose';
+
+const monthSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    days: { type: Number, required: true },
+    isIntercalary: { type: Boolean, default: false },
+  },
+  { _id: false }
+);
+const leapSchema = new mongoose.Schema(
+  { name: String, monthIndex: Number, interval: Number, offset: Number, addDays: Number },
+  { _id: false }
+);
+const moonSchema = new mongoose.Schema(
+  { name: String, cycleLength: Number, offsetDays: Number, color: String },
+  { _id: false }
+);
+const seasonSchema = new mongoose.Schema(
+  { name: String, startMonthIndex: Number, startDay: Number, color: String },
+  { _id: false }
+);
+const holidaySchema = new mongoose.Schema(
+  { name: String, monthIndex: Number, day: Number, color: String },
+  { _id: false }
+);
+const calDateSchema = new mongoose.Schema(
+  { year: Number, monthIndex: Number, day: Number },
+  { _id: false }
+);
+
+const calendarSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  description: { type: String, default: '' },
+  months: { type: [monthSchema], default: [] },
+  weekdays: { type: [String], default: [] },
+  weekdayMode: { type: String, enum: ['continuous', 'resetEachMonth'], default: 'continuous' },
+  epoch: { year: { type: Number, default: 1 }, weekdayIndex: { type: Number, default: 0 } },
+  yearSuffix: { type: String, default: '' },
+  namedYears: {
+    type: [new mongoose.Schema({ year: Number, name: String }, { _id: false })],
+    default: [],
+  },
+  leapDays: { type: [leapSchema], default: [] },
+  moons: { type: [moonSchema], default: [] },
+  seasons: { type: [seasonSchema], default: [] },
+  holidays: { type: [holidaySchema], default: [] },
+  currentDate: { type: calDateSchema, default: () => ({ year: 1, monthIndex: 0, day: 1 }) },
+  campaignId: { type: mongoose.Schema.Types.ObjectId, required: true, index: true, unique: true },
+  createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+});
+
+calendarSchema.pre('save', function () {
+  this.updatedAt = new Date();
+});
+
+export const Calendar = mongoose.models.Calendar || mongoose.model('Calendar', calendarSchema);

--- a/app/server/db/models/Event.ts
+++ b/app/server/db/models/Event.ts
@@ -1,0 +1,70 @@
+import mongoose from 'mongoose';
+import { normalizeTags } from '~/server/utils/helpers';
+
+const linkSchema = new mongoose.Schema(
+  {
+    kind: {
+      type: String,
+      enum: ['character', 'player', 'race', 'location', 'lore'],
+      required: true,
+    },
+    id: { type: mongoose.Schema.Types.ObjectId, required: true },
+  },
+  { _id: false }
+);
+const cropSchema = new mongoose.Schema(
+  { x: Number, y: Number, width: Number, height: Number },
+  { _id: false }
+);
+const imageSchema = new mongoose.Schema(
+  {
+    url: { type: String, required: true },
+    caption: { type: String, default: '' },
+    crop: { type: cropSchema, default: null },
+  },
+  { _id: false }
+);
+const calDateSchema = new mongoose.Schema(
+  { year: Number, monthIndex: Number, day: Number },
+  { _id: false }
+);
+
+const eventSchema = new mongoose.Schema({
+  title: { type: String, required: true },
+  content: { type: String, default: '' },
+  gmContent: { type: String, default: '' },
+  isPublic: { type: Boolean, default: false },
+  isEpic: { type: Boolean, default: false },
+  start: { type: calDateSchema, required: true },
+  end: { type: calDateSchema, default: null },
+  startOrdinal: { type: Number, required: true },
+  endOrdinal: { type: Number, required: true },
+  links: { type: [linkSchema], default: [] },
+  sessionId: { type: mongoose.Schema.Types.ObjectId, default: null },
+  images: { type: [imageSchema], default: [] },
+  tags: { type: [String], default: [] },
+  color: { type: String, default: null },
+  campaignId: { type: mongoose.Schema.Types.ObjectId, required: true, index: true },
+  calendarId: { type: mongoose.Schema.Types.ObjectId, required: true },
+  createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+});
+
+// istanbul ignore next
+if (typeof (eventSchema as { index?: unknown }).index === 'function') {
+  eventSchema.index({ campaignId: 1, startOrdinal: 1 });
+  eventSchema.index({ isPublic: 1 });
+  eventSchema.index({ isEpic: 1 });
+  eventSchema.index({ 'links.id': 1 });
+  eventSchema.index({ tags: 1 });
+  eventSchema.index({ sessionId: 1 });
+  eventSchema.index({ title: 'text', content: 'text' });
+}
+
+eventSchema.pre('save', function () {
+  if (this.isModified('tags')) this.tags = normalizeTags(this.tags as string[]);
+  this.updatedAt = new Date();
+});
+
+export const Event = mongoose.models.Event || mongoose.model('Event', eventSchema);

--- a/app/server/db/models/Lore.ts
+++ b/app/server/db/models/Lore.ts
@@ -1,0 +1,61 @@
+import mongoose from 'mongoose';
+import { normalizeTags } from '~/server/utils/helpers';
+
+const linkSchema = new mongoose.Schema(
+  {
+    kind: { type: String, enum: ['race', 'character', 'player', 'location'], required: true },
+    id: { type: mongoose.Schema.Types.ObjectId, required: true },
+  },
+  { _id: false }
+);
+
+const cropSchema = new mongoose.Schema(
+  {
+    x: { type: Number, required: true },
+    y: { type: Number, required: true },
+    width: { type: Number, required: true },
+    height: { type: Number, required: true },
+  },
+  { _id: false }
+);
+
+const imageSchema = new mongoose.Schema(
+  {
+    url: { type: String, required: true },
+    caption: { type: String, default: '' },
+    crop: { type: cropSchema, default: null },
+  },
+  { _id: false }
+);
+
+const loreSchema = new mongoose.Schema({
+  title: { type: String, required: true },
+  content: { type: String, default: '' },
+  gmContent: { type: String, default: '' },
+  isPublic: { type: Boolean, default: false },
+  images: { type: [imageSchema], default: [] },
+  links: { type: [linkSchema], default: [] },
+  tags: { type: [String], default: [] },
+  campaignId: { type: mongoose.Schema.Types.ObjectId, required: true, index: true },
+  createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+});
+
+// istanbul ignore next
+if (typeof (loreSchema as { index?: unknown }).index === 'function') {
+  loreSchema.index({ campaignId: 1, updatedAt: -1 });
+  loreSchema.index({ isPublic: 1 });
+  loreSchema.index({ tags: 1 });
+  loreSchema.index({ 'links.id': 1 });
+  loreSchema.index({ title: 'text', content: 'text' });
+}
+
+loreSchema.pre('save', function () {
+  if (this.isModified('tags')) {
+    this.tags = normalizeTags(this.tags as string[]);
+  }
+  this.updatedAt = new Date();
+});
+
+export const Lore = mongoose.models.Lore || mongoose.model('Lore', loreSchema);

--- a/app/server/functions/calendars.ts
+++ b/app/server/functions/calendars.ts
@@ -83,6 +83,8 @@ export const upsertCalendar = createServerFn({ method: 'POST' })
       if (!member.isGM) throw new Error('Forbidden');
 
       const cfg = toConfig(data);
+      const cd = validateDate(cfg, data.currentDate);
+      if (!cd.ok) throw new Error(cd.error ?? 'Current date is invalid for this calendar');
       const doc = (await Calendar.findOneAndUpdate(
         { campaignId: data.campaignId },
         {
@@ -112,7 +114,10 @@ export const upsertCalendar = createServerFn({ method: 'POST' })
       )) as AnyDoc;
 
       // Re-validate every event against the new config and recompute ordinals.
-      const events = (await Event.find({ campaignId: data.campaignId }).lean()) as AnyDoc[];
+      const events = (await Event.find(
+        { campaignId: data.campaignId },
+        { start: 1, end: 1 }
+      ).lean()) as AnyDoc[];
       const invalidEventIds: string[] = [];
       const ops: AnyBulkWriteOperation[] = [];
       for (const ev of events) {
@@ -124,13 +129,14 @@ export const upsertCalendar = createServerFn({ method: 'POST' })
           invalidEventIds.push(String(ev._id));
           continue;
         }
+        const startOrd = toOrdinal(cfg, start);
         ops.push({
           updateOne: {
             filter: { _id: ev._id },
             update: {
               $set: {
-                startOrdinal: toOrdinal(cfg, start),
-                endOrdinal: toOrdinal(cfg, end ?? start),
+                startOrdinal: startOrd,
+                endOrdinal: end ? toOrdinal(cfg, end) : startOrd,
               },
             },
           },
@@ -158,6 +164,13 @@ export const setCurrentDate = createServerFn({ method: 'POST' })
     try {
       const member = await requireCampaignMember(data.campaignId);
       if (!member.isGM) throw new Error('Forbidden');
+      const existing = (await Calendar.findOne({
+        campaignId: data.campaignId,
+      }).lean()) as AnyDoc | null;
+      if (!existing) throw new Error('Not found');
+      const cfg = toConfig(existing);
+      const cd = validateDate(cfg, data.currentDate);
+      if (!cd.ok) throw new Error(cd.error ?? 'Current date is invalid for this calendar');
       const doc = (await Calendar.findOneAndUpdate(
         { campaignId: data.campaignId },
         { $set: { currentDate: data.currentDate, updatedAt: new Date() } },

--- a/app/server/functions/calendars.ts
+++ b/app/server/functions/calendars.ts
@@ -1,0 +1,196 @@
+import { createServerFn } from '@tanstack/react-start';
+import type { AnyBulkWriteOperation } from 'mongoose';
+import { requireCampaignMember } from '../utils/requireCampaignMember';
+import { serverCaptureException } from '../utils/posthog';
+import { Calendar } from '../db/models/Calendar';
+import { Event } from '../db/models/Event';
+import {
+  getCalendarSchema,
+  upsertCalendarSchema,
+  setCurrentDateSchema,
+  deleteCalendarSchema,
+} from '~/types/schemas/calendars';
+import type { CalendarData } from '~/types/calendar';
+import { toOrdinal, validateDate, type CalendarConfig, type CalDate } from '~/utils/calendarEngine';
+
+type AnyDoc = Record<string, unknown> & { _id: unknown };
+
+function toConfig(doc: Record<string, unknown>): CalendarConfig {
+  return {
+    months: doc.months as CalendarConfig['months'],
+    weekdays: doc.weekdays as string[],
+    weekdayMode: doc.weekdayMode as CalendarConfig['weekdayMode'],
+    epoch: doc.epoch as CalendarConfig['epoch'],
+    yearSuffix: doc.yearSuffix as string,
+    leapDays: doc.leapDays as CalendarConfig['leapDays'],
+    moons: doc.moons as CalendarConfig['moons'],
+    seasons: doc.seasons as CalendarConfig['seasons'],
+    holidays: doc.holidays as CalendarConfig['holidays'],
+  };
+}
+
+function serialize(doc: AnyDoc, canEdit: boolean): CalendarData {
+  return {
+    id: String(doc._id),
+    campaignId: String(doc.campaignId),
+    createdBy: String(doc.createdBy),
+    name: (doc.name as string) ?? '',
+    description: (doc.description as string) ?? '',
+    months: (doc.months as CalendarData['months']) ?? [],
+    weekdays: (doc.weekdays as string[]) ?? [],
+    weekdayMode: (doc.weekdayMode as CalendarData['weekdayMode']) ?? 'continuous',
+    epoch: (doc.epoch as CalendarData['epoch']) ?? { year: 1, weekdayIndex: 0 },
+    yearSuffix: (doc.yearSuffix as string) ?? '',
+    namedYears: (doc.namedYears as CalendarData['namedYears']) ?? [],
+    leapDays: (doc.leapDays as CalendarData['leapDays']) ?? [],
+    moons: (doc.moons as CalendarData['moons']) ?? [],
+    seasons: (doc.seasons as CalendarData['seasons']) ?? [],
+    holidays: (doc.holidays as CalendarData['holidays']) ?? [],
+    currentDate: (doc.currentDate as CalDate) ?? { year: 1, monthIndex: 0, day: 1 },
+    createdAt: (doc.createdAt as Date)?.toISOString?.() ?? '',
+    updatedAt: (doc.updatedAt as Date)?.toISOString?.() ?? '',
+    canEdit,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// getCalendar
+// ---------------------------------------------------------------------------
+
+export const getCalendar = createServerFn({ method: 'GET' })
+  .inputValidator(getCalendarSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      const doc = (await Calendar.findOne({ campaignId: data.campaignId }).lean()) as AnyDoc | null;
+      if (!doc) return null;
+      return serialize(doc, member.isGM);
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'getCalendar', campaignId: data.campaignId });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// upsertCalendar
+// ---------------------------------------------------------------------------
+
+export const upsertCalendar = createServerFn({ method: 'POST' })
+  .inputValidator(upsertCalendarSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      if (!member.isGM) throw new Error('Forbidden');
+
+      const cfg = toConfig(data);
+      const doc = (await Calendar.findOneAndUpdate(
+        { campaignId: data.campaignId },
+        {
+          $set: {
+            name: data.name,
+            description: data.description,
+            months: data.months,
+            weekdays: data.weekdays,
+            weekdayMode: data.weekdayMode,
+            epoch: data.epoch,
+            yearSuffix: data.yearSuffix,
+            namedYears: data.namedYears,
+            leapDays: data.leapDays,
+            moons: data.moons,
+            seasons: data.seasons,
+            holidays: data.holidays,
+            currentDate: data.currentDate,
+            updatedAt: new Date(),
+          },
+          $setOnInsert: {
+            campaignId: data.campaignId,
+            createdBy: member.userId,
+            createdAt: new Date(),
+          },
+        },
+        { new: true, upsert: true, lean: true }
+      )) as AnyDoc;
+
+      // Re-validate every event against the new config and recompute ordinals.
+      const events = (await Event.find({ campaignId: data.campaignId }).lean()) as AnyDoc[];
+      const invalidEventIds: string[] = [];
+      const ops: AnyBulkWriteOperation[] = [];
+      for (const ev of events) {
+        const start = ev.start as CalDate;
+        const end = (ev.end as CalDate | null) ?? null;
+        const startOk = validateDate(cfg, start).ok;
+        const endOk = end ? validateDate(cfg, end).ok : true;
+        if (!startOk || !endOk) {
+          invalidEventIds.push(String(ev._id));
+          continue;
+        }
+        ops.push({
+          updateOne: {
+            filter: { _id: ev._id },
+            update: {
+              $set: {
+                startOrdinal: toOrdinal(cfg, start),
+                endOrdinal: toOrdinal(cfg, end ?? start),
+              },
+            },
+          },
+        });
+      }
+      if (ops.length) await Event.bulkWrite(ops);
+
+      return { success: true, calendar: serialize(doc, true), invalidEventIds };
+    } catch (e) {
+      serverCaptureException(e, undefined, {
+        action: 'upsertCalendar',
+        campaignId: data.campaignId,
+      });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// setCurrentDate
+// ---------------------------------------------------------------------------
+
+export const setCurrentDate = createServerFn({ method: 'POST' })
+  .inputValidator(setCurrentDateSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      if (!member.isGM) throw new Error('Forbidden');
+      const doc = (await Calendar.findOneAndUpdate(
+        { campaignId: data.campaignId },
+        { $set: { currentDate: data.currentDate, updatedAt: new Date() } },
+        { new: true, lean: true }
+      )) as AnyDoc | null;
+      if (!doc) throw new Error('Not found');
+      return { success: true, calendar: serialize(doc, true) };
+    } catch (e) {
+      serverCaptureException(e, undefined, {
+        action: 'setCurrentDate',
+        campaignId: data.campaignId,
+      });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// deleteCalendar
+// ---------------------------------------------------------------------------
+
+export const deleteCalendar = createServerFn({ method: 'POST' })
+  .inputValidator(deleteCalendarSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      if (!member.isGM) throw new Error('Forbidden');
+      await Calendar.deleteOne({ campaignId: data.campaignId });
+      return { success: true };
+    } catch (e) {
+      serverCaptureException(e, undefined, {
+        action: 'deleteCalendar',
+        campaignId: data.campaignId,
+      });
+      throw e;
+    }
+  });

--- a/app/server/functions/characters.ts
+++ b/app/server/functions/characters.ts
@@ -5,6 +5,7 @@ import { serverCaptureException, serverCaptureEvent } from '../utils/posthog';
 import { normalizeTags } from '../utils/helpers';
 import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
 import { pruneLoreLinks } from '../utils/pruneLoreLinks';
+import { pruneEventLinks } from '../utils/pruneEventLinks';
 import { ensureTags as ensureTagsFn } from './tags';
 import type { CharacterData, CharacterListItem, PictureCrop } from '~/types/character';
 import {
@@ -308,6 +309,7 @@ export const deleteCharacter = createServerFn({ method: 'POST' })
       );
 
       await pruneLoreLinks('character', data.id, data.campaignId);
+      await pruneEventLinks('character', data.id, data.campaignId);
 
       serverCaptureEvent(sessionUserId, 'character_deleted', {
         campaign_id: data.campaignId,

--- a/app/server/functions/characters.ts
+++ b/app/server/functions/characters.ts
@@ -4,6 +4,7 @@ import { Character } from '../db/models/Character';
 import { serverCaptureException, serverCaptureEvent } from '../utils/posthog';
 import { normalizeTags } from '../utils/helpers';
 import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
+import { pruneLoreLinks } from '../utils/pruneLoreLinks';
 import { ensureTags as ensureTagsFn } from './tags';
 import type { CharacterData, CharacterListItem, PictureCrop } from '~/types/character';
 import {
@@ -305,6 +306,8 @@ export const deleteCharacter = createServerFn({ method: 'POST' })
         { campaignId: data.campaignId, 'relationships.characterId': data.id },
         { $pull: { relationships: { characterId: data.id } } }
       );
+
+      await pruneLoreLinks('character', data.id, data.campaignId);
 
       serverCaptureEvent(sessionUserId, 'character_deleted', {
         campaign_id: data.campaignId,

--- a/app/server/functions/events.ts
+++ b/app/server/functions/events.ts
@@ -193,9 +193,14 @@ export const createEvent = createServerFn({ method: 'POST' })
 
       const sv = validateDate(cfg, data.start);
       if (!sv.ok) throw new Error(sv.error);
+      const startOrdinal = toOrdinal(cfg, data.start);
+      let endOrdinal = startOrdinal;
       if (data.end) {
         const ev = validateDate(cfg, data.end);
         if (!ev.ok) throw new Error(ev.error);
+        endOrdinal = toOrdinal(cfg, data.end);
+        if (endOrdinal < startOrdinal)
+          throw new Error('Event end date must be on or after the start date.');
       }
 
       const doc = (await Event.create({
@@ -206,8 +211,8 @@ export const createEvent = createServerFn({ method: 'POST' })
         isEpic: data.isEpic,
         start: data.start,
         end: data.end,
-        startOrdinal: toOrdinal(cfg, data.start),
-        endOrdinal: toOrdinal(cfg, data.end ?? data.start),
+        startOrdinal,
+        endOrdinal,
         links: data.links,
         sessionId: data.sessionId,
         images: data.images,
@@ -252,9 +257,14 @@ export const updateEvent = createServerFn({ method: 'POST' })
 
       const sv = validateDate(cfg, data.start);
       if (!sv.ok) throw new Error(sv.error);
+      const startOrdinal = toOrdinal(cfg, data.start);
+      let endOrdinal = startOrdinal;
       if (data.end) {
         const ev = validateDate(cfg, data.end);
         if (!ev.ok) throw new Error(ev.error);
+        endOrdinal = toOrdinal(cfg, data.end);
+        if (endOrdinal < startOrdinal)
+          throw new Error('Event end date must be on or after the start date.');
       }
 
       const updated = (await Event.findOneAndUpdate(
@@ -268,8 +278,8 @@ export const updateEvent = createServerFn({ method: 'POST' })
             isEpic: data.isEpic,
             start: data.start,
             end: data.end,
-            startOrdinal: toOrdinal(cfg, data.start),
-            endOrdinal: toOrdinal(cfg, data.end ?? data.start),
+            startOrdinal,
+            endOrdinal,
             links: data.links,
             sessionId: data.sessionId,
             images: data.images,

--- a/app/server/functions/events.ts
+++ b/app/server/functions/events.ts
@@ -1,0 +1,318 @@
+import { createServerFn } from '@tanstack/react-start';
+import { requireCampaignMember } from '../utils/requireCampaignMember';
+import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
+import { serverCaptureException } from '../utils/posthog';
+import { Event } from '../db/models/Event';
+import { Calendar } from '../db/models/Calendar';
+import { Character } from '../db/models/Character';
+import { Player } from '../db/models/Player';
+import { Location } from '../db/models/Location';
+import { Race } from '../db/models/Race';
+import { Lore } from '../db/models/Lore';
+import {
+  listEventsSchema,
+  getEventSchema,
+  createEventSchema,
+  updateEventSchema,
+  deleteEventSchema,
+} from '~/types/schemas/events';
+import type { EventData, EventLink, EventListItem } from '~/types/event';
+import { toOrdinal, validateDate } from '~/utils/calendarEngine';
+import type { CalendarConfig, CalDate } from '~/utils/calendarEngine';
+
+type AnyDoc = Record<string, unknown> & { _id: unknown };
+
+async function loadConfig(campaignId: string): Promise<CalendarConfig> {
+  const cal = (await Calendar.findOne({ campaignId }).lean()) as AnyDoc | null;
+  if (!cal) throw new Error('No calendar exists for this campaign. Create one first.');
+  return {
+    months: cal.months as CalendarConfig['months'],
+    weekdays: cal.weekdays as string[],
+    weekdayMode: cal.weekdayMode as CalendarConfig['weekdayMode'],
+    epoch: cal.epoch as CalendarConfig['epoch'],
+    yearSuffix: cal.yearSuffix as string,
+    leapDays: cal.leapDays as CalendarConfig['leapDays'],
+    moons: cal.moons as CalendarConfig['moons'],
+    seasons: cal.seasons as CalendarConfig['seasons'],
+    holidays: cal.holidays as CalendarConfig['holidays'],
+  };
+}
+
+function baseSerialize(doc: AnyDoc) {
+  return {
+    id: String(doc._id),
+    campaignId: String(doc.campaignId),
+    calendarId: String(doc.calendarId),
+    createdBy: String(doc.createdBy),
+    title: (doc.title as string) ?? '',
+    content: (doc.content as string) ?? '',
+    isPublic: Boolean(doc.isPublic),
+    isEpic: Boolean(doc.isEpic),
+    start: doc.start as CalDate,
+    end: (doc.end as CalDate | null) ?? null,
+    startOrdinal: Number(doc.startOrdinal ?? 0),
+    endOrdinal: Number(doc.endOrdinal ?? 0),
+    links: ((doc.links as unknown[]) ?? []).map((l) => {
+      const lk = l as Record<string, unknown>;
+      return { kind: lk.kind as EventLink['kind'], id: String(lk.id) };
+    }) as EventLink[],
+    sessionId: doc.sessionId ? String(doc.sessionId) : null,
+    images: ((doc.images as unknown[]) ?? []).map((i) => {
+      const img = i as Record<string, unknown>;
+      return {
+        url: String(img.url),
+        caption: (img.caption as string) ?? '',
+        crop: (img.crop as EventData['images'][number]['crop']) ?? null,
+      };
+    }),
+    tags: (doc.tags as string[]) ?? [],
+    color: (doc.color as string | null) ?? null,
+    createdAt: (doc.createdAt as Date)?.toISOString?.() ?? '',
+    updatedAt: (doc.updatedAt as Date)?.toISOString?.() ?? '',
+  };
+}
+
+async function resolveLinkLabels(links: EventLink[]): Promise<EventLink[]> {
+  return Promise.all(
+    links.map(async (link) => {
+      let label = '';
+      try {
+        if (link.kind === 'character') {
+          const c = (await Character.findById(
+            link.id,
+            'firstName lastName'
+          ).lean()) as AnyDoc | null;
+          if (c) label = `${c.firstName ?? ''} ${c.lastName ?? ''}`.trim();
+        } else if (link.kind === 'player') {
+          const p = (await Player.findById(link.id, 'firstName lastName').lean()) as AnyDoc | null;
+          if (p) label = `${p.firstName ?? ''} ${p.lastName ?? ''}`.trim();
+        } else if (link.kind === 'location') {
+          const loc = (await Location.findById(link.id, 'name').lean()) as AnyDoc | null;
+          if (loc) label = String(loc.name ?? '');
+        } else if (link.kind === 'race') {
+          const r = (await Race.findById(link.id, 'title').lean()) as AnyDoc | null;
+          if (r) label = String(r.title ?? '');
+        } else if (link.kind === 'lore') {
+          const l = (await Lore.findById(link.id, 'title').lean()) as AnyDoc | null;
+          if (l) label = String(l.title ?? '');
+        }
+      } catch {
+        label = '';
+      }
+      return { ...link, label };
+    })
+  );
+}
+
+// ---------------------------------------------------------------------------
+// listEvents
+// ---------------------------------------------------------------------------
+
+export const listEvents = createServerFn({ method: 'GET' })
+  .inputValidator(listEventsSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      const filter: Record<string, unknown> = { campaignId: data.campaignId };
+
+      if (!member.isGM) {
+        filter.isPublic = true;
+      } else if (data.visibility === 'public') {
+        filter.isPublic = true;
+      } else if (data.visibility === 'private') {
+        filter.isPublic = false;
+      }
+
+      if (data.epicOnly) filter.isEpic = true;
+      if (data.tags?.length) filter.tags = { $all: data.tags };
+      if (data.search) filter.$text = { $search: data.search };
+      if (data.linkedKind && data.linkedId) {
+        filter.links = { $elemMatch: { kind: data.linkedKind, id: data.linkedId } };
+      }
+
+      const docs = (await Event.find(filter).sort({ startOrdinal: 1 }).lean()) as AnyDoc[];
+      const items: EventListItem[] = docs.map((doc) => ({
+        ...baseSerialize(doc),
+        canEdit: member.isGM,
+      }));
+      return items;
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'listEvents', campaignId: data.campaignId });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// getEvent
+// ---------------------------------------------------------------------------
+
+export const getEvent = createServerFn({ method: 'GET' })
+  .inputValidator(getEventSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      const doc = (await Event.findById(data.id).lean()) as AnyDoc | null;
+      if (!doc || String(doc.campaignId) !== data.campaignId) return null;
+      if (!member.isGM && !doc.isPublic) return null;
+
+      const links = await resolveLinkLabels(
+        ((doc.links as unknown[]) ?? []).map((l) => {
+          const lk = l as Record<string, unknown>;
+          return { kind: lk.kind as EventLink['kind'], id: String(lk.id) };
+        })
+      );
+
+      const result: EventData = {
+        ...baseSerialize(doc),
+        gmContent: member.isGM ? ((doc.gmContent as string) ?? '') : '',
+        links,
+        canEdit: member.isGM,
+      };
+      return result;
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'getEvent', eventId: data.id });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// createEvent
+// ---------------------------------------------------------------------------
+
+export const createEvent = createServerFn({ method: 'POST' })
+  .inputValidator(createEventSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      if (!member.isGM) throw new Error('Forbidden');
+
+      const cfg = await loadConfig(data.campaignId);
+      const cal = (await Calendar.findOne({ campaignId: data.campaignId }, '_id').lean()) as AnyDoc;
+
+      const sv = validateDate(cfg, data.start);
+      if (!sv.ok) throw new Error(sv.error);
+      if (data.end) {
+        const ev = validateDate(cfg, data.end);
+        if (!ev.ok) throw new Error(ev.error);
+      }
+
+      const doc = (await Event.create({
+        title: data.title,
+        content: data.content,
+        gmContent: data.gmContent,
+        isPublic: data.isPublic,
+        isEpic: data.isEpic,
+        start: data.start,
+        end: data.end,
+        startOrdinal: toOrdinal(cfg, data.start),
+        endOrdinal: toOrdinal(cfg, data.end ?? data.start),
+        links: data.links,
+        sessionId: data.sessionId,
+        images: data.images,
+        tags: data.tags,
+        color: data.color,
+        campaignId: data.campaignId,
+        calendarId: cal._id,
+        createdBy: member.userId,
+      })) as AnyDoc;
+
+      return {
+        success: true,
+        event: {
+          ...baseSerialize(doc),
+          gmContent: (data.gmContent as string) ?? '',
+          canEdit: true,
+        },
+      };
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'createEvent', campaignId: data.campaignId });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// updateEvent
+// ---------------------------------------------------------------------------
+
+export const updateEvent = createServerFn({ method: 'POST' })
+  .inputValidator(updateEventSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      if (!member.isGM) throw new Error('Forbidden');
+
+      const existing = (await Event.findById(data.id).lean()) as AnyDoc | null;
+      if (!existing || String(existing.campaignId) !== data.campaignId)
+        throw new Error('Not found');
+
+      const cfg = await loadConfig(data.campaignId);
+
+      const sv = validateDate(cfg, data.start);
+      if (!sv.ok) throw new Error(sv.error);
+      if (data.end) {
+        const ev = validateDate(cfg, data.end);
+        if (!ev.ok) throw new Error(ev.error);
+      }
+
+      const updated = (await Event.findOneAndUpdate(
+        { _id: data.id, campaignId: data.campaignId },
+        {
+          $set: {
+            title: data.title,
+            content: data.content,
+            gmContent: data.gmContent,
+            isPublic: data.isPublic,
+            isEpic: data.isEpic,
+            start: data.start,
+            end: data.end,
+            startOrdinal: toOrdinal(cfg, data.start),
+            endOrdinal: toOrdinal(cfg, data.end ?? data.start),
+            links: data.links,
+            sessionId: data.sessionId,
+            images: data.images,
+            tags: data.tags,
+            color: data.color,
+            updatedAt: new Date(),
+          },
+        },
+        { new: true, lean: true }
+      )) as AnyDoc;
+
+      return {
+        success: true,
+        event: {
+          ...baseSerialize(updated),
+          gmContent: (data.gmContent as string) ?? '',
+          canEdit: true,
+        },
+      };
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'updateEvent', eventId: data.id });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// deleteEvent
+// ---------------------------------------------------------------------------
+
+export const deleteEvent = createServerFn({ method: 'POST' })
+  .inputValidator(deleteEventSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      if (!member.isGM) throw new Error('Forbidden');
+
+      const existing = (await Event.findById(data.id).lean()) as AnyDoc | null;
+      if (!existing || String(existing.campaignId) !== data.campaignId)
+        throw new Error('Not found');
+
+      await Event.deleteOne({ _id: data.id, campaignId: data.campaignId });
+      // Signature: removeDocumentRefsFromScreens(campaignId, collection, documentId)
+      await removeDocumentRefsFromScreens(data.campaignId, 'events', data.id);
+      return { success: true };
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'deleteEvent', eventId: data.id });
+      throw e;
+    }
+  });

--- a/app/server/functions/events.ts
+++ b/app/server/functions/events.ts
@@ -22,10 +22,10 @@ import type { CalendarConfig, CalDate } from '~/utils/calendarEngine';
 
 type AnyDoc = Record<string, unknown> & { _id: unknown };
 
-async function loadConfig(campaignId: string): Promise<CalendarConfig> {
+async function loadCalendar(campaignId: string): Promise<{ cfg: CalendarConfig; id: unknown }> {
   const cal = (await Calendar.findOne({ campaignId }).lean()) as AnyDoc | null;
   if (!cal) throw new Error('No calendar exists for this campaign. Create one first.');
-  return {
+  const cfg: CalendarConfig = {
     months: cal.months as CalendarConfig['months'],
     weekdays: cal.weekdays as string[],
     weekdayMode: cal.weekdayMode as CalendarConfig['weekdayMode'],
@@ -36,6 +36,7 @@ async function loadConfig(campaignId: string): Promise<CalendarConfig> {
     seasons: cal.seasons as CalendarConfig['seasons'],
     holidays: cal.holidays as CalendarConfig['holidays'],
   };
+  return { cfg, id: cal._id };
 }
 
 function baseSerialize(doc: AnyDoc) {
@@ -115,6 +116,7 @@ export const listEvents = createServerFn({ method: 'GET' })
       const member = await requireCampaignMember(data.campaignId);
       const filter: Record<string, unknown> = { campaignId: data.campaignId };
 
+      // Events are GM-owned (no player-authored events), so non-GMs see only public events — no "see your own" branch like lore.
       if (!member.isGM) {
         filter.isPublic = true;
       } else if (data.visibility === 'public') {
@@ -186,8 +188,8 @@ export const createEvent = createServerFn({ method: 'POST' })
       const member = await requireCampaignMember(data.campaignId);
       if (!member.isGM) throw new Error('Forbidden');
 
-      const cfg = await loadConfig(data.campaignId);
-      const cal = (await Calendar.findOne({ campaignId: data.campaignId }, '_id').lean()) as AnyDoc;
+      const { cfg, id: calendarId } = await loadCalendar(data.campaignId);
+      const safeGmContent = member.isGM ? (data.gmContent ?? '') : '';
 
       const sv = validateDate(cfg, data.start);
       if (!sv.ok) throw new Error(sv.error);
@@ -199,7 +201,7 @@ export const createEvent = createServerFn({ method: 'POST' })
       const doc = (await Event.create({
         title: data.title,
         content: data.content,
-        gmContent: data.gmContent,
+        gmContent: safeGmContent,
         isPublic: data.isPublic,
         isEpic: data.isEpic,
         start: data.start,
@@ -212,7 +214,7 @@ export const createEvent = createServerFn({ method: 'POST' })
         tags: data.tags,
         color: data.color,
         campaignId: data.campaignId,
-        calendarId: cal._id,
+        calendarId: calendarId,
         createdBy: member.userId,
       })) as AnyDoc;
 
@@ -220,7 +222,7 @@ export const createEvent = createServerFn({ method: 'POST' })
         success: true,
         event: {
           ...baseSerialize(doc),
-          gmContent: (data.gmContent as string) ?? '',
+          gmContent: safeGmContent,
           canEdit: true,
         },
       };
@@ -245,7 +247,8 @@ export const updateEvent = createServerFn({ method: 'POST' })
       if (!existing || String(existing.campaignId) !== data.campaignId)
         throw new Error('Not found');
 
-      const cfg = await loadConfig(data.campaignId);
+      const { cfg } = await loadCalendar(data.campaignId);
+      const safeGmContent = member.isGM ? (data.gmContent ?? '') : '';
 
       const sv = validateDate(cfg, data.start);
       if (!sv.ok) throw new Error(sv.error);
@@ -260,7 +263,7 @@ export const updateEvent = createServerFn({ method: 'POST' })
           $set: {
             title: data.title,
             content: data.content,
-            gmContent: data.gmContent,
+            gmContent: safeGmContent,
             isPublic: data.isPublic,
             isEpic: data.isEpic,
             start: data.start,
@@ -282,7 +285,7 @@ export const updateEvent = createServerFn({ method: 'POST' })
         success: true,
         event: {
           ...baseSerialize(updated),
-          gmContent: (data.gmContent as string) ?? '',
+          gmContent: safeGmContent,
           canEdit: true,
         },
       };

--- a/app/server/functions/gmscreens.ts
+++ b/app/server/functions/gmscreens.ts
@@ -213,6 +213,21 @@ const COLLECTION_REGISTRY: Record<string, CollectionFetcher> = {
         ) as Promise<Array<{ _id: unknown; title?: string; content?: string; isPublic?: boolean }>>;
     },
   },
+  events: {
+    async fetch(ids: string[], campaignId: string) {
+      const { Event } = await import('../db/models/Event');
+      return Event.find({ _id: { $in: ids }, campaignId }, '_id title content isPublic')
+        .lean()
+        .then((docs) =>
+          docs.map((d) => ({
+            _id: d._id,
+            title: (d as { title?: string }).title,
+            content: (d as { content?: string }).content,
+            isPublic: (d as { isPublic?: boolean }).isPublic,
+          }))
+        ) as Promise<Array<{ _id: unknown; title?: string; content?: string; isPublic?: boolean }>>;
+    },
+  },
   location: {
     async fetch(ids: string[], campaignId: string) {
       const { Location } = await import('../db/models/Location');

--- a/app/server/functions/gmscreens.ts
+++ b/app/server/functions/gmscreens.ts
@@ -198,6 +198,21 @@ const COLLECTION_REGISTRY: Record<string, CollectionFetcher> = {
       >;
     },
   },
+  lore: {
+    async fetch(ids: string[], campaignId: string) {
+      const { Lore } = await import('../db/models/Lore');
+      return Lore.find({ _id: { $in: ids }, campaignId }, '_id title content isPublic')
+        .lean()
+        .then((docs) =>
+          docs.map((d) => ({
+            _id: d._id,
+            title: (d as { title?: string }).title,
+            content: (d as { content?: string }).content,
+            isPublic: (d as { isPublic?: boolean }).isPublic,
+          }))
+        ) as Promise<Array<{ _id: unknown; title?: string; content?: string; isPublic?: boolean }>>;
+    },
+  },
   location: {
     async fetch(ids: string[], campaignId: string) {
       const { Location } = await import('../db/models/Location');

--- a/app/server/functions/locations.ts
+++ b/app/server/functions/locations.ts
@@ -4,6 +4,7 @@ import { Location } from '../db/models/Location';
 import { serverCaptureException, serverCaptureEvent } from '../utils/posthog';
 import { normalizeTags } from '../utils/helpers';
 import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
+import { pruneLoreLinks } from '../utils/pruneLoreLinks';
 import { ensureTags as ensureTagsFn } from './tags';
 import { S3Client, DeleteObjectCommand } from '@aws-sdk/client-s3';
 import type { LocationData, LocationListItem, LocationRef } from '~/types/location';
@@ -357,6 +358,8 @@ export const deleteLocation = createServerFn({ method: 'POST' })
           locationId: data.id,
         });
       }
+
+      await pruneLoreLinks('location', data.id, data.campaignId);
 
       serverCaptureEvent(sessionUserId, 'location_deleted', {
         campaign_id: data.campaignId,

--- a/app/server/functions/locations.ts
+++ b/app/server/functions/locations.ts
@@ -5,6 +5,7 @@ import { serverCaptureException, serverCaptureEvent } from '../utils/posthog';
 import { normalizeTags } from '../utils/helpers';
 import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
 import { pruneLoreLinks } from '../utils/pruneLoreLinks';
+import { pruneEventLinks } from '../utils/pruneEventLinks';
 import { ensureTags as ensureTagsFn } from './tags';
 import { S3Client, DeleteObjectCommand } from '@aws-sdk/client-s3';
 import type { LocationData, LocationListItem, LocationRef } from '~/types/location';
@@ -360,6 +361,7 @@ export const deleteLocation = createServerFn({ method: 'POST' })
       }
 
       await pruneLoreLinks('location', data.id, data.campaignId);
+      await pruneEventLinks('location', data.id, data.campaignId);
 
       serverCaptureEvent(sessionUserId, 'location_deleted', {
         campaign_id: data.campaignId,

--- a/app/server/functions/lore.ts
+++ b/app/server/functions/lore.ts
@@ -159,7 +159,7 @@ export const createLore = createServerFn({ method: 'POST' })
       const doc = (await Lore.create({
         title: data.title,
         content: data.content,
-        gmContent: data.gmContent,
+        gmContent: member.isGM ? data.gmContent : '',
         isPublic: data.isPublic,
         images: data.images,
         links: data.links,
@@ -202,7 +202,7 @@ export const updateLore = createServerFn({ method: 'POST' })
           $set: {
             title: data.title,
             content: data.content,
-            gmContent: data.gmContent,
+            gmContent: member.isGM ? data.gmContent : '',
             isPublic: data.isPublic,
             images: data.images,
             links: data.links,

--- a/app/server/functions/lore.ts
+++ b/app/server/functions/lore.ts
@@ -15,6 +15,7 @@ import {
   deleteLoreSchema,
 } from '~/types/schemas/lore';
 import type { LoreData, LoreLink, LoreListItem } from '~/types/lore';
+import type { PictureCrop } from '~/types/character';
 
 type AnyDoc = Record<string, unknown> & { _id: unknown };
 
@@ -31,7 +32,7 @@ function baseSerialize(doc: AnyDoc) {
       return {
         url: String(img.url),
         caption: (img.caption as string) ?? '',
-        crop: (img.crop as never) ?? null,
+        crop: (img.crop as unknown as PictureCrop) ?? null,
       };
     }),
     links: ((doc.links as unknown[]) ?? []).map((l) => {
@@ -46,29 +47,32 @@ function baseSerialize(doc: AnyDoc) {
 
 // Resolve {kind,id} -> display label across the four entity collections.
 async function resolveLinkLabels(links: LoreLink[]): Promise<LoreLink[]> {
-  const out: LoreLink[] = [];
-  for (const link of links) {
-    let label = '';
-    try {
-      if (link.kind === 'character') {
-        const c = (await Character.findById(link.id, 'firstName lastName').lean()) as AnyDoc | null;
-        if (c) label = `${c.firstName ?? ''} ${c.lastName ?? ''}`.trim();
-      } else if (link.kind === 'player') {
-        const p = (await Player.findById(link.id, 'firstName lastName').lean()) as AnyDoc | null;
-        if (p) label = `${p.firstName ?? ''} ${p.lastName ?? ''}`.trim();
-      } else if (link.kind === 'location') {
-        const loc = (await Location.findById(link.id, 'name').lean()) as AnyDoc | null;
-        if (loc) label = String(loc.name ?? '');
-      } else if (link.kind === 'race') {
-        const r = (await Race.findById(link.id, 'title').lean()) as AnyDoc | null;
-        if (r) label = String(r.title ?? '');
+  return Promise.all(
+    links.map(async (link) => {
+      let label = '';
+      try {
+        if (link.kind === 'character') {
+          const c = (await Character.findById(
+            link.id,
+            'firstName lastName'
+          ).lean()) as AnyDoc | null;
+          if (c) label = `${c.firstName ?? ''} ${c.lastName ?? ''}`.trim();
+        } else if (link.kind === 'player') {
+          const p = (await Player.findById(link.id, 'firstName lastName').lean()) as AnyDoc | null;
+          if (p) label = `${p.firstName ?? ''} ${p.lastName ?? ''}`.trim();
+        } else if (link.kind === 'location') {
+          const loc = (await Location.findById(link.id, 'name').lean()) as AnyDoc | null;
+          if (loc) label = String(loc.name ?? '');
+        } else if (link.kind === 'race') {
+          const r = (await Race.findById(link.id, 'title').lean()) as AnyDoc | null;
+          if (r) label = String(r.title ?? '');
+        }
+      } catch {
+        label = '';
       }
-    } catch {
-      label = '';
-    }
-    out.push({ ...link, label });
-  }
-  return out;
+      return { ...link, label };
+    })
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -165,7 +169,11 @@ export const createLore = createServerFn({ method: 'POST' })
       })) as AnyDoc;
       return {
         success: true,
-        lore: { ...baseSerialize(doc), gmContent: (doc.gmContent as string) ?? '', canEdit: true },
+        lore: {
+          ...baseSerialize(doc),
+          gmContent: member.isGM ? (data.gmContent ?? '') : '',
+          canEdit: true,
+        },
       };
     } catch (e) {
       serverCaptureException(e, undefined, { action: 'createLore', campaignId: data.campaignId });
@@ -182,7 +190,7 @@ export const updateLore = createServerFn({ method: 'POST' })
   .handler(async ({ data }) => {
     try {
       const member = await requireCampaignMember(data.campaignId);
-      const existing = (await Lore.findById(data.id)) as AnyDoc | null;
+      const existing = (await Lore.findById(data.id).lean()) as AnyDoc | null;
       if (!existing || String(existing.campaignId) !== data.campaignId)
         throw new Error('Not found');
       if (String(existing.createdBy) !== member.userId && !member.isGM)
@@ -208,7 +216,7 @@ export const updateLore = createServerFn({ method: 'POST' })
         success: true,
         lore: {
           ...baseSerialize(updated),
-          gmContent: (updated.gmContent as string) ?? '',
+          gmContent: member.isGM ? (data.gmContent ?? '') : '',
           canEdit: true,
         },
       };
@@ -227,7 +235,7 @@ export const deleteLore = createServerFn({ method: 'POST' })
   .handler(async ({ data }) => {
     try {
       const member = await requireCampaignMember(data.campaignId);
-      const existing = (await Lore.findById(data.id)) as AnyDoc | null;
+      const existing = (await Lore.findById(data.id).lean()) as AnyDoc | null;
       if (!existing || String(existing.campaignId) !== data.campaignId)
         throw new Error('Not found');
       if (String(existing.createdBy) !== member.userId && !member.isGM)

--- a/app/server/functions/lore.ts
+++ b/app/server/functions/lore.ts
@@ -1,0 +1,243 @@
+import { createServerFn } from '@tanstack/react-start';
+import { requireCampaignMember } from '../utils/requireCampaignMember';
+import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
+import { serverCaptureException } from '../utils/posthog';
+import { Lore } from '../db/models/Lore';
+import { Character } from '../db/models/Character';
+import { Player } from '../db/models/Player';
+import { Location } from '../db/models/Location';
+import { Race } from '../db/models/Race';
+import {
+  listLoreSchema,
+  getLoreSchema,
+  createLoreSchema,
+  updateLoreSchema,
+  deleteLoreSchema,
+} from '~/types/schemas/lore';
+import type { LoreData, LoreLink, LoreListItem } from '~/types/lore';
+
+type AnyDoc = Record<string, unknown> & { _id: unknown };
+
+function baseSerialize(doc: AnyDoc) {
+  return {
+    id: String(doc._id),
+    campaignId: String(doc.campaignId),
+    createdBy: String(doc.createdBy),
+    title: (doc.title as string) ?? '',
+    content: (doc.content as string) ?? '',
+    isPublic: Boolean(doc.isPublic),
+    images: ((doc.images as unknown[]) ?? []).map((i) => {
+      const img = i as Record<string, unknown>;
+      return {
+        url: String(img.url),
+        caption: (img.caption as string) ?? '',
+        crop: (img.crop as never) ?? null,
+      };
+    }),
+    links: ((doc.links as unknown[]) ?? []).map((l) => {
+      const lk = l as Record<string, unknown>;
+      return { kind: lk.kind as LoreLink['kind'], id: String(lk.id) };
+    }) as LoreLink[],
+    tags: (doc.tags as string[]) ?? [],
+    createdAt: (doc.createdAt as Date)?.toISOString?.() ?? '',
+    updatedAt: (doc.updatedAt as Date)?.toISOString?.() ?? '',
+  };
+}
+
+// Resolve {kind,id} -> display label across the four entity collections.
+async function resolveLinkLabels(links: LoreLink[]): Promise<LoreLink[]> {
+  const out: LoreLink[] = [];
+  for (const link of links) {
+    let label = '';
+    try {
+      if (link.kind === 'character') {
+        const c = (await Character.findById(link.id, 'firstName lastName').lean()) as AnyDoc | null;
+        if (c) label = `${c.firstName ?? ''} ${c.lastName ?? ''}`.trim();
+      } else if (link.kind === 'player') {
+        const p = (await Player.findById(link.id, 'firstName lastName').lean()) as AnyDoc | null;
+        if (p) label = `${p.firstName ?? ''} ${p.lastName ?? ''}`.trim();
+      } else if (link.kind === 'location') {
+        const loc = (await Location.findById(link.id, 'name').lean()) as AnyDoc | null;
+        if (loc) label = String(loc.name ?? '');
+      } else if (link.kind === 'race') {
+        const r = (await Race.findById(link.id, 'title').lean()) as AnyDoc | null;
+        if (r) label = String(r.title ?? '');
+      }
+    } catch {
+      label = '';
+    }
+    out.push({ ...link, label });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// listLore
+// ---------------------------------------------------------------------------
+
+export const listLore = createServerFn({ method: 'GET' })
+  .inputValidator(listLoreSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      const filter: Record<string, unknown> = { campaignId: data.campaignId };
+
+      if (!member.isGM) {
+        filter.$or = [{ isPublic: true }, { createdBy: member.userId }];
+      } else if (data.visibility === 'public') {
+        filter.isPublic = true;
+      } else if (data.visibility === 'private') {
+        filter.isPublic = false;
+      }
+
+      if (data.tags?.length) filter.tags = { $all: data.tags };
+      if (data.search) filter.$text = { $search: data.search };
+      if (data.linkedKind && data.linkedId) {
+        filter.links = { $elemMatch: { kind: data.linkedKind, id: data.linkedId } };
+      }
+
+      const docs = (await Lore.find(filter).sort({ updatedAt: -1 }).lean()) as AnyDoc[];
+      const items: LoreListItem[] = docs.map((doc) => ({
+        ...baseSerialize(doc),
+        canEdit: String(doc.createdBy) === member.userId || member.isGM,
+      }));
+      return items;
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'listLore', campaignId: data.campaignId });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// getLore
+// ---------------------------------------------------------------------------
+
+export const getLore = createServerFn({ method: 'GET' })
+  .inputValidator(getLoreSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      const doc = (await Lore.findById(data.id).lean()) as AnyDoc | null;
+      if (!doc || String(doc.campaignId) !== data.campaignId) return null;
+
+      const isCreator = String(doc.createdBy) === member.userId;
+      if (!member.isGM && !isCreator && !doc.isPublic) return null;
+
+      const links = await resolveLinkLabels(
+        ((doc.links as unknown[]) ?? []).map((l) => {
+          const lk = l as Record<string, unknown>;
+          return { kind: lk.kind as LoreLink['kind'], id: String(lk.id) };
+        })
+      );
+
+      const result: LoreData = {
+        ...baseSerialize(doc),
+        gmContent: member.isGM ? ((doc.gmContent as string) ?? '') : '',
+        links,
+        canEdit: isCreator || member.isGM,
+      };
+      return result;
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'getLore', loreId: data.id });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// createLore
+// ---------------------------------------------------------------------------
+
+export const createLore = createServerFn({ method: 'POST' })
+  .inputValidator(createLoreSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      const doc = (await Lore.create({
+        title: data.title,
+        content: data.content,
+        gmContent: data.gmContent,
+        isPublic: data.isPublic,
+        images: data.images,
+        links: data.links,
+        tags: data.tags,
+        campaignId: data.campaignId,
+        createdBy: member.userId,
+      })) as AnyDoc;
+      return {
+        success: true,
+        lore: { ...baseSerialize(doc), gmContent: (doc.gmContent as string) ?? '', canEdit: true },
+      };
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'createLore', campaignId: data.campaignId });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// updateLore
+// ---------------------------------------------------------------------------
+
+export const updateLore = createServerFn({ method: 'POST' })
+  .inputValidator(updateLoreSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      const existing = (await Lore.findById(data.id)) as AnyDoc | null;
+      if (!existing || String(existing.campaignId) !== data.campaignId)
+        throw new Error('Not found');
+      if (String(existing.createdBy) !== member.userId && !member.isGM)
+        throw new Error('Forbidden');
+
+      const updated = (await Lore.findOneAndUpdate(
+        { _id: data.id, campaignId: data.campaignId },
+        {
+          $set: {
+            title: data.title,
+            content: data.content,
+            gmContent: data.gmContent,
+            isPublic: data.isPublic,
+            images: data.images,
+            links: data.links,
+            tags: data.tags,
+            updatedAt: new Date(),
+          },
+        },
+        { new: true, lean: true }
+      )) as AnyDoc;
+      return {
+        success: true,
+        lore: {
+          ...baseSerialize(updated),
+          gmContent: (updated.gmContent as string) ?? '',
+          canEdit: true,
+        },
+      };
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'updateLore', loreId: data.id });
+      throw e;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// deleteLore
+// ---------------------------------------------------------------------------
+
+export const deleteLore = createServerFn({ method: 'POST' })
+  .inputValidator(deleteLoreSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      const existing = (await Lore.findById(data.id)) as AnyDoc | null;
+      if (!existing || String(existing.campaignId) !== data.campaignId)
+        throw new Error('Not found');
+      if (String(existing.createdBy) !== member.userId && !member.isGM)
+        throw new Error('Forbidden');
+      await Lore.deleteOne({ _id: data.id, campaignId: data.campaignId });
+      // Signature: removeDocumentRefsFromScreens(campaignId, collection, documentId)
+      await removeDocumentRefsFromScreens(data.campaignId, 'lore', data.id);
+      return { success: true };
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'deleteLore', loreId: data.id });
+      throw e;
+    }
+  });

--- a/app/server/functions/lore.ts
+++ b/app/server/functions/lore.ts
@@ -1,6 +1,7 @@
 import { createServerFn } from '@tanstack/react-start';
 import { requireCampaignMember } from '../utils/requireCampaignMember';
 import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
+import { pruneEventLinks } from '../utils/pruneEventLinks';
 import { serverCaptureException } from '../utils/posthog';
 import { Lore } from '../db/models/Lore';
 import { Character } from '../db/models/Character';
@@ -243,6 +244,7 @@ export const deleteLore = createServerFn({ method: 'POST' })
       await Lore.deleteOne({ _id: data.id, campaignId: data.campaignId });
       // Signature: removeDocumentRefsFromScreens(campaignId, collection, documentId)
       await removeDocumentRefsFromScreens(data.campaignId, 'lore', data.id);
+      await pruneEventLinks('lore', data.id, data.campaignId);
       return { success: true };
     } catch (e) {
       serverCaptureException(e, undefined, { action: 'deleteLore', loreId: data.id });

--- a/app/server/functions/lore.ts
+++ b/app/server/functions/lore.ts
@@ -197,13 +197,16 @@ export const updateLore = createServerFn({ method: 'POST' })
       if (String(existing.createdBy) !== member.userId && !member.isGM)
         throw new Error('Forbidden');
 
+      // gmContent is GM-only at write. For a non-GM creator editing their own
+      // lore, OMIT the field entirely so any GM-authored gmContent is PRESERVED —
+      // overwriting it with '' would silently destroy the GM's private notes.
       const updated = (await Lore.findOneAndUpdate(
         { _id: data.id, campaignId: data.campaignId },
         {
           $set: {
             title: data.title,
             content: data.content,
-            gmContent: member.isGM ? data.gmContent : '',
+            ...(member.isGM ? { gmContent: data.gmContent } : {}),
             isPublic: data.isPublic,
             images: data.images,
             links: data.links,
@@ -217,7 +220,9 @@ export const updateLore = createServerFn({ method: 'POST' })
         success: true,
         lore: {
           ...baseSerialize(updated),
-          gmContent: member.isGM ? (data.gmContent ?? '') : '',
+          // Reflect the persisted value: GM sees what they wrote; a non-GM never
+          // receives gmContent regardless of what's stored.
+          gmContent: member.isGM ? ((updated.gmContent as string) ?? '') : '',
           canEdit: true,
         },
       };

--- a/app/server/functions/players.ts
+++ b/app/server/functions/players.ts
@@ -7,6 +7,7 @@ import { Campaign } from '../db/models/Campaign';
 import { requireCampaignMember } from '../utils/requireCampaignMember';
 import { Player } from '../db/models/Player';
 import { Character } from '../db/models/Character';
+import { Lore } from '../db/models/Lore';
 import { serverCaptureException, serverCaptureEvent } from '../utils/posthog';
 import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
 import { pruneLoreLinks } from '../utils/pruneLoreLinks';
@@ -721,6 +722,21 @@ export const completeJoinWizard = createServerFn({ method: 'POST' })
             },
           }
         );
+      }
+
+      // 6. Create Lore documents linked to the new player
+      for (const entry of data.lore ?? []) {
+        await Lore.create({
+          title: entry.title,
+          content: entry.content,
+          gmContent: '',
+          isPublic: entry.isPublic,
+          images: [],
+          tags: [],
+          links: [{ kind: 'player', id: playerDoc._id }],
+          campaignId: data.campaignId,
+          createdBy: userId,
+        });
       }
 
       serverCaptureEvent(sessionUserId, 'join_wizard_completed', {

--- a/app/server/functions/players.ts
+++ b/app/server/functions/players.ts
@@ -11,6 +11,7 @@ import { Lore } from '../db/models/Lore';
 import { serverCaptureException, serverCaptureEvent } from '../utils/posthog';
 import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
 import { pruneLoreLinks } from '../utils/pruneLoreLinks';
+import { pruneEventLinks } from '../utils/pruneEventLinks';
 import type { PlayerData, PlayerListItem } from '~/types/player';
 import type { PictureCrop } from '~/types/character';
 import {
@@ -344,6 +345,7 @@ export const deletePlayer = createServerFn({ method: 'POST' })
       }
 
       await pruneLoreLinks('player', data.id, data.campaignId);
+      await pruneEventLinks('player', data.id, data.campaignId);
 
       serverCaptureEvent(sessionUserId, 'player_deleted', {
         campaign_id: data.campaignId,

--- a/app/server/functions/players.ts
+++ b/app/server/functions/players.ts
@@ -9,6 +9,7 @@ import { Player } from '../db/models/Player';
 import { Character } from '../db/models/Character';
 import { serverCaptureException, serverCaptureEvent } from '../utils/posthog';
 import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
+import { pruneLoreLinks } from '../utils/pruneLoreLinks';
 import type { PlayerData, PlayerListItem } from '~/types/player';
 import type { PictureCrop } from '~/types/character';
 import {
@@ -340,6 +341,8 @@ export const deletePlayer = createServerFn({ method: 'POST' })
           playerId: data.id,
         });
       }
+
+      await pruneLoreLinks('player', data.id, data.campaignId);
 
       serverCaptureEvent(sessionUserId, 'player_deleted', {
         campaign_id: data.campaignId,

--- a/app/server/functions/races.ts
+++ b/app/server/functions/races.ts
@@ -5,6 +5,7 @@ import { serverCaptureException, serverCaptureEvent } from '../utils/posthog';
 import { normalizeTags } from '../utils/helpers';
 import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
 import { pruneLoreLinks } from '../utils/pruneLoreLinks';
+import { pruneEventLinks } from '../utils/pruneEventLinks';
 import { ensureTags as ensureTagsFn } from './tags';
 import type { RaceData, RaceListItem } from '~/types/race';
 import {
@@ -180,6 +181,7 @@ export const deleteRace = createServerFn({ method: 'POST' })
       }
 
       await pruneLoreLinks('race', data.id, data.campaignId);
+      await pruneEventLinks('race', data.id, data.campaignId);
 
       serverCaptureEvent(sessionUserId!, 'race_deleted', {
         campaign_id: data.campaignId,

--- a/app/server/functions/races.ts
+++ b/app/server/functions/races.ts
@@ -4,6 +4,7 @@ import { Race } from '../db/models/Race';
 import { serverCaptureException, serverCaptureEvent } from '../utils/posthog';
 import { normalizeTags } from '../utils/helpers';
 import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
+import { pruneLoreLinks } from '../utils/pruneLoreLinks';
 import { ensureTags as ensureTagsFn } from './tags';
 import type { RaceData, RaceListItem } from '~/types/race';
 import {
@@ -177,6 +178,8 @@ export const deleteRace = createServerFn({ method: 'POST' })
           race_id: data.id,
         });
       }
+
+      await pruneLoreLinks('race', data.id, data.campaignId);
 
       serverCaptureEvent(sessionUserId!, 'race_deleted', {
         campaign_id: data.campaignId,

--- a/app/server/functions/tabletop-hydration.ts
+++ b/app/server/functions/tabletop-hydration.ts
@@ -186,8 +186,10 @@ const COLLECTION_REGISTRY: Record<string, CollectionFetcher> = {
  */
 export async function hydrateRefs(
   refs: Array<{ collection: string; documentId: string }>,
-  campaignId: string
+  campaignId: string,
+  opts: { isGM?: boolean } = {}
 ): Promise<Record<string, HydratedDocument>> {
+  const isGM = opts.isGM ?? true;
   const grouped = new Map<string, Set<string>>();
   for (const ref of refs) {
     if (!ref.collection || !ref.documentId) continue;
@@ -208,6 +210,9 @@ export async function hydrateRefs(
 
       const docs = await fetcher.fetch(Array.from(idSet), campaignId);
       for (const doc of docs) {
+        // Events can carry private GM content; never hydrate a non-public event
+        // for a non-GM viewer, or its title/content would leak on a shared screen.
+        if (!isGM && collectionName === 'events' && doc.isPublic === false) continue;
         const id = String(doc._id);
         hydrated[`${collectionName}:${id}`] = {
           id,

--- a/app/server/functions/tabletop-hydration.ts
+++ b/app/server/functions/tabletop-hydration.ts
@@ -119,6 +119,21 @@ const COLLECTION_REGISTRY: Record<string, CollectionFetcher> = {
         ) as Promise<Array<{ _id: unknown; title?: string; content?: string }>>;
     },
   },
+  lore: {
+    async fetch(ids: string[], campaignId: string) {
+      const { Lore } = await import('../db/models/Lore');
+      return Lore.find({ _id: { $in: ids }, campaignId }, '_id title content isPublic')
+        .lean()
+        .then((docs) =>
+          docs.map((d) => ({
+            _id: d._id,
+            title: (d as { title?: string }).title,
+            content: (d as { content?: string }).content,
+            isPublic: (d as { isPublic?: boolean }).isPublic,
+          }))
+        ) as Promise<Array<{ _id: unknown; title?: string; content?: string; isPublic?: boolean }>>;
+    },
+  },
   player: {
     async fetch(ids: string[], campaignId: string) {
       const { Player } = await import('../db/models/Player');

--- a/app/server/functions/tabletop-hydration.ts
+++ b/app/server/functions/tabletop-hydration.ts
@@ -134,6 +134,21 @@ const COLLECTION_REGISTRY: Record<string, CollectionFetcher> = {
         ) as Promise<Array<{ _id: unknown; title?: string; content?: string; isPublic?: boolean }>>;
     },
   },
+  events: {
+    async fetch(ids: string[], campaignId: string) {
+      const { Event } = await import('../db/models/Event');
+      return Event.find({ _id: { $in: ids }, campaignId }, '_id title content isPublic')
+        .lean()
+        .then((docs) =>
+          docs.map((d) => ({
+            _id: d._id,
+            title: (d as { title?: string }).title,
+            content: (d as { content?: string }).content,
+            isPublic: (d as { isPublic?: boolean }).isPublic,
+          }))
+        ) as Promise<Array<{ _id: unknown; title?: string; content?: string; isPublic?: boolean }>>;
+    },
+  },
   player: {
     async fetch(ids: string[], campaignId: string) {
       const { Player } = await import('../db/models/Player');

--- a/app/server/functions/tabletop.ts
+++ b/app/server/functions/tabletop.ts
@@ -413,7 +413,9 @@ export const getTabletopScreen = createServerFn({ method: 'GET' })
         refs.push({ collection: w.collection, documentId: w.documentId });
       }
 
-      const hydrated = await hydrateRefs(refs, data.campaignId);
+      const hydrated = await hydrateRefs(refs, data.campaignId, {
+        isGM: member.role === 'gm',
+      });
 
       return {
         ...serializeTabletopScreen(doc),

--- a/app/server/utils/oauth.ts
+++ b/app/server/utils/oauth.ts
@@ -354,7 +354,15 @@ interface UserDoc {
 
 export async function upsertUser(profile: OAuthProfile): Promise<SessionUser> {
   await connectDB();
-  if (!isDBConnected()) return toSessionUser(profile, 'unknown');
+  if (!isDBConnected()) {
+    // With no DB connection we can neither look up nor persist the account, so
+    // minting a session would log the user into an unpersisted, role-less
+    // "unknown" session. Fail loudly (consistent with the catch below) so the
+    // OAuth callback redirects to an error page instead of a broken login.
+    const e = new Error('upsertUser: database not connected');
+    serverCaptureException(e, profile.id, { action: 'upsertUser', provider: profile.provider });
+    throw e;
+  }
 
   try {
     const nameParts = (profile.name ?? '').split(' ');

--- a/app/server/utils/oauth.ts
+++ b/app/server/utils/oauth.ts
@@ -364,25 +364,49 @@ export async function upsertUser(profile: OAuthProfile): Promise<SessionUser> {
       accessToken: profile.accessToken ? encryptToken(profile.accessToken) : null,
       refreshToken: profile.refreshToken ? encryptToken(profile.refreshToken) : null,
     };
-    const stored = (await User.findOneAndUpdate(
+    const $set = {
+      provider: profile.provider,
+      providerId: profile.id,
+      ...(profile.email && { email: profile.email }),
+      ...(profile.name && {
+        firstName: nameParts[0] ?? '',
+        lastName: nameParts.slice(1).join(' ') ?? '',
+      }),
+      ...(profile.avatar && { avatarUrl: profile.avatar }),
+      oauthTokens,
+      lastLoginAt: new Date(),
+    };
+
+    // 1. Returning user — match by the OAuth subject id.
+    let stored = (await User.findOneAndUpdate(
       { providerId: profile.id },
-      {
-        $set: {
-          provider: profile.provider,
-          providerId: profile.id,
-          ...(profile.email && { email: profile.email }),
-          ...(profile.name && {
-            firstName: nameParts[0] ?? '',
-            lastName: nameParts.slice(1).join(' ') ?? '',
-          }),
-          ...(profile.avatar && { avatarUrl: profile.avatar }),
-          oauthTokens,
-          lastLoginAt: new Date(),
-        },
-        $setOnInsert: { createdAt: new Date(), role: 'unknown' },
-      },
-      { upsert: true, returnDocument: 'after', new: true }
+      { $set },
+      { returnDocument: 'after', new: true }
     )) as UserDoc | null;
+
+    // 2. First login for a pre-provisioned account. The dev seed (and the
+    //    invite flow) create User docs keyed only by email, with no providerId,
+    //    to be "claimed" on first OAuth login. Link the OAuth identity onto that
+    //    existing doc — which preserves its campaign memberships. Only claim
+    //    docs with no providerId yet, so we never hijack an account already
+    //    bound to a different provider identity.
+    if (!stored && profile.email) {
+      stored = (await User.findOneAndUpdate(
+        { email: profile.email, providerId: null },
+        { $set },
+        { returnDocument: 'after', new: true }
+      )) as UserDoc | null;
+    }
+
+    // 3. Brand-new user — create the account.
+    if (!stored) {
+      stored = (await User.findOneAndUpdate(
+        { providerId: profile.id },
+        { $set, $setOnInsert: { createdAt: new Date(), role: 'unknown' } },
+        { upsert: true, returnDocument: 'after', new: true }
+      )) as UserDoc | null;
+    }
+
     return toSessionUser(profile, stored?.role ?? 'unknown', stored);
   } catch (e) {
     serverCaptureException(e, profile.id, { action: 'upsertUser', provider: profile.provider });

--- a/app/server/utils/oauth.ts
+++ b/app/server/utils/oauth.ts
@@ -409,8 +409,13 @@ export async function upsertUser(profile: OAuthProfile): Promise<SessionUser> {
 
     return toSessionUser(profile, stored?.role ?? 'unknown', stored);
   } catch (e) {
+    // A write failure here (lost connection, duplicate-key from the unique email
+    // index, etc.) means we could NOT persist/claim the account. Swallowing it and
+    // returning a fallback session would log the user into a broken, unpersisted
+    // session and redirect them to /campaigns. Capture it, then rethrow so the
+    // OAuth callback's catch redirects to an error page instead.
     serverCaptureException(e, profile.id, { action: 'upsertUser', provider: profile.provider });
-    return toSessionUser(profile, 'unknown');
+    throw e;
   }
 }
 

--- a/app/server/utils/pruneEventLinks.ts
+++ b/app/server/utils/pruneEventLinks.ts
@@ -1,0 +1,7 @@
+import { Event } from '../db/models/Event';
+import type { EventLinkKind } from '~/types/event';
+
+/** Remove any event links pointing at a deleted entity so chips don't dangle. */
+export async function pruneEventLinks(kind: EventLinkKind, id: string, campaignId: string) {
+  await Event.updateMany({ campaignId, 'links.id': id }, { $pull: { links: { kind, id } } });
+}

--- a/app/server/utils/pruneLoreLinks.ts
+++ b/app/server/utils/pruneLoreLinks.ts
@@ -1,0 +1,7 @@
+import { Lore } from '../db/models/Lore';
+import type { LoreLinkKind } from '~/types/lore';
+
+/** Remove any lore links pointing at a deleted entity so tabs/chips don't dangle. */
+export async function pruneLoreLinks(kind: LoreLinkKind, id: string, campaignId: string) {
+  await Lore.updateMany({ campaignId, 'links.id': id }, { $pull: { links: { kind, id } } });
+}

--- a/app/services/eventsTimeline.ts
+++ b/app/services/eventsTimeline.ts
@@ -1,0 +1,30 @@
+import type { TimelineEvent } from '~/services/mocks/types';
+import type { EventListItem } from '~/types/event';
+import type { CalendarConfig, CalDate } from '~/utils/calendarEngine';
+import { formatDate, toOrdinal } from '~/utils/calendarEngine';
+
+export function eventsToTimeline(
+  cfg: CalendarConfig,
+  events: EventListItem[],
+  currentDate: CalDate
+): TimelineEvent[] {
+  const cur = toOrdinal(cfg, currentDate);
+  const withOrd = events.map((e) => ({
+    e,
+    startOrd: toOrdinal(cfg, e.start),
+    endOrd: toOrdinal(cfg, e.end ?? e.start),
+  }));
+  withOrd.sort((a, b) => b.startOrd - a.startOrd); // newest first
+  return withOrd.map(({ e, startOrd, endOrd }) => {
+    const isCurrent = cur >= startOrd && cur <= endOrd;
+    const evt: TimelineEvent = {
+      id: e.id,
+      calendarDate: formatDate(cfg, e.start),
+      sessionName: e.title,
+      summary: (e.content || '').slice(0, 160),
+      importance: 'major',
+    };
+    if (isCurrent) evt.isCurrent = true;
+    return evt;
+  });
+}

--- a/app/types/calendar.ts
+++ b/app/types/calendar.ts
@@ -1,0 +1,32 @@
+import type {
+  CalMonth,
+  CalLeapRule,
+  CalMoon,
+  CalSeason,
+  CalHoliday,
+  CalDate,
+} from '~/utils/calendarEngine';
+
+export type { CalMonth, CalLeapRule, CalMoon, CalSeason, CalHoliday, CalDate };
+
+export interface CalendarData {
+  id: string;
+  campaignId: string;
+  createdBy: string;
+  name: string;
+  description: string;
+  months: CalMonth[];
+  weekdays: string[];
+  weekdayMode: 'continuous' | 'resetEachMonth';
+  epoch: { year: number; weekdayIndex: number };
+  yearSuffix: string;
+  namedYears: { year: number; name: string }[];
+  leapDays: CalLeapRule[];
+  moons: CalMoon[];
+  seasons: CalSeason[];
+  holidays: CalHoliday[];
+  currentDate: CalDate;
+  createdAt: string;
+  updatedAt: string;
+  canEdit: boolean;
+}

--- a/app/types/calendar.ts
+++ b/app/types/calendar.ts
@@ -5,6 +5,7 @@ import type {
   CalSeason,
   CalHoliday,
   CalDate,
+  CalendarConfig,
 } from '~/utils/calendarEngine';
 
 export type { CalMonth, CalLeapRule, CalMoon, CalSeason, CalHoliday, CalDate };
@@ -29,4 +30,18 @@ export interface CalendarData {
   createdAt: string;
   updatedAt: string;
   canEdit: boolean;
+}
+
+export function calendarConfigFromData(c: CalendarData): CalendarConfig {
+  return {
+    months: c.months,
+    weekdays: c.weekdays,
+    weekdayMode: c.weekdayMode,
+    epoch: c.epoch,
+    yearSuffix: c.yearSuffix,
+    leapDays: c.leapDays,
+    moons: c.moons,
+    seasons: c.seasons,
+    holidays: c.holidays,
+  };
 }

--- a/app/types/event.ts
+++ b/app/types/event.ts
@@ -1,0 +1,41 @@
+import type { CalDate } from '~/utils/calendarEngine';
+
+export type EventLinkKind = 'character' | 'player' | 'race' | 'location' | 'lore';
+
+export interface EventLink {
+  kind: EventLinkKind;
+  id: string;
+  label?: string;
+}
+
+export interface EventImage {
+  url: string;
+  caption: string;
+  crop: { x: number; y: number; width: number; height: number } | null;
+}
+
+export interface EventData {
+  id: string;
+  campaignId: string;
+  calendarId: string;
+  createdBy: string;
+  title: string;
+  content: string;
+  gmContent: string;
+  isPublic: boolean;
+  isEpic: boolean;
+  start: CalDate;
+  end: CalDate | null;
+  startOrdinal: number;
+  endOrdinal: number;
+  links: EventLink[];
+  sessionId: string | null;
+  images: EventImage[];
+  tags: string[];
+  color: string | null;
+  createdAt: string;
+  updatedAt: string;
+  canEdit: boolean;
+}
+
+export type EventListItem = Omit<EventData, 'gmContent'>;

--- a/app/types/lore.ts
+++ b/app/types/lore.ts
@@ -1,0 +1,35 @@
+import type { PictureCrop } from './character';
+
+export type LoreLinkKind = 'race' | 'character' | 'player' | 'location';
+
+export interface LoreLink {
+  kind: LoreLinkKind;
+  id: string;
+  /** Resolved display label (entity name/title); read-time only, not persisted. */
+  label?: string;
+}
+
+export interface LoreImage {
+  url: string;
+  caption: string;
+  crop: PictureCrop | null;
+}
+
+export interface LoreData {
+  id: string;
+  campaignId: string;
+  createdBy: string;
+  title: string;
+  content: string;
+  gmContent: string;
+  isPublic: boolean;
+  images: LoreImage[];
+  links: LoreLink[];
+  tags: string[];
+  createdAt: string;
+  updatedAt: string;
+  canEdit: boolean;
+}
+
+/** List item omits the GM-only body. */
+export type LoreListItem = Omit<LoreData, 'gmContent'>;

--- a/app/types/schemas/calendars.ts
+++ b/app/types/schemas/calendars.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 const calDate = z.object({
   year: z.number().int(),
   monthIndex: z.number().int().min(0),
-  day: z.number().int().min(0),
+  day: z.number().int().min(1),
 });
 
 const month = z.object({

--- a/app/types/schemas/calendars.ts
+++ b/app/types/schemas/calendars.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod';
+
+const calDate = z.object({
+  year: z.number().int(),
+  monthIndex: z.number().int().min(0),
+  day: z.number().int().min(0),
+});
+
+const month = z.object({
+  name: z.string().trim().min(1),
+  days: z.number().int().min(0),
+  isIntercalary: z.boolean().optional(),
+});
+
+const leapRule = z.object({
+  name: z.string().trim().min(1),
+  monthIndex: z.number().int().min(0),
+  interval: z.number().int().min(1),
+  offset: z.number().int(),
+  addDays: z.number().int().min(1),
+});
+
+const moon = z.object({
+  name: z.string().trim().min(1),
+  cycleLength: z.number().positive(),
+  offsetDays: z.number(),
+  color: z.string().optional(),
+});
+
+const season = z.object({
+  name: z.string().trim().min(1),
+  startMonthIndex: z.number().int().min(0),
+  startDay: z.number().int().min(1),
+  color: z.string().optional(),
+});
+
+const holiday = z.object({
+  name: z.string().trim().min(1),
+  monthIndex: z.number().int().min(0),
+  day: z.number().int().min(1),
+  color: z.string().optional(),
+});
+
+const calendarFields = {
+  name: z.string().trim().min(1),
+  description: z.string().default(''),
+  months: z.array(month).min(1),
+  weekdays: z.array(z.string().trim().min(1)).min(1),
+  weekdayMode: z.enum(['continuous', 'resetEachMonth']).default('continuous'),
+  epoch: z.object({ year: z.number().int(), weekdayIndex: z.number().int().min(0) }),
+  yearSuffix: z.string().default(''),
+  namedYears: z
+    .array(z.object({ year: z.number().int(), name: z.string().trim().min(1) }))
+    .default([]),
+  leapDays: z.array(leapRule).default([]),
+  moons: z.array(moon).default([]),
+  seasons: z.array(season).default([]),
+  holidays: z.array(holiday).default([]),
+  currentDate: calDate,
+};
+
+export const getCalendarSchema = z.object({ campaignId: z.string().trim().min(1) });
+export const upsertCalendarSchema = z.object({
+  campaignId: z.string().trim().min(1),
+  ...calendarFields,
+});
+export const setCurrentDateSchema = z.object({
+  campaignId: z.string().trim().min(1),
+  currentDate: calDate,
+});
+export const deleteCalendarSchema = z.object({ campaignId: z.string().trim().min(1) });

--- a/app/types/schemas/events.ts
+++ b/app/types/schemas/events.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+
+const linkKind = z.enum(['character', 'player', 'race', 'location', 'lore']);
+const eventLink = z.object({ kind: linkKind, id: z.string().trim().min(1) });
+const calDate = z.object({
+  year: z.number().int(),
+  monthIndex: z.number().int().min(0),
+  day: z.number().int().min(1),
+});
+const eventImage = z.object({
+  url: z.string().trim().min(1),
+  caption: z.string().trim().default(''),
+  crop: z
+    .object({
+      x: z.number().finite(),
+      y: z.number().finite(),
+      width: z.number().finite(),
+      height: z.number().finite(),
+    })
+    .nullable()
+    .default(null),
+});
+
+const eventFields = {
+  title: z.string().trim().min(1),
+  content: z.string().default(''),
+  gmContent: z.string().default(''),
+  isPublic: z.boolean().default(false),
+  isEpic: z.boolean().default(false),
+  start: calDate,
+  end: calDate.nullable().default(null),
+  links: z.array(eventLink).default([]),
+  sessionId: z.string().trim().min(1).nullable().default(null),
+  images: z.array(eventImage).default([]),
+  tags: z.array(z.string()).default([]),
+  color: z.string().trim().min(1).nullable().default(null),
+};
+
+export const listEventsSchema = z.object({
+  campaignId: z.string().trim().min(1),
+  search: z.string().trim().optional(),
+  tags: z.array(z.string()).optional(),
+  visibility: z.enum(['all', 'public', 'private']).optional(),
+  epicOnly: z.boolean().optional(),
+  linkedKind: linkKind.optional(),
+  linkedId: z.string().trim().min(1).optional(),
+});
+export const getEventSchema = z.object({
+  id: z.string().trim().min(1),
+  campaignId: z.string().trim().min(1),
+});
+export const createEventSchema = z.object({ campaignId: z.string().trim().min(1), ...eventFields });
+export const updateEventSchema = z.object({
+  id: z.string().trim().min(1),
+  campaignId: z.string().trim().min(1),
+  ...eventFields,
+});
+export const deleteEventSchema = getEventSchema;

--- a/app/types/schemas/events.ts
+++ b/app/types/schemas/events.ts
@@ -12,10 +12,10 @@ const eventImage = z.object({
   caption: z.string().trim().default(''),
   crop: z
     .object({
-      x: z.number().finite(),
-      y: z.number().finite(),
-      width: z.number().finite(),
-      height: z.number().finite(),
+      x: z.number().finite().min(0).max(1),
+      y: z.number().finite().min(0).max(1),
+      width: z.number().finite().gt(0).max(1),
+      height: z.number().finite().gt(0).max(1),
     })
     .nullable()
     .default(null),

--- a/app/types/schemas/gmscreens.ts
+++ b/app/types/schemas/gmscreens.ts
@@ -13,6 +13,7 @@ export const SUPPORTED_COLLECTIONS: [string, ...string[]] = [
   'player',
   'location',
   'monster',
+  'lore',
 ];
 
 // ---------------------------------------------------------------------------

--- a/app/types/schemas/gmscreens.ts
+++ b/app/types/schemas/gmscreens.ts
@@ -14,6 +14,7 @@ export const SUPPORTED_COLLECTIONS: [string, ...string[]] = [
   'location',
   'monster',
   'lore',
+  'events',
 ];
 
 // ---------------------------------------------------------------------------

--- a/app/types/schemas/lore.ts
+++ b/app/types/schemas/lore.ts
@@ -12,10 +12,10 @@ const loreImageSchema = z.object({
   caption: z.string().trim().default(''),
   crop: z
     .object({
-      x: z.number().finite(),
-      y: z.number().finite(),
-      width: z.number().finite(),
-      height: z.number().finite(),
+      x: z.number().finite().min(0).max(1),
+      y: z.number().finite().min(0).max(1),
+      width: z.number().finite().gt(0).max(1),
+      height: z.number().finite().gt(0).max(1),
     })
     .nullable()
     .default(null),

--- a/app/types/schemas/lore.ts
+++ b/app/types/schemas/lore.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+
+const linkKind = z.enum(['race', 'character', 'player', 'location']);
+
+const loreLinkSchema = z.object({
+  kind: linkKind,
+  id: z.string().trim().min(1),
+});
+
+const loreImageSchema = z.object({
+  url: z.string().trim().min(1),
+  caption: z.string().trim().default(''),
+  crop: z
+    .object({
+      x: z.number().finite(),
+      y: z.number().finite(),
+      width: z.number().finite(),
+      height: z.number().finite(),
+    })
+    .nullable()
+    .default(null),
+});
+
+const loreFields = {
+  title: z.string().trim().min(1),
+  content: z.string().default(''),
+  gmContent: z.string().default(''),
+  isPublic: z.boolean().default(false),
+  images: z.array(loreImageSchema).default([]),
+  links: z.array(loreLinkSchema).default([]),
+  tags: z.array(z.string()).default([]),
+};
+
+export const createLoreSchema = z.object({ campaignId: z.string().trim().min(1), ...loreFields });
+export const updateLoreSchema = z.object({
+  id: z.string().trim().min(1),
+  campaignId: z.string().trim().min(1),
+  ...loreFields,
+});
+export const deleteLoreSchema = z.object({
+  id: z.string().trim().min(1),
+  campaignId: z.string().trim().min(1),
+});
+export const getLoreSchema = deleteLoreSchema;
+export const listLoreSchema = z.object({
+  campaignId: z.string().trim().min(1),
+  search: z.string().trim().optional(),
+  tags: z.array(z.string()).optional(),
+  visibility: z.enum(['all', 'public', 'private']).optional(),
+  linkedKind: linkKind.optional(),
+  linkedId: z.string().trim().min(1).optional(),
+});

--- a/app/types/schemas/players.ts
+++ b/app/types/schemas/players.ts
@@ -115,4 +115,14 @@ export const completeJoinWizardSchema = z.object({
     )
     .optional()
     .default([]),
+  lore: z
+    .array(
+      z.object({
+        title: z.string().trim().min(1),
+        content: z.string().default(''),
+        isPublic: z.boolean().default(false),
+      })
+    )
+    .optional()
+    .default([]),
 });

--- a/app/types/schemas/tabletop.ts
+++ b/app/types/schemas/tabletop.ts
@@ -52,6 +52,7 @@ const TABLETOP_COLLECTIONS: [string, ...string[]] = [
   'player',
   'location',
   'monster',
+  'lore',
 ];
 
 export const openTabletopWindowSchema = z.object({

--- a/app/types/schemas/tabletop.ts
+++ b/app/types/schemas/tabletop.ts
@@ -53,6 +53,7 @@ const TABLETOP_COLLECTIONS: [string, ...string[]] = [
   'location',
   'monster',
   'lore',
+  'events',
 ];
 
 export const openTabletopWindowSchema = z.object({

--- a/app/utils/calendarEngine.ts
+++ b/app/utils/calendarEngine.ts
@@ -1,0 +1,83 @@
+export interface CalMonth {
+  name: string;
+  days: number;
+  /** Festival/intercalary day: sits between months, outside the week cycle. */
+  isIntercalary?: boolean;
+}
+
+export interface CalLeapRule {
+  name: string;
+  /** Index into `months` that the extra day(s) attach to. */
+  monthIndex: number;
+  /** Rule fires when ((year - offset) mod interval) === 0. interval >= 1. */
+  interval: number;
+  offset: number;
+  addDays: number;
+}
+
+export interface CalMoon {
+  name: string;
+  cycleLength: number;
+  offsetDays: number;
+  color?: string;
+}
+
+export interface CalSeason {
+  name: string;
+  startMonthIndex: number;
+  startDay: number;
+  color?: string;
+}
+
+export interface CalHoliday {
+  name: string;
+  monthIndex: number;
+  day: number;
+  color?: string;
+}
+
+/** The subset of a Calendar the pure engine needs. */
+export interface CalendarConfig {
+  months: CalMonth[];
+  weekdays: string[];
+  weekdayMode: 'continuous' | 'resetEachMonth';
+  /** Ordinal 0 === { year: epoch.year, monthIndex: 0, day: 1 }. */
+  epoch: { year: number; weekdayIndex: number };
+  leapDays: CalLeapRule[];
+  yearSuffix?: string;
+  moons?: CalMoon[];
+  seasons?: CalSeason[];
+  holidays?: CalHoliday[];
+}
+
+/** A human calendar date. `day` is 1-based; `monthIndex` is 0-based. */
+export interface CalDate {
+  year: number;
+  monthIndex: number;
+  day: number;
+}
+
+/** True modulo (always non-negative for positive m). */
+function mod(n: number, m: number): number {
+  return ((n % m) + m) % m;
+}
+
+function leapRuleApplies(rule: CalLeapRule, year: number): boolean {
+  if (rule.interval < 1) return false;
+  return mod(year - rule.offset, rule.interval) === 0;
+}
+
+export function daysInMonth(cfg: CalendarConfig, year: number, monthIndex: number): number {
+  const base = cfg.months[monthIndex]?.days ?? 0;
+  let extra = 0;
+  for (const rule of cfg.leapDays) {
+    if (rule.monthIndex === monthIndex && leapRuleApplies(rule, year)) extra += rule.addDays;
+  }
+  return base + extra;
+}
+
+export function daysInYear(cfg: CalendarConfig, year: number): number {
+  let total = 0;
+  for (let m = 0; m < cfg.months.length; m++) total += daysInMonth(cfg, year, m);
+  return total;
+}

--- a/app/utils/calendarEngine.ts
+++ b/app/utils/calendarEngine.ts
@@ -81,3 +81,51 @@ export function daysInYear(cfg: CalendarConfig, year: number): number {
   for (let m = 0; m < cfg.months.length; m++) total += daysInMonth(cfg, year, m);
   return total;
 }
+
+/** Signed day count from the epoch-year's first day to `year`'s first day. */
+function yearStartOrdinal(cfg: CalendarConfig, year: number): number {
+  let total = 0;
+  if (year >= cfg.epoch.year) {
+    for (let y = cfg.epoch.year; y < year; y++) total += daysInYear(cfg, y);
+  } else {
+    for (let y = year; y < cfg.epoch.year; y++) total -= daysInYear(cfg, y);
+  }
+  return total;
+}
+
+function daysBeforeMonth(cfg: CalendarConfig, year: number, monthIndex: number): number {
+  let total = 0;
+  for (let m = 0; m < monthIndex; m++) total += daysInMonth(cfg, year, m);
+  return total;
+}
+
+export function toOrdinal(cfg: CalendarConfig, date: CalDate): number {
+  return (
+    yearStartOrdinal(cfg, date.year) +
+    daysBeforeMonth(cfg, date.year, date.monthIndex) +
+    (date.day - 1)
+  );
+}
+
+export function fromOrdinal(cfg: CalendarConfig, ordinal: number): CalDate {
+  let year = cfg.epoch.year;
+  let rem = ordinal;
+  if (rem >= 0) {
+    while (rem >= daysInYear(cfg, year)) {
+      rem -= daysInYear(cfg, year);
+      year++;
+    }
+  } else {
+    while (rem < 0) {
+      year--;
+      rem += daysInYear(cfg, year);
+    }
+  }
+  // rem is now in [0, daysInYear(year)). Walk months; 0-length months are skipped.
+  let monthIndex = 0;
+  while (rem >= daysInMonth(cfg, year, monthIndex)) {
+    rem -= daysInMonth(cfg, year, monthIndex);
+    monthIndex++;
+  }
+  return { year, monthIndex, day: rem + 1 };
+}

--- a/app/utils/calendarEngine.ts
+++ b/app/utils/calendarEngine.ts
@@ -108,6 +108,10 @@ export function toOrdinal(cfg: CalendarConfig, date: CalDate): number {
 }
 
 export function fromOrdinal(cfg: CalendarConfig, ordinal: number): CalDate {
+  // A calendar whose year has zero total days would make the walks below loop forever.
+  if (daysInYear(cfg, cfg.epoch.year) <= 0) {
+    throw new RangeError('Calendar has a zero-length year; cannot map ordinals to dates.');
+  }
   let year = cfg.epoch.year;
   let rem = ordinal;
   if (rem >= 0) {

--- a/app/utils/calendarEngine.ts
+++ b/app/utils/calendarEngine.ts
@@ -107,6 +107,51 @@ export function toOrdinal(cfg: CalendarConfig, date: CalDate): number {
   );
 }
 
+export interface ValidateResult {
+  ok: boolean;
+  error?: string;
+}
+
+export function validateDate(cfg: CalendarConfig, date: CalDate): ValidateResult {
+  if (
+    !Number.isInteger(date.monthIndex) ||
+    date.monthIndex < 0 ||
+    date.monthIndex >= cfg.months.length
+  ) {
+    return { ok: false, error: 'Month is out of range' };
+  }
+  if (!Number.isInteger(date.day) || date.day < 1) {
+    return { ok: false, error: 'Day must be 1 or greater' };
+  }
+  const dim = daysInMonth(cfg, date.year, date.monthIndex);
+  if (date.day > dim) {
+    return {
+      ok: false,
+      error: `Day ${date.day} exceeds ${dim} for ${cfg.months[date.monthIndex]!.name}`,
+    };
+  }
+  return { ok: true };
+}
+
+export function compareDates(cfg: CalendarConfig, a: CalDate, b: CalDate): -1 | 0 | 1 {
+  const d = toOrdinal(cfg, a) - toOrdinal(cfg, b);
+  return d < 0 ? -1 : d > 0 ? 1 : 0;
+}
+
+export function addDays(cfg: CalendarConfig, date: CalDate, n: number): CalDate {
+  return fromOrdinal(cfg, toOrdinal(cfg, date) + n);
+}
+
+/** Weekday index, or -1 for intercalary days in resetEachMonth mode. */
+export function weekdayOf(cfg: CalendarConfig, date: CalDate): number {
+  const w = cfg.weekdays.length;
+  if (cfg.weekdayMode === 'resetEachMonth') {
+    if (cfg.months[date.monthIndex]?.isIntercalary) return -1;
+    return mod(date.day - 1, w);
+  }
+  return mod(cfg.epoch.weekdayIndex + toOrdinal(cfg, date), w);
+}
+
 export function fromOrdinal(cfg: CalendarConfig, ordinal: number): CalDate {
   // A calendar whose year has zero total days would make the walks below loop forever.
   if (daysInYear(cfg, cfg.epoch.year) <= 0) {

--- a/app/utils/calendarEngine.ts
+++ b/app/utils/calendarEngine.ts
@@ -184,3 +184,78 @@ export function weekdayOf(cfg: CalendarConfig, date: CalDate): number {
   }
   return mod(cfg.epoch.weekdayIndex + toOrdinal(cfg, date), w);
 }
+
+/** Rows of week-length cells; null = padding (leading/trailing blanks). */
+export function monthGrid(
+  cfg: CalendarConfig,
+  year: number,
+  monthIndex: number
+): (number | null)[][] {
+  const total = daysInMonth(cfg, year, monthIndex);
+  const w = cfg.weekdays.length;
+  const lead =
+    cfg.weekdayMode === 'continuous'
+      ? mod(cfg.epoch.weekdayIndex + toOrdinal(cfg, { year, monthIndex, day: 1 }), w)
+      : 0;
+  const cells: (number | null)[] = [];
+  for (let i = 0; i < lead; i++) cells.push(null);
+  for (let d = 1; d <= total; d++) cells.push(d);
+  while (cells.length % w !== 0) cells.push(null);
+  const rows: (number | null)[][] = [];
+  for (let i = 0; i < cells.length; i += w) rows.push(cells.slice(i, i + w));
+  return rows;
+}
+
+/** Phase as a 0..1 fraction (0 = new). Display-only. */
+export function moonPhase(_cfg: CalendarConfig, moon: CalMoon, ordinal: number): number {
+  return mod(ordinal - moon.offsetDays, moon.cycleLength) / moon.cycleLength;
+}
+
+/** The active season for an ordinal, or null if no seasons configured. */
+export function seasonOf(cfg: CalendarConfig, ordinal: number): CalSeason | null {
+  if (!cfg.seasons?.length) return null;
+  const date = fromOrdinal(cfg, ordinal);
+  // Start ordinal of each season within this date's year.
+  const starts = cfg.seasons.map((s) => ({
+    s,
+    o: toOrdinal(cfg, { year: date.year, monthIndex: s.startMonthIndex, day: s.startDay }),
+  }));
+  starts.sort((a, b) => a.o - b.o);
+  let active: CalSeason = starts[starts.length - 1]!.s; // wraps from previous year
+  for (const { s, o } of starts) {
+    if (ordinal >= o) active = s;
+  }
+  return active;
+}
+
+export function holidaysOn(
+  cfg: CalendarConfig,
+  _year: number,
+  monthIndex: number,
+  day: number
+): CalHoliday[] {
+  return (cfg.holidays ?? []).filter((h) => h.monthIndex === monthIndex && h.day === day);
+}
+
+function ordinalSuffix(n: number): string {
+  const v = n % 100;
+  if (v >= 11 && v <= 13) return `${n}th`;
+  switch (n % 10) {
+    case 1:
+      return `${n}st`;
+    case 2:
+      return `${n}nd`;
+    case 3:
+      return `${n}rd`;
+    default:
+      return `${n}th`;
+  }
+}
+
+export function formatDate(cfg: CalendarConfig, date: CalDate): string {
+  const m = cfg.months[date.monthIndex];
+  const yearLabel = `${date.year}${cfg.yearSuffix ? ` ${cfg.yearSuffix}` : ''}`;
+  if (!m) return yearLabel;
+  if (m.isIntercalary) return `${m.name}, ${yearLabel}`;
+  return `${ordinalSuffix(date.day)} ${m.name}, ${yearLabel}`;
+}

--- a/app/utils/calendarEngine.ts
+++ b/app/utils/calendarEngine.ts
@@ -185,7 +185,10 @@ export function weekdayOf(cfg: CalendarConfig, date: CalDate): number {
   return mod(cfg.epoch.weekdayIndex + toOrdinal(cfg, date), w);
 }
 
-/** Rows of week-length cells; null = padding (leading/trailing blanks). */
+/**
+ * Rows of week-length cells; null = padding (leading/trailing blanks).
+ * Not meaningful for isIntercalary months (those render as a single banner, not a grid).
+ */
 export function monthGrid(
   cfg: CalendarConfig,
   year: number,

--- a/app/utils/calendarEngine.ts
+++ b/app/utils/calendarEngine.ts
@@ -107,12 +107,42 @@ export function toOrdinal(cfg: CalendarConfig, date: CalDate): number {
   );
 }
 
+export function fromOrdinal(cfg: CalendarConfig, ordinal: number): CalDate {
+  // A calendar whose year has zero total days would make the walks below loop forever.
+  if (daysInYear(cfg, cfg.epoch.year) <= 0) {
+    throw new RangeError('Calendar has a zero-length year; cannot map ordinals to dates.');
+  }
+  let year = cfg.epoch.year;
+  let rem = ordinal;
+  if (rem >= 0) {
+    while (rem >= daysInYear(cfg, year)) {
+      rem -= daysInYear(cfg, year);
+      year++;
+    }
+  } else {
+    while (rem < 0) {
+      year--;
+      rem += daysInYear(cfg, year);
+    }
+  }
+  // rem is now in [0, daysInYear(year)). Walk months; 0-length months are skipped.
+  let monthIndex = 0;
+  while (rem >= daysInMonth(cfg, year, monthIndex)) {
+    rem -= daysInMonth(cfg, year, monthIndex);
+    monthIndex++;
+  }
+  return { year, monthIndex, day: rem + 1 };
+}
+
 export interface ValidateResult {
   ok: boolean;
   error?: string;
 }
 
 export function validateDate(cfg: CalendarConfig, date: CalDate): ValidateResult {
+  if (!Number.isInteger(date.year)) {
+    return { ok: false, error: 'Year must be an integer' };
+  }
   if (
     !Number.isInteger(date.monthIndex) ||
     date.monthIndex < 0 ||
@@ -142,7 +172,10 @@ export function addDays(cfg: CalendarConfig, date: CalDate, n: number): CalDate 
   return fromOrdinal(cfg, toOrdinal(cfg, date) + n);
 }
 
-/** Weekday index, or -1 for intercalary days in resetEachMonth mode. */
+/**
+ * Weekday index, or -1 for intercalary days in resetEachMonth mode.
+ * Precondition: cfg.weekdays is non-empty (enforced by the calendar schema).
+ */
 export function weekdayOf(cfg: CalendarConfig, date: CalDate): number {
   const w = cfg.weekdays.length;
   if (cfg.weekdayMode === 'resetEachMonth') {
@@ -150,31 +183,4 @@ export function weekdayOf(cfg: CalendarConfig, date: CalDate): number {
     return mod(date.day - 1, w);
   }
   return mod(cfg.epoch.weekdayIndex + toOrdinal(cfg, date), w);
-}
-
-export function fromOrdinal(cfg: CalendarConfig, ordinal: number): CalDate {
-  // A calendar whose year has zero total days would make the walks below loop forever.
-  if (daysInYear(cfg, cfg.epoch.year) <= 0) {
-    throw new RangeError('Calendar has a zero-length year; cannot map ordinals to dates.');
-  }
-  let year = cfg.epoch.year;
-  let rem = ordinal;
-  if (rem >= 0) {
-    while (rem >= daysInYear(cfg, year)) {
-      rem -= daysInYear(cfg, year);
-      year++;
-    }
-  } else {
-    while (rem < 0) {
-      year--;
-      rem += daysInYear(cfg, year);
-    }
-  }
-  // rem is now in [0, daysInYear(year)). Walk months; 0-length months are skipped.
-  let monthIndex = 0;
-  while (rem >= daysInMonth(cfg, year, monthIndex)) {
-    rem -= daysInMonth(cfg, year, monthIndex);
-    monthIndex++;
-  }
-  return { year, monthIndex, day: rem + 1 };
 }

--- a/app/utils/harptos.ts
+++ b/app/utils/harptos.ts
@@ -1,0 +1,53 @@
+import type { CalendarConfig, CalMonth } from '~/utils/calendarEngine';
+
+// 12 months x 30 days, 5 festivals as length-1 intercalary "months", Shieldmeet
+// as a length-0 intercalary month that gains a day every 4 years. weekdayMode
+// resetEachMonth: each month is three fresh 10-day tendays; festivals have no slot.
+export const HARPTOS_MONTHS: CalMonth[] = [
+  { name: 'Hammer', days: 30 },
+  { name: 'Midwinter', days: 1, isIntercalary: true },
+  { name: 'Alturiak', days: 30 },
+  { name: 'Ches', days: 30 },
+  { name: 'Tarsakh', days: 30 },
+  { name: 'Greengrass', days: 1, isIntercalary: true },
+  { name: 'Mirtul', days: 30 },
+  { name: 'Kythorn', days: 30 },
+  { name: 'Flamerule', days: 30 },
+  { name: 'Midsummer', days: 1, isIntercalary: true },
+  { name: 'Shieldmeet', days: 0, isIntercalary: true },
+  { name: 'Eleasis', days: 30 },
+  { name: 'Eleint', days: 30 },
+  { name: 'Highharvestide', days: 1, isIntercalary: true },
+  { name: 'Marpenoth', days: 30 },
+  { name: 'Uktar', days: 30 },
+  { name: 'The Feast of the Moon', days: 1, isIntercalary: true },
+  { name: 'Nightal', days: 30 },
+];
+
+export const HARPTOS_CONFIG: CalendarConfig = {
+  months: HARPTOS_MONTHS,
+  weekdays: [
+    'First',
+    'Second',
+    'Third',
+    'Fourth',
+    'Fifth',
+    'Sixth',
+    'Seventh',
+    'Eighth',
+    'Ninth',
+    'Tenth',
+  ],
+  weekdayMode: 'resetEachMonth',
+  epoch: { year: 1372, weekdayIndex: 0 },
+  leapDays: [{ name: 'Shieldmeet', monthIndex: 10, interval: 4, offset: 0, addDays: 1 }],
+  yearSuffix: 'DR',
+  moons: [{ name: 'Selûne', cycleLength: 30, offsetDays: 0 }],
+  seasons: [
+    { name: 'Winter', startMonthIndex: 0, startDay: 1 },
+    { name: 'Spring', startMonthIndex: 3, startDay: 1 },
+    { name: 'Summer', startMonthIndex: 8, startDay: 1 },
+    { name: 'Autumn', startMonthIndex: 13, startDay: 1 },
+  ],
+  holidays: [],
+};

--- a/app/utils/queryKeys.ts
+++ b/app/utils/queryKeys.ts
@@ -169,6 +169,19 @@ export const queryKeys = {
     linked: (campaignId: string, kind: string, id: string) =>
       ['lore', 'linked', campaignId, kind, id] as const,
   },
+  calendar: {
+    all: ['calendar'] as const,
+    detail: (campaignId: string) => ['calendar', 'detail', campaignId] as const,
+  },
+  events: {
+    all: ['events'] as const,
+    list: (campaignId: string, filters?: string) =>
+      ['events', 'list', campaignId, filters ?? ''] as const,
+    detail: (id: string, campaignId: string) => ['events', 'detail', id, campaignId] as const,
+    linked: (campaignId: string, kind: string, id: string) =>
+      ['events', 'linked', campaignId, kind, id] as const,
+    epic: (campaignId: string) => ['events', 'epic', campaignId] as const,
+  },
   monsters: {
     all: ['monsters'] as const,
     list: (

--- a/app/utils/queryKeys.ts
+++ b/app/utils/queryKeys.ts
@@ -161,6 +161,14 @@ export const queryKeys = {
     list: (campaignId: string, mapId: string) =>
       ['mapDrawings', 'list', campaignId, mapId] as const,
   },
+  lore: {
+    all: ['lore'] as const,
+    list: (campaignId: string, filters?: string) =>
+      ['lore', 'list', campaignId, filters ?? ''] as const,
+    detail: (id: string, campaignId: string) => ['lore', 'detail', id, campaignId] as const,
+    linked: (campaignId: string, kind: string, id: string) =>
+      ['lore', 'linked', campaignId, kind, id] as const,
+  },
   monsters: {
     all: ['monsters'] as const,
     list: (

--- a/docs/specs/2026-06-16-lore-design.md
+++ b/docs/specs/2026-06-16-lore-design.md
@@ -1,0 +1,218 @@
+# Lore — Design Spec
+
+**Date:** 2026-06-16
+**Branch:** `wiki-updates`
+**Status:** Approved (design); pending implementation plan
+
+## Summary
+
+Lore is a new wiki entity that captures history, stories, and flavor about anything in
+the game. A piece of lore is fundamentally a public Markdown body plus an optional
+GM-only Markdown section, can carry images, and can be linked to any number of game
+entities — **Race, Character, Player, Location**. Lore behaves like other wiki entities
+(Characters, Races): a GM (or the lore's creator) can edit it, and it can be dragged out
+onto the tabletop and GM screens anywhere a Race/Character can.
+
+Lore linked to a Player surfaces in a **Lore tab** in the Player information window.
+Players can author lore (public or private) during player creation and while editing
+their player. Private lore is readable only by its author and the GM; public lore is
+readable by everyone in the campaign.
+
+This feature mirrors the existing **Character** feature end-to-end. Where a decision is
+not stated below, follow the Character implementation as the template.
+
+## Decisions (locked)
+
+1. **Link model:** one lore entry can link to _many_ entities of mixed types; entities
+   can have many lore. Stored as a polymorphic `links: [{ kind, id }]` array.
+2. **Player lore model:** a single unified `Lore` collection. "Player lore" is simply a
+   lore doc whose `links` include that player. No separate embedded sub-collection.
+3. **Visibility:** `isPublic` flag controls whether non-GM/non-author can see the entry
+   at all; plus an optional GM-only Markdown section (`gmContent`), exactly like Character
+   `notes`/`gmNotes`.
+4. **Reseed:** build and test against ephemeral Mongo first, then pause for explicit
+   go-ahead before running the destructive `dev:clear` + `dev:seed` against the dev DB.
+5. **Edit permissions:** any campaign member may create lore; only the creator or a GM may
+   edit/delete it.
+6. **Lore wiki category:** visible to all members (not GM-only).
+7. **Images:** an array of images per lore entry (mirrors Location `images`), not a single
+   picture.
+
+## Architecture
+
+Lore is a first-class campaign-scoped collection with the same shape of moving parts as
+Character: Mongoose model → Zod schemas → server functions (gated by
+`requireCampaignMember`) → React Query hooks → wiki UI (panel/card/modal/view-modal/window)
+→ drag-out registration → seed data → tests.
+
+### 1. Data model — `app/server/db/models/Lore.ts`
+
+```
+linkSchema ({ _id: false }):
+  kind: String enum ['race','character','player','location'], required
+  id:   ObjectId, required        // id of the linked document
+
+imageSchema ({ _id: false }):
+  url:     String, required
+  caption: String, default ''
+  crop:    { x, y, width, height } | null   // same shape as PictureCrop
+
+loreSchema:
+  title:      String, required
+  content:    String, default ''            // public Markdown
+  gmContent:  String, default ''            // GM-only Markdown
+  isPublic:   Boolean, default false
+  images:     [imageSchema], default []
+  links:      [linkSchema],  default []
+  tags:       [String], default [] (normalizeTags)
+  campaignId: ObjectId, required
+  createdBy:  ObjectId ref User, required
+  createdAt / updatedAt: Date
+
+Indexes: campaignId, { campaignId, updatedAt: -1 }, isPublic, tags,
+         'links.id', text index on title + content
+Hooks:   pre('save') normalize tags + bump updatedAt (mirror Character)
+```
+
+### 2. Types — `app/types/lore.ts`
+
+```ts
+interface LoreLink { kind: 'race'|'character'|'player'|'location'; id: string; label?: string }
+interface LoreImage { url: string; caption: string; crop: PictureCrop | null }
+interface LoreData {
+  id, campaignId, createdBy, title, content, gmContent, isPublic,
+  images: LoreImage[], links: LoreLink[], tags: string[],
+  createdAt, updatedAt, canEdit: boolean
+}
+interface LoreListItem  // excludes gmContent
+```
+
+`label` on `LoreLink` is a denormalized display string resolved server-side for read
+responses (entity name/title), so the UI can render link chips without N extra fetches.
+
+### 3. Zod schemas — `app/types/schemas/lore.ts`
+
+`createLoreSchema`, `updateLoreSchema` (create + `id`), `deleteLoreSchema` ({id,campaignId}),
+`listLoreSchema` ({ campaignId, search?, tags?, visibility?, linkedKind?, linkedId? }),
+`getLoreSchema` ({id,campaignId}). Link entries validated as `{ kind: enum, id: string.min(1) }`.
+
+### 4. Server functions — `app/server/functions/lore.ts`
+
+All wrapped with `createServerFn`, gated by `requireCampaignMember`.
+
+- `listLore` — filters: `search` (text), `tags`, `visibility` ('all'|'public'|'private'),
+  and `linkedKind`+`linkedId` (for the Player tab and entity-scoped views). Visibility
+  rule: GM sees all; non-GM sees `isPublic === true` OR `createdBy === userId`. Returns
+  `LoreListItem[]` (no `gmContent`) sorted by `updatedAt` desc.
+- `getLore` — visibility + permission check; strips `gmContent` for non-GM; resolves
+  `links[].label`; returns `LoreData & { canEdit }` where `canEdit = isCreator || isGM`.
+- `createLore` — any member; returns created lore.
+- `updateLore` — creator or GM only.
+- `deleteLore` — creator or GM only; calls `removeDocumentRefsFromScreens('lore', id)`.
+- **Link integrity:** when a Character/Player/Location/Race is deleted, prune any
+  `Lore.links` entries pointing at it (extend each entity's delete handler with a
+  `$pull` on `lore.links`), mirroring how character relationships are cleaned up today.
+
+### 5. Hooks — `app/hooks/useLore.ts`
+
+Query keys under `queryKeys.lore` (`list`, `detail`, `linked`). Hooks: `useLore(campaignId,
+filters)`, `useLoreEntry(id, campaignId)`, `useLinkedLore(campaignId, kind, id)`,
+`useCreateLore`, `useUpdateLore`, `useDeleteLore` (invalidate list + detail + linked +
+`gmscreens.all`, following the Character mutation pattern).
+
+### 6. Wiki UI — `app/components/wiki/lore/`
+
+- Register `{ id: 'lore', label: 'Lore', icon: BookOpen }` in `WIKI_CATEGORIES`
+  (`WikiPanel.tsx`), visible to all members; switch renders `LorePanel`.
+- `LorePanel` — mirrors `CharactersPanel`: search/visibility/tag filter bar, `LoreCard`
+  list, create button; opens `LoreModal` (edit) when `canEdit`, else `LoreViewModal`.
+- `LoreCard` — draggable; payload `{ collection: 'lore', documentId, title }`; uses
+  `setTokenDragImage` (first image or a book glyph). Shows public/private icon, tags,
+  and a compact "linked to" summary.
+- `LoreModal` (create/edit, via `useModalForm`) — fields: title, isPublic toggle,
+  `content` MarkdownEditor, `gmContent` MarkdownEditor (GM-only), multi-image upload
+  (compress → `uploadToR2('uploads/lore')`), tags, and a **Links editor**: a picker that
+  searches across races/characters/players/locations and adds/removes `{kind,id}` links.
+  Header has `ShowOnTabletopButton` (GM-only) in edit/view contexts.
+- `LoreViewModal` + `LoreWindow` (read-only display) — images gallery, public `content`,
+  `gmContent` (GM only), and clickable "Linked to" chips that open the linked entity.
+
+### 7. Drag-out registration (the cross-cutting "collection" sites)
+
+Register `'lore'` everywhere a collection string is mapped (the same set Character uses):
+
+1. `LoreCard` drag payload (`collection: 'lore'`).
+2. `GMScreensView` collection→component switch → `LoreWindowWrapper`.
+3. `TabletopView` collection→component switch → `LoreWindowWrapper`.
+4. `GMScreensView` + `TabletopView` window-title public/private icon sites (lore has
+   `isPublic`).
+5. `LoreWindowWrapper` + `EditLoreModalWrapper` (new, mirrors `CharacterWindowWrapper`).
+6. `ShowOnTabletopButton` usages in `LoreModal`/`LoreViewModal` (`collection="lore"`).
+
+Drag-out behavior then matches Race/Character exactly.
+
+### 8. Player Lore tab — `app/components/wiki/players/PlayerWindow.tsx`
+
+Add a `Lore` tab. Content uses `useLinkedLore(campaignId, 'player', playerId)` and renders
+a `LoreList` (add/edit/remove when `canManage = isOwnPlayer || isGM`). Add/edit opens
+`LoreModal` pre-seeded with a `player` link to this player. Server-side visibility means a
+non-owner viewer only sees that player's _public_ lore; the owner and GM also see private
+lore. Tab is always shown for managers; for non-managers it is shown when the player has
+≥1 visible lore entry.
+
+### 9. Player creation & editing lore
+
+- **Join wizard** (`app/routes/campaign/join.tsx` + `app/components/join-wizard/`): add a
+  `StepLore` allowing the player to add 0+ lore entries (title, public/private, content).
+  Extend `WizardPlayerState` with `lore: WizardLore[]`, `completeJoinWizardSchema` with a
+  `lore` array, and `completeJoinWizard` to create lore docs linked to the new player.
+- **PlayerModal** (edit): a Lore management section reusing the tab's `LoreList`/`LoreModal`
+  flow so a player can add/edit/remove their lore while editing.
+
+### 10. Seed data + generated images
+
+- Extend `scripts/dev_seed.py` (rich-session-history campaign) with several lore entries:
+  - linked to a **race** (flavor sourced from `docs/srd/races`),
+  - linked to a **town/location** (Phandalin),
+  - linked to an **NPC character**,
+  - linked to a **player**,
+  - a mix of public/private, some with `gmContent`, some with images.
+- Generate deterministic placeholder images into `public/uploads/seed-lore/` (extend
+  `scripts/gen_seed_avatars.mjs` or add a sibling generator; wire into `npm run dev:seed`).
+
+### 11. Tests
+
+- **Server unit** (`tests/server/functions/lore.test.ts`): visibility gating (GM vs member
+  vs author), `gmContent` stripping, create (any member) vs edit/delete (creator-or-GM),
+  `linkedKind`/`linkedId` filtering, and the **cross-user private-lore** case (author and
+  GM see private lore; other members do not). Mongoose models / session mocked per the
+  existing server-fn test pattern.
+- **Component** (`tests/components/...`): LorePanel render/list, LoreCard drag payload,
+  LoreModal create/edit + links editor, PlayerWindow Lore tab gating.
+- **Seed harness**: extend the ephemeral-Mongo seed integration test to assert lore docs
+  are created and well-formed.
+- **E2E (Playwright, `e2e/lore/`)**: GM creates and edits lore in the wiki panel; dragging
+  lore onto the tabletop opens a `LoreWindow`; the Player Lore tab renders linked lore.
+  **Honesty note:** the e2e harness seeds a single GM session, so the cross-user
+  public-vs-private visibility check is covered by server unit tests, not browser e2e.
+
+### 12. Reseed (final, gated)
+
+After implementation and green unit + e2e tests, pause for explicit confirmation, then run
+`npm run dev:clear -- --force` followed by `npm run dev:seed` against the dev environment.
+
+## Out of scope (YAGNI)
+
+- Versioning/history of lore edits.
+- Rich link types beyond the four entity kinds.
+- Cross-campaign / global lore (lore is campaign-scoped like everything else).
+- Reordering/pinning lore within a tab beyond `updatedAt` sort.
+
+## Risks / open notes
+
+- **Link integrity** adds a small `$pull` to four existing delete handlers; must be covered
+  by tests so deletions don't leave dangling lore links.
+- **`links[].label` denormalization** is read-time only (not stored), so renames of linked
+  entities are always reflected.
+- The **e2e cross-user limitation** is intentional given the single-GM seed; documented
+  above so coverage expectations are clear.

--- a/docs/specs/2026-06-16-lore-plan.md
+++ b/docs/specs/2026-06-16-lore-plan.md
@@ -1,0 +1,1632 @@
+# Lore Feature Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a campaign-scoped "Lore" wiki entity — public/GM Markdown + images, linkable to many Race/Character/Player/Location entities — that edits, drags out, and shows on tabletop/GM screens like Characters, surfaces in a Player Lore tab, and is authorable during player creation/editing.
+
+**Architecture:** Lore mirrors the existing **Character** feature end-to-end: Mongoose model → Zod schemas → server functions (gated by `requireCampaignMember`) → React Query hooks → wiki UI (panel/card/edit-modal/view-modal/window/wrapper) → drag-out registration in `TabletopView`/`GMScreensView` → Player tab + join wizard → seed data → unit/component/e2e tests. The one novel concept is a polymorphic `links: [{kind, id}]` array; everything else follows established patterns. **Template files** named below are real files in the repo — open them and adapt; this plan gives the exact deltas and the full code for novel parts.
+
+**Tech Stack:** TanStack Start, React 19, TypeScript, Mongoose/MongoDB, React Query, Zod, Vitest (happy-dom), Playwright (e2e), Tailwind, ReactMarkdown + remark-gfm, CodeMirror (MarkdownEditor), Cloudflare R2 (uploadToR2), Python seed (`scripts/dev_seed.py`).
+
+**Spec:** `docs/specs/2026-06-16-lore-design.md`
+
+---
+
+## Conventions for this plan
+
+- **Run unit tests:** `npm run test:unit -- <path>` (Vitest). Full suite: `npm run test:unit`.
+- **Typecheck:** `npx tsc --noEmit`.
+- **E2E:** `npx playwright test <path>` (requires `npm run dev:seed` then dev server; globalSetup mints the GM session).
+- **Commits:** conventional commits; end body with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`. Work on branch `wiki-updates`.
+- Each task is TDD where logic exists: failing test → run (fail) → implement → run (pass) → commit.
+- "Adapt from `<file>`" means: copy that file's structure and replace Character-isms with Lore-isms exactly as the task specifies. The template file is real — open it.
+
+---
+
+## File Structure
+
+**Create:**
+
+- `app/server/db/models/Lore.ts` — Mongoose model
+- `app/types/lore.ts` — `LoreData`, `LoreListItem`, `LoreLink`, `LoreImage`
+- `app/types/schemas/lore.ts` — Zod schemas
+- `app/server/functions/lore.ts` — CRUD + visibility + link-label resolution
+- `app/server/utils/pruneLoreLinks.ts` — shared helper to `$pull` links on entity delete
+- `app/hooks/useLore.ts` — query hooks + mutations
+- `app/components/wiki/lore/LorePanel.tsx`
+- `app/components/wiki/lore/LoreCard.tsx`
+- `app/components/wiki/lore/LoreModal.tsx` — create/edit form (incl. Links editor)
+- `app/components/wiki/lore/LoreLinksEditor.tsx` — entity link add/remove sub-component
+- `app/components/wiki/lore/LoreViewModal.tsx`
+- `app/components/wiki/lore/LoreWindow.tsx` — read-only display
+- `app/components/mainview/gmscreens/LoreWindowWrapper.tsx` — `LoreWindowWrapper` + `EditLoreModalWrapper`
+- `app/components/wiki/lore/LoreList.tsx` — embedded list for Player tab / PlayerModal
+- `app/components/join-wizard/StepLore.tsx`
+- `scripts/gen_seed_lore_images.mjs` — deterministic lore image generator
+- Tests: `tests/server/functions/lore.test.ts`, `tests/server/utils/pruneLoreLinks.test.ts`, `tests/components/wiki/lore/LoreCard.test.tsx`, `tests/components/wiki/lore/LoreModal.test.tsx`, `tests/components/wiki/lore/LorePanel.test.tsx`, `tests/components/wiki/players/PlayerWindowLoreTab.test.tsx`, `e2e/lore/lore-editor.spec.ts`, `e2e/lore/lore-drag-drop.spec.ts`
+
+**Modify:**
+
+- `app/utils/queryKeys.ts` — add `lore` keys
+- `app/components/wiki/WikiPanel.tsx` — register Lore category + panel
+- `app/components/mainview/TabletopView.tsx` — collection switch + title sites
+- `app/components/mainview/gmscreens/GMScreensView.tsx` — collection switch + title sites
+- `app/server/functions/characters.ts`, `players.ts`, `locations.ts`, `races.ts` — call `pruneLoreLinks` on delete
+- `app/components/wiki/players/PlayerWindow.tsx` — Lore tab
+- `app/components/wiki/players/PlayerModal.tsx` — Lore section
+- `app/components/join-wizard/JoinWizard.tsx` + `app/routes/campaign/join.tsx` — wire StepLore
+- `app/types/schemas/players.ts` + `app/server/functions/players.ts` (`completeJoinWizard`) — accept + create wizard lore
+- `scripts/dev_seed.py` — seed lore entries
+- `package.json` — wire `gen_seed_lore_images.mjs` into `dev:seed`
+
+---
+
+## Phase 1 — Data layer
+
+### Task 1: Lore types
+
+**Files:**
+
+- Create: `app/types/lore.ts`
+
+- [ ] **Step 1: Create the types file**
+
+```ts
+import type { PictureCrop } from './character';
+
+export type LoreLinkKind = 'race' | 'character' | 'player' | 'location';
+
+export interface LoreLink {
+  kind: LoreLinkKind;
+  id: string;
+  /** Resolved display label (entity name/title); read-time only, not persisted. */
+  label?: string;
+}
+
+export interface LoreImage {
+  url: string;
+  caption: string;
+  crop: PictureCrop | null;
+}
+
+export interface LoreData {
+  id: string;
+  campaignId: string;
+  createdBy: string;
+  title: string;
+  content: string;
+  gmContent: string;
+  isPublic: boolean;
+  images: LoreImage[];
+  links: LoreLink[];
+  tags: string[];
+  createdAt: string;
+  updatedAt: string;
+  canEdit: boolean;
+}
+
+/** List item omits the GM-only body. */
+export type LoreListItem = Omit<LoreData, 'gmContent'>;
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS (no references yet).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/types/lore.ts
+git commit -m "feat(lore): add Lore TypeScript types"
+```
+
+### Task 2: Zod schemas
+
+**Files:**
+
+- Create: `app/types/schemas/lore.ts`
+
+- [ ] **Step 1: Create schemas** (model on `app/types/schemas/characters.ts`)
+
+```ts
+import { z } from 'zod';
+
+const linkKind = z.enum(['race', 'character', 'player', 'location']);
+
+const loreLinkSchema = z.object({
+  kind: linkKind,
+  id: z.string().trim().min(1),
+});
+
+const loreImageSchema = z.object({
+  url: z.string().trim().min(1),
+  caption: z.string().trim().default(''),
+  crop: z
+    .object({
+      x: z.number().finite(),
+      y: z.number().finite(),
+      width: z.number().finite(),
+      height: z.number().finite(),
+    })
+    .nullable()
+    .default(null),
+});
+
+const loreFields = {
+  title: z.string().trim().min(1),
+  content: z.string().default(''),
+  gmContent: z.string().default(''),
+  isPublic: z.boolean().default(false),
+  images: z.array(loreImageSchema).default([]),
+  links: z.array(loreLinkSchema).default([]),
+  tags: z.array(z.string()).default([]),
+};
+
+export const createLoreSchema = z.object({ campaignId: z.string().trim().min(1), ...loreFields });
+export const updateLoreSchema = z.object({
+  id: z.string().trim().min(1),
+  campaignId: z.string().trim().min(1),
+  ...loreFields,
+});
+export const deleteLoreSchema = z.object({
+  id: z.string().trim().min(1),
+  campaignId: z.string().trim().min(1),
+});
+export const getLoreSchema = deleteLoreSchema;
+export const listLoreSchema = z.object({
+  campaignId: z.string().trim().min(1),
+  search: z.string().trim().optional(),
+  tags: z.array(z.string()).optional(),
+  visibility: z.enum(['all', 'public', 'private']).optional(),
+  linkedKind: linkKind.optional(),
+  linkedId: z.string().trim().min(1).optional(),
+});
+```
+
+- [ ] **Step 2: Typecheck** — Run: `npx tsc --noEmit` → PASS.
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/types/schemas/lore.ts
+git commit -m "feat(lore): add Lore Zod schemas"
+```
+
+### Task 3: Lore Mongoose model
+
+**Files:**
+
+- Create: `app/server/db/models/Lore.ts`
+- Test: `tests/server/db/lore-model.test.ts`
+
+Reference: `app/server/db/models/Character.ts` (sub-schema + `normalizeTags` + `pre('save')` pattern), `app/server/db/models/Location.ts` (`images` array).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { Lore } from '~/server/db/models/Lore';
+
+describe('Lore model', () => {
+  it('defines the expected paths', () => {
+    const paths = Object.keys(Lore.schema.paths);
+    expect(paths).toEqual(
+      expect.arrayContaining([
+        'title',
+        'content',
+        'gmContent',
+        'isPublic',
+        'images',
+        'links',
+        'tags',
+        'campaignId',
+        'createdBy',
+        'createdAt',
+        'updatedAt',
+      ])
+    );
+  });
+
+  it('links require a kind enum and an id', () => {
+    const linkPath = Lore.schema.path('links');
+    // @ts-expect-error caster schema is present at runtime
+    const sub = linkPath.caster.schema;
+    expect(sub.path('kind').options.enum).toEqual(['race', 'character', 'player', 'location']);
+    expect(sub.path('id').options.required).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run → FAIL** — Run: `npm run test:unit -- tests/server/db/lore-model.test.ts` → FAIL ("Cannot find module Lore").
+
+- [ ] **Step 3: Implement the model**
+
+```ts
+import mongoose from 'mongoose';
+import { normalizeTags } from '../../utils/normalizeTags';
+
+const linkSchema = new mongoose.Schema(
+  {
+    kind: { type: String, enum: ['race', 'character', 'player', 'location'], required: true },
+    id: { type: mongoose.Schema.Types.ObjectId, required: true },
+  },
+  { _id: false }
+);
+
+const cropSchema = new mongoose.Schema(
+  {
+    x: { type: Number, required: true },
+    y: { type: Number, required: true },
+    width: { type: Number, required: true },
+    height: { type: Number, required: true },
+  },
+  { _id: false }
+);
+
+const imageSchema = new mongoose.Schema(
+  {
+    url: { type: String, required: true },
+    caption: { type: String, default: '' },
+    crop: { type: cropSchema, default: null },
+  },
+  { _id: false }
+);
+
+const loreSchema = new mongoose.Schema({
+  title: { type: String, required: true },
+  content: { type: String, default: '' },
+  gmContent: { type: String, default: '' },
+  isPublic: { type: Boolean, default: false },
+  images: { type: [imageSchema], default: [] },
+  links: { type: [linkSchema], default: [] },
+  tags: { type: [String], default: [] },
+  campaignId: { type: mongoose.Schema.Types.ObjectId, required: true, index: true },
+  createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+});
+
+loreSchema.index({ campaignId: 1, updatedAt: -1 });
+loreSchema.index({ isPublic: 1 });
+loreSchema.index({ tags: 1 });
+loreSchema.index({ 'links.id': 1 });
+loreSchema.index({ title: 'text', content: 'text' });
+
+loreSchema.pre('save', function (next) {
+  this.tags = normalizeTags(this.tags as string[]);
+  this.updatedAt = new Date();
+  next();
+});
+
+export const Lore = mongoose.models.Lore || mongoose.model('Lore', loreSchema);
+```
+
+- [ ] **Step 4: Run → PASS** — Run: `npm run test:unit -- tests/server/db/lore-model.test.ts` → PASS.
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/server/db/models/Lore.ts tests/server/db/lore-model.test.ts
+git commit -m "feat(lore): add Lore Mongoose model"
+```
+
+---
+
+## Phase 2 — Server functions
+
+### Task 4: Lore CRUD + visibility server functions
+
+**Files:**
+
+- Create: `app/server/functions/lore.ts`
+- Test: `tests/server/functions/lore.test.ts`
+
+Reference: `app/server/functions/characters.ts` (mocking pattern, `requireCampaignMember`, visibility filtering, `removeDocumentRefsFromScreens`) and `tests/server/functions/sessions.test.ts` (test harness mocks).
+
+Behavior contract:
+
+- `listLore({campaignId, search?, tags?, visibility?, linkedKind?, linkedId?})` → `LoreListItem[]` sorted by `updatedAt` desc. Non-GM filter: `isPublic === true OR createdBy === userId`. If `linkedKind`+`linkedId` given, also require a matching entry in `links`. Never returns `gmContent`.
+- `getLore({id, campaignId})` → `LoreData & {canEdit}`; 404→`null`; non-GM denied if not public and not creator; `gmContent` stripped for non-GM; `links[].label` resolved (see Task 5 uses helper here too — but label resolution lives inline in `getLore`/`listLore`). `canEdit = isCreator || isGM`.
+- `createLore` — any member.
+- `updateLore` / `deleteLore` — creator or GM only (else throw `Forbidden`). `deleteLore` calls `removeDocumentRefsFromScreens('lore', id, campaignId)`.
+
+- [ ] **Step 1: Write failing tests** (full file)
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tanstack/react-start', () => ({
+  createServerFn: () => ({
+    inputValidator: () => ({ handler: (fn: unknown) => fn }),
+    handler: (fn: unknown) => fn,
+  }),
+}));
+vi.mock('~/server/session', () => ({ getSession: vi.fn() }));
+vi.mock('~/server/db/connection', () => ({ connectDB: vi.fn(), isDBConnected: vi.fn(() => true) }));
+vi.mock('~/server/db/models/User', () => ({ User: { findOne: vi.fn() } }));
+vi.mock('~/server/db/models/Campaign', () => ({ Campaign: { findById: vi.fn() } }));
+vi.mock('~/server/db/models/Lore', () => ({
+  Lore: {
+    find: vi.fn(),
+    findById: vi.fn(),
+    create: vi.fn(),
+    findOneAndUpdate: vi.fn(),
+    deleteOne: vi.fn(),
+  },
+}));
+vi.mock('~/server/utils/removeDocumentRefsFromScreens', () => ({
+  removeDocumentRefsFromScreens: vi.fn(),
+}));
+vi.mock('~/server/utils/posthog', () => ({
+  serverCaptureException: vi.fn(),
+  serverCaptureEvent: vi.fn(),
+}));
+
+import { getSession } from '~/server/session';
+import { User } from '~/server/db/models/User';
+import { Campaign } from '~/server/db/models/Campaign';
+import { Lore } from '~/server/db/models/Lore';
+import { removeDocumentRefsFromScreens } from '~/server/utils/removeDocumentRefsFromScreens';
+import { listLore, getLore, createLore, updateLore, deleteLore } from '~/server/functions/lore';
+
+const session = { id: 'sess-1' } as never;
+const dbUser = { _id: 'user-1' };
+const gmCampaign = {
+  _id: 'camp-1',
+  gameMasterId: 'user-1',
+  members: [{ userId: 'user-1', role: 'gm' }],
+};
+const playerCampaign = {
+  _id: 'camp-1',
+  gameMasterId: 'gm-x',
+  members: [{ userId: 'user-1', role: 'player' }],
+};
+
+const _list = listLore as unknown as (a: { data: Record<string, unknown> }) => Promise<unknown[]>;
+const _get = getLore as unknown as (a: {
+  data: Record<string, unknown>;
+}) => Promise<Record<string, unknown> | null>;
+const _create = createLore as unknown as (a: { data: Record<string, unknown> }) => Promise<unknown>;
+const _update = updateLore as unknown as (a: { data: Record<string, unknown> }) => Promise<unknown>;
+const _delete = deleteLore as unknown as (a: { data: Record<string, unknown> }) => Promise<unknown>;
+
+function mockFindReturning(docs: unknown[]) {
+  vi.mocked(Lore.find).mockReturnValue({
+    sort: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue(docs) }),
+  } as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getSession).mockResolvedValue(session);
+  vi.mocked(User.findOne).mockResolvedValue(dbUser as never);
+  vi.mocked(Campaign.findById).mockResolvedValue(gmCampaign as never);
+});
+
+describe('listLore', () => {
+  it('restricts non-GM members to public or own lore', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    mockFindReturning([]);
+    await _list({ data: { campaignId: 'camp-1' } });
+    const filter = vi.mocked(Lore.find).mock.calls[0][0] as Record<string, unknown>;
+    expect(filter).toMatchObject({ campaignId: 'camp-1' });
+    expect(JSON.stringify(filter)).toContain('$or'); // isPublic OR createdBy === user
+  });
+
+  it('adds a links filter when linkedKind/linkedId provided', async () => {
+    mockFindReturning([]);
+    await _list({ data: { campaignId: 'camp-1', linkedKind: 'player', linkedId: 'p-1' } });
+    const filter = vi.mocked(Lore.find).mock.calls[0][0] as Record<string, unknown>;
+    expect(filter.links).toEqual({ $elemMatch: { kind: 'player', id: 'p-1' } });
+  });
+
+  it('never returns gmContent', async () => {
+    mockFindReturning([
+      {
+        _id: 'l1',
+        title: 'T',
+        content: 'c',
+        gmContent: 'secret',
+        isPublic: true,
+        images: [],
+        links: [],
+        tags: [],
+        campaignId: 'camp-1',
+        createdBy: 'user-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+    const res = (await _list({ data: { campaignId: 'camp-1' } })) as Record<string, unknown>[];
+    expect(res[0]).not.toHaveProperty('gmContent');
+  });
+});
+
+describe('getLore', () => {
+  it('strips gmContent for non-GM viewers', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    vi.mocked(Lore.findById).mockReturnValue({
+      lean: vi
+        .fn()
+        .mockResolvedValue({
+          _id: 'l1',
+          title: 'T',
+          content: 'c',
+          gmContent: 'secret',
+          isPublic: true,
+          images: [],
+          links: [],
+          tags: [],
+          campaignId: 'camp-1',
+          createdBy: 'someone',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }),
+    } as never);
+    const res = await _get({ data: { id: 'l1', campaignId: 'camp-1' } });
+    expect(res?.gmContent).toBe('');
+    expect(res?.canEdit).toBe(false);
+  });
+
+  it('returns null for a private lore a non-owner non-GM requests', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    vi.mocked(Lore.findById).mockReturnValue({
+      lean: vi
+        .fn()
+        .mockResolvedValue({
+          _id: 'l1',
+          isPublic: false,
+          createdBy: 'someone-else',
+          campaignId: 'camp-1',
+          title: 'T',
+          content: '',
+          gmContent: '',
+          images: [],
+          links: [],
+          tags: [],
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }),
+    } as never);
+    const res = await _get({ data: { id: 'l1', campaignId: 'camp-1' } });
+    expect(res).toBeNull();
+  });
+});
+
+describe('updateLore / deleteLore permissions', () => {
+  it('forbids a non-creator non-GM from updating', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    vi.mocked(Lore.findById).mockResolvedValue({
+      _id: 'l1',
+      campaignId: 'camp-1',
+      createdBy: 'someone-else',
+    } as never);
+    await expect(_update({ data: { id: 'l1', campaignId: 'camp-1', title: 'X' } })).rejects.toThrow(
+      'Forbidden'
+    );
+  });
+
+  it('lets the creator delete and clears screen refs', async () => {
+    vi.mocked(Lore.findById).mockResolvedValue({
+      _id: 'l1',
+      campaignId: 'camp-1',
+      createdBy: 'user-1',
+    } as never);
+    vi.mocked(Lore.deleteOne).mockResolvedValue({ deletedCount: 1 } as never);
+    const res = await _delete({ data: { id: 'l1', campaignId: 'camp-1' } });
+    expect(res).toEqual({ success: true });
+    expect(removeDocumentRefsFromScreens).toHaveBeenCalledWith('lore', 'l1', 'camp-1');
+  });
+});
+
+describe('createLore', () => {
+  it('allows any member to create', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    vi.mocked(Lore.create).mockResolvedValue({
+      _id: 'new',
+      title: 'T',
+      content: '',
+      gmContent: '',
+      isPublic: false,
+      images: [],
+      links: [],
+      tags: [],
+      campaignId: 'camp-1',
+      createdBy: 'user-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as never);
+    const res = (await _create({ data: { campaignId: 'camp-1', title: 'T' } })) as Record<
+      string,
+      unknown
+    >;
+    expect(res.success).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run → FAIL** — Run: `npm run test:unit -- tests/server/functions/lore.test.ts` → FAIL ("Cannot find module lore").
+
+- [ ] **Step 3: Implement `app/server/functions/lore.ts`**
+
+Implement using the Character template (`app/server/functions/characters.ts`). Key code:
+
+```ts
+import { createServerFn } from '@tanstack/react-start';
+import { requireCampaignMember } from '../utils/requireCampaignMember';
+import { removeDocumentRefsFromScreens } from '../utils/removeDocumentRefsFromScreens';
+import { serverCaptureException } from '../utils/posthog';
+import { Lore } from '../db/models/Lore';
+import { Character } from '../db/models/Character';
+import { Player } from '../db/models/Player';
+import { Location } from '../db/models/Location';
+import { Race } from '../db/models/Race';
+import {
+  listLoreSchema,
+  getLoreSchema,
+  createLoreSchema,
+  updateLoreSchema,
+  deleteLoreSchema,
+} from '~/types/schemas/lore';
+import type { LoreData, LoreLink, LoreListItem } from '~/types/lore';
+
+type AnyDoc = Record<string, unknown> & { _id: unknown };
+
+function baseSerialize(doc: AnyDoc) {
+  return {
+    id: String(doc._id),
+    campaignId: String(doc.campaignId),
+    createdBy: String(doc.createdBy),
+    title: (doc.title as string) ?? '',
+    content: (doc.content as string) ?? '',
+    isPublic: Boolean(doc.isPublic),
+    images: ((doc.images as unknown[]) ?? []).map((i) => {
+      const img = i as Record<string, unknown>;
+      return {
+        url: String(img.url),
+        caption: (img.caption as string) ?? '',
+        crop: (img.crop as never) ?? null,
+      };
+    }),
+    links: ((doc.links as unknown[]) ?? []).map((l) => {
+      const lk = l as Record<string, unknown>;
+      return { kind: lk.kind as LoreLink['kind'], id: String(lk.id) };
+    }) as LoreLink[],
+    tags: (doc.tags as string[]) ?? [],
+    createdAt: (doc.createdAt as Date)?.toISOString?.() ?? '',
+    updatedAt: (doc.updatedAt as Date)?.toISOString?.() ?? '',
+  };
+}
+
+// Resolve {kind,id} -> display label across the four entity collections.
+async function resolveLinkLabels(links: LoreLink[]): Promise<LoreLink[]> {
+  const out: LoreLink[] = [];
+  for (const link of links) {
+    let label = '';
+    try {
+      if (link.kind === 'character') {
+        const c = (await Character.findById(link.id, 'firstName lastName').lean()) as AnyDoc | null;
+        if (c) label = `${c.firstName ?? ''} ${c.lastName ?? ''}`.trim();
+      } else if (link.kind === 'player') {
+        const p = (await Player.findById(link.id, 'firstName lastName').lean()) as AnyDoc | null;
+        if (p) label = `${p.firstName ?? ''} ${p.lastName ?? ''}`.trim();
+      } else if (link.kind === 'location') {
+        const loc = (await Location.findById(link.id, 'name').lean()) as AnyDoc | null;
+        if (loc) label = String(loc.name ?? '');
+      } else if (link.kind === 'race') {
+        const r = (await Race.findById(link.id, 'title').lean()) as AnyDoc | null;
+        if (r) label = String(r.title ?? '');
+      }
+    } catch {
+      label = '';
+    }
+    out.push({ ...link, label });
+  }
+  return out;
+}
+
+export const listLore = createServerFn({ method: 'GET' })
+  .inputValidator(listLoreSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      const filter: Record<string, unknown> = { campaignId: data.campaignId };
+
+      if (!member.isGM) {
+        filter.$or = [{ isPublic: true }, { createdBy: member.userId }];
+      } else if (data.visibility === 'public') {
+        filter.isPublic = true;
+      } else if (data.visibility === 'private') {
+        filter.isPublic = false;
+      }
+
+      if (data.tags?.length) filter.tags = { $all: data.tags };
+      if (data.search) filter.$text = { $search: data.search };
+      if (data.linkedKind && data.linkedId) {
+        filter.links = { $elemMatch: { kind: data.linkedKind, id: data.linkedId } };
+      }
+
+      const docs = (await Lore.find(filter).sort({ updatedAt: -1 }).lean()) as AnyDoc[];
+      const items: LoreListItem[] = docs.map((doc) => ({
+        ...baseSerialize(doc),
+        canEdit: String(doc.createdBy) === member.userId || member.isGM,
+      }));
+      return items;
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'listLore', campaignId: data.campaignId });
+      throw e;
+    }
+  });
+
+export const getLore = createServerFn({ method: 'GET' })
+  .inputValidator(getLoreSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      const doc = (await Lore.findById(data.id).lean()) as AnyDoc | null;
+      if (!doc || String(doc.campaignId) !== data.campaignId) return null;
+
+      const isCreator = String(doc.createdBy) === member.userId;
+      if (!member.isGM && !isCreator && !doc.isPublic) return null;
+
+      const links = await resolveLinkLabels(
+        ((doc.links as unknown[]) ?? []).map((l) => {
+          const lk = l as Record<string, unknown>;
+          return { kind: lk.kind as LoreLink['kind'], id: String(lk.id) };
+        })
+      );
+
+      const result: LoreData = {
+        ...baseSerialize(doc),
+        gmContent: member.isGM ? ((doc.gmContent as string) ?? '') : '',
+        links,
+        canEdit: isCreator || member.isGM,
+      };
+      return result;
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'getLore', loreId: data.id });
+      throw e;
+    }
+  });
+
+export const createLore = createServerFn({ method: 'POST' })
+  .inputValidator(createLoreSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      const doc = (await Lore.create({
+        title: data.title,
+        content: data.content,
+        gmContent: data.gmContent,
+        isPublic: data.isPublic,
+        images: data.images,
+        links: data.links,
+        tags: data.tags,
+        campaignId: data.campaignId,
+        createdBy: member.userId,
+      })) as AnyDoc;
+      return {
+        success: true,
+        lore: { ...baseSerialize(doc), gmContent: data.gmContent, canEdit: true },
+      };
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'createLore', campaignId: data.campaignId });
+      throw e;
+    }
+  });
+
+export const updateLore = createServerFn({ method: 'POST' })
+  .inputValidator(updateLoreSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      const existing = (await Lore.findById(data.id)) as AnyDoc | null;
+      if (!existing || String(existing.campaignId) !== data.campaignId)
+        throw new Error('Not found');
+      if (String(existing.createdBy) !== member.userId && !member.isGM)
+        throw new Error('Forbidden');
+
+      const updated = (await Lore.findOneAndUpdate(
+        { _id: data.id, campaignId: data.campaignId },
+        {
+          $set: {
+            title: data.title,
+            content: data.content,
+            gmContent: data.gmContent,
+            isPublic: data.isPublic,
+            images: data.images,
+            links: data.links,
+            tags: data.tags,
+            updatedAt: new Date(),
+          },
+        },
+        { new: true, lean: true }
+      )) as AnyDoc;
+      return {
+        success: true,
+        lore: { ...baseSerialize(updated), gmContent: data.gmContent, canEdit: true },
+      };
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'updateLore', loreId: data.id });
+      throw e;
+    }
+  });
+
+export const deleteLore = createServerFn({ method: 'POST' })
+  .inputValidator(deleteLoreSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      const existing = (await Lore.findById(data.id)) as AnyDoc | null;
+      if (!existing || String(existing.campaignId) !== data.campaignId)
+        throw new Error('Not found');
+      if (String(existing.createdBy) !== member.userId && !member.isGM)
+        throw new Error('Forbidden');
+      await Lore.deleteOne({ _id: data.id, campaignId: data.campaignId });
+      await removeDocumentRefsFromScreens('lore', data.id, data.campaignId);
+      return { success: true };
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'deleteLore', loreId: data.id });
+      throw e;
+    }
+  });
+```
+
+> NOTE: confirm `removeDocumentRefsFromScreens` signature by opening `app/server/utils/removeDocumentRefsFromScreens.ts` (it is called from `characters.ts` delete). Match its argument order; the test asserts `('lore', id, campaignId)` — adjust both test and call if the real signature differs.
+
+- [ ] **Step 4: Run → PASS** — Run: `npm run test:unit -- tests/server/functions/lore.test.ts` → PASS. Then `npx tsc --noEmit` → PASS.
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/server/functions/lore.ts tests/server/functions/lore.test.ts
+git commit -m "feat(lore): add Lore CRUD server functions with visibility gating"
+```
+
+### Task 5: Link-integrity pruning helper + wire into entity deletes
+
+**Files:**
+
+- Create: `app/server/utils/pruneLoreLinks.ts`
+- Test: `tests/server/utils/pruneLoreLinks.test.ts`
+- Modify: `app/server/functions/characters.ts`, `players.ts`, `locations.ts`, `races.ts` (each delete handler)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+vi.mock('~/server/db/models/Lore', () => ({ Lore: { updateMany: vi.fn() } }));
+import { Lore } from '~/server/db/models/Lore';
+import { pruneLoreLinks } from '~/server/utils/pruneLoreLinks';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('pruneLoreLinks', () => {
+  it('pulls matching links from all lore in the campaign', async () => {
+    vi.mocked(Lore.updateMany).mockResolvedValue({ modifiedCount: 2 } as never);
+    await pruneLoreLinks('character', 'c-1', 'camp-1');
+    expect(Lore.updateMany).toHaveBeenCalledWith(
+      { campaignId: 'camp-1', 'links.id': 'c-1' },
+      { $pull: { links: { kind: 'character', id: 'c-1' } } }
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run → FAIL** — Run: `npm run test:unit -- tests/server/utils/pruneLoreLinks.test.ts` → FAIL.
+
+- [ ] **Step 3: Implement helper**
+
+```ts
+import { Lore } from '../db/models/Lore';
+import type { LoreLinkKind } from '~/types/lore';
+
+/** Remove any lore links pointing at a deleted entity so tabs/chips don't dangle. */
+export async function pruneLoreLinks(kind: LoreLinkKind, id: string, campaignId: string) {
+  await Lore.updateMany({ campaignId, 'links.id': id }, { $pull: { links: { kind, id } } });
+}
+```
+
+- [ ] **Step 4: Run → PASS** — Run: `npm run test:unit -- tests/server/utils/pruneLoreLinks.test.ts` → PASS.
+
+- [ ] **Step 5: Wire into each delete handler**
+
+In `app/server/functions/characters.ts` `deleteCharacter` handler, after the existing relationship cleanup and before returning, add:
+
+```ts
+import { pruneLoreLinks } from '../utils/pruneLoreLinks';
+// ...inside deleteCharacter, after existing cleanup:
+await pruneLoreLinks('character', data.id, data.campaignId);
+```
+
+Repeat the analogous one-liner in:
+
+- `players.ts` `deletePlayer` → `await pruneLoreLinks('player', data.id, data.campaignId);`
+- `locations.ts` delete handler → `await pruneLoreLinks('location', <idField>, data.campaignId);`
+- `races.ts` delete handler → `await pruneLoreLinks('race', <idField>, data.campaignId);`
+
+(Open each file; match the existing handler's id/campaignId variable names.)
+
+- [ ] **Step 6: Run typecheck + affected server tests**
+
+Run: `npx tsc --noEmit` → PASS.
+Run: `npm run test:unit -- tests/server/functions` → PASS (existing delete tests still green; if a test asserts exact call counts, update it to allow the new `pruneLoreLinks` call).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/server/utils/pruneLoreLinks.ts tests/server/utils/pruneLoreLinks.test.ts app/server/functions/characters.ts app/server/functions/players.ts app/server/functions/locations.ts app/server/functions/races.ts
+git commit -m "feat(lore): prune dangling lore links when linked entities are deleted"
+```
+
+---
+
+## Phase 3 — Hooks
+
+### Task 6: Query keys + useLore hooks
+
+**Files:**
+
+- Modify: `app/utils/queryKeys.ts`
+- Create: `app/hooks/useLore.ts`
+
+Reference: `app/hooks/useCharacters.ts` (server-fn dynamic-import wrappers, `createMutationHook`, query keys).
+
+- [ ] **Step 1: Add query keys** to `app/utils/queryKeys.ts` (alongside `characters`):
+
+```ts
+  lore: {
+    all: ['lore'] as const,
+    list: (campaignId: string, filters?: string) => ['lore', 'list', campaignId, filters ?? ''] as const,
+    detail: (id: string, campaignId: string) => ['lore', 'detail', id, campaignId] as const,
+    linked: (campaignId: string, kind: string, id: string) => ['lore', 'linked', campaignId, kind, id] as const,
+  },
+```
+
+- [ ] **Step 2: Implement `app/hooks/useLore.ts`** (adapt from `useCharacters.ts`)
+
+Provide: dynamic-import server-fn wrappers (`listLoreFn`, `getLoreFn`, `createLoreFn`, `updateLoreFn`, `deleteLoreFn`); hooks:
+
+- `useLore(campaignId, filters?: { search?; tags?; visibility?; linkedKind?; linkedId? })` → `{ lore: LoreListItem[], isLoading, error }`, query key `queryKeys.lore.list(campaignId, JSON.stringify(filters ?? {}))`, enabled when `campaignId` truthy.
+- `useLoreEntry(id, campaignId)` → `{ lore: LoreData | null, isLoading, error }`, key `detail`, enabled when both truthy.
+- `useLinkedLore(campaignId, kind, id)` → calls `listLoreFn` with `{campaignId, linkedKind: kind, linkedId: id}`, key `linked`, enabled when all truthy.
+- `useCreateLore`, `useUpdateLore`, `useDeleteLore` via `createMutationHook`, invalidating `['lore','list',campaignId]` (exact:false), the detail key, `['lore','linked',campaignId]` (exact:false), and `queryKeys.gmscreens.all`.
+
+```ts
+import { useQuery } from '@tanstack/react-query';
+import { createServerFn } from '@tanstack/react-start';
+import { queryKeys } from '~/utils/queryKeys';
+import { createMutationHook } from './createMutationHook'; // confirm exact path/name used by useCharacters
+import {
+  listLoreSchema,
+  getLoreSchema,
+  createLoreSchema,
+  updateLoreSchema,
+  deleteLoreSchema,
+} from '~/types/schemas/lore';
+import type { LoreData, LoreListItem } from '~/types/lore';
+
+const listLoreFn = createServerFn({ method: 'GET' })
+  .inputValidator(listLoreSchema)
+  .handler(async ({ data }) => {
+    const { listLore } = await import('~/server/functions/lore');
+    return listLore({ data });
+  });
+const getLoreFn = createServerFn({ method: 'GET' })
+  .inputValidator(getLoreSchema)
+  .handler(async ({ data }) => {
+    const { getLore } = await import('~/server/functions/lore');
+    return getLore({ data });
+  });
+const createLoreFn = createServerFn({ method: 'POST' })
+  .inputValidator(createLoreSchema)
+  .handler(async ({ data }) => {
+    const { createLore } = await import('~/server/functions/lore');
+    return createLore({ data });
+  });
+const updateLoreFn = createServerFn({ method: 'POST' })
+  .inputValidator(updateLoreSchema)
+  .handler(async ({ data }) => {
+    const { updateLore } = await import('~/server/functions/lore');
+    return updateLore({ data });
+  });
+const deleteLoreFn = createServerFn({ method: 'POST' })
+  .inputValidator(deleteLoreSchema)
+  .handler(async ({ data }) => {
+    const { deleteLore } = await import('~/server/functions/lore');
+    return deleteLore({ data });
+  });
+
+export interface LoreFilters {
+  search?: string;
+  tags?: string[];
+  visibility?: 'all' | 'public' | 'private';
+  linkedKind?: 'race' | 'character' | 'player' | 'location';
+  linkedId?: string;
+}
+
+export function useLore(campaignId: string, filters?: LoreFilters) {
+  const {
+    data = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.lore.list(campaignId, JSON.stringify(filters ?? {})),
+    queryFn: () => listLoreFn({ data: { campaignId, ...filters } }),
+    enabled: !!campaignId,
+  });
+  return {
+    lore: data as LoreListItem[],
+    isLoading,
+    error: error instanceof Error ? error.message : error ? String(error) : null,
+  };
+}
+
+export function useLoreEntry(id: string, campaignId: string) {
+  const {
+    data = null,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.lore.detail(id, campaignId),
+    queryFn: () => getLoreFn({ data: { id, campaignId } }),
+    enabled: !!id && !!campaignId,
+  });
+  return {
+    lore: data as LoreData | null,
+    isLoading,
+    error: error instanceof Error ? error.message : error ? String(error) : null,
+  };
+}
+
+export function useLinkedLore(campaignId: string, kind: LoreFilters['linkedKind'], id: string) {
+  const {
+    data = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.lore.linked(campaignId, kind ?? '', id),
+    queryFn: () => listLoreFn({ data: { campaignId, linkedKind: kind, linkedId: id } }),
+    enabled: !!campaignId && !!kind && !!id,
+  });
+  return {
+    lore: data as LoreListItem[],
+    isLoading,
+    error: error instanceof Error ? error.message : error ? String(error) : null,
+  };
+}
+
+// useCreateLore / useUpdateLore / useDeleteLore: build with createMutationHook exactly as
+// useCharacters.ts builds useCreateCharacter etc. Invalidate:
+//   ['lore','list',campaignId] (exact:false), queryKeys.lore.detail(id,campaignId),
+//   ['lore','linked',campaignId] (exact:false), queryKeys.gmscreens.all
+export const useCreateLore = createMutationHook({
+  actionName: 'createLore',
+  mutationFn: async (
+    input: import('~/types/schemas/lore')['createLoreSchema'] extends never
+      ? never
+      : Record<string, unknown>
+  ) => createLoreFn({ data: input as never }),
+  onSuccess: (qc, _d, v: Record<string, unknown>) => {
+    qc.invalidateQueries({ queryKey: ['lore', 'list', v.campaignId], exact: false });
+    qc.invalidateQueries({ queryKey: ['lore', 'linked', v.campaignId], exact: false });
+  },
+  errorContext: (v: Record<string, unknown>) => ({
+    action: 'createLore',
+    campaignId: v.campaignId,
+  }),
+});
+export const useUpdateLore = createMutationHook({
+  actionName: 'updateLore',
+  mutationFn: async (input: Record<string, unknown>) => updateLoreFn({ data: input as never }),
+  onSuccess: (qc, _d, v: Record<string, unknown>) => {
+    qc.invalidateQueries({ queryKey: ['lore', 'list', v.campaignId], exact: false });
+    qc.invalidateQueries({ queryKey: queryKeys.lore.detail(String(v.id), String(v.campaignId)) });
+    qc.invalidateQueries({ queryKey: ['lore', 'linked', v.campaignId], exact: false });
+    qc.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+  },
+  errorContext: (v: Record<string, unknown>) => ({ action: 'updateLore', loreId: v.id }),
+});
+export const useDeleteLore = createMutationHook({
+  actionName: 'deleteLore',
+  mutationFn: async (input: Record<string, unknown>) => deleteLoreFn({ data: input as never }),
+  onSuccess: (qc, _d, v: Record<string, unknown>) => {
+    qc.removeQueries({ queryKey: queryKeys.lore.detail(String(v.id), String(v.campaignId)) });
+    qc.invalidateQueries({ queryKey: ['lore', 'list', v.campaignId], exact: false });
+    qc.invalidateQueries({ queryKey: ['lore', 'linked', v.campaignId], exact: false });
+    qc.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+  },
+  errorContext: (v: Record<string, unknown>) => ({ action: 'deleteLore', loreId: v.id }),
+});
+```
+
+> NOTE: open `app/hooks/useCharacters.ts` and copy the _exact_ `createMutationHook` import path and call shape; the snippet above is structural. Match the real helper's signature (it may take typed inputs rather than `Record<string,unknown>`). Define typed `CreateLoreInput`/`UpdateLoreInput`/`DeleteLoreInput` interfaces mirroring the schemas.
+
+- [ ] **Step 3: Typecheck** — Run: `npx tsc --noEmit` → PASS.
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/utils/queryKeys.ts app/hooks/useLore.ts
+git commit -m "feat(lore): add query keys and useLore hooks"
+```
+
+---
+
+## Phase 4 — Wiki UI
+
+### Task 7: LoreLinksEditor (entity link picker)
+
+**Files:**
+
+- Create: `app/components/wiki/lore/LoreLinksEditor.tsx`
+
+Novel component. Props: `{ campaignId: string; links: LoreLink[]; onChange: (links: LoreLink[]) => void; disabled?: boolean }`. It lets the user add `{kind,id}` links and remove them. For each kind it loads candidates: `useCharacters(campaignId)`, `usePlayers(campaignId)`, `useLocations(campaignId)`, `useRaces(campaignId)` (open each hook file to confirm the returned list field + id/label fields). UI: a kind `<select>` (Race/Character/Player/Location) + a searchable entity `<select>` of that kind's items, an "Add link" button, and a chip list of current links (label + kind badge + remove ✕).
+
+- [ ] **Step 1: Implement** (skeleton; fill candidate hooks per real signatures)
+
+```tsx
+import { useState } from 'react';
+import { X } from 'lucide-react';
+import { useCharacters } from '~/hooks/useCharacters';
+import { usePlayers } from '~/hooks/usePlayers';
+import { useLocations } from '~/hooks/useLocations';
+import { useRaces } from '~/hooks/useRaces';
+import type { LoreLink, LoreLinkKind } from '~/types/lore';
+
+interface Candidate {
+  id: string;
+  label: string;
+}
+
+export function LoreLinksEditor({
+  campaignId,
+  links,
+  onChange,
+  disabled,
+}: {
+  campaignId: string;
+  links: LoreLink[];
+  onChange: (l: LoreLink[]) => void;
+  disabled?: boolean;
+}) {
+  const [kind, setKind] = useState<LoreLinkKind>('character');
+  const [selectedId, setSelectedId] = useState('');
+
+  const { characters } = useCharacters(campaignId);
+  const { players } = usePlayers(campaignId);
+  const { locations } = useLocations(campaignId);
+  const { races } = useRaces(campaignId, { enabled: true });
+
+  const candidates: Candidate[] =
+    kind === 'character'
+      ? characters.map((c) => ({ id: c.id, label: `${c.firstName} ${c.lastName}`.trim() }))
+      : kind === 'player'
+        ? players.map((p) => ({ id: p.id, label: `${p.firstName} ${p.lastName}`.trim() }))
+        : kind === 'location'
+          ? locations.map((l) => ({ id: l.id, label: l.name }))
+          : races.map((r) => ({ id: r.id, label: r.title }));
+
+  const addLink = () => {
+    if (!selectedId) return;
+    if (links.some((l) => l.kind === kind && l.id === selectedId)) return;
+    const label = candidates.find((c) => c.id === selectedId)?.label;
+    onChange([...links, { kind, id: selectedId, label }]);
+    setSelectedId('');
+  };
+  const removeLink = (k: LoreLinkKind, id: string) =>
+    onChange(links.filter((l) => !(l.kind === k && l.id === id)));
+
+  return (
+    <div className="space-y-2" data-testid="lore-links-editor">
+      <p className="text-[10px] uppercase tracking-wider text-slate-500">Linked to</p>
+      <div className="flex flex-wrap gap-2">
+        {links.map((l) => (
+          <span
+            key={`${l.kind}:${l.id}`}
+            className="inline-flex items-center gap-1 rounded bg-white/[0.06] px-2 py-1 text-xs text-slate-300"
+          >
+            <span className="text-[9px] uppercase text-slate-500">{l.kind}</span>
+            {l.label ?? l.id}
+            {!disabled && (
+              <button
+                type="button"
+                aria-label={`Remove ${l.label ?? l.id}`}
+                onClick={() => removeLink(l.kind, l.id)}
+              >
+                <X className="h-3 w-3 text-slate-500 hover:text-rose-400" />
+              </button>
+            )}
+          </span>
+        ))}
+        {links.length === 0 && <span className="text-xs text-slate-500">No links yet.</span>}
+      </div>
+      {!disabled && (
+        <div className="flex items-center gap-2">
+          <select
+            value={kind}
+            onChange={(e) => {
+              setKind(e.target.value as LoreLinkKind);
+              setSelectedId('');
+            }}
+            className="bg-white/[0.05] border border-white/[0.08] rounded px-2 py-1 text-xs text-slate-300"
+          >
+            <option value="character">Character</option>
+            <option value="player">Player</option>
+            <option value="location">Location</option>
+            <option value="race">Race</option>
+          </select>
+          <select
+            aria-label="Entity to link"
+            value={selectedId}
+            onChange={(e) => setSelectedId(e.target.value)}
+            className="flex-1 bg-white/[0.05] border border-white/[0.08] rounded px-2 py-1 text-xs text-slate-300"
+          >
+            <option value="">Select…</option>
+            {candidates.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.label}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={addLink}
+            disabled={!selectedId}
+            className="rounded bg-white/[0.06] px-2 py-1 text-xs text-slate-300 disabled:opacity-40"
+          >
+            Add link
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+> NOTE: confirm `useLocations`/`useRaces` exist with those names/signatures; open `app/hooks/`. Adjust list field names (`locations`, `races`) to match.
+
+- [ ] **Step 2: Typecheck** — `npx tsc --noEmit` → PASS.
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/components/wiki/lore/LoreLinksEditor.tsx
+git commit -m "feat(lore): add entity links editor"
+```
+
+### Task 8: LoreModal (create/edit) + test
+
+**Files:**
+
+- Create: `app/components/wiki/lore/LoreModal.tsx`
+- Test: `tests/components/wiki/lore/LoreModal.test.tsx`
+
+Adapt from `app/components/wiki/characters/CharacterModal.tsx`. Differences: fields are `title` (required), `isPublic` toggle, `content` (MarkdownEditor), `gmContent` (MarkdownEditor, GM-only — gate on `campaign?.isGM`), `images` (multi-image upload — adapt Location's multi-image input if present, else repeated `ImageCropInput`; store `LoreImage[]`), `tags` (TagAutocompleteInput), and `<LoreLinksEditor>`. Save via `useCreateLore`/`useUpdateLore`. Upload via `uploadToR2(compressed, 'uploads/lore')`. Header `ShowOnTabletopButton collection="lore"` in edit context. Use `useModalForm`. Props: `{ isOpen; onClose; campaignId; loreId?; initialLinks?: LoreLink[] }` (the `initialLinks` lets the Player tab/wizard pre-link to a player).
+
+- [ ] **Step 1: Write failing component test**
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LoreModal } from '~/components/wiki/lore/LoreModal';
+
+vi.mock('~/hooks/useLore', () => ({
+  useLoreEntry: () => ({ lore: null, isLoading: false }),
+  useCreateLore: () => ({ create: vi.fn().mockResolvedValue({ success: true }), isLoading: false }),
+  useUpdateLore: () => ({ update: vi.fn(), isLoading: false }),
+}));
+vi.mock('~/hooks/useCampaigns', () => ({ useCampaign: () => ({ campaign: { isGM: true } }) }));
+vi.mock('~/hooks/useCharacters', () => ({ useCharacters: () => ({ characters: [] }) }));
+vi.mock('~/hooks/usePlayers', () => ({ usePlayers: () => ({ players: [] }) }));
+vi.mock('~/hooks/useLocations', () => ({ useLocations: () => ({ locations: [] }) }));
+vi.mock('~/hooks/useRaces', () => ({ useRaces: () => ({ races: [] }) }));
+
+describe('LoreModal', () => {
+  it('renders a title input and the links editor in create mode', () => {
+    render(<LoreModal isOpen onClose={() => {}} campaignId="c1" />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByTestId('lore-links-editor')).toBeInTheDocument();
+  });
+
+  it('requires a title before saving', () => {
+    render(<LoreModal isOpen onClose={() => {}} campaignId="c1" />);
+    fireEvent.click(screen.getByRole('button', { name: /create lore/i }));
+    expect(screen.getByText(/title is required/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run → FAIL** — `npm run test:unit -- tests/components/wiki/lore/LoreModal.test.tsx` → FAIL.
+- [ ] **Step 3: Implement `LoreModal.tsx`** per the adaptation notes above (use CharacterModal as the structural template; validation: `title` required → error text "Title is required"; submit button label "Create Lore"/"Update Lore").
+- [ ] **Step 4: Run → PASS** + `npx tsc --noEmit` → PASS.
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/wiki/lore/LoreModal.tsx tests/components/wiki/lore/LoreModal.test.tsx
+git commit -m "feat(lore): add Lore create/edit modal"
+```
+
+### Task 9: LoreWindow + LoreViewModal + wrappers
+
+**Files:**
+
+- Create: `app/components/wiki/lore/LoreWindow.tsx`, `app/components/wiki/lore/LoreViewModal.tsx`, `app/components/mainview/gmscreens/LoreWindowWrapper.tsx`
+
+Adapt from `CharacterWindow.tsx`, `CharacterViewModal.tsx`, `CharacterWindowWrapper.tsx`.
+
+- `LoreWindow({ lore, onEdit? })`: header (title, public/private icon), images gallery, `content` via ReactMarkdown + `MARKDOWN_PROSE_CLASSES`, `gmContent` section when present, and a "Linked to" chip row (render `lore.links` labels; clicking is a no-op or future nav — render as static chips).
+- `LoreViewModal({ isOpen, onClose, loreId, campaignId })`: portal modal wrapping `LoreWindow` via `useLoreEntry`, with `ShowOnTabletopButton collection="lore"`.
+- `LoreWindowWrapper({ loreId, campaignId, onEdit })` + `EditLoreModalWrapper({ campaignId, loreId, onClose })` mirroring `CharacterWindowWrapper.tsx`.
+
+- [ ] **Step 1: Implement the three files** (no new logic; follow templates).
+- [ ] **Step 2: Typecheck** — `npx tsc --noEmit` → PASS.
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/components/wiki/lore/LoreWindow.tsx app/components/wiki/lore/LoreViewModal.tsx app/components/mainview/gmscreens/LoreWindowWrapper.tsx
+git commit -m "feat(lore): add Lore read-only window, view modal, and wrappers"
+```
+
+### Task 10: LoreCard + LorePanel + register in WikiPanel + test
+
+**Files:**
+
+- Create: `app/components/wiki/lore/LoreCard.tsx`, `app/components/wiki/lore/LorePanel.tsx`
+- Modify: `app/components/wiki/WikiPanel.tsx`
+- Test: `tests/components/wiki/lore/LoreCard.test.tsx`, `tests/components/wiki/lore/LorePanel.test.tsx`
+
+`LoreCard` adapts `CharacterCard.tsx`: draggable, `e.dataTransfer.setData('application/x-cartyx-document', JSON.stringify({ collection: 'lore', documentId: lore.id, title: lore.title }))`, `setTokenDragImage` (first image url or null → glyph), shows title, public/private icon, tags, compact link summary. `LorePanel` adapts `CharactersPanel.tsx` (search/visibility/tag filters via `useLore`, create button → `LoreModal`, click → edit if `canEdit` else `LoreViewModal`).
+
+In `WikiPanel.tsx`: add to `WIKI_CATEGORIES` `{ id: 'lore', label: 'Lore', icon: BookOpen }` (import `BookOpen` from lucide-react) and add a switch branch `selectedCategory === 'lore' → <LorePanel onBack={...} />`.
+
+- [ ] **Step 1: Write failing LoreCard test**
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LoreCard } from '~/components/wiki/lore/LoreCard';
+
+const lore = {
+  id: 'l1',
+  title: 'The Fall of Phandalin',
+  isPublic: true,
+  tags: [],
+  images: [],
+  links: [],
+  campaignId: 'c1',
+  createdBy: 'u1',
+  content: '',
+  createdAt: '',
+  updatedAt: '',
+  canEdit: true,
+};
+
+describe('LoreCard', () => {
+  it('sets the drag payload with collection lore', () => {
+    const onClick = vi.fn();
+    render(<LoreCard lore={lore as never} onClick={onClick} />);
+    const card = screen.getByText('The Fall of Phandalin').closest('[draggable="true"]')!;
+    const setData = vi.fn();
+    fireEvent.dragStart(card, { dataTransfer: { setData, setDragImage: vi.fn() } as never });
+    const payload = JSON.parse(
+      setData.mock.calls.find((c) => c[0] === 'application/x-cartyx-document')![1]
+    );
+    expect(payload).toMatchObject({
+      collection: 'lore',
+      documentId: 'l1',
+      title: 'The Fall of Phandalin',
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run → FAIL** → implement `LoreCard.tsx`, `LorePanel.tsx`, and the `WikiPanel.tsx` edits.
+- [ ] **Step 3: LorePanel test** — assert it renders the "Lore" header and a create button (mock `useLore` to return one item; mock `useCampaign`).
+- [ ] **Step 4: Run → PASS** + `npx tsc --noEmit` → PASS.
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/wiki/lore/LoreCard.tsx app/components/wiki/lore/LorePanel.tsx app/components/wiki/WikiPanel.tsx tests/components/wiki/lore/LoreCard.test.tsx tests/components/wiki/lore/LorePanel.test.tsx
+git commit -m "feat(lore): add Lore wiki panel and draggable card"
+```
+
+---
+
+## Phase 5 — Drag-out registration
+
+### Task 11: Register 'lore' in TabletopView and GMScreensView
+
+**Files:**
+
+- Modify: `app/components/mainview/TabletopView.tsx`, `app/components/mainview/gmscreens/GMScreensView.tsx`
+
+In both files' collection→component switch (where `w.collection === 'character'` etc.), add:
+
+```tsx
+} else if (w.collection === 'lore') {
+  windowContent = (
+    <LoreWindowWrapper
+      loreId={w.documentId}
+      campaignId={campaignId}
+      onEdit={isGM ? () => setEditingLoreId(w.documentId) : undefined}
+    />
+  );
+```
+
+Add the import `import { LoreWindowWrapper, EditLoreModalWrapper } from '~/components/mainview/gmscreens/LoreWindowWrapper';`, an `editingLoreId` state (mirror `editingCharacterId`), the `EditLoreModalWrapper` render at the bottom (mirror `EditCharacterModalWrapper`), and add `'lore'` to the window-title public/private-icon condition (where it checks `collection === 'character' || 'rule' || 'location'`).
+
+- [ ] **Step 1: Apply edits in both files** (mirror every `editingCharacterId`/`CharacterWindowWrapper` site for lore).
+- [ ] **Step 2: Typecheck** — `npx tsc --noEmit` → PASS.
+- [ ] **Step 3: Run existing tabletop/gmscreen unit tests** — `npm run test:unit -- tests/components` (and any `tests/server/db/gmscreen.test.ts`) → PASS.
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/components/mainview/TabletopView.tsx app/components/mainview/gmscreens/GMScreensView.tsx
+git commit -m "feat(lore): render Lore windows on tabletop and GM screens"
+```
+
+---
+
+## Phase 6 — Player integration
+
+### Task 12: LoreList embedded component
+
+**Files:**
+
+- Create: `app/components/wiki/lore/LoreList.tsx`
+
+Adapt from `app/components/shared/RelationshipList.tsx`. Props: `{ campaignId; lore: LoreListItem[]; canManage: boolean; onAdd: () => void; onOpen: (id: string) => void; onEdit: (id: string) => void; onRemove: (id: string) => void }`. Renders each lore row (title, public/private badge, edit/remove when `canManage`), an Add button when `canManage`, and an empty state.
+
+- [ ] **Step 1: Implement** + **Step 2: Typecheck PASS** + **Step 3: Commit**
+
+```bash
+git add app/components/wiki/lore/LoreList.tsx
+git commit -m "feat(lore): add embedded LoreList component"
+```
+
+### Task 13: Player Lore tab + test
+
+**Files:**
+
+- Modify: `app/components/wiki/players/PlayerWindow.tsx`
+- Test: `tests/components/wiki/players/PlayerWindowLoreTab.test.tsx`
+
+Add `{ id: 'lore', label: 'Lore' }` to the `tabs` array. Add a tab-content block:
+
+```tsx
+{
+  activeTab === 'lore' && (
+    <PlayerLoreTab campaignId={player.campaignId} playerId={player.id} canManage={player.canEdit} />
+  );
+}
+```
+
+Implement `PlayerLoreTab` (inline in the file or a small co-located component) using `useLinkedLore(campaignId, 'player', playerId)` + `LoreList`, with `LoreModal` (open with `initialLinks={[{ kind: 'player', id: playerId }]}`) for add/edit and `useDeleteLore` for remove, and `LoreViewModal` for open. `canManage = player.canEdit` (owner or GM — confirm `canEdit` semantics on PlayerData).
+
+- [ ] **Step 1: Write failing test** — mock `useLinkedLore` to return one public lore; assert the Lore tab button renders and clicking it shows the lore title. Mock `LoreModal`/`LoreViewModal` to simple stubs to avoid query client.
+- [ ] **Step 2: Run → FAIL → implement → Run → PASS** + `npx tsc --noEmit` PASS.
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/components/wiki/players/PlayerWindow.tsx tests/components/wiki/players/PlayerWindowLoreTab.test.tsx
+git commit -m "feat(lore): add Lore tab to the Player window"
+```
+
+### Task 14: PlayerModal Lore section (editing)
+
+**Files:**
+
+- Modify: `app/components/wiki/players/PlayerModal.tsx`
+
+In edit mode (`isEdit`), add a "Lore" section near the bottom of the form that reuses the same `PlayerLoreTab` flow (linked-lore list + add/edit/remove), so a player can manage their lore while editing. (Creation-time lore is handled by the wizard in Task 15.)
+
+- [ ] **Step 1: Implement** (only render the section when `isEdit && playerId`, since linking needs an existing player id).
+- [ ] **Step 2: Typecheck PASS; run** `npm run test:unit -- tests/components/wiki/players` (existing PlayerModal tests still green).
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/components/wiki/players/PlayerModal.tsx
+git commit -m "feat(lore): manage player lore from the player edit modal"
+```
+
+### Task 15: Join-wizard StepLore + completeJoinWizard
+
+**Files:**
+
+- Create: `app/components/join-wizard/StepLore.tsx`
+- Modify: `app/components/join-wizard/JoinWizard.tsx`, `app/routes/campaign/join.tsx`, `app/types/schemas/players.ts`, `app/server/functions/players.ts`
+- Test: extend `tests/server/functions/players.test.ts` (if present) for wizard lore creation
+
+`WizardLore` shape: `{ title: string; content: string; isPublic: boolean }`. Add `lore: WizardLore[]` to `WizardPlayerState`. `StepLore` lets the player add/remove simple lore entries (title, public/private toggle, content textarea/MarkdownEditor). Insert the step before `StepReview`. In `completeJoinWizardSchema` add `lore: z.array(z.object({ title: z.string().trim().min(1), content: z.string().default(''), isPublic: z.boolean().default(false) })).optional().default([])`. In `completeJoinWizard` server fn, after the Player doc is created, create one Lore doc per wizard lore entry, `links: [{ kind: 'player', id: newPlayerId }]`, `createdBy: userId`, `campaignId`.
+
+- [ ] **Step 1: Write failing server test** — `completeJoinWizard` with two lore entries creates two `Lore` docs each linked to the new player. (Mock `Lore.create`; assert call count + link payload.)
+- [ ] **Step 2: Run → FAIL → implement schema + server changes → Run → PASS**.
+- [ ] **Step 3: Implement `StepLore.tsx` + wire into JoinWizard/route** (mirror `StepBackstory`/`StepPlayerInfo` plumbing: receives `lore`, `onUpdate`, `onNext`, `onBack`).
+- [ ] **Step 4: Typecheck PASS**; run `npm run test:unit -- tests/server/functions/players.test.ts` → PASS.
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/join-wizard/StepLore.tsx app/components/join-wizard/JoinWizard.tsx app/routes/campaign/join.tsx app/types/schemas/players.ts app/server/functions/players.ts tests/server/functions/players.test.ts
+git commit -m "feat(lore): let players author lore during character creation"
+```
+
+---
+
+## Phase 7 — Seed data + images
+
+### Task 16: Lore image generator
+
+**Files:**
+
+- Create: `scripts/gen_seed_lore_images.mjs`
+- Modify: `package.json`
+
+Adapt `scripts/gen_seed_avatars.mjs`. Generate deterministic PNG/SVG banners for a fixed list of lore slugs into `public/uploads/seed-lore/<slug>.png` (e.g. solid gradient + title text + book glyph; deterministic by slug hash). Export the same path convention the seed will reference: `/uploads/seed-lore/<slug>.png`.
+
+- [ ] **Step 1: Implement generator** producing one image per slug in a `LORE_SLUGS` array (e.g. `dragon-legend`, `phandalin-history`, `elf-origins`, `harpers-secret`).
+- [ ] **Step 2: Wire into dev:seed** — in `package.json`, update the `dev:seed` script to also run `node scripts/gen_seed_lore_images.mjs` (alongside the existing avatar generation).
+- [ ] **Step 3: Run it** — `node scripts/gen_seed_lore_images.mjs` → files appear under `public/uploads/seed-lore/`.
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/gen_seed_lore_images.mjs package.json public/uploads/seed-lore/
+git commit -m "feat(lore): generate seed lore images"
+```
+
+### Task 17: Seed lore data
+
+**Files:**
+
+- Modify: `scripts/dev_seed.py`
+
+Add a `build_lore_docs(campaign_id, gm_id, player_ids, character_ids, location_ids, race_refs, now)` helper and insert into the `Lore` collection for the rich-session-history campaign. Author **at least 5** entries with real flavor text (sourced from in-repo SRD `docs/srd/races/*` for race lore and public Phandalin/Lost Mine background for location lore — paraphrase, keep it short):
+
+- **"Origins of the Elves"** → linked `{kind:'race', id:<elf race id or title-ref>}`, public, image `elf-origins`.
+- **"A Short History of Phandalin"** → linked `{kind:'location', id:<phandalin id>}`, public, image `phandalin-history`.
+- **"The Black Spider's Web"** → linked to an NPC `{kind:'character', id:<npc id>}`, **private**, with `gmContent` (GM-only secret).
+- **"Legend of the Sleeping Dragon"** → linked to a location AND a character (multi-link), public, image `dragon-legend`.
+- **"<Player>'s Oath"** → linked `{kind:'player', id:<a player id>}`, **private** (player + GM only), demonstrating player-scoped private lore. Add one more **public** player lore so the tab shows both visibility states.
+
+Match the field names from `app/server/db/models/Lore.ts` exactly: `title, content, gmContent, isPublic, images:[{url,caption,crop:None}], links:[{kind,id}], tags, campaignId, createdBy, createdAt, updatedAt`. Reference generated images via `/uploads/seed-lore/<slug>.png`. Use the already-created character/location/player ObjectIds captured earlier in the seed run.
+
+- [ ] **Step 1: Implement `build_lore_docs` + insert** in the rich campaign branch (near where notes/chat/dice are built).
+- [ ] **Step 2: Extend the seed harness test** — open the ephemeral-Mongo seed integration test (per memory: seed runs against `mongodb-memory-server`, never dev Atlas) and add assertions: ≥5 lore docs created; at least one each linked to race/location/character/player; at least one private with non-empty `gmContent`.
+- [ ] **Step 3: Run the seed harness** against ephemeral Mongo (the existing test command) → PASS.
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/dev_seed.py tests/<seed-harness-test-path>
+git commit -m "feat(lore): seed sample lore linked to races, locations, characters, and players"
+```
+
+---
+
+## Phase 8 — E2E tests (required: lore editor + drag-and-drop)
+
+> Prereq for running locally: `npm run dev:seed` (ephemeral or a disposable dev DB), then `npx playwright test`. globalSetup mints the GM session and writes `e2e/.auth/seed-data.json`. Extend `e2e/globalSetup.ts` if a known lore id is needed by tests (add it to the seed-data JSON), following how it records `locationId`.
+
+### Task 18: E2E — lore editor works
+
+**Files:**
+
+- Create: `e2e/lore/lore-editor.spec.ts`
+
+Reference: `e2e/locations/location-gallery.spec.ts` (navigation + wiki interactions) and `e2e/fixtures/tabletop-fixtures.ts`.
+
+- [ ] **Step 1: Write the spec** — flow: open the campaign wiki → Lore category → click Create → fill title + public content + toggle public → save → assert the new lore appears in the list and opening it shows the content. Use `mockPostHog`/`blockPartyKit` in `beforeEach` like existing specs.
+
+```ts
+import { test, expect } from '../fixtures/tabletop-fixtures';
+import { mockPostHog, blockPartyKit } from '../fixtures/network-mocks';
+
+test.describe('Lore editor', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockPostHog(page);
+    await blockPartyKit(page);
+  });
+
+  test('GM creates a lore entry and sees it in the list', async ({ page, campaignUrl }) => {
+    await page.goto(campaignUrl);
+    // open wiki + Lore category (use the wiki nav affordance; match data-testid/labels in WikiPanel)
+    await page.getByRole('button', { name: /lore/i }).first().click();
+    await page
+      .getByRole('button', { name: /create|add lore/i })
+      .first()
+      .click();
+    const dialog = page.getByRole('dialog');
+    await dialog.getByLabel(/title/i).fill('The Sunless Citadel');
+    await dialog.getByText(/edit/i).first().click(); // MarkdownEditor edit mode if needed
+    // type into the markdown editor content area (match the editor's testid/role)
+    await dialog.getByRole('button', { name: /create lore/i }).click();
+    await expect(page.getByText('The Sunless Citadel')).toBeVisible();
+  });
+});
+```
+
+> NOTE: selectors must be reconciled with the real DOM during implementation — add stable `data-testid`s to `LorePanel`/`LoreModal` (e.g. `data-testid="lore-create-button"`, `data-testid="lore-card"`) in Task 8/10 to make these robust. If the MarkdownEditor is hard to type into via Playwright, target its CodeMirror content with `.cm-content`.
+
+- [ ] **Step 2: Run** — `npx playwright test e2e/lore/lore-editor.spec.ts` → PASS (with dev server + seed running).
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/lore/lore-editor.spec.ts app/components/wiki/lore/LorePanel.tsx app/components/wiki/lore/LoreModal.tsx
+git commit -m "test(lore): e2e for the lore editor"
+```
+
+### Task 19: E2E — drag and drop works
+
+**Files:**
+
+- Create: `e2e/lore/lore-drag-drop.spec.ts`
+
+Reference: `e2e/tabletop/tabletop-windows.spec.ts` and `tabletop-monster-tokens.spec.ts` (existing drag specs show how this codebase drives HTML5 drag-and-drop in Playwright — copy that technique, whether `dragTo`, manual `dispatchEvent` of dragstart/drop with a shared `DataTransfer`, or a helper).
+
+- [ ] **Step 1: Write the spec** — flow: navigate to the tabletop with a screen; open the wiki Lore list; drag a `LoreCard` onto the tabletop surface; assert a Lore window appears showing the lore title/content. Use the same drag mechanism as the existing tabletop drag specs.
+
+```ts
+import { test, expect } from '../fixtures/tabletop-fixtures';
+import { mockPostHog, blockPartyKit } from '../fixtures/network-mocks';
+
+test.describe('Lore drag and drop', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockPostHog(page);
+    await blockPartyKit(page);
+  });
+
+  test('dragging a lore card onto the tabletop opens a lore window', async ({
+    page,
+    tabletopUrl,
+  }) => {
+    await page.goto(tabletopUrl);
+    await expect(page.getByTestId('tabletop-view')).toBeVisible();
+    // open the wiki Lore list (match the wiki toggle used by existing specs)
+    const card = page.getByTestId('lore-card').first();
+    const surface = page.getByTestId('tabletop-view');
+    // Use the SAME drag technique as tabletop-windows.spec.ts:
+    await card.dragTo(surface);
+    // a lore window should open on the surface
+    await expect(page.getByTestId('tabletop-window').filter({ hasText: /./ })).toBeVisible();
+  });
+});
+```
+
+> NOTE: HTML5 drag-and-drop via `dragTo` is unreliable for `dataTransfer`-based DnD. Open `e2e/tabletop/tabletop-windows.spec.ts` and reuse its exact drag helper (it already solves this for character/monster cards). Add `data-testid="lore-card"` (Task 10) and confirm the tabletop window testid used by existing specs.
+
+- [ ] **Step 2: Run** — `npx playwright test e2e/lore/lore-drag-drop.spec.ts` → PASS.
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/lore/lore-drag-drop.spec.ts
+git commit -m "test(lore): e2e for lore drag-and-drop onto the tabletop"
+```
+
+---
+
+## Phase 9 — Full verification + reseed
+
+### Task 20: Full suite green + typecheck
+
+- [ ] **Step 1:** `npx tsc --noEmit` → PASS.
+- [ ] **Step 2:** `npm run test:unit` → all PASS.
+- [ ] **Step 3:** `npx playwright test e2e/lore` → PASS.
+- [ ] **Step 4:** Fix any regressions; re-run until green.
+- [ ] **Step 5: Commit** any fixes.
+
+### Task 21: Reseed dev environment (GATED — confirm first)
+
+- [ ] **Step 1: STOP and get explicit user confirmation** before running destructive commands against the dev DB.
+- [ ] **Step 2:** `npm run dev:clear -- --force`
+- [ ] **Step 3:** `npm run dev:seed`
+- [ ] **Step 4:** Manually verify in the running app: Lore category lists seeded lore; a private player lore is hidden from non-owners; drag-out works; Player Lore tab shows linked lore.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Data model → Tasks 1–3. Server fns + visibility + `linkedTo` + label resolution → Task 4. Link integrity → Task 5. Hooks → Task 6. Wiki UI (panel/card/modal/view/window/wrappers + links editor) → Tasks 7–10. Drag-out registration → Task 11. Player Lore tab → Tasks 12–13. PlayerModal lore → Task 14. Wizard creation lore → Task 15. Seed images → Task 16. Seed data → Task 17. E2E editor + drag-drop → Tasks 18–19. Reseed → Task 21. ✅ All spec sections covered.
+- Explicit user requirement (E2E for editor + drag-and-drop) → Tasks 18 & 19. ✅
+
+**Placeholder scan:** Component-clone tasks (9, 12, 14) intentionally delegate to named real template files with explicit deltas rather than re-pasting hundreds of existing lines; novel logic (model, server fns, pruning, links editor, hooks, seed, e2e) has full code. "NOTE" callouts flag the few signatures the implementer must confirm against real files (`removeDocumentRefsFromScreens`, `createMutationHook`, `useLocations`/`useRaces`, drag helper, MarkdownEditor selector) — these are verification steps, not vague instructions.
+
+**Type consistency:** `LoreData`/`LoreListItem`/`LoreLink`/`LoreImage` (Task 1) are used consistently in schemas (2), model (3), server fns (4), hooks (6), and components. `collection: 'lore'` string is consistent across LoreCard (10), TabletopView/GMScreensView (11), and ShowOnTabletopButton usages (8/9). `pruneLoreLinks(kind, id, campaignId)` signature consistent between helper (5) and call sites.
+
+**Known confirmations deferred to implementation (flagged inline):** exact `removeDocumentRefsFromScreens` arg order; `createMutationHook` shape; existence/return-field names of `useLocations`/`useRaces`; the e2e drag helper technique; MarkdownEditor Playwright targeting. Each is called out at its task.

--- a/docs/superpowers/plans/2026-06-16-calendars-and-events.md
+++ b/docs/superpowers/plans/2026-06-16-calendars-and-events.md
@@ -1,0 +1,2632 @@
+# Calendars & Events Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a GM-authored custom **Calendar** (Calendar of Harptos fidelity: custom months, tendays, named years, leap days, moons, seasons, holidays) and a dated **Event** datatype (public/GM text, links to characters/players/races/locations/lore/sessions, `isEpic`), surfaced through a calendar list/grid view for all members and a GM-only events manager — then rewire the dashboard epic timeline to read real epic events.
+
+**Architecture:** All date arithmetic lives in ONE pure module, `app/utils/calendarEngine.ts` (no DB/React/IO), imported by client, server, and a Python port in the seed. Events store structured `{year,monthIndex,day}` dates as the source of truth plus denormalized integer ordinals for sorting; the server recomputes ordinals on every event write and re-validates all events when the calendar changes. Everything else mirrors the existing **Lore** vertical slice (model → schema → server fn → hook → wiki panel/card/modal).
+
+**Tech Stack:** TanStack Start (`createServerFn` RPC), Mongoose/MongoDB, React + TanStack Query, Zod, Vitest (happy-dom, globals), Playwright e2e, Python (pymongo) seed, `@resvg/resvg-js` for seed images.
+
+**Spec:** `docs/superpowers/specs/2026-06-16-calendars-and-events-design.md`
+
+**Conventions (verified in repo):**
+- `~` alias → `app/`. Server fns use `createServerFn({method}).inputValidator(zodSchema).handler(...)`.
+- Permissions via `requireCampaignMember(campaignId) → { userId, sessionUserId, isGM }`.
+- Mutations use `createMutationHook` from `~/hooks/createMutationHook`.
+- Mongoose pluralizes models → collections `calendars`, `events`.
+- Run a single unit test: `npm test -- tests/path/to/file.test.ts`. Full suite: `npm test`. Typecheck: `npm run typecheck`. Lint: `npm run lint`. Single e2e: `npx playwright test e2e/calendar/<file>.spec.ts`.
+- Commits: the lefthook pre-commit `format` task fails to re-stage files under the gitignored `docs/superpowers/`; for commits that touch ONLY plan/spec docs use `git commit --no-verify`. Code commits run hooks normally.
+
+---
+
+## File Structure
+
+**Create:**
+- `app/utils/calendarEngine.ts` — pure date-math engine (the crux)
+- `app/types/calendar.ts`, `app/types/event.ts` — shared TS types
+- `app/types/schemas/calendars.ts`, `app/types/schemas/events.ts` — Zod schemas
+- `app/server/db/models/Calendar.ts`, `app/server/db/models/Event.ts` — Mongoose models
+- `app/server/functions/calendars.ts`, `app/server/functions/events.ts` — server fns
+- `app/server/utils/pruneEventLinks.ts` — link pruning helper
+- `app/hooks/useCalendar.ts`, `app/hooks/useEvents.ts` — query/mutation hooks
+- `app/services/eventsTimeline.ts` — maps epic Events → `TimelineEvent[]`
+- `app/components/wiki/calendar/` — `CalendarPanel.tsx`, `CalendarGridView.tsx`, `EventListView.tsx`, `CalendarEditorModal.tsx`, `EventsPanel.tsx`, `EventCard.tsx`, `EventModal.tsx`, `EventViewModal.tsx`, `EventWindow.tsx`, `EventLinksEditor.tsx`, `CalDatePicker.tsx`
+- `app/components/mainview/gmscreens/EventWindowWrapper.tsx`
+- `scripts/gen_seed_event_images.mjs` — event banner generator
+- Tests: `tests/utils/calendarEngine.test.ts`, `tests/server/functions/calendars.test.ts`, `tests/server/functions/events.test.ts`, `tests/utils/calendarEngine.parity.test.ts`, `e2e/calendar/calendar-events.spec.ts`, `e2e/calendar/event-drag-drop.spec.ts`
+
+**Modify:**
+- `app/utils/queryKeys.ts` — add `calendar`, `events` keys
+- `app/components/wiki/WikiPanel.tsx` — add Calendar (all) + Events (gmOnly) categories
+- `app/server/functions/gmscreens.ts` — register `events` collection fetcher
+- `app/server/functions/{characters,players,locations,races,lore}.ts` — call `pruneEventLinks` on delete
+- `app/components/mainview/widgets/CampaignTimelineWidget.tsx` — read real epic events
+- `scripts/dev_seed.py` — `build_calendar_doc`, `build_event_docs`, orchestration + a Python `to_ordinal` port
+- `package.json` — add event image generator to the `dev:seed` chain
+- `app/services/mocks/timelineService.ts` — leave as fallback; widget no longer depends on it for campaigns with events
+
+---
+
+# PHASE 1 — Calendar engine + types + schemas
+
+The engine is pure and must be exhaustively tested BEFORE anything else uses it.
+
+## Task 1: Engine types and leap/length math
+
+**Files:**
+- Create: `app/utils/calendarEngine.ts`
+- Test: `tests/utils/calendarEngine.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/utils/calendarEngine.test.ts
+import { describe, it, expect } from 'vitest';
+import { daysInMonth, daysInYear, type CalendarConfig } from '~/utils/calendarEngine';
+
+// Minimal config: 2 months (30, 30), 5-day week, leap +1 to month 1 every 4 years.
+const cfg: CalendarConfig = {
+  months: [
+    { name: 'Alpha', days: 30 },
+    { name: 'Beta', days: 30 },
+  ],
+  weekdays: ['d1', 'd2', 'd3', 'd4', 'd5'],
+  weekdayMode: 'continuous',
+  epoch: { year: 1, weekdayIndex: 0 },
+  leapDays: [{ name: 'Leap', monthIndex: 1, interval: 4, offset: 0, addDays: 1 }],
+};
+
+describe('daysInMonth / daysInYear', () => {
+  it('returns base length in a non-leap year', () => {
+    expect(daysInMonth(cfg, 1, 1)).toBe(30); // year 1 % 4 !== 0
+    expect(daysInYear(cfg, 1)).toBe(60);
+  });
+  it('adds leap days in a matching year', () => {
+    expect(daysInMonth(cfg, 4, 1)).toBe(31); // 4 % 4 === 0
+    expect(daysInYear(cfg, 4)).toBe(61);
+  });
+  it('handles negative years for leap matching', () => {
+    expect(daysInMonth(cfg, -4, 1)).toBe(31);
+    expect(daysInMonth(cfg, -1, 1)).toBe(30);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `npm test -- tests/utils/calendarEngine.test.ts`
+Expected: FAIL — `daysInMonth is not a function` / module not found.
+
+- [ ] **Step 3: Implement the types + length math**
+
+```typescript
+// app/utils/calendarEngine.ts
+export interface CalMonth {
+  name: string;
+  days: number;
+  /** Festival/intercalary day: sits between months, outside the week cycle. */
+  isIntercalary?: boolean;
+}
+
+export interface CalLeapRule {
+  name: string;
+  /** Index into `months` that the extra day(s) attach to. */
+  monthIndex: number;
+  /** Rule fires when ((year - offset) mod interval) === 0. interval >= 1. */
+  interval: number;
+  offset: number;
+  addDays: number;
+}
+
+export interface CalMoon {
+  name: string;
+  cycleLength: number;
+  offsetDays: number;
+  color?: string;
+}
+
+export interface CalSeason {
+  name: string;
+  startMonthIndex: number;
+  startDay: number;
+  color?: string;
+}
+
+export interface CalHoliday {
+  name: string;
+  monthIndex: number;
+  day: number;
+  color?: string;
+}
+
+/** The subset of a Calendar the pure engine needs. */
+export interface CalendarConfig {
+  months: CalMonth[];
+  weekdays: string[];
+  weekdayMode: 'continuous' | 'resetEachMonth';
+  /** Ordinal 0 === { year: epoch.year, monthIndex: 0, day: 1 }. */
+  epoch: { year: number; weekdayIndex: number };
+  leapDays: CalLeapRule[];
+  yearSuffix?: string;
+  moons?: CalMoon[];
+  seasons?: CalSeason[];
+  holidays?: CalHoliday[];
+}
+
+/** A human calendar date. `day` is 1-based; `monthIndex` is 0-based. */
+export interface CalDate {
+  year: number;
+  monthIndex: number;
+  day: number;
+}
+
+/** True modulo (always non-negative for positive m). */
+function mod(n: number, m: number): number {
+  return ((n % m) + m) % m;
+}
+
+function leapRuleApplies(rule: CalLeapRule, year: number): boolean {
+  if (rule.interval < 1) return false;
+  return mod(year - rule.offset, rule.interval) === 0;
+}
+
+export function daysInMonth(cfg: CalendarConfig, year: number, monthIndex: number): number {
+  const base = cfg.months[monthIndex]?.days ?? 0;
+  let extra = 0;
+  for (const rule of cfg.leapDays) {
+    if (rule.monthIndex === monthIndex && leapRuleApplies(rule, year)) extra += rule.addDays;
+  }
+  return base + extra;
+}
+
+export function daysInYear(cfg: CalendarConfig, year: number): number {
+  let total = 0;
+  for (let m = 0; m < cfg.months.length; m++) total += daysInMonth(cfg, year, m);
+  return total;
+}
+```
+
+- [ ] **Step 4: Run and confirm pass**
+
+Run: `npm test -- tests/utils/calendarEngine.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/utils/calendarEngine.ts tests/utils/calendarEngine.test.ts
+git commit -m "feat(calendar): engine length + leap math"
+```
+
+## Task 2: `toOrdinal` / `fromOrdinal` (exact inverses)
+
+**Files:**
+- Modify: `app/utils/calendarEngine.ts`
+- Test: `tests/utils/calendarEngine.test.ts`
+
+- [ ] **Step 1: Write the failing tests (incl. round-trip property)**
+
+```typescript
+// append to tests/utils/calendarEngine.test.ts
+import { toOrdinal, fromOrdinal } from '~/utils/calendarEngine';
+
+describe('toOrdinal / fromOrdinal', () => {
+  it('epoch first day is ordinal 0', () => {
+    expect(toOrdinal(cfg, { year: 1, monthIndex: 0, day: 1 })).toBe(0);
+  });
+  it('counts within a year', () => {
+    expect(toOrdinal(cfg, { year: 1, monthIndex: 0, day: 2 })).toBe(1);
+    expect(toOrdinal(cfg, { year: 1, monthIndex: 1, day: 1 })).toBe(30);
+  });
+  it('crosses a leap year boundary', () => {
+    // year 1,2,3 are 60 days; year 4 (leap) is 61. Start of year 5:
+    expect(toOrdinal(cfg, { year: 5, monthIndex: 0, day: 1 })).toBe(60 * 3 + 61);
+  });
+  it('handles negative ordinals (before epoch)', () => {
+    // last day of year 0 (60 days) is ordinal -1
+    expect(toOrdinal(cfg, { year: 0, monthIndex: 1, day: 30 })).toBe(-1);
+  });
+  it('round-trips fromOrdinal(toOrdinal(d)) === d across many dates', () => {
+    for (let year = -6; year <= 8; year++) {
+      for (let m = 0; m < cfg.months.length; m++) {
+        for (let day = 1; day <= daysInMonthHelper(year, m); day++) {
+          const d = { year, monthIndex: m, day };
+          expect(fromOrdinal(cfg, toOrdinal(cfg, d))).toEqual(d);
+        }
+      }
+    }
+  });
+});
+
+function daysInMonthHelper(year: number, m: number): number {
+  // mirror engine for the loop bound
+  const base = cfg.months[m]!.days;
+  const leap = cfg.leapDays.some(
+    (r) => r.monthIndex === m && ((((year - r.offset) % r.interval) + r.interval) % r.interval) === 0
+  );
+  return base + (leap ? 1 : 0);
+}
+```
+
+- [ ] **Step 2: Run and confirm fail**
+
+Run: `npm test -- tests/utils/calendarEngine.test.ts`
+Expected: FAIL — `toOrdinal is not a function`.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// append to app/utils/calendarEngine.ts
+
+/** Signed day count from the epoch-year's first day to `year`'s first day. */
+function yearStartOrdinal(cfg: CalendarConfig, year: number): number {
+  let total = 0;
+  if (year >= cfg.epoch.year) {
+    for (let y = cfg.epoch.year; y < year; y++) total += daysInYear(cfg, y);
+  } else {
+    for (let y = year; y < cfg.epoch.year; y++) total -= daysInYear(cfg, y);
+  }
+  return total;
+}
+
+function daysBeforeMonth(cfg: CalendarConfig, year: number, monthIndex: number): number {
+  let total = 0;
+  for (let m = 0; m < monthIndex; m++) total += daysInMonth(cfg, year, m);
+  return total;
+}
+
+export function toOrdinal(cfg: CalendarConfig, date: CalDate): number {
+  return yearStartOrdinal(cfg, date.year) + daysBeforeMonth(cfg, date.year, date.monthIndex) + (date.day - 1);
+}
+
+export function fromOrdinal(cfg: CalendarConfig, ordinal: number): CalDate {
+  let year = cfg.epoch.year;
+  let rem = ordinal;
+  if (rem >= 0) {
+    while (rem >= daysInYear(cfg, year)) {
+      rem -= daysInYear(cfg, year);
+      year++;
+    }
+  } else {
+    while (rem < 0) {
+      year--;
+      rem += daysInYear(cfg, year);
+    }
+  }
+  // rem is now in [0, daysInYear(year)). Walk months; 0-length months are skipped.
+  let monthIndex = 0;
+  while (rem >= daysInMonth(cfg, year, monthIndex)) {
+    rem -= daysInMonth(cfg, year, monthIndex);
+    monthIndex++;
+  }
+  return { year, monthIndex, day: rem + 1 };
+}
+```
+
+- [ ] **Step 4: Run and confirm pass**
+
+Run: `npm test -- tests/utils/calendarEngine.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/utils/calendarEngine.ts tests/utils/calendarEngine.test.ts
+git commit -m "feat(calendar): toOrdinal/fromOrdinal with round-trip tests"
+```
+
+## Task 3: `validateDate`, `compareDates`, `addDays`, `weekdayOf`
+
+**Files:**
+- Modify: `app/utils/calendarEngine.ts`
+- Test: `tests/utils/calendarEngine.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// append to tests/utils/calendarEngine.test.ts
+import { validateDate, compareDates, addDays, weekdayOf } from '~/utils/calendarEngine';
+
+describe('validateDate', () => {
+  it('accepts an in-range date', () => {
+    expect(validateDate(cfg, { year: 1, monthIndex: 0, day: 30 }).ok).toBe(true);
+  });
+  it('rejects a day beyond the month length', () => {
+    expect(validateDate(cfg, { year: 1, monthIndex: 0, day: 31 }).ok).toBe(false);
+  });
+  it('rejects an out-of-range month', () => {
+    expect(validateDate(cfg, { year: 1, monthIndex: 9, day: 1 }).ok).toBe(false);
+  });
+  it('rejects a day in a zero-length (non-leap) month', () => {
+    const z: CalendarConfig = { ...cfg, months: [{ name: 'A', days: 30 }, { name: 'Z', days: 0 }] };
+    expect(validateDate(z, { year: 1, monthIndex: 1, day: 1 }).ok).toBe(false);
+  });
+});
+
+describe('compareDates / addDays', () => {
+  it('orders dates', () => {
+    expect(compareDates(cfg, { year: 1, monthIndex: 0, day: 1 }, { year: 1, monthIndex: 0, day: 2 })).toBe(-1);
+    expect(compareDates(cfg, { year: 2, monthIndex: 0, day: 1 }, { year: 1, monthIndex: 0, day: 1 })).toBe(1);
+  });
+  it('adds days across a month boundary', () => {
+    expect(addDays(cfg, { year: 1, monthIndex: 0, day: 30 }, 1)).toEqual({ year: 1, monthIndex: 1, day: 1 });
+  });
+});
+
+describe('weekdayOf', () => {
+  it('continuous mode flows across months', () => {
+    expect(weekdayOf(cfg, { year: 1, monthIndex: 0, day: 1 })).toBe(0);
+    expect(weekdayOf(cfg, { year: 1, monthIndex: 0, day: 6 })).toBe(0); // 5-day week
+  });
+  it('resetEachMonth mode resets day 1 to weekday 0 and returns -1 for intercalary', () => {
+    const r: CalendarConfig = {
+      ...cfg,
+      weekdayMode: 'resetEachMonth',
+      months: [{ name: 'A', days: 30 }, { name: 'Fest', days: 1, isIntercalary: true }],
+    };
+    expect(weekdayOf(r, { year: 1, monthIndex: 0, day: 1 })).toBe(0);
+    expect(weekdayOf(r, { year: 1, monthIndex: 0, day: 7 })).toBe(1);
+    expect(weekdayOf(r, { year: 1, monthIndex: 1, day: 1 })).toBe(-1);
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm fail**
+
+Run: `npm test -- tests/utils/calendarEngine.test.ts`
+Expected: FAIL — functions undefined.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// append to app/utils/calendarEngine.ts
+export interface ValidateResult {
+  ok: boolean;
+  error?: string;
+}
+
+export function validateDate(cfg: CalendarConfig, date: CalDate): ValidateResult {
+  if (!Number.isInteger(date.monthIndex) || date.monthIndex < 0 || date.monthIndex >= cfg.months.length) {
+    return { ok: false, error: 'Month is out of range' };
+  }
+  if (!Number.isInteger(date.day) || date.day < 1) {
+    return { ok: false, error: 'Day must be 1 or greater' };
+  }
+  const dim = daysInMonth(cfg, date.year, date.monthIndex);
+  if (date.day > dim) {
+    return { ok: false, error: `Day ${date.day} exceeds ${dim} for ${cfg.months[date.monthIndex]!.name}` };
+  }
+  return { ok: true };
+}
+
+export function compareDates(cfg: CalendarConfig, a: CalDate, b: CalDate): -1 | 0 | 1 {
+  const d = toOrdinal(cfg, a) - toOrdinal(cfg, b);
+  return d < 0 ? -1 : d > 0 ? 1 : 0;
+}
+
+export function addDays(cfg: CalendarConfig, date: CalDate, n: number): CalDate {
+  return fromOrdinal(cfg, toOrdinal(cfg, date) + n);
+}
+
+/** Weekday index, or -1 for intercalary days in resetEachMonth mode. */
+export function weekdayOf(cfg: CalendarConfig, date: CalDate): number {
+  const w = cfg.weekdays.length;
+  if (cfg.weekdayMode === 'resetEachMonth') {
+    if (cfg.months[date.monthIndex]?.isIntercalary) return -1;
+    return mod(date.day - 1, w);
+  }
+  return mod(cfg.epoch.weekdayIndex + toOrdinal(cfg, date), w);
+}
+```
+
+- [ ] **Step 4: Run and confirm pass**
+
+Run: `npm test -- tests/utils/calendarEngine.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/utils/calendarEngine.ts tests/utils/calendarEngine.test.ts
+git commit -m "feat(calendar): validateDate, compareDates, addDays, weekdayOf"
+```
+
+## Task 4: Display helpers — `monthGrid`, `moonPhase`, `seasonOf`, `holidaysOn`, `formatDate`
+
+**Files:**
+- Modify: `app/utils/calendarEngine.ts`
+- Test: `tests/utils/calendarEngine.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// append to tests/utils/calendarEngine.test.ts
+import { monthGrid, moonPhase, seasonOf, holidaysOn, formatDate } from '~/utils/calendarEngine';
+
+describe('monthGrid', () => {
+  it('chunks days into week rows, padding the last row with null', () => {
+    const grid = monthGrid(cfg, 1, 0); // 30 days, 5-day week, continuous, day1 weekday 0
+    expect(grid.length).toBe(6);
+    expect(grid[0]).toEqual([1, 2, 3, 4, 5]);
+    expect(grid[5]).toEqual([26, 27, 28, 29, 30]);
+  });
+  it('adds leading blanks in continuous mode when day 1 is mid-week', () => {
+    // month 1 of year 1 starts at ordinal 30 -> weekday 30 % 5 = 0; force offset
+    const off: CalendarConfig = { ...cfg, epoch: { year: 1, weekdayIndex: 2 } };
+    const grid = monthGrid(off, 1, 0);
+    expect(grid[0]!.slice(0, 2)).toEqual([null, null]);
+    expect(grid[0]![2]).toBe(1);
+  });
+});
+
+describe('moonPhase / seasonOf / holidaysOn / formatDate', () => {
+  const dcfg: CalendarConfig = {
+    ...cfg,
+    moons: [{ name: 'Luna', cycleLength: 10, offsetDays: 0 }],
+    seasons: [
+      { name: 'Cold', startMonthIndex: 0, startDay: 1 },
+      { name: 'Warm', startMonthIndex: 1, startDay: 1 },
+    ],
+    holidays: [{ name: 'Feast', monthIndex: 0, day: 15 }],
+    yearSuffix: 'DR',
+  };
+  it('moonPhase returns a 0..1 fraction', () => {
+    expect(moonPhase(dcfg, dcfg.moons![0]!, 0)).toBeCloseTo(0, 5);
+    expect(moonPhase(dcfg, dcfg.moons![0]!, 5)).toBeCloseTo(0.5, 5);
+  });
+  it('seasonOf picks the active season', () => {
+    expect(seasonOf(dcfg, toOrdinal(dcfg, { year: 1, monthIndex: 0, day: 5 }))?.name).toBe('Cold');
+    expect(seasonOf(dcfg, toOrdinal(dcfg, { year: 1, monthIndex: 1, day: 5 }))?.name).toBe('Warm');
+  });
+  it('holidaysOn returns matching holidays', () => {
+    expect(holidaysOn(dcfg, 1, 0, 15).map((h) => h.name)).toEqual(['Feast']);
+    expect(holidaysOn(dcfg, 1, 0, 16)).toEqual([]);
+  });
+  it('formatDate renders normal vs intercalary', () => {
+    expect(formatDate(dcfg, { year: 1482, monthIndex: 0, day: 11 })).toBe('11th Alpha, 1482 DR');
+    const ic: CalendarConfig = { ...dcfg, months: [{ name: 'Midsummer', days: 1, isIntercalary: true }] };
+    expect(formatDate(ic, { year: 1482, monthIndex: 0, day: 1 })).toBe('Midsummer, 1482 DR');
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm fail**
+
+Run: `npm test -- tests/utils/calendarEngine.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// append to app/utils/calendarEngine.ts
+
+/** Rows of week-length cells; null = padding (leading/trailing blanks). */
+export function monthGrid(cfg: CalendarConfig, year: number, monthIndex: number): (number | null)[][] {
+  const total = daysInMonth(cfg, year, monthIndex);
+  const w = cfg.weekdays.length;
+  const lead =
+    cfg.weekdayMode === 'continuous' ? mod(cfg.epoch.weekdayIndex + toOrdinal(cfg, { year, monthIndex, day: 1 }), w) : 0;
+  const cells: (number | null)[] = [];
+  for (let i = 0; i < lead; i++) cells.push(null);
+  for (let d = 1; d <= total; d++) cells.push(d);
+  while (cells.length % w !== 0) cells.push(null);
+  const rows: (number | null)[][] = [];
+  for (let i = 0; i < cells.length; i += w) rows.push(cells.slice(i, i + w));
+  return rows;
+}
+
+/** Phase as a 0..1 fraction (0 = new). Display-only. */
+export function moonPhase(_cfg: CalendarConfig, moon: CalMoon, ordinal: number): number {
+  return mod(ordinal - moon.offsetDays, moon.cycleLength) / moon.cycleLength;
+}
+
+/** The active season for an ordinal, or null if no seasons configured. */
+export function seasonOf(cfg: CalendarConfig, ordinal: number): CalSeason | null {
+  if (!cfg.seasons?.length) return null;
+  const date = fromOrdinal(cfg, ordinal);
+  // Start ordinal of each season within this date's year.
+  const starts = cfg.seasons.map((s) => ({
+    s,
+    o: toOrdinal(cfg, { year: date.year, monthIndex: s.startMonthIndex, day: s.startDay }),
+  }));
+  starts.sort((a, b) => a.o - b.o);
+  let active: CalSeason = starts[starts.length - 1]!.s; // wraps from previous year
+  for (const { s, o } of starts) {
+    if (ordinal >= o) active = s;
+  }
+  return active;
+}
+
+export function holidaysOn(cfg: CalendarConfig, _year: number, monthIndex: number, day: number): CalHoliday[] {
+  return (cfg.holidays ?? []).filter((h) => h.monthIndex === monthIndex && h.day === day);
+}
+
+function ordinalSuffix(n: number): string {
+  const v = n % 100;
+  if (v >= 11 && v <= 13) return `${n}th`;
+  switch (n % 10) {
+    case 1: return `${n}st`;
+    case 2: return `${n}nd`;
+    case 3: return `${n}rd`;
+    default: return `${n}th`;
+  }
+}
+
+export function formatDate(cfg: CalendarConfig, date: CalDate): string {
+  const m = cfg.months[date.monthIndex];
+  const yearLabel = `${date.year}${cfg.yearSuffix ? ` ${cfg.yearSuffix}` : ''}`;
+  if (!m) return yearLabel;
+  if (m.isIntercalary) return `${m.name}, ${yearLabel}`;
+  return `${ordinalSuffix(date.day)} ${m.name}, ${yearLabel}`;
+}
+```
+
+- [ ] **Step 4: Run and confirm pass**
+
+Run: `npm test -- tests/utils/calendarEngine.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/utils/calendarEngine.ts tests/utils/calendarEngine.test.ts
+git commit -m "feat(calendar): monthGrid, moonPhase, seasonOf, holidaysOn, formatDate"
+```
+
+## Task 5: Harptos-specific engine assertions
+
+**Files:**
+- Modify: `tests/utils/calendarEngine.test.ts`
+- Create: `app/utils/harptos.ts` (the canonical Harptos config, reused by seed + a future "preset" button)
+
+- [ ] **Step 1: Write the Harptos config + failing tests**
+
+```typescript
+// app/utils/harptos.ts
+import type { CalendarConfig } from '~/utils/calendarEngine';
+
+// 12 months x 30 days, 5 festivals as length-1 intercalary "months", Shieldmeet
+// as a length-0 intercalary month that gains a day every 4 years. weekdayMode
+// resetEachMonth: each month is three fresh 10-day tendays; festivals have no slot.
+export const HARPTOS_MONTHS = [
+  { name: 'Hammer', days: 30 },
+  { name: 'Midwinter', days: 1, isIntercalary: true },
+  { name: 'Alturiak', days: 30 },
+  { name: 'Ches', days: 30 },
+  { name: 'Tarsakh', days: 30 },
+  { name: 'Greengrass', days: 1, isIntercalary: true },
+  { name: 'Mirtul', days: 30 },
+  { name: 'Kythorn', days: 30 },
+  { name: 'Flamerule', days: 30 },
+  { name: 'Midsummer', days: 1, isIntercalary: true },
+  { name: 'Shieldmeet', days: 0, isIntercalary: true },
+  { name: 'Eleasis', days: 30 },
+  { name: 'Eleint', days: 30 },
+  { name: 'Highharvestide', days: 1, isIntercalary: true },
+  { name: 'Marpenoth', days: 30 },
+  { name: 'Uktar', days: 30 },
+  { name: 'The Feast of the Moon', days: 1, isIntercalary: true },
+  { name: 'Nightal', days: 30 },
+];
+
+export const HARPTOS_CONFIG: CalendarConfig = {
+  months: HARPTOS_MONTHS,
+  weekdays: ['First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth', 'Seventh', 'Eighth', 'Ninth', 'Tenth'],
+  weekdayMode: 'resetEachMonth',
+  epoch: { year: 1372, weekdayIndex: 0 },
+  leapDays: [{ name: 'Shieldmeet', monthIndex: 10, interval: 4, offset: 0, addDays: 1 }],
+  yearSuffix: 'DR',
+  moons: [{ name: 'Selûne', cycleLength: 30, offsetDays: 0 }],
+  seasons: [
+    { name: 'Winter', startMonthIndex: 0, startDay: 1 },
+    { name: 'Spring', startMonthIndex: 3, startDay: 1 },
+    { name: 'Summer', startMonthIndex: 8, startDay: 1 },
+    { name: 'Autumn', startMonthIndex: 13, startDay: 1 },
+  ],
+  holidays: [],
+};
+```
+
+```typescript
+// append to tests/utils/calendarEngine.test.ts
+import { HARPTOS_CONFIG } from '~/utils/harptos';
+
+describe('Harptos', () => {
+  it('a normal year has 365 days', () => {
+    expect(daysInYear(HARPTOS_CONFIG, 1373)).toBe(365); // 1373 % 4 !== 0
+  });
+  it('a Shieldmeet year has 366 days', () => {
+    expect(daysInYear(HARPTOS_CONFIG, 1372)).toBe(366); // 1372 % 4 === 0
+  });
+  it('Shieldmeet has no placeable day in a non-leap year', () => {
+    expect(validateDate(HARPTOS_CONFIG, { year: 1373, monthIndex: 10, day: 1 }).ok).toBe(false);
+  });
+  it('Shieldmeet day 1 is valid in a leap year', () => {
+    expect(validateDate(HARPTOS_CONFIG, { year: 1488, monthIndex: 10, day: 1 }).ok).toBe(true);
+  });
+  it('round-trips across a Shieldmeet year', () => {
+    for (let m = 0; m < HARPTOS_CONFIG.months.length; m++) {
+      for (let day = 1; day <= daysInMonth(HARPTOS_CONFIG, 1488, m); day++) {
+        const d = { year: 1488, monthIndex: m, day };
+        expect(fromOrdinal(HARPTOS_CONFIG, toOrdinal(HARPTOS_CONFIG, d))).toEqual(d);
+      }
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm fail, then pass (config already satisfies the engine)**
+
+Run: `npm test -- tests/utils/calendarEngine.test.ts`
+Expected: initially FAIL (missing `~/utils/harptos`); after creating the file, PASS.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/utils/harptos.ts tests/utils/calendarEngine.test.ts
+git commit -m "feat(calendar): canonical Harptos config + engine assertions"
+```
+
+## Task 6: Shared TS types + Zod schemas
+
+**Files:**
+- Create: `app/types/calendar.ts`, `app/types/event.ts`, `app/types/schemas/calendars.ts`, `app/types/schemas/events.ts`
+
+- [ ] **Step 1: Write the types**
+
+```typescript
+// app/types/calendar.ts
+import type {
+  CalMonth, CalLeapRule, CalMoon, CalSeason, CalHoliday, CalDate,
+} from '~/utils/calendarEngine';
+
+export type { CalMonth, CalLeapRule, CalMoon, CalSeason, CalHoliday, CalDate };
+
+export interface CalendarData {
+  id: string;
+  campaignId: string;
+  createdBy: string;
+  name: string;
+  description: string;
+  months: CalMonth[];
+  weekdays: string[];
+  weekdayMode: 'continuous' | 'resetEachMonth';
+  epoch: { year: number; weekdayIndex: number };
+  yearSuffix: string;
+  namedYears: { year: number; name: string }[];
+  leapDays: CalLeapRule[];
+  moons: CalMoon[];
+  seasons: CalSeason[];
+  holidays: CalHoliday[];
+  currentDate: CalDate;
+  createdAt: string;
+  updatedAt: string;
+  canEdit: boolean;
+}
+```
+
+```typescript
+// app/types/event.ts
+import type { CalDate } from '~/utils/calendarEngine';
+
+export type EventLinkKind = 'character' | 'player' | 'race' | 'location' | 'lore';
+
+export interface EventLink {
+  kind: EventLinkKind;
+  id: string;
+  label?: string;
+}
+
+export interface EventImage {
+  url: string;
+  caption: string;
+  crop: { x: number; y: number; width: number; height: number } | null;
+}
+
+export interface EventData {
+  id: string;
+  campaignId: string;
+  calendarId: string;
+  createdBy: string;
+  title: string;
+  content: string;
+  gmContent: string;
+  isPublic: boolean;
+  isEpic: boolean;
+  start: CalDate;
+  end: CalDate | null;
+  startOrdinal: number;
+  endOrdinal: number;
+  links: EventLink[];
+  sessionId: string | null;
+  images: EventImage[];
+  tags: string[];
+  color: string | null;
+  createdAt: string;
+  updatedAt: string;
+  canEdit: boolean;
+}
+
+export type EventListItem = Omit<EventData, 'gmContent'>;
+```
+
+- [ ] **Step 2: Write the Zod schemas**
+
+```typescript
+// app/types/schemas/calendars.ts
+import { z } from 'zod';
+
+const calDate = z.object({
+  year: z.number().int(),
+  monthIndex: z.number().int().min(0),
+  day: z.number().int().min(0),
+});
+
+const month = z.object({
+  name: z.string().trim().min(1),
+  days: z.number().int().min(0),
+  isIntercalary: z.boolean().optional(),
+});
+
+const leapRule = z.object({
+  name: z.string().trim().min(1),
+  monthIndex: z.number().int().min(0),
+  interval: z.number().int().min(1),
+  offset: z.number().int(),
+  addDays: z.number().int().min(1),
+});
+
+const moon = z.object({
+  name: z.string().trim().min(1),
+  cycleLength: z.number().positive(),
+  offsetDays: z.number(),
+  color: z.string().optional(),
+});
+
+const season = z.object({
+  name: z.string().trim().min(1),
+  startMonthIndex: z.number().int().min(0),
+  startDay: z.number().int().min(1),
+  color: z.string().optional(),
+});
+
+const holiday = z.object({
+  name: z.string().trim().min(1),
+  monthIndex: z.number().int().min(0),
+  day: z.number().int().min(1),
+  color: z.string().optional(),
+});
+
+const calendarFields = {
+  name: z.string().trim().min(1),
+  description: z.string().default(''),
+  months: z.array(month).min(1),
+  weekdays: z.array(z.string().trim().min(1)).min(1),
+  weekdayMode: z.enum(['continuous', 'resetEachMonth']).default('continuous'),
+  epoch: z.object({ year: z.number().int(), weekdayIndex: z.number().int().min(0) }),
+  yearSuffix: z.string().default(''),
+  namedYears: z.array(z.object({ year: z.number().int(), name: z.string().trim().min(1) })).default([]),
+  leapDays: z.array(leapRule).default([]),
+  moons: z.array(moon).default([]),
+  seasons: z.array(season).default([]),
+  holidays: z.array(holiday).default([]),
+  currentDate: calDate,
+};
+
+export const getCalendarSchema = z.object({ campaignId: z.string().trim().min(1) });
+export const upsertCalendarSchema = z.object({ campaignId: z.string().trim().min(1), ...calendarFields });
+export const setCurrentDateSchema = z.object({ campaignId: z.string().trim().min(1), currentDate: calDate });
+export const deleteCalendarSchema = z.object({ campaignId: z.string().trim().min(1) });
+```
+
+```typescript
+// app/types/schemas/events.ts
+import { z } from 'zod';
+
+const linkKind = z.enum(['character', 'player', 'race', 'location', 'lore']);
+const eventLink = z.object({ kind: linkKind, id: z.string().trim().min(1) });
+const calDate = z.object({
+  year: z.number().int(),
+  monthIndex: z.number().int().min(0),
+  day: z.number().int().min(1),
+});
+const eventImage = z.object({
+  url: z.string().trim().min(1),
+  caption: z.string().trim().default(''),
+  crop: z
+    .object({ x: z.number(), y: z.number(), width: z.number(), height: z.number() })
+    .nullable()
+    .default(null),
+});
+
+const eventFields = {
+  title: z.string().trim().min(1),
+  content: z.string().default(''),
+  gmContent: z.string().default(''),
+  isPublic: z.boolean().default(false),
+  isEpic: z.boolean().default(false),
+  start: calDate,
+  end: calDate.nullable().default(null),
+  links: z.array(eventLink).default([]),
+  sessionId: z.string().trim().min(1).nullable().default(null),
+  images: z.array(eventImage).default([]),
+  tags: z.array(z.string()).default([]),
+  color: z.string().trim().min(1).nullable().default(null),
+};
+
+export const listEventsSchema = z.object({
+  campaignId: z.string().trim().min(1),
+  search: z.string().trim().optional(),
+  tags: z.array(z.string()).optional(),
+  visibility: z.enum(['all', 'public', 'private']).optional(),
+  epicOnly: z.boolean().optional(),
+  linkedKind: linkKind.optional(),
+  linkedId: z.string().trim().min(1).optional(),
+});
+export const getEventSchema = z.object({ id: z.string().trim().min(1), campaignId: z.string().trim().min(1) });
+export const createEventSchema = z.object({ campaignId: z.string().trim().min(1), ...eventFields });
+export const updateEventSchema = z.object({
+  id: z.string().trim().min(1),
+  campaignId: z.string().trim().min(1),
+  ...eventFields,
+});
+export const deleteEventSchema = getEventSchema;
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/types/calendar.ts app/types/event.ts app/types/schemas/calendars.ts app/types/schemas/events.ts
+git commit -m "feat(calendar): shared types + zod schemas for calendar and events"
+```
+
+---
+
+# PHASE 2 — DB models, server functions, hooks
+
+## Task 7: Mongoose models
+
+**Files:**
+- Create: `app/server/db/models/Calendar.ts`, `app/server/db/models/Event.ts`
+
+- [ ] **Step 1: Implement `Calendar.ts`** (mirrors `Lore.ts` sub-schema style)
+
+```typescript
+// app/server/db/models/Calendar.ts
+import mongoose from 'mongoose';
+
+const monthSchema = new mongoose.Schema(
+  { name: { type: String, required: true }, days: { type: Number, required: true }, isIntercalary: { type: Boolean, default: false } },
+  { _id: false }
+);
+const leapSchema = new mongoose.Schema(
+  { name: String, monthIndex: Number, interval: Number, offset: Number, addDays: Number },
+  { _id: false }
+);
+const moonSchema = new mongoose.Schema(
+  { name: String, cycleLength: Number, offsetDays: Number, color: String },
+  { _id: false }
+);
+const seasonSchema = new mongoose.Schema(
+  { name: String, startMonthIndex: Number, startDay: Number, color: String },
+  { _id: false }
+);
+const holidaySchema = new mongoose.Schema(
+  { name: String, monthIndex: Number, day: Number, color: String },
+  { _id: false }
+);
+const calDateSchema = new mongoose.Schema(
+  { year: Number, monthIndex: Number, day: Number },
+  { _id: false }
+);
+
+const calendarSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  description: { type: String, default: '' },
+  months: { type: [monthSchema], default: [] },
+  weekdays: { type: [String], default: [] },
+  weekdayMode: { type: String, enum: ['continuous', 'resetEachMonth'], default: 'continuous' },
+  epoch: { year: { type: Number, default: 1 }, weekdayIndex: { type: Number, default: 0 } },
+  yearSuffix: { type: String, default: '' },
+  namedYears: { type: [new mongoose.Schema({ year: Number, name: String }, { _id: false })], default: [] },
+  leapDays: { type: [leapSchema], default: [] },
+  moons: { type: [moonSchema], default: [] },
+  seasons: { type: [seasonSchema], default: [] },
+  holidays: { type: [holidaySchema], default: [] },
+  currentDate: { type: calDateSchema, default: () => ({ year: 1, monthIndex: 0, day: 1 }) },
+  campaignId: { type: mongoose.Schema.Types.ObjectId, required: true, index: true, unique: true },
+  createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+});
+
+calendarSchema.pre('save', function () {
+  this.updatedAt = new Date();
+});
+
+export const Calendar = mongoose.models.Calendar || mongoose.model('Calendar', calendarSchema);
+```
+
+- [ ] **Step 2: Implement `Event.ts`**
+
+```typescript
+// app/server/db/models/Event.ts
+import mongoose from 'mongoose';
+import { normalizeTags } from '~/server/utils/helpers';
+
+const linkSchema = new mongoose.Schema(
+  {
+    kind: { type: String, enum: ['character', 'player', 'race', 'location', 'lore'], required: true },
+    id: { type: mongoose.Schema.Types.ObjectId, required: true },
+  },
+  { _id: false }
+);
+const cropSchema = new mongoose.Schema(
+  { x: Number, y: Number, width: Number, height: Number },
+  { _id: false }
+);
+const imageSchema = new mongoose.Schema(
+  { url: { type: String, required: true }, caption: { type: String, default: '' }, crop: { type: cropSchema, default: null } },
+  { _id: false }
+);
+const calDateSchema = new mongoose.Schema(
+  { year: Number, monthIndex: Number, day: Number },
+  { _id: false }
+);
+
+const eventSchema = new mongoose.Schema({
+  title: { type: String, required: true },
+  content: { type: String, default: '' },
+  gmContent: { type: String, default: '' },
+  isPublic: { type: Boolean, default: false },
+  isEpic: { type: Boolean, default: false },
+  start: { type: calDateSchema, required: true },
+  end: { type: calDateSchema, default: null },
+  startOrdinal: { type: Number, required: true },
+  endOrdinal: { type: Number, required: true },
+  links: { type: [linkSchema], default: [] },
+  sessionId: { type: mongoose.Schema.Types.ObjectId, default: null },
+  images: { type: [imageSchema], default: [] },
+  tags: { type: [String], default: [] },
+  color: { type: String, default: null },
+  campaignId: { type: mongoose.Schema.Types.ObjectId, required: true, index: true },
+  calendarId: { type: mongoose.Schema.Types.ObjectId, required: true },
+  createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+});
+
+// istanbul ignore next
+if (typeof (eventSchema as { index?: unknown }).index === 'function') {
+  eventSchema.index({ campaignId: 1, startOrdinal: 1 });
+  eventSchema.index({ isPublic: 1 });
+  eventSchema.index({ isEpic: 1 });
+  eventSchema.index({ 'links.id': 1 });
+  eventSchema.index({ tags: 1 });
+  eventSchema.index({ sessionId: 1 });
+  eventSchema.index({ title: 'text', content: 'text' });
+}
+
+eventSchema.pre('save', function () {
+  if (this.isModified('tags')) this.tags = normalizeTags(this.tags as string[]);
+  this.updatedAt = new Date();
+});
+
+export const Event = mongoose.models.Event || mongoose.model('Event', eventSchema);
+```
+
+- [ ] **Step 3: Typecheck + commit**
+
+Run: `npm run typecheck`
+```bash
+git add app/server/db/models/Calendar.ts app/server/db/models/Event.ts
+git commit -m "feat(calendar): Calendar and Event mongoose models"
+```
+
+## Task 8: Calendar server functions (with edit re-validation transaction)
+
+**Files:**
+- Create: `app/server/functions/calendars.ts`
+- Test: `tests/server/functions/calendars.test.ts`
+
+- [ ] **Step 1: Write the failing test** (mirror the `lore.test.ts` mock harness exactly)
+
+```typescript
+// tests/server/functions/calendars.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tanstack/react-start', () => ({
+  createServerFn: () => ({ inputValidator: () => ({ handler: (fn: unknown) => fn }), handler: (fn: unknown) => fn }),
+}));
+vi.mock('~/server/session', () => ({ getSession: vi.fn() }));
+vi.mock('~/server/db/connection', () => ({ connectDB: vi.fn(), isDBConnected: vi.fn(() => true) }));
+vi.mock('~/server/db/models/User', () => ({ User: { findOne: vi.fn() } }));
+vi.mock('~/server/db/models/Campaign', () => ({ Campaign: { findById: vi.fn() } }));
+vi.mock('~/server/db/models/Calendar', () => ({
+  Calendar: { findOne: vi.fn(), findOneAndUpdate: vi.fn(), deleteOne: vi.fn() },
+}));
+vi.mock('~/server/db/models/Event', () => ({ Event: { find: vi.fn(), bulkWrite: vi.fn() } }));
+vi.mock('~/server/utils/posthog', () => ({ serverCaptureException: vi.fn(), serverCaptureEvent: vi.fn() }));
+
+import { getSession } from '~/server/session';
+import { User } from '~/server/db/models/User';
+import { Campaign } from '~/server/db/models/Campaign';
+import { Calendar } from '~/server/db/models/Calendar';
+import { upsertCalendar, getCalendar } from '~/server/functions/calendars';
+
+const session = { id: 'sess-1' } as never;
+const gmCampaign = { _id: 'camp-1', gameMasterId: 'user-1', members: [{ userId: 'user-1', role: 'gm' }] };
+const playerCampaign = { _id: 'camp-1', gameMasterId: 'gm-x', members: [{ userId: 'user-1', role: 'player' }] };
+
+const _upsert = upsertCalendar as unknown as (a: { data: Record<string, unknown> }) => Promise<unknown>;
+const _get = getCalendar as unknown as (a: { data: Record<string, unknown> }) => Promise<unknown>;
+
+const baseInput = {
+  campaignId: 'camp-1',
+  name: 'Harptos',
+  description: '',
+  months: [{ name: 'A', days: 30 }],
+  weekdays: ['d1'],
+  weekdayMode: 'continuous',
+  epoch: { year: 1, weekdayIndex: 0 },
+  yearSuffix: 'DR',
+  namedYears: [],
+  leapDays: [],
+  moons: [],
+  seasons: [],
+  holidays: [],
+  currentDate: { year: 1, monthIndex: 0, day: 1 },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getSession).mockResolvedValue(session);
+  vi.mocked(User.findOne).mockResolvedValue({ _id: 'user-1' } as never);
+  vi.mocked(Campaign.findById).mockResolvedValue(gmCampaign as never);
+});
+
+describe('upsertCalendar', () => {
+  it('forbids a non-GM from saving', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    await expect(_upsert({ data: baseInput })).rejects.toThrow('Forbidden');
+  });
+  it('upserts for a GM', async () => {
+    vi.mocked(Calendar.findOneAndUpdate).mockResolvedValue({ _id: 'cal-1', ...baseInput } as never);
+    vi.mocked((await import('~/server/db/models/Event')).Event.find).mockReturnValue({ lean: vi.fn().mockResolvedValue([]) } as never);
+    const res = (await _upsert({ data: baseInput })) as Record<string, unknown>;
+    expect(res.success).toBe(true);
+  });
+});
+
+describe('getCalendar', () => {
+  it('returns null when none exists', async () => {
+    vi.mocked(Calendar.findOne).mockReturnValue({ lean: vi.fn().mockResolvedValue(null) } as never);
+    expect(await _get({ data: { campaignId: 'camp-1' } })).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm fail**
+
+Run: `npm test -- tests/server/functions/calendars.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `calendars.ts`**
+
+```typescript
+// app/server/functions/calendars.ts
+import { createServerFn } from '@tanstack/react-start';
+import { requireCampaignMember } from '../utils/requireCampaignMember';
+import { serverCaptureException } from '../utils/posthog';
+import { Calendar } from '../db/models/Calendar';
+import { Event } from '../db/models/Event';
+import {
+  getCalendarSchema, upsertCalendarSchema, setCurrentDateSchema, deleteCalendarSchema,
+} from '~/types/schemas/calendars';
+import type { CalendarData } from '~/types/calendar';
+import { toOrdinal, validateDate, type CalendarConfig, type CalDate } from '~/utils/calendarEngine';
+
+type AnyDoc = Record<string, unknown> & { _id: unknown };
+
+function toConfig(doc: Record<string, unknown>): CalendarConfig {
+  return {
+    months: doc.months as CalendarConfig['months'],
+    weekdays: doc.weekdays as string[],
+    weekdayMode: doc.weekdayMode as CalendarConfig['weekdayMode'],
+    epoch: doc.epoch as CalendarConfig['epoch'],
+    yearSuffix: doc.yearSuffix as string,
+    leapDays: doc.leapDays as CalendarConfig['leapDays'],
+    moons: doc.moons as CalendarConfig['moons'],
+    seasons: doc.seasons as CalendarConfig['seasons'],
+    holidays: doc.holidays as CalendarConfig['holidays'],
+  };
+}
+
+function serialize(doc: AnyDoc, canEdit: boolean): CalendarData {
+  return {
+    id: String(doc._id),
+    campaignId: String(doc.campaignId),
+    createdBy: String(doc.createdBy),
+    name: (doc.name as string) ?? '',
+    description: (doc.description as string) ?? '',
+    months: (doc.months as CalendarData['months']) ?? [],
+    weekdays: (doc.weekdays as string[]) ?? [],
+    weekdayMode: (doc.weekdayMode as CalendarData['weekdayMode']) ?? 'continuous',
+    epoch: (doc.epoch as CalendarData['epoch']) ?? { year: 1, weekdayIndex: 0 },
+    yearSuffix: (doc.yearSuffix as string) ?? '',
+    namedYears: (doc.namedYears as CalendarData['namedYears']) ?? [],
+    leapDays: (doc.leapDays as CalendarData['leapDays']) ?? [],
+    moons: (doc.moons as CalendarData['moons']) ?? [],
+    seasons: (doc.seasons as CalendarData['seasons']) ?? [],
+    holidays: (doc.holidays as CalendarData['holidays']) ?? [],
+    currentDate: (doc.currentDate as CalDate) ?? { year: 1, monthIndex: 0, day: 1 },
+    createdAt: (doc.createdAt as Date)?.toISOString?.() ?? '',
+    updatedAt: (doc.updatedAt as Date)?.toISOString?.() ?? '',
+    canEdit,
+  };
+}
+
+export const getCalendar = createServerFn({ method: 'GET' })
+  .inputValidator(getCalendarSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      const doc = (await Calendar.findOne({ campaignId: data.campaignId }).lean()) as AnyDoc | null;
+      if (!doc) return null;
+      return serialize(doc, member.isGM);
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'getCalendar', campaignId: data.campaignId });
+      throw e;
+    }
+  });
+
+export const upsertCalendar = createServerFn({ method: 'POST' })
+  .inputValidator(upsertCalendarSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      if (!member.isGM) throw new Error('Forbidden');
+
+      const cfg = toConfig(data);
+      const doc = (await Calendar.findOneAndUpdate(
+        { campaignId: data.campaignId },
+        {
+          $set: {
+            name: data.name, description: data.description, months: data.months,
+            weekdays: data.weekdays, weekdayMode: data.weekdayMode, epoch: data.epoch,
+            yearSuffix: data.yearSuffix, namedYears: data.namedYears, leapDays: data.leapDays,
+            moons: data.moons, seasons: data.seasons, holidays: data.holidays,
+            currentDate: data.currentDate, updatedAt: new Date(),
+          },
+          $setOnInsert: { campaignId: data.campaignId, createdBy: member.userId, createdAt: new Date() },
+        },
+        { new: true, upsert: true, lean: true }
+      )) as AnyDoc;
+
+      // Re-validate every event against the new config and recompute ordinals.
+      const events = (await Event.find({ campaignId: data.campaignId }).lean()) as AnyDoc[];
+      const invalidEventIds: string[] = [];
+      const ops: Record<string, unknown>[] = [];
+      for (const ev of events) {
+        const start = ev.start as CalDate;
+        const end = (ev.end as CalDate | null) ?? null;
+        const startOk = validateDate(cfg, start).ok;
+        const endOk = end ? validateDate(cfg, end).ok : true;
+        if (!startOk || !endOk) {
+          invalidEventIds.push(String(ev._id));
+          continue;
+        }
+        ops.push({
+          updateOne: {
+            filter: { _id: ev._id },
+            update: {
+              $set: { startOrdinal: toOrdinal(cfg, start), endOrdinal: toOrdinal(cfg, end ?? start) },
+            },
+          },
+        });
+      }
+      if (ops.length) await Event.bulkWrite(ops);
+
+      return { success: true, calendar: serialize(doc, true), invalidEventIds };
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'upsertCalendar', campaignId: data.campaignId });
+      throw e;
+    }
+  });
+
+export const setCurrentDate = createServerFn({ method: 'POST' })
+  .inputValidator(setCurrentDateSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      if (!member.isGM) throw new Error('Forbidden');
+      const doc = (await Calendar.findOneAndUpdate(
+        { campaignId: data.campaignId },
+        { $set: { currentDate: data.currentDate, updatedAt: new Date() } },
+        { new: true, lean: true }
+      )) as AnyDoc | null;
+      if (!doc) throw new Error('Not found');
+      return { success: true, calendar: serialize(doc, true) };
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'setCurrentDate', campaignId: data.campaignId });
+      throw e;
+    }
+  });
+
+export const deleteCalendar = createServerFn({ method: 'POST' })
+  .inputValidator(deleteCalendarSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      if (!member.isGM) throw new Error('Forbidden');
+      await Calendar.deleteOne({ campaignId: data.campaignId });
+      return { success: true };
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'deleteCalendar', campaignId: data.campaignId });
+      throw e;
+    }
+  });
+```
+
+- [ ] **Step 4: Run and confirm pass + typecheck**
+
+Run: `npm test -- tests/server/functions/calendars.test.ts && npm run typecheck`
+Expected: PASS, no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/server/functions/calendars.ts tests/server/functions/calendars.test.ts
+git commit -m "feat(calendar): calendar server fns + edit re-validation transaction"
+```
+
+## Task 9: Event server functions (ordinal recompute + visibility + gmContent gating)
+
+**Files:**
+- Create: `app/server/functions/events.ts`
+- Test: `tests/server/functions/events.test.ts`
+
+- [ ] **Step 1: Write failing tests** (mirror `lore.test.ts`; add ordinal + GM-only assertions)
+
+```typescript
+// tests/server/functions/events.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tanstack/react-start', () => ({
+  createServerFn: () => ({ inputValidator: () => ({ handler: (fn: unknown) => fn }), handler: (fn: unknown) => fn }),
+}));
+vi.mock('~/server/session', () => ({ getSession: vi.fn() }));
+vi.mock('~/server/db/connection', () => ({ connectDB: vi.fn(), isDBConnected: vi.fn(() => true) }));
+vi.mock('~/server/db/models/User', () => ({ User: { findOne: vi.fn() } }));
+vi.mock('~/server/db/models/Campaign', () => ({ Campaign: { findById: vi.fn() } }));
+vi.mock('~/server/db/models/Calendar', () => ({ Calendar: { findOne: vi.fn() } }));
+vi.mock('~/server/db/models/Event', () => ({
+  Event: { find: vi.fn(), findById: vi.fn(), create: vi.fn(), findOneAndUpdate: vi.fn(), deleteOne: vi.fn() },
+}));
+vi.mock('~/server/functions/gmscreens-helpers', () => ({ removeDocumentRefsFromScreens: vi.fn() }));
+vi.mock('~/server/utils/posthog', () => ({ serverCaptureException: vi.fn(), serverCaptureEvent: vi.fn() }));
+vi.mock('~/server/db/models/Character', () => ({ Character: { findById: vi.fn() } }));
+vi.mock('~/server/db/models/Player', () => ({ Player: { findById: vi.fn() } }));
+vi.mock('~/server/db/models/Location', () => ({ Location: { findById: vi.fn() } }));
+vi.mock('~/server/db/models/Race', () => ({ Race: { findById: vi.fn() } }));
+vi.mock('~/server/db/models/Lore', () => ({ Lore: { findById: vi.fn() } }));
+
+import { getSession } from '~/server/session';
+import { User } from '~/server/db/models/User';
+import { Campaign } from '~/server/db/models/Campaign';
+import { Calendar } from '~/server/db/models/Calendar';
+import { Event } from '~/server/db/models/Event';
+import { listEvents, createEvent } from '~/server/functions/events';
+
+const gmCampaign = { _id: 'camp-1', gameMasterId: 'user-1', members: [{ userId: 'user-1', role: 'gm' }] };
+const playerCampaign = { _id: 'camp-1', gameMasterId: 'gm-x', members: [{ userId: 'user-1', role: 'player' }] };
+const calDoc = {
+  months: [{ name: 'A', days: 30 }], weekdays: ['d1'], weekdayMode: 'continuous',
+  epoch: { year: 1, weekdayIndex: 0 }, yearSuffix: 'DR', leapDays: [], moons: [], seasons: [], holidays: [],
+  _id: 'cal-1',
+};
+
+const _list = listEvents as unknown as (a: { data: Record<string, unknown> }) => Promise<unknown[]>;
+const _create = createEvent as unknown as (a: { data: Record<string, unknown> }) => Promise<Record<string, unknown>>;
+
+function mockEventFind(docs: unknown[]) {
+  vi.mocked(Event.find).mockReturnValue({ sort: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue(docs) }) } as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getSession).mockResolvedValue({ id: 'sess-1' } as never);
+  vi.mocked(User.findOne).mockResolvedValue({ _id: 'user-1' } as never);
+  vi.mocked(Campaign.findById).mockResolvedValue(gmCampaign as never);
+  vi.mocked(Calendar.findOne).mockReturnValue({ lean: vi.fn().mockResolvedValue(calDoc) } as never);
+});
+
+describe('listEvents', () => {
+  it('restricts non-GM to public events', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    mockEventFind([]);
+    await _list({ data: { campaignId: 'camp-1' } });
+    const filter = vi.mocked(Event.find).mock.calls[0][0] as Record<string, unknown>;
+    expect(filter.isPublic).toBe(true);
+  });
+  it('adds epicOnly filter', async () => {
+    mockEventFind([]);
+    await _list({ data: { campaignId: 'camp-1', epicOnly: true } });
+    const filter = vi.mocked(Event.find).mock.calls[0][0] as Record<string, unknown>;
+    expect(filter.isEpic).toBe(true);
+  });
+  it('never returns gmContent', async () => {
+    mockEventFind([{ _id: 'e1', title: 'T', content: 'c', gmContent: 'secret', isPublic: true, isEpic: false, start: { year: 1, monthIndex: 0, day: 1 }, end: null, startOrdinal: 0, endOrdinal: 0, links: [], images: [], tags: [], campaignId: 'camp-1', calendarId: 'cal-1', createdBy: 'user-1', createdAt: new Date(), updatedAt: new Date() }]);
+    const res = (await _list({ data: { campaignId: 'camp-1' } })) as Record<string, unknown>[];
+    expect(res[0]).not.toHaveProperty('gmContent');
+  });
+});
+
+describe('createEvent', () => {
+  it('forbids a non-GM', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    await expect(_create({ data: { campaignId: 'camp-1', title: 'T', start: { year: 1, monthIndex: 0, day: 1 } } })).rejects.toThrow('Forbidden');
+  });
+  it('computes startOrdinal/endOrdinal from the calendar', async () => {
+    vi.mocked(Event.create).mockImplementation(async (doc: Record<string, unknown>) => ({ _id: 'e1', ...doc }) as never);
+    await _create({ data: { campaignId: 'camp-1', title: 'T', start: { year: 1, monthIndex: 0, day: 2 }, end: null } });
+    const arg = vi.mocked(Event.create).mock.calls[0][0] as Record<string, unknown>;
+    expect(arg.startOrdinal).toBe(1);
+    expect(arg.endOrdinal).toBe(1);
+  });
+  it('rejects an out-of-range date', async () => {
+    await expect(_create({ data: { campaignId: 'camp-1', title: 'T', start: { year: 1, monthIndex: 0, day: 99 } } })).rejects.toThrow(/Day/);
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm fail**
+
+Run: `npm test -- tests/server/functions/events.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `events.ts`**
+
+```typescript
+// app/server/functions/events.ts
+import { createServerFn } from '@tanstack/react-start';
+import { requireCampaignMember } from '../utils/requireCampaignMember';
+import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
+import { serverCaptureException } from '../utils/posthog';
+import { Event } from '../db/models/Event';
+import { Calendar } from '../db/models/Calendar';
+import { Character } from '../db/models/Character';
+import { Player } from '../db/models/Player';
+import { Location } from '../db/models/Location';
+import { Race } from '../db/models/Race';
+import { Lore } from '../db/models/Lore';
+import {
+  listEventsSchema, getEventSchema, createEventSchema, updateEventSchema, deleteEventSchema,
+} from '~/types/schemas/events';
+import type { EventData, EventLink, EventListItem } from '~/types/event';
+import { toOrdinal, validateDate, type CalendarConfig, type CalDate } from '~/utils/calendarEngine';
+
+type AnyDoc = Record<string, unknown> & { _id: unknown };
+
+async function loadConfig(campaignId: string): Promise<CalendarConfig> {
+  const cal = (await Calendar.findOne({ campaignId }).lean()) as AnyDoc | null;
+  if (!cal) throw new Error('No calendar exists for this campaign. Create one first.');
+  return {
+    months: cal.months as CalendarConfig['months'],
+    weekdays: cal.weekdays as string[],
+    weekdayMode: cal.weekdayMode as CalendarConfig['weekdayMode'],
+    epoch: cal.epoch as CalendarConfig['epoch'],
+    yearSuffix: cal.yearSuffix as string,
+    leapDays: cal.leapDays as CalendarConfig['leapDays'],
+    moons: cal.moons as CalendarConfig['moons'],
+    seasons: cal.seasons as CalendarConfig['seasons'],
+    holidays: cal.holidays as CalendarConfig['holidays'],
+  };
+}
+
+function baseSerialize(doc: AnyDoc) {
+  return {
+    id: String(doc._id),
+    campaignId: String(doc.campaignId),
+    calendarId: String(doc.calendarId),
+    createdBy: String(doc.createdBy),
+    title: (doc.title as string) ?? '',
+    content: (doc.content as string) ?? '',
+    isPublic: Boolean(doc.isPublic),
+    isEpic: Boolean(doc.isEpic),
+    start: doc.start as CalDate,
+    end: (doc.end as CalDate | null) ?? null,
+    startOrdinal: Number(doc.startOrdinal ?? 0),
+    endOrdinal: Number(doc.endOrdinal ?? 0),
+    links: ((doc.links as unknown[]) ?? []).map((l) => {
+      const lk = l as Record<string, unknown>;
+      return { kind: lk.kind as EventLink['kind'], id: String(lk.id) };
+    }) as EventLink[],
+    sessionId: doc.sessionId ? String(doc.sessionId) : null,
+    images: ((doc.images as unknown[]) ?? []).map((i) => {
+      const img = i as Record<string, unknown>;
+      return { url: String(img.url), caption: (img.caption as string) ?? '', crop: (img.crop as EventData['images'][number]['crop']) ?? null };
+    }),
+    tags: (doc.tags as string[]) ?? [],
+    color: (doc.color as string | null) ?? null,
+    createdAt: (doc.createdAt as Date)?.toISOString?.() ?? '',
+    updatedAt: (doc.updatedAt as Date)?.toISOString?.() ?? '',
+  };
+}
+
+async function resolveLinkLabels(links: EventLink[]): Promise<EventLink[]> {
+  return Promise.all(
+    links.map(async (link) => {
+      let label = '';
+      try {
+        if (link.kind === 'character') {
+          const c = (await Character.findById(link.id, 'firstName lastName').lean()) as AnyDoc | null;
+          if (c) label = `${c.firstName ?? ''} ${c.lastName ?? ''}`.trim();
+        } else if (link.kind === 'player') {
+          const p = (await Player.findById(link.id, 'firstName lastName').lean()) as AnyDoc | null;
+          if (p) label = `${p.firstName ?? ''} ${p.lastName ?? ''}`.trim();
+        } else if (link.kind === 'location') {
+          const loc = (await Location.findById(link.id, 'name').lean()) as AnyDoc | null;
+          if (loc) label = String(loc.name ?? '');
+        } else if (link.kind === 'race') {
+          const r = (await Race.findById(link.id, 'title').lean()) as AnyDoc | null;
+          if (r) label = String(r.title ?? '');
+        } else if (link.kind === 'lore') {
+          const l = (await Lore.findById(link.id, 'title').lean()) as AnyDoc | null;
+          if (l) label = String(l.title ?? '');
+        }
+      } catch {
+        label = '';
+      }
+      return { ...link, label };
+    })
+  );
+}
+
+export const listEvents = createServerFn({ method: 'GET' })
+  .inputValidator(listEventsSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      const filter: Record<string, unknown> = { campaignId: data.campaignId };
+      if (!member.isGM) filter.isPublic = true;
+      else if (data.visibility === 'public') filter.isPublic = true;
+      else if (data.visibility === 'private') filter.isPublic = false;
+      if (data.epicOnly) filter.isEpic = true;
+      if (data.tags?.length) filter.tags = { $all: data.tags };
+      if (data.search) filter.$text = { $search: data.search };
+      if (data.linkedKind && data.linkedId) filter.links = { $elemMatch: { kind: data.linkedKind, id: data.linkedId } };
+
+      const docs = (await Event.find(filter).sort({ startOrdinal: 1 }).lean()) as AnyDoc[];
+      const items: EventListItem[] = docs.map((doc) => ({
+        ...baseSerialize(doc),
+        canEdit: member.isGM,
+      }));
+      return items;
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'listEvents', campaignId: data.campaignId });
+      throw e;
+    }
+  });
+
+export const getEvent = createServerFn({ method: 'GET' })
+  .inputValidator(getEventSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      const doc = (await Event.findById(data.id).lean()) as AnyDoc | null;
+      if (!doc || String(doc.campaignId) !== data.campaignId) return null;
+      if (!member.isGM && !doc.isPublic) return null;
+      const links = await resolveLinkLabels(
+        ((doc.links as unknown[]) ?? []).map((l) => {
+          const lk = l as Record<string, unknown>;
+          return { kind: lk.kind as EventLink['kind'], id: String(lk.id) };
+        })
+      );
+      const result: EventData = {
+        ...baseSerialize(doc),
+        gmContent: member.isGM ? ((doc.gmContent as string) ?? '') : '',
+        links,
+        canEdit: member.isGM,
+      };
+      return result;
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'getEvent', eventId: data.id });
+      throw e;
+    }
+  });
+
+export const createEvent = createServerFn({ method: 'POST' })
+  .inputValidator(createEventSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      if (!member.isGM) throw new Error('Forbidden');
+      const cfg = await loadConfig(data.campaignId);
+      const cal = (await Calendar.findOne({ campaignId: data.campaignId }, '_id').lean()) as AnyDoc;
+      const sv = validateDate(cfg, data.start);
+      if (!sv.ok) throw new Error(sv.error);
+      if (data.end) {
+        const ev = validateDate(cfg, data.end);
+        if (!ev.ok) throw new Error(ev.error);
+      }
+      const doc = (await Event.create({
+        title: data.title, content: data.content, gmContent: data.gmContent,
+        isPublic: data.isPublic, isEpic: data.isEpic,
+        start: data.start, end: data.end,
+        startOrdinal: toOrdinal(cfg, data.start),
+        endOrdinal: toOrdinal(cfg, data.end ?? data.start),
+        links: data.links, sessionId: data.sessionId, images: data.images, tags: data.tags, color: data.color,
+        campaignId: data.campaignId, calendarId: cal._id, createdBy: member.userId,
+      })) as AnyDoc;
+      return { success: true, event: { ...baseSerialize(doc), gmContent: data.gmContent, canEdit: true } };
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'createEvent', campaignId: data.campaignId });
+      throw e;
+    }
+  });
+
+export const updateEvent = createServerFn({ method: 'POST' })
+  .inputValidator(updateEventSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      if (!member.isGM) throw new Error('Forbidden');
+      const existing = (await Event.findById(data.id).lean()) as AnyDoc | null;
+      if (!existing || String(existing.campaignId) !== data.campaignId) throw new Error('Not found');
+      const cfg = await loadConfig(data.campaignId);
+      const sv = validateDate(cfg, data.start);
+      if (!sv.ok) throw new Error(sv.error);
+      if (data.end) {
+        const ev = validateDate(cfg, data.end);
+        if (!ev.ok) throw new Error(ev.error);
+      }
+      const updated = (await Event.findOneAndUpdate(
+        { _id: data.id, campaignId: data.campaignId },
+        {
+          $set: {
+            title: data.title, content: data.content, gmContent: data.gmContent,
+            isPublic: data.isPublic, isEpic: data.isEpic, start: data.start, end: data.end,
+            startOrdinal: toOrdinal(cfg, data.start), endOrdinal: toOrdinal(cfg, data.end ?? data.start),
+            links: data.links, sessionId: data.sessionId, images: data.images, tags: data.tags, color: data.color,
+            updatedAt: new Date(),
+          },
+        },
+        { new: true, lean: true }
+      )) as AnyDoc;
+      return { success: true, event: { ...baseSerialize(updated), gmContent: data.gmContent, canEdit: true } };
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'updateEvent', eventId: data.id });
+      throw e;
+    }
+  });
+
+export const deleteEvent = createServerFn({ method: 'POST' })
+  .inputValidator(deleteEventSchema)
+  .handler(async ({ data }) => {
+    try {
+      const member = await requireCampaignMember(data.campaignId);
+      if (!member.isGM) throw new Error('Forbidden');
+      const existing = (await Event.findById(data.id).lean()) as AnyDoc | null;
+      if (!existing || String(existing.campaignId) !== data.campaignId) throw new Error('Not found');
+      await Event.deleteOne({ _id: data.id, campaignId: data.campaignId });
+      await removeDocumentRefsFromScreens(data.campaignId, 'events', data.id);
+      return { success: true };
+    } catch (e) {
+      serverCaptureException(e, undefined, { action: 'deleteEvent', eventId: data.id });
+      throw e;
+    }
+  });
+```
+
+- [ ] **Step 4: Run and confirm pass + typecheck**
+
+Run: `npm test -- tests/server/functions/events.test.ts && npm run typecheck`
+Expected: PASS, no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/server/functions/events.ts tests/server/functions/events.test.ts
+git commit -m "feat(calendar): event server fns with ordinal recompute + visibility gating"
+```
+
+## Task 10: Link pruning + gmscreens registration + query keys
+
+**Files:**
+- Create: `app/server/utils/pruneEventLinks.ts`
+- Modify: `app/server/functions/{characters,players,locations,races,lore}.ts`, `app/server/functions/gmscreens.ts`, `app/utils/queryKeys.ts`
+
+- [ ] **Step 1: Create `pruneEventLinks.ts`**
+
+```typescript
+// app/server/utils/pruneEventLinks.ts
+import { Event } from '../db/models/Event';
+import type { EventLinkKind } from '~/types/event';
+
+/** Remove any event links pointing at a deleted entity so chips don't dangle. */
+export async function pruneEventLinks(kind: EventLinkKind, id: string, campaignId: string) {
+  await Event.updateMany({ campaignId, 'links.id': id }, { $pull: { links: { kind, id } } });
+}
+```
+
+- [ ] **Step 2: Add a `pruneEventLinks` call beside each existing `pruneLoreLinks` call**
+
+In `app/server/functions/locations.ts`, immediately after `await pruneLoreLinks('location', data.id, data.campaignId);` add:
+```typescript
+      await pruneEventLinks('location', data.id, data.campaignId);
+```
+And add the import at the top: `import { pruneEventLinks } from '../utils/pruneEventLinks';`
+
+Repeat the same pattern (matching `kind`) in:
+- `app/server/functions/characters.ts` → `await pruneEventLinks('character', data.id, data.campaignId);`
+- `app/server/functions/players.ts` → `await pruneEventLinks('player', data.id, data.campaignId);`
+- `app/server/functions/races.ts` → `await pruneEventLinks('race', data.id, data.campaignId);`
+- `app/server/functions/lore.ts` (in `deleteLore`, after the screen-ref cleanup) → add `import { pruneEventLinks } from '../utils/pruneEventLinks';` and `await pruneEventLinks('lore', data.id, data.campaignId);`
+
+- [ ] **Step 3: Register the `events` collection in `gmscreens.ts`**
+
+In `app/server/functions/gmscreens.ts`, add to `COLLECTION_REGISTRY` (next to the `lore` entry):
+```typescript
+  events: {
+    async fetch(ids: string[], campaignId: string) {
+      const { Event } = await import('../db/models/Event');
+      return Event.find({ _id: { $in: ids }, campaignId }, '_id title content isPublic')
+        .lean()
+        .then((docs) =>
+          docs.map((d) => ({
+            _id: d._id,
+            title: (d as { title?: string }).title,
+            content: (d as { content?: string }).content,
+            isPublic: (d as { isPublic?: boolean }).isPublic,
+          }))
+        ) as Promise<Array<{ _id: unknown; title?: string; content?: string; isPublic?: boolean }>>;
+    },
+  },
+```
+
+- [ ] **Step 4: Add query keys**
+
+In `app/utils/queryKeys.ts`, add inside the `queryKeys` object (after `lore`):
+```typescript
+  calendar: {
+    all: ['calendar'] as const,
+    detail: (campaignId: string) => ['calendar', 'detail', campaignId] as const,
+  },
+  events: {
+    all: ['events'] as const,
+    list: (campaignId: string, filters?: string) => ['events', 'list', campaignId, filters ?? ''] as const,
+    detail: (id: string, campaignId: string) => ['events', 'detail', id, campaignId] as const,
+    linked: (campaignId: string, kind: string, id: string) => ['events', 'linked', campaignId, kind, id] as const,
+    epic: (campaignId: string) => ['events', 'epic', campaignId] as const,
+  },
+```
+
+- [ ] **Step 5: Typecheck, run affected suites, commit**
+
+Run: `npm run typecheck && npm test`
+Expected: PASS.
+```bash
+git add app/server/utils/pruneEventLinks.ts app/server/functions/ app/utils/queryKeys.ts
+git commit -m "feat(calendar): prune event links on entity delete, gmscreen fetch, query keys"
+```
+
+## Task 11: Hooks
+
+**Files:**
+- Create: `app/hooks/useCalendar.ts`, `app/hooks/useEvents.ts`
+
+- [ ] **Step 1: Implement `useCalendar.ts`** (mirror `useLore.ts` server-fn wrapper + `createMutationHook` pattern)
+
+```typescript
+// app/hooks/useCalendar.ts
+import { createServerFn } from '@tanstack/react-start';
+import { useQuery } from '@tanstack/react-query';
+import type { CalendarData, CalDate } from '~/types/calendar';
+import { queryKeys } from '~/utils/queryKeys';
+import { extractErrorMessage } from '~/utils/errors';
+import { createMutationHook } from '~/hooks/createMutationHook';
+import {
+  getCalendarSchema, upsertCalendarSchema, setCurrentDateSchema, deleteCalendarSchema,
+} from '~/types/schemas/calendars';
+
+const getCalendarFn = createServerFn({ method: 'GET' })
+  .inputValidator(getCalendarSchema)
+  .handler(async ({ data }) => {
+    const { getCalendar } = await import('~/server/functions/calendars');
+    return getCalendar({ data });
+  });
+const upsertCalendarFn = createServerFn({ method: 'POST' })
+  .inputValidator(upsertCalendarSchema)
+  .handler(async ({ data }) => {
+    const { upsertCalendar } = await import('~/server/functions/calendars');
+    return upsertCalendar({ data });
+  });
+const setCurrentDateFn = createServerFn({ method: 'POST' })
+  .inputValidator(setCurrentDateSchema)
+  .handler(async ({ data }) => {
+    const { setCurrentDate } = await import('~/server/functions/calendars');
+    return setCurrentDate({ data });
+  });
+const deleteCalendarFn = createServerFn({ method: 'POST' })
+  .inputValidator(deleteCalendarSchema)
+  .handler(async ({ data }) => {
+    const { deleteCalendar } = await import('~/server/functions/calendars');
+    return deleteCalendar({ data });
+  });
+
+export function useCalendar(campaignId: string) {
+  const { data: calendar = null, isLoading, error } = useQuery({
+    queryKey: queryKeys.calendar.detail(campaignId),
+    queryFn: () => getCalendarFn({ data: { campaignId } }),
+    enabled: !!campaignId,
+  });
+  return { calendar: calendar as CalendarData | null, isLoading, error: extractErrorMessage(error) };
+}
+
+export type UpsertCalendarInput = { campaignId: string } & Omit<
+  CalendarData,
+  'id' | 'createdBy' | 'createdAt' | 'updatedAt' | 'canEdit'
+>;
+
+export const useUpsertCalendar = createMutationHook({
+  actionName: 'save',
+  mutationFn: async (input: UpsertCalendarInput) => upsertCalendarFn({ data: input }),
+  onSuccess: (qc, _d, { campaignId }) => {
+    qc.invalidateQueries({ queryKey: queryKeys.calendar.detail(campaignId) });
+    qc.invalidateQueries({ queryKey: ['events', 'list', campaignId], exact: false });
+    qc.invalidateQueries({ queryKey: queryKeys.events.epic(campaignId) });
+  },
+  errorContext: () => ({ action: 'upsertCalendar' }),
+});
+
+export const useSetCurrentDate = createMutationHook({
+  actionName: 'setCurrentDate',
+  mutationFn: async (input: { campaignId: string; currentDate: CalDate }) => setCurrentDateFn({ data: input }),
+  onSuccess: (qc, _d, { campaignId }) => {
+    qc.invalidateQueries({ queryKey: queryKeys.calendar.detail(campaignId) });
+    qc.invalidateQueries({ queryKey: queryKeys.events.epic(campaignId) });
+  },
+  errorContext: () => ({ action: 'setCurrentDate' }),
+});
+
+export const useDeleteCalendar = createMutationHook({
+  actionName: 'remove',
+  mutationFn: async (input: { campaignId: string }) => deleteCalendarFn({ data: input }),
+  onSuccess: (qc, _d, { campaignId }) => qc.invalidateQueries({ queryKey: queryKeys.calendar.detail(campaignId) }),
+  errorContext: () => ({ action: 'deleteCalendar' }),
+});
+```
+
+- [ ] **Step 2: Implement `useEvents.ts`** (mirror `useLore.ts` exactly, swapping types/keys; add `useEpicEvents`)
+
+```typescript
+// app/hooks/useEvents.ts
+import { createServerFn } from '@tanstack/react-start';
+import { useQuery } from '@tanstack/react-query';
+import type { EventData, EventListItem, EventLinkKind } from '~/types/event';
+import type { CalDate } from '~/types/calendar';
+import { queryKeys } from '~/utils/queryKeys';
+import { extractErrorMessage } from '~/utils/errors';
+import { createMutationHook } from '~/hooks/createMutationHook';
+import {
+  listEventsSchema, getEventSchema, createEventSchema, updateEventSchema, deleteEventSchema,
+} from '~/types/schemas/events';
+
+const listEventsFn = createServerFn({ method: 'GET' })
+  .inputValidator(listEventsSchema)
+  .handler(async ({ data }) => {
+    const { listEvents } = await import('~/server/functions/events');
+    return listEvents({ data });
+  });
+const getEventFn = createServerFn({ method: 'GET' })
+  .inputValidator(getEventSchema)
+  .handler(async ({ data }) => {
+    const { getEvent } = await import('~/server/functions/events');
+    return getEvent({ data });
+  });
+const createEventFn = createServerFn({ method: 'POST' })
+  .inputValidator(createEventSchema)
+  .handler(async ({ data }) => {
+    const { createEvent } = await import('~/server/functions/events');
+    return createEvent({ data });
+  });
+const updateEventFn = createServerFn({ method: 'POST' })
+  .inputValidator(updateEventSchema)
+  .handler(async ({ data }) => {
+    const { updateEvent } = await import('~/server/functions/events');
+    return updateEvent({ data });
+  });
+const deleteEventFn = createServerFn({ method: 'POST' })
+  .inputValidator(deleteEventSchema)
+  .handler(async ({ data }) => {
+    const { deleteEvent } = await import('~/server/functions/events');
+    return deleteEvent({ data });
+  });
+
+export interface EventFilters {
+  search?: string;
+  tags?: string[];
+  visibility?: 'all' | 'public' | 'private';
+  epicOnly?: boolean;
+  linkedKind?: EventLinkKind;
+  linkedId?: string;
+}
+
+export function useEvents(campaignId: string, filters?: EventFilters) {
+  const { data: events = [], isLoading, error } = useQuery({
+    queryKey: queryKeys.events.list(campaignId, JSON.stringify(filters ?? {})),
+    queryFn: () => listEventsFn({ data: { campaignId, ...filters } }),
+    enabled: !!campaignId,
+  });
+  return { events: events as EventListItem[], isLoading, error: extractErrorMessage(error) };
+}
+
+export function useEpicEvents(campaignId: string) {
+  const { data: events = [], isLoading, error } = useQuery({
+    queryKey: queryKeys.events.epic(campaignId),
+    queryFn: () => listEventsFn({ data: { campaignId, epicOnly: true } }),
+    enabled: !!campaignId,
+  });
+  return { events: events as EventListItem[], isLoading, error: extractErrorMessage(error) };
+}
+
+export function useEvent(id: string, campaignId: string) {
+  const { data: event = null, isLoading, error } = useQuery({
+    queryKey: queryKeys.events.detail(id, campaignId),
+    queryFn: () => getEventFn({ data: { id, campaignId } }),
+    enabled: !!id && !!campaignId,
+  });
+  return { event: event as EventData | null, isLoading, error: extractErrorMessage(error) };
+}
+
+export function useLinkedEvents(campaignId: string, kind: string, id: string) {
+  const { data: events = [], isLoading, error } = useQuery({
+    queryKey: queryKeys.events.linked(campaignId, kind, id),
+    queryFn: () => listEventsFn({ data: { campaignId, linkedKind: kind as EventLinkKind, linkedId: id } }),
+    enabled: !!campaignId && !!kind && !!id,
+  });
+  return { events: events as EventListItem[], isLoading, error: extractErrorMessage(error) };
+}
+
+export interface EventMutationInput {
+  id?: string;
+  campaignId: string;
+  title: string;
+  content?: string;
+  gmContent?: string;
+  isPublic?: boolean;
+  isEpic?: boolean;
+  start: CalDate;
+  end?: CalDate | null;
+  links?: { kind: EventLinkKind; id: string }[];
+  sessionId?: string | null;
+  images?: { url: string; caption: string; crop: { x: number; y: number; width: number; height: number } | null }[];
+  tags?: string[];
+  color?: string | null;
+}
+
+function invalidateEvents(qc: import('@tanstack/react-query').QueryClient, campaignId: string) {
+  qc.invalidateQueries({ queryKey: ['events', 'list', campaignId], exact: false });
+  qc.invalidateQueries({ queryKey: ['events', 'linked', campaignId], exact: false });
+  qc.invalidateQueries({ queryKey: queryKeys.events.epic(campaignId) });
+  qc.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+}
+
+export const useCreateEvent = createMutationHook({
+  actionName: 'create',
+  mutationFn: async (input: EventMutationInput) => createEventFn({ data: input }),
+  onSuccess: (qc, _d, { campaignId }) => invalidateEvents(qc, campaignId),
+  errorContext: () => ({ action: 'createEvent' }),
+});
+
+export const useUpdateEvent = createMutationHook({
+  actionName: 'update',
+  mutationFn: async (input: EventMutationInput & { id: string }) => updateEventFn({ data: input }),
+  onSuccess: (qc, _d, v) => {
+    invalidateEvents(qc, v.campaignId);
+    qc.invalidateQueries({ queryKey: queryKeys.events.detail(v.id, v.campaignId) });
+  },
+  errorContext: (v) => ({ action: 'updateEvent', eventId: v.id }),
+});
+
+export const useDeleteEvent = createMutationHook({
+  actionName: 'remove',
+  mutationFn: async (input: { id: string; campaignId: string }) => deleteEventFn({ data: input }),
+  onSuccess: (qc, _d, v) => {
+    invalidateEvents(qc, v.campaignId);
+    qc.removeQueries({ queryKey: queryKeys.events.detail(v.id, v.campaignId) });
+  },
+  errorContext: (v) => ({ action: 'deleteEvent', eventId: v.id }),
+});
+```
+
+- [ ] **Step 3: Typecheck + commit**
+
+Run: `npm run typecheck`
+```bash
+git add app/hooks/useCalendar.ts app/hooks/useEvents.ts
+git commit -m "feat(calendar): calendar + events query/mutation hooks"
+```
+
+---
+
+# PHASE 3 — Calendar viewing (read-only) + wiki category
+
+> UI tasks mirror the existing Lore components named in each step. Where a step says "mirror `<File>`", copy that file's structure, styling classes, and imports, then swap the data hook/types. Keep the listed `data-testid`s — the e2e specs depend on them.
+
+## Task 12: Add Calendar + Events wiki categories
+
+**Files:**
+- Modify: `app/components/wiki/WikiPanel.tsx`
+
+- [ ] **Step 1: Add icons + categories**
+
+Add `CalendarDays` and `CalendarClock` to the existing `lucide-react` import. Add to `WIKI_CATEGORIES` (after `lore`):
+```typescript
+  { id: 'calendar', label: 'Calendar', icon: CalendarDays },
+  { id: 'events', label: 'Events', icon: CalendarClock, gmOnly: true },
+```
+Extend the `WikiCategoryId` union type to include `'calendar' | 'events'`.
+
+- [ ] **Step 2: Add render branches** (next to the `lore` branch)
+
+```tsx
+) : selectedCategory === 'calendar' ? (
+  <CalendarPanel onBack={() => setSelectedCategory(null)} />
+) : selectedCategory === 'events' && isGM ? (
+  <EventsPanel onBack={() => setSelectedCategory(null)} />
+```
+Add imports: `import { CalendarPanel } from './calendar/CalendarPanel';` and `import { EventsPanel } from './calendar/EventsPanel';`
+
+- [ ] **Step 3: Update the WikiPanel category test**
+
+Find the existing `tests/.../WikiPanel*.test.tsx` that asserts the category list (the lore commit `8abc94e` updated it). Add `Calendar` to the all-members assertion and `Events` to the GM-only assertion. Run: `npm test -- tests/components` and fix the assertion. Commit after Task 14 (panels must exist to import). For now, create stub panels in Task 13 first so this compiles.
+
+## Task 13: `CalDatePicker` + `CalendarGridView` + `EventListView`
+
+**Files:**
+- Create: `app/components/wiki/calendar/CalDatePicker.tsx`, `CalendarGridView.tsx`, `EventListView.tsx`
+
+- [ ] **Step 1: `CalDatePicker.tsx`** — calendar-aware Year/Month/Day picker
+
+Props: `{ cfg: CalendarConfig; value: CalDate; onChange: (d: CalDate) => void; disabled?: boolean; idPrefix: string }`.
+Render: a number input for `year`; a `<select>` of `cfg.months` (label = name; option value = index); a `<select>` of days `1..daysInMonth(cfg, value.year, value.monthIndex)`. On year/month change, clamp `day` to the new `daysInMonth`. For an intercalary month with `daysInMonth === 0` (e.g. Shieldmeet in a non-leap year), disable the day select and show "no days this year" — the parent must surface that the date is invalid via `validateDate`. Add `data-testid={`${idPrefix}-year`}`, `-month`, `-day`.
+
+```tsx
+// key logic
+import { daysInMonth, type CalDate, type CalendarConfig } from '~/utils/calendarEngine';
+const maxDay = daysInMonth(cfg, value.year, value.monthIndex);
+// month options:
+{cfg.months.map((m, i) => (<option key={i} value={i}>{m.name}</option>))}
+// day options:
+{Array.from({ length: maxDay }, (_, i) => i + 1).map((d) => (<option key={d} value={d}>{d}</option>))}
+```
+
+- [ ] **Step 2: `CalendarGridView.tsx`** — month grid driven by the engine
+
+Props: `{ cfg: CalendarConfig; year: number; monthIndex: number; events: EventListItem[]; currentDate: CalDate; onPrev(): void; onNext(): void; onSelectDay(date: CalDate): void }`.
+Logic:
+- If `cfg.months[monthIndex].isIntercalary`, render a single festival banner card (the month name + any events on day 1) instead of a grid.
+- Else render `weekdays` header row, then `monthGrid(cfg, year, monthIndex)` rows of cells. For each non-null cell day:
+  - tint if `holidaysOn(cfg, year, monthIndex, day).length` (use holiday color),
+  - ring if `compareDates(cfg, {year,monthIndex,day}, currentDate) === 0`,
+  - render event chips for events whose `[startOrdinal,endOrdinal]` span contains `toOrdinal(cfg,{year,monthIndex,day})` (compute day ordinal once per cell). Multi-day events get a spanning style.
+- Show moon phase + season for the month via `moonPhase`/`seasonOf` in a small footer.
+- `data-testid="calendar-grid"`.
+
+- [ ] **Step 3: `EventListView.tsx`** — agenda grouped by year → month
+
+Props: `{ cfg: CalendarConfig; events: EventListItem[]; isGM: boolean; onSelect(e: EventListItem): void }`.
+Logic: events arrive already sorted by `startOrdinal` (server). Group by `start.year`, then `start.monthIndex`. Each row: `formatDate(cfg, e.start)` (+ "– " + day(s) when `end`), title, `EPIC` badge when `e.isEpic`, public/private indicator when `isGM`, linked-entity count. Empty state "No events". `data-testid="event-list"`, each row `data-testid="event-row"` + `data-event-id`.
+
+- [ ] **Step 4: Typecheck + commit**
+
+Run: `npm run typecheck`
+```bash
+git add app/components/wiki/calendar/CalDatePicker.tsx app/components/wiki/calendar/CalendarGridView.tsx app/components/wiki/calendar/EventListView.tsx
+git commit -m "feat(calendar): date picker, grid view, list view (engine-driven)"
+```
+
+## Task 14: `CalendarPanel` (list default, grid toggle) + `EventViewModal` + `EventWindow`
+
+**Files:**
+- Create: `app/components/wiki/calendar/CalendarPanel.tsx`, `EventViewModal.tsx`, `EventWindow.tsx`
+
+- [ ] **Step 1: `EventWindow.tsx`** — read-only content display (mirror `LoreWindow.tsx`)
+
+Renders title + epic/visibility badges, `formatDate(cfg, start)` (+ end), tags, images, public `content` via `ReactMarkdown` + `remarkGfm` with `MARKDOWN_PROSE_CLASSES`, a GM-only `gmContent` section (amber banner) when present, and linked-entity chips (reuse the kind→badge colors from `EventLinksEditor`). Needs the calendar via `useCalendar(campaignId)` to format the date. `data-testid="event-window"`.
+
+- [ ] **Step 2: `EventViewModal.tsx`** — wraps `EventWindow` in a modal (mirror `LoreViewModal.tsx`)
+
+Fetch via `useEvent(eventId, campaignId)`; loading/not-found states; "Edit" button only when `event.canEdit` (opens `EventModal` — created in Task 15).
+
+- [ ] **Step 3: `CalendarPanel.tsx`** (mirror `LorePanel.tsx`)
+
+```tsx
+// behavior
+const { campaign } = useCampaign(campaignId);
+const isGM = campaign?.isGM ?? false;
+const { calendar, isLoading } = useCalendar(campaignId);
+const { events } = useEvents(campaignId); // visibility-filtered server-side
+const [view, setView] = useState<'list' | 'grid'>('list');           // list default
+const [cursor, setCursor] = useState<{ year: number; monthIndex: number } | null>(null);
+const [viewEventId, setViewEventId] = useState<string | undefined>();
+```
+- Header `WikiCategoryHeader title="Calendar"` + a list/grid toggle (`data-testid="calendar-view-toggle"`).
+- When no calendar exists: empty state. For GM, a "Set up calendar" button + a "Use Calendar of Harptos" button that calls `useUpsertCalendar().save({ campaignId, ...HARPTOS_CONFIG defaults })` (see Task 16 editor for the full payload); for players, "The GM hasn't set up a calendar yet."
+- Build the engine `cfg` from `calendar` (it already matches `CalendarConfig` shape).
+- `view === 'list'` → `<EventListView cfg events isGM onSelect={(e) => setViewEventId(e.id)} />`; `view === 'grid'` → `<CalendarGridView ... />` with `cursor` defaulting to `calendar.currentDate`'s year/month and `onPrev/onNext` stepping month index (wrap to prev/next year at the ends).
+- GM-only "Configure calendar" button opens `CalendarEditorModal` (Task 16).
+- Render `EventViewModal` when `viewEventId` set.
+
+- [ ] **Step 4: Wire WikiPanel test + run**
+
+Complete Task 12 Step 3 now (panels exist). Run: `npm run typecheck && npm test -- tests/components`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/wiki/calendar/CalendarPanel.tsx app/components/wiki/calendar/EventViewModal.tsx app/components/wiki/calendar/EventWindow.tsx app/components/wiki/WikiPanel.tsx tests/
+git commit -m "feat(calendar): Calendar wiki panel (list/grid), event view modal + window"
+```
+
+---
+
+# PHASE 4 — Calendar editor + Events management (GM)
+
+## Task 15: `EventLinksEditor`, `EventCard`, `EventModal`, `EventsPanel`
+
+**Files:**
+- Create: `app/components/wiki/calendar/EventLinksEditor.tsx`, `EventCard.tsx`, `EventModal.tsx`, `EventsPanel.tsx`
+
+- [ ] **Step 1: `EventLinksEditor.tsx`** — copy `LoreLinksEditor.tsx` verbatim, then add the `lore` kind
+
+Add `useLore` to the entity hooks and a `lore` branch to `candidates` (`lore.map((l) => ({ id: l.id, label: l.title }))`), extend `KIND_LABELS`/`KIND_BADGE_COLORS` with `lore: 'Lore'`. Change the type to `EventLinkKind`. `data-testid="event-links-editor"`.
+
+- [ ] **Step 2: `EventCard.tsx`** — copy `LoreCard.tsx`, swap the drag payload + testids
+
+Drag payload: `{ collection: 'events', documentId: event.id, title: event.title }`. Root `data-testid="event-card"`, `data-event-id={event.id}`, title span `data-testid="event-card-title"`. Show epic badge + public/private icon + `formatDate` start.
+
+- [ ] **Step 3: `EventModal.tsx`** — copy `LoreModal.tsx` structure; swap fields
+
+Fields/state: `title, content, gmContent, isPublic, isEpic, start, end (nullable), links, sessionId, images, tags, color`. Use `CalDatePicker` (from Task 13) for `start` and an optional `end` (a "multi-day" checkbox toggles the end picker). Always show the GM Notes (`gmContent`) editor since only GMs reach this panel. Validation: title required; on submit, run `validateDate(cfg, start)` (and `end` if set) client-side and show the engine's error message inline before calling the mutation. testids: `event-title-input`, `event-create-button` (on the panel), `event-epic-toggle`. Save via `useCreateEvent`/`useUpdateEvent`; delete via `useDeleteEvent` with confirm.
+
+- [ ] **Step 4: `EventsPanel.tsx`** — copy `LorePanel.tsx`; GM-only management list
+
+Use `useEvents(campaignId, { search, visibility, tags, epicOnly })`, `WikiFilterBar` with `createButtonTestId="event-create-button"` and an extra "Epic only" toggle, render `EventCard` list, open `EventModal` for create/edit. Requires a calendar to exist — if none, show "Create a calendar first" linking to the Calendar category.
+
+- [ ] **Step 5: Typecheck + commit**
+
+Run: `npm run typecheck && npm test -- tests/components`
+```bash
+git add app/components/wiki/calendar/
+git commit -m "feat(calendar): events management UI (links editor, card, modal, panel)"
+```
+
+## Task 16: `CalendarEditorModal` (GM config)
+
+**Files:**
+- Create: `app/components/wiki/calendar/CalendarEditorModal.tsx`
+
+- [ ] **Step 1: Build the editor** (mirror `LoreModal.tsx` modal chrome)
+
+Props: `{ isOpen; onClose; campaignId; calendar: CalendarData | null }`.
+Sections (each a simple add/remove list editor):
+- Name, description, `yearSuffix`, `weekdayMode` (radio).
+- **Weekdays:** editable ordered string list.
+- **Months:** ordered rows of `{ name, days, isIntercalary }`.
+- **Leap days:** rows of `{ name, monthIndex (select from months), interval, offset, addDays }`.
+- **Moons / Seasons / Holidays / Named years:** simple row editors matching their schemas.
+- **Current date:** a `CalDatePicker` built from the in-progress config.
+- A prominent **"Load Calendar of Harptos"** button that fills every field from `HARPTOS_CONFIG` + `{ name: 'Calendar of Harptos', currentDate: { year: 1491, monthIndex: 6, day: 15 } }` (Mirtul 1491 DR; `monthIndex` 6 = Mirtul in the intercalary-inclusive month list).
+- On save call `useUpsertCalendar().save({ campaignId, ...config })`. If the response has `invalidEventIds.length`, show a warning toast/banner: "N events now have dates outside the new calendar and need fixing" (do not block the save).
+- `data-testid="calendar-editor"`, save button `data-testid="calendar-save-button"`, Harptos button `data-testid="calendar-harptos-button"`.
+
+- [ ] **Step 2: Typecheck + commit**
+
+Run: `npm run typecheck`
+```bash
+git add app/components/wiki/calendar/CalendarEditorModal.tsx app/components/wiki/calendar/CalendarPanel.tsx
+git commit -m "feat(calendar): GM calendar editor with Harptos preset + invalid-date warning"
+```
+
+## Task 17: Tabletop/GM-screen event window wrapper
+
+**Files:**
+- Create: `app/components/mainview/gmscreens/EventWindowWrapper.tsx`
+- Modify: the gmscreens window renderer that maps `collection` → wrapper (find where `LoreWindowWrapper` is referenced and add an `events` case)
+
+- [ ] **Step 1: Implement** (mirror `LoreWindowWrapper.tsx`) — fetch via `useEvent`, render `EventWindow`, loading/not-found states. Register the `events` collection in the renderer switch next to `lore`.
+
+- [ ] **Step 2: Typecheck + commit**
+
+Run: `npm run typecheck`
+```bash
+git add app/components/mainview/gmscreens/
+git commit -m "feat(calendar): render event windows on tabletop/GM screens"
+```
+
+---
+
+# PHASE 5 — Seed data (Calendar of Harptos + sample events)
+
+## Task 18: Python `to_ordinal` port + parity test
+
+**Files:**
+- Modify: `scripts/dev_seed.py` (add a `harptos.py` sibling or inline helpers)
+- Create: `scripts/seed_calendar_data.py`, `tests/utils/calendarEngine.parity.test.ts`
+
+- [ ] **Step 1: Create `scripts/seed_calendar_data.py`** with the Harptos config + a faithful `to_ordinal` port
+
+```python
+# scripts/seed_calendar_data.py
+"""Calendar of Harptos seed config + a port of calendarEngine.toOrdinal.
+
+Mirrors app/utils/harptos.ts and app/utils/calendarEngine.ts EXACTLY. A vitest
+parity test (calendarEngine.parity.test.ts) asserts the TS engine and these
+numbers agree for the seeded dates, so the two ports cannot silently diverge.
+"""
+
+HARPTOS_MONTHS = [
+    {"name": "Hammer", "days": 30},
+    {"name": "Midwinter", "days": 1, "isIntercalary": True},
+    {"name": "Alturiak", "days": 30},
+    {"name": "Ches", "days": 30},
+    {"name": "Tarsakh", "days": 30},
+    {"name": "Greengrass", "days": 1, "isIntercalary": True},
+    {"name": "Mirtul", "days": 30},
+    {"name": "Kythorn", "days": 30},
+    {"name": "Flamerule", "days": 30},
+    {"name": "Midsummer", "days": 1, "isIntercalary": True},
+    {"name": "Shieldmeet", "days": 0, "isIntercalary": True},
+    {"name": "Eleasis", "days": 30},
+    {"name": "Eleint", "days": 30},
+    {"name": "Highharvestide", "days": 1, "isIntercalary": True},
+    {"name": "Marpenoth", "days": 30},
+    {"name": "Uktar", "days": 30},
+    {"name": "The Feast of the Moon", "days": 1, "isIntercalary": True},
+    {"name": "Nightal", "days": 30},
+]
+
+HARPTOS = {
+    "name": "Calendar of Harptos",
+    "description": "The calendar of the Forgotten Realms, devised by Harptos of Kaalinth.",
+    "months": HARPTOS_MONTHS,
+    "weekdays": ["First", "Second", "Third", "Fourth", "Fifth",
+                 "Sixth", "Seventh", "Eighth", "Ninth", "Tenth"],
+    "weekdayMode": "resetEachMonth",
+    "epoch": {"year": 1372, "weekdayIndex": 0},
+    "yearSuffix": "DR",
+    "namedYears": [
+        {"year": 1358, "name": "Year of Shadows"},
+        {"year": 1385, "name": "Year of Blue Fire"},
+    ],
+    "leapDays": [{"name": "Shieldmeet", "monthIndex": 10, "interval": 4, "offset": 0, "addDays": 1}],
+    "moons": [{"name": "Selûne", "cycleLength": 30, "offsetDays": 0}],
+    "seasons": [
+        {"name": "Winter", "startMonthIndex": 0, "startDay": 1},
+        {"name": "Spring", "startMonthIndex": 3, "startDay": 1},
+        {"name": "Summer", "startMonthIndex": 8, "startDay": 1},
+        {"name": "Autumn", "startMonthIndex": 13, "startDay": 1},
+    ],
+    "holidays": [],
+    "currentDate": {"year": 1491, "monthIndex": 6, "day": 15},  # Mirtul 1491 DR
+}
+
+
+def _leap_applies(rule, year):
+    if rule["interval"] < 1:
+        return False
+    return (year - rule["offset"]) % rule["interval"] == 0
+
+
+def days_in_month(cfg, year, month_index):
+    base = cfg["months"][month_index]["days"]
+    extra = sum(r["addDays"] for r in cfg["leapDays"]
+                if r["monthIndex"] == month_index and _leap_applies(r, year))
+    return base + extra
+
+
+def days_in_year(cfg, year):
+    return sum(days_in_month(cfg, year, m) for m in range(len(cfg["months"])))
+
+
+def to_ordinal(cfg, date):
+    year, month_index, day = date["year"], date["monthIndex"], date["day"]
+    epoch_year = cfg["epoch"]["year"]
+    if year >= epoch_year:
+        year_start = sum(days_in_year(cfg, y) for y in range(epoch_year, year))
+    else:
+        year_start = -sum(days_in_year(cfg, y) for y in range(year, epoch_year))
+    before_month = sum(days_in_month(cfg, year, m) for m in range(month_index))
+    return year_start + before_month + (day - 1)
+```
+
+- [ ] **Step 2: Write the parity test** (asserts TS engine matches the Python numbers for seed dates)
+
+```typescript
+// tests/utils/calendarEngine.parity.test.ts
+import { describe, it, expect } from 'vitest';
+import { toOrdinal } from '~/utils/calendarEngine';
+import { HARPTOS_CONFIG } from '~/utils/harptos';
+
+// These ordinals are produced by scripts/seed_calendar_data.py:to_ordinal for the
+// seeded sample-event dates. If the engines diverge, this test fails.
+// Regenerate with:  python3 -c "import sys; sys.path.insert(0,'scripts'); \
+//   from seed_calendar_data import HARPTOS, to_ordinal; \
+//   print(to_ordinal(HARPTOS, {'year':1491,'monthIndex':6,'day':15}))"
+const EXPECTED: Array<[{ year: number; monthIndex: number; day: number }, number]> = [
+  [{ year: 1491, monthIndex: 6, day: 15 }, /* fill from python */ 0],
+  [{ year: 1488, monthIndex: 10, day: 1 }, /* fill from python */ 0],
+  [{ year: 1358, monthIndex: 0, day: 1 }, /* fill from python */ 0],
+];
+
+describe('calendar engine parity (TS vs Python seed port)', () => {
+  it('matches the Python to_ordinal for seed dates', () => {
+    for (const [date, expected] of EXPECTED) {
+      expect(toOrdinal(HARPTOS_CONFIG, date)).toBe(expected);
+    }
+  });
+});
+```
+
+Then run the python one-liner shown in the comment for each date and paste the real numbers into `EXPECTED` (replace the `0` placeholders). Run: `npm test -- tests/utils/calendarEngine.parity.test.ts` → PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/seed_calendar_data.py tests/utils/calendarEngine.parity.test.ts
+git commit -m "feat(calendar): python Harptos seed config + TS/Python ordinal parity test"
+```
+
+## Task 19: `build_calendar_doc` + `build_event_docs` + orchestration
+
+**Files:**
+- Modify: `scripts/dev_seed.py`
+
+- [ ] **Step 1: Add builders** near `build_lore_docs`
+
+```python
+from seed_calendar_data import HARPTOS, to_ordinal  # add to imports
+
+def build_calendar_doc(*, campaign_id, gm_id, now):
+    """One Calendar of Harptos document for the rich campaign."""
+    doc = dict(HARPTOS)
+    doc.update({
+        "campaignId": campaign_id,
+        "createdBy": gm_id,
+        "createdAt": now,
+        "updatedAt": now,
+    })
+    return doc
+
+
+def build_event_docs(*, campaign_id, calendar_id, gm_id, now,
+                     character_ids, location_ids, race_ids, player_ids, session_ids):
+    """~10 sample events on the Harptos calendar, linked to seeded entities."""
+    def ev(title, content, start, *, public, epic=False, end=None, links=None,
+           gm_content="", tags=None, session_id=None, day_offset=0):
+        ts = now - timedelta(days=day_offset)
+        return {
+            "title": title, "content": content, "gmContent": gm_content,
+            "isPublic": public, "isEpic": epic,
+            "start": start, "end": end,
+            "startOrdinal": to_ordinal(HARPTOS, start),
+            "endOrdinal": to_ordinal(HARPTOS, end or start),
+            "links": links or [], "sessionId": session_id, "images": [],
+            "tags": tags or [], "color": None,
+            "campaignId": campaign_id, "calendarId": calendar_id, "createdBy": gm_id,
+            "createdAt": ts, "updatedAt": ts,
+        }
+
+    phandalin = location_ids.get("Phandalin") or (next(iter(location_ids.values())) if location_ids else ObjectId())
+    npc0 = character_ids[0] if character_ids else ObjectId()
+    player0 = player_ids[0] if player_ids else ObjectId()
+    elf = race_ids.get("Elf") or (next(iter(race_ids.values())) if race_ids else ObjectId())
+    session0 = session_ids[0] if session_ids else None
+
+    return [
+        ev("The Time of Troubles", "The gods walked Faerûn as mortals; Mystra fell at Mistmere.",
+           {"year": 1358, "monthIndex": 6, "day": 15}, public=True, epic=True,
+           tags=["world", "history"]),
+        ev("The Spellplague", "Blue fire swept the Weave; magic itself convulsed across the Realms.",
+           {"year": 1385, "monthIndex": 8, "day": 1}, public=True, epic=True,
+           tags=["world", "history"]),
+        ev("Shieldmeet Grand Council", "Rulers renewed pacts on the leap-day festival of Shieldmeet.",
+           {"year": 1488, "monthIndex": 10, "day": 1}, public=True,
+           tags=["festival", "politics"]),
+        ev("Founding of Phandalin", "Settlers rebuilt the ruined town atop the old Phandelver pact lands.",
+           {"year": 1451, "monthIndex": 3, "day": 8}, public=True,
+           links=[{"kind": "location", "id": phandalin}], tags=["history"]),
+        ev("The Siege of Phandalin", "Redbrands stormed the town over two desperate days.",
+           {"year": 1491, "monthIndex": 4, "day": 11}, end={"year": 1491, "monthIndex": 4, "day": 12},
+           public=True, epic=True,
+           links=[{"kind": "location", "id": phandalin}, {"kind": "character", "id": npc0}],
+           tags=["campaign", "battle"], session_id=session0),
+        ev("Gundren's Disappearance", "Gundren Rockseeker vanished on the Triboar Trail.",
+           {"year": 1491, "monthIndex": 4, "day": 2}, public=False,
+           gm_content="Captured by Cragmaw goblins on the Black Spider's orders.",
+           links=[{"kind": "character", "id": npc0}], tags=["campaign", "secret"]),
+        ev("Wave Echo Cave Rediscovered", "The lost mine and its Forge of Spells came to light again.",
+           {"year": 1491, "monthIndex": 4, "day": 20}, public=True,
+           links=[{"kind": "location", "id": phandalin}], tags=["campaign"]),
+        ev("Greengrass in Phandalin", "The spring festival of Greengrass was kept with garlands and ale.",
+           {"year": 1491, "monthIndex": 5, "day": 1}, public=True,
+           links=[{"kind": "player", "id": player0}], tags=["festival"]),
+        ev("The Elven Retreat", "The elves withdrew to their hidden refuges as the age turned.",
+           {"year": 1344, "monthIndex": 12, "day": 20}, public=True,
+           links=[{"kind": "race", "id": elf}], tags=["history", "elf"]),
+        ev("Council Vote at Neverwinter", "A closed council set the season's trade compacts.",
+           {"year": 1491, "monthIndex": 6, "day": 10}, public=False,
+           gm_content="Sets up the next arc's politics.", tags=["politics", "secret"]),
+    ]
+```
+
+- [ ] **Step 2: Call them in the orchestrator** (after lore insert, in the `rich_session_history` block)
+
+```python
+        cal_doc = build_calendar_doc(campaign_id=campaign_id, gm_id=gm_id, now=now)
+        cal_result = db.calendars.insert_one(cal_doc)
+        calendar_id = cal_result.inserted_id
+        print(f"    calendar   inserted 1")
+
+        event_docs = build_event_docs(
+            campaign_id=campaign_id, calendar_id=calendar_id, gm_id=gm_id, now=now,
+            character_ids=character_ids, location_ids=location_ids, race_ids=race_ids,
+            player_ids=player_doc_ids, session_ids=session_ids,
+        )
+        if event_docs:
+            db.events.insert_many(event_docs)
+        print(f"    events     inserted {len(event_docs)}")
+```
+Note: confirm `session_ids` is available in that scope; if sessions are built earlier as `session_docs`, capture their ids (`[s["_id"] for s in session_docs]`) and pass them. If not readily available, pass `session_ids=[]` (the one session link simply becomes null).
+
+- [ ] **Step 3: Run the seed against an ephemeral Mongo** (per repo memory: never the dev Atlas DB)
+
+Run the seed integration the same way the repo tests `dev_seed.py` (throwaway `mongodb-memory-server`). Verify it inserts 1 calendar + 10 events with no exceptions and that `startOrdinal` values are integers.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/dev_seed.py
+git commit -m "feat(calendar): seed Calendar of Harptos + 10 sample events"
+```
+
+## Task 20: Event seed banner images
+
+**Files:**
+- Create: `scripts/gen_seed_event_images.mjs`
+- Modify: `package.json` (`dev:seed` chain)
+
+- [ ] **Step 1: Copy `gen_seed_lore_images.mjs`** to `gen_seed_event_images.mjs`; change `LORE_SLUGS` → event slugs, output dir to `public/uploads/seed-events/`, and the glyph to a calendar/star motif. (Optional: only needed if seed events reference image URLs; current `build_event_docs` seeds `images: []`, so this is a nice-to-have. If keeping events imageless, skip this task.)
+
+- [ ] **Step 2: Add to the seed chain** in `package.json`:
+```
+"dev:seed": "node scripts/run-python.cjs dev_seed.py && node scripts/gen_seed_avatars.mjs && node scripts/gen_seed_lore_images.mjs && node scripts/gen_seed_event_images.mjs",
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/gen_seed_event_images.mjs package.json
+git commit -m "feat(calendar): generate seed event banner images"
+```
+
+---
+
+# PHASE 6 — Epic timeline widget
+
+## Task 21: Map epic events → `TimelineEvent` and feed the widget
+
+**Files:**
+- Create: `app/services/eventsTimeline.ts`
+- Modify: `app/components/mainview/widgets/CampaignTimelineWidget.tsx`
+- Test: `tests/services/eventsTimeline.test.ts`
+
+- [ ] **Step 1: Write the failing mapper test**
+
+```typescript
+// tests/services/eventsTimeline.test.ts
+import { describe, it, expect } from 'vitest';
+import { eventsToTimeline } from '~/services/eventsTimeline';
+import { HARPTOS_CONFIG } from '~/utils/harptos';
+import type { EventListItem } from '~/types/event';
+
+const cfg = HARPTOS_CONFIG;
+const base: EventListItem = {
+  id: 'e1', campaignId: 'c', calendarId: 'cal', createdBy: 'u', title: 'Siege',
+  content: 'A great siege', isPublic: true, isEpic: true,
+  start: { year: 1491, monthIndex: 4, day: 11 }, end: { year: 1491, monthIndex: 4, day: 12 },
+  startOrdinal: 0, endOrdinal: 0, links: [], sessionId: null, images: [], tags: [], color: null,
+  createdAt: '', updatedAt: '', canEdit: false,
+};
+
+describe('eventsToTimeline', () => {
+  it('maps an epic event to a major TimelineEvent, newest first', () => {
+    const older = { ...base, id: 'e0', start: { year: 1358, monthIndex: 0, day: 1 }, end: null };
+    const out = eventsToTimeline(cfg, [base, older], { year: 1491, monthIndex: 4, day: 11 });
+    expect(out[0].id).toBe('e1'); // newest first
+    expect(out[0].importance).toBe('major');
+    expect(out[0].calendarDate).toContain('Tarsakh');
+    expect(out[0].isCurrent).toBe(true); // currentDate within the span
+    expect(out[1].isCurrent).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm fail**
+
+Run: `npm test -- tests/services/eventsTimeline.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the mapper**
+
+```typescript
+// app/services/eventsTimeline.ts
+import type { TimelineEvent } from '~/services/mocks/types';
+import type { EventListItem } from '~/types/event';
+import type { CalendarConfig, CalDate } from '~/utils/calendarEngine';
+import { formatDate, toOrdinal } from '~/utils/calendarEngine';
+
+export function eventsToTimeline(
+  cfg: CalendarConfig,
+  events: EventListItem[],
+  currentDate: CalDate
+): TimelineEvent[] {
+  const cur = toOrdinal(cfg, currentDate);
+  const sorted = [...events].sort((a, b) => b.startOrdinal - a.startOrdinal); // newest first
+  return sorted.map((e) => {
+    const isCurrent = cur >= e.startOrdinal && cur <= e.endOrdinal;
+    const evt: TimelineEvent = {
+      id: e.id,
+      calendarDate: formatDate(cfg, e.start),
+      sessionName: e.title,
+      summary: (e.content || '').slice(0, 160),
+      importance: 'major',
+    };
+    if (isCurrent) evt.isCurrent = true;
+    return evt;
+  });
+}
+```
+
+- [ ] **Step 4: Run and confirm pass**
+
+Run: `npm test -- tests/services/eventsTimeline.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Feed real epic events into the widget**
+
+The widget already accepts an optional `events` prop and falls back to `getTimelineEvents()` (the mock). Create a small wrapper used on the dashboard so the widget stays presentational. In the dashboard render site (where `<CampaignTimelineWidget />` is used — `app/routes/campaigns/$campaignId/play.tsx` / `DashboardView`), add:
+
+```tsx
+import { useCalendar } from '~/hooks/useCalendar';
+import { useEpicEvents } from '~/hooks/useEvents';
+import { eventsToTimeline } from '~/services/eventsTimeline';
+// ...
+const { calendar } = useCalendar(campaignId);
+const { events: epic } = useEpicEvents(campaignId);
+const timelineEvents = calendar
+  ? eventsToTimeline(
+      {
+        months: calendar.months, weekdays: calendar.weekdays, weekdayMode: calendar.weekdayMode,
+        epoch: calendar.epoch, yearSuffix: calendar.yearSuffix, leapDays: calendar.leapDays,
+        moons: calendar.moons, seasons: calendar.seasons, holidays: calendar.holidays,
+      },
+      epic,
+      calendar.currentDate
+    )
+  : undefined; // undefined => widget keeps its mock fallback when no calendar exists
+// ...
+<CampaignTimelineWidget events={timelineEvents} />
+```
+The widget's existing empty/loading states cover the "calendar exists but no epic events" case (`timelineEvents` is `[]`).
+
+- [ ] **Step 6: Typecheck, run, commit**
+
+Run: `npm run typecheck && npm test -- tests/services/eventsTimeline.test.ts`
+```bash
+git add app/services/eventsTimeline.ts tests/services/eventsTimeline.test.ts app/routes/campaigns app/components/mainview
+git commit -m "feat(calendar): epic timeline reads real epic events"
+```
+
+---
+
+# PHASE 7 — E2E
+
+## Task 22: Calendar/Events e2e (GM create + player visibility + timeline)
+
+**Files:**
+- Create: `e2e/calendar/calendar-events.spec.ts`
+
+- [ ] **Step 1: Write the spec** (mirror `e2e/lore/lore-editor.spec.ts`; relies on seed from Task 19)
+
+```typescript
+// e2e/calendar/calendar-events.spec.ts
+import { test, expect } from '../fixtures/tabletop-fixtures';
+import { mockPostHog, blockPartyKit } from '../fixtures/network-mocks';
+
+test.describe('Calendar & Events', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockPostHog(page);
+    await blockPartyKit(page);
+  });
+
+  test('GM sees seeded events on the calendar list', async ({ page, campaignUrl }) => {
+    await page.goto(campaignUrl);
+    await page.getByRole('tab', { name: 'Wiki' }).click();
+    await page.getByRole('button', { name: 'Calendar' }).click();
+    await expect(page.getByTestId('event-list')).toBeVisible({ timeout: 10_000 });
+    // A seeded public epic event is visible.
+    await expect(page.getByText('The Siege of Phandalin').first()).toBeVisible();
+  });
+
+  test('GM can create an event via the Events manager', async ({ page, campaignUrl }) => {
+    await page.goto(campaignUrl);
+    await page.getByRole('tab', { name: 'Wiki' }).click();
+    await page.getByRole('button', { name: 'Events' }).click();
+    await page.getByTestId('event-create-button').click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await page.getByTestId('event-title-input').fill('E2E Festival');
+    // Date pickers default to the calendar current date; just submit.
+    await page.getByRole('button', { name: /Create Event/i }).click();
+    await expect(page.getByText('E2E Festival').first()).toBeVisible({ timeout: 10_000 });
+  });
+});
+```
+
+- [ ] **Step 2: Run** (requires `npm run dev:seed` + dev server, per the lore spec preconditions)
+
+Run: `npx playwright test e2e/calendar/calendar-events.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/calendar/calendar-events.spec.ts
+git commit -m "test(calendar): e2e for calendar list + event creation"
+```
+
+## Task 23: Event drag-drop e2e
+
+**Files:**
+- Create: `e2e/calendar/event-drag-drop.spec.ts`
+
+- [ ] **Step 1: Copy `e2e/lore/lore-drag-drop.spec.ts`**, swapping: Wiki → **Events** category, `lore-card` → `event-card`, `data-lore-id` → `data-event-id`, `lore-card-title` → `event-card-title`, payload `collection: 'lore'` → `'events'`, and the asserted window testid `lore-window` → `event-window`.
+
+- [ ] **Step 2: Run + commit**
+
+Run: `npx playwright test e2e/calendar/event-drag-drop.spec.ts`
+```bash
+git add e2e/calendar/event-drag-drop.spec.ts
+git commit -m "test(calendar): e2e for dragging an event onto the tabletop"
+```
+
+## Task 24: Final verification
+
+- [ ] **Step 1:** `npm run typecheck` → no errors.
+- [ ] **Step 2:** `npm run lint` → no errors (fix any with `npm run lint:fix`).
+- [ ] **Step 3:** `npm test` → full unit suite passes (engine, parity, calendars, events, timeline, WikiPanel).
+- [ ] **Step 4:** `npx playwright test e2e/calendar` → both specs pass.
+- [ ] **Step 5:** Manual smoke: GM loads the Harptos preset, advances current date, creates an epic multi-day event, confirms it appears on the list, the grid (spanning chip), and the dashboard timeline; a player account sees public events only and no Events category.
+
+---
+
+## Notes on cross-cutting conventions
+
+- **gmContent posture:** events are GM-only to write, but `getEvent`/`listEvents` still strip `gmContent` for non-GM viewers (defensive parity with Lore).
+- **Ordinals are server-authoritative:** never trust client-sent `startOrdinal`/`endOrdinal`; the server always recomputes from the calendar config (mirrors the `gmContent` coercion pattern).
+- **One source of date math:** if you find yourself adding/subtracting days or computing a weekday outside `calendarEngine.ts`, stop and add a function to the engine with a test instead.

--- a/docs/superpowers/specs/2026-06-16-calendars-and-events-design.md
+++ b/docs/superpowers/specs/2026-06-16-calendars-and-events-design.md
@@ -1,0 +1,232 @@
+# Calendars & Events — Design
+
+**Date:** 2026-06-16
+**Status:** Approved (brainstorm), ready for implementation plan
+**Branch:** feature work off `wiki-updates`; PRs target `dev`
+
+## Summary
+
+Two new wiki datatypes, modeled closely on the existing **Lore** vertical slice:
+
+1. **Calendar** — a GM-authored custom calendar (custom months, custom weekdays/tendays, named years, leap days, moons, seasons, holidays) with full Kanka-style fidelity. Exactly **one calendar per campaign**. Viewable by all members; editable only by the GM.
+2. **Event** — a dated world/campaign happening with public + GM-only markdown, placed on the calendar, linkable to characters, players, races, locations, lore, and sessions. **GM-only to create and manage.** Players consume events through the Calendar view and the dashboard's epic timeline.
+
+A single pure **calendar engine** module owns all date math. Moons, seasons, and holidays are display-only derivations and never affect storage or sorting. The dashboard's epic timeline widget is rewired to read real events the GM tags as epic.
+
+The seed dataset ships the authentic **Calendar of Harptos** (Forgotten Realms) plus ~10 sample events, including real FR world events and Phandalin-campaign events linked to existing seeded entities.
+
+## Goals / Non-goals
+
+**Goals**
+- Faithful custom-calendar support: custom months & lengths, custom weekday/tenday count, named years/epochs, leap days, moons, seasons, holidays.
+- Events with exact start day + optional end day (multi-day spans), public/GM text, per-event visibility, an `isEpic` flag, and links to 5 entity kinds + sessions.
+- Calendar view (list/agenda default, toggle to month grid) for all members; GM-only Events management UI.
+- Dramatically fewer date-math defects than Kanka by isolating all date arithmetic in one pure, exhaustively tested module.
+- Authentic Harptos seed calendar + sample events.
+- Rewire the dashboard epic timeline to real epic events.
+
+**Non-goals (deferred)**
+- Multiple calendars per campaign (schema carries `calendarId` so this is a non-breaking future addition).
+- Recurring events (annual recurrence is covered by calendar **holidays**; one-off events are not recurring).
+- Partial/fuzzy event dates (year-only / month-only). All event dates are exact days.
+- Time-of-day on events.
+
+## Decisions (from brainstorm)
+
+| Decision | Choice |
+|---|---|
+| Calendar fidelity | Full: custom months/weekdays/years **+ leap days, moons, seasons, holidays** |
+| Calendars per campaign | **One** (events still carry `calendarId`) |
+| Event date model | **Start day + optional end day, exact days** (multi-day spans) |
+| Event visibility | **Per-event `isPublic`** + public `content` / GM-only `gmContent` (mirrors Lore) |
+| `isEpic` | Independent GM-only flag; drives the timeline; independent of `isPublic` |
+| Default calendar view | **List/agenda**, with a toggle to month grid |
+| Date representation | **Approach 1:** structured `{year,month,day}` = source of truth; denormalized integer ordinal = derived sort index; one pure engine |
+| Seed calendar | **Calendar of Harptos** (verified) |
+
+## Architecture & file layout
+
+Mirrors the Lore slice, plus one shared pure module.
+
+- **Shared types:** `app/types/calendar.ts`, `app/types/event.ts`
+- **Zod schemas:** `app/types/schemas/calendars.ts`, `app/types/schemas/events.ts`
+- **DB models:** `app/server/db/models/Calendar.ts`, `app/server/db/models/Event.ts`
+- **Calendar engine (the crux):** `app/utils/calendarEngine.ts` — pure functions only; no DB, React, or IO; imported by **both** client and server
+- **Server functions:** `app/server/functions/calendars.ts`, `app/server/functions/events.ts`
+- **Hooks:** `app/hooks/useCalendar.ts`, `app/hooks/useEvents.ts`
+- **Components:** `app/components/wiki/calendar/` — `CalendarPanel`, `CalendarGridView`, `EventListView`, `CalendarEditorModal`, `EventsPanel`, `EventCard`, `EventModal`, `EventViewModal`, `EventWindow`, `EventLinksEditor`, `EventWindowWrapper`
+- **Seed:** extend `scripts/dev_seed.py` (`build_calendar_doc`, `build_event_docs`); new `scripts/gen_seed_event_images.mjs`
+- **Tests:** `tests/utils/calendarEngine.test.ts`, `tests/server/functions/{calendars,events}.test.ts`, `e2e/calendar/*.spec.ts`
+
+**The invariant that prevents the Kanka bug class:** no date arithmetic exists anywhere except `calendarEngine.ts`. Components, server functions, the timeline, and the Python seed all go through the engine (the Python seed ports `toOrdinal`, asserted equal to the TS engine in a test).
+
+## Data model
+
+### `Calendar` (one per campaign)
+```
+campaignId
+name, description?
+months:    [{ name, days, isIntercalary?: boolean }]   // ordered; intercalary = festival day outside the week cycle
+weekdays:  [string]                                    // ordered names; length = days per week/tenday
+weekdayMode: 'continuous' | 'resetEachMonth'           // Harptos = resetEachMonth
+epoch:     { year, weekdayIndex }                      // ordinal 0 = day 1 of this year; weekday it lands on (continuous mode)
+yearSuffix?: string                                    // e.g. "DR"
+namedYears?: [{ year, name }]                          // optional ("Year of ...")
+leapDays:  [{ name, monthIndex, interval, offset, addDays }]  // adds days to a month in matching years
+moons:     [{ name, cycleLength, offsetDays, color? }]        // display-only
+seasons:   [{ name, startMonthIndex, startDay, color? }]      // display-only; runs until next season start
+holidays:  [{ name, monthIndex, day, color? }]                // recurring annually; display-only
+currentDate: { year, monthIndex, day }                 // GM-set "now"; drives ringed day + timeline isCurrent
+createdBy, createdAt, updatedAt
+```
+
+### `Event`
+```
+campaignId, calendarId
+title
+content     // public markdown
+gmContent   // GM-only markdown
+isPublic, isEpic
+start:  { year, monthIndex, day }
+end:    { year, monthIndex, day } | null
+startOrdinal, endOrdinal           // denormalized ints computed by the engine; INDEXED
+links:  [{ kind: 'character'|'player'|'race'|'location'|'lore', id }]
+sessionId?                         // optional "happened during session N"
+images?, tags?, color?
+createdBy, createdAt, updatedAt
+```
+**Indexes:** `campaignId`, `{campaignId, startOrdinal}`, `isPublic`, `isEpic`, `links.id`, `tags`, `sessionId`.
+
+## The calendar engine — `app/utils/calendarEngine.ts`
+
+Pure functions; config in, values out. This is where correctness is won.
+
+- `toOrdinal(cal, {year,month,day}) → int` and `fromOrdinal(cal, n) → {year,month,day}` — exact inverses
+- `daysInMonth(cal, year, monthIndex)` / `daysInYear(cal, year)` — leap-aware (leap rule matches a year when `(year - offset) % interval === 0`)
+- `weekdayOf(cal, ordinal)` — respects `weekdayMode`; intercalary days return no weekday slot
+- `monthGrid(cal, year, monthIndex)` — week rows of day cells (leading blanks) for the grid view
+- `moonPhase(cal, moon, ordinal)`, `seasonOf(cal, ordinal)`, `holidaysOn(cal, year, month, day)` — display helpers, never persisted
+- `compareDates`, `addDays`
+- `validateDate(cal, date) → {ok} | {error}` — rejects out-of-range months/days (e.g. day 31 in a 30-day month, a day in a 0-length Shieldmeet in a non-leap year)
+
+### Two server-enforced integrity rules (the second Kanka killer)
+1. **On event create/update:** server calls `validateDate`, then computes `startOrdinal`/`endOrdinal` via the engine. Client-supplied ordinals are ignored.
+2. **On calendar update:** in one transaction, re-validate every event's dates against the new config and recompute all ordinals. Events whose dates became invalid (e.g. a shortened month) are **flagged back to the GM**, never silently moved.
+
+## Permissions & visibility
+
+Via the existing `requireCampaignMember` → `{ userId, isGM }`.
+
+| Action | Who |
+|---|---|
+| View calendar (config, grid, list) | Any member |
+| Create / edit / delete calendar, set `currentDate` | GM only |
+| Create / edit / delete events, set `isEpic` | GM only |
+| View events | Members: `isPublic` events with public `content` only. GM: all events + `gmContent`. |
+
+`gmContent` is stripped from non-GM responses and never persisted from a non-GM writer (defensive parity with Lore). Wiki categories: **Calendar** visible to all; **Events** is `gmOnly`.
+
+## Server functions & hooks
+
+**`calendars.ts`:** `getCalendar(campaignId)`, `upsertCalendar(input)` *(GM; runs the re-validate + recompute-all-events transaction)*, `setCurrentDate(input)` *(GM)*, `deleteCalendar` *(GM)*.
+
+**`events.ts`:** `listEvents(campaignId, filters)` *(visibility-filtered; sorted by `startOrdinal`; filters: search, tags, linkedKind/Id, epicOnly, visibility, date range)*, `getEvent(id)`, `createEvent` *(GM)*, `updateEvent` *(GM)*, `deleteEvent` *(GM; + GM-screen ref cleanup)*. Create/update validate dates + recompute ordinals and resolve link labels (Lore's `resolveLinkLabels`, extended with `lore` kind and optional `session`).
+
+**Link pruning:** extend the `pruneLoreLinks` pattern so deleting a character/player/race/location/lore `$pull`s that link from events too. Deleting an event clears its GM-screen references.
+
+**Hooks (React Query, `createMutationHook`):** `useCalendar`, `useUpsertCalendar`, `useSetCurrentDate`, `useDeleteCalendar`; `useEvents`, `useEvent`, `useLinkedEvents`, `useCreateEvent`, `useUpdateEvent`, `useDeleteEvent`. Keys under `['calendar', campaignId]` and `['events', …]`; mutations invalidate list/detail/linked + the timeline query.
+
+## UI components
+
+**Wiki integration** (`WikiPanel.tsx` `WIKI_CATEGORIES`): add `{ id:'calendar', label:'Calendar', icon: CalendarDays }` (all members) and `{ id:'events', label:'Events', icon: CalendarClock, gmOnly:true }`.
+
+**Calendar category → `CalendarPanel`:**
+- **List/agenda view (default)** + toggle to **grid view**.
+- *List:* events grouped by year → month (engine-ordered); each row shows title, day(s), epic badge, public/private (GM only), holiday markers, linked-entity chips. Members see public events only.
+- *Grid:* `monthGrid(...)` renders the dynamic month (Harptos: 10-wide tenday rows); holidays tinted, `currentDate` ringed, multi-day events as spanning chips, moon/season indicators from the engine; festival/intercalary days render as single banners between months. Month/year nav; click a day → that day's events.
+- Clicking an event → `EventViewModal` (public content + linked entities; `gmContent` and edit only if GM).
+- **GM-only "Configure calendar"** → `CalendarEditorModal` (months, weekdays, leap days, moons, seasons, holidays, current date). All date inputs everywhere are calendar-aware Year/Month/Day pickers driven by the config.
+
+**Events category (GM only) → `EventsPanel`:** standard management list — `WikiFilterBar` (search/tags/epic filter), draggable `EventCard` list (like `LoreCard`), `EventModal` (title, public content, GM content, start/optional-end pickers, `isPublic`, `isEpic`, links via `EventLinksEditor`, optional session, images, tags), delete-with-confirm. `EventWindow` + `EventWindowWrapper` so events display on tabletop/GM screens like Lore.
+
+## Epic timeline fix
+
+`CampaignTimelineWidget.tsx` is currently fed by mock `services/mocks/timelineService.ts`.
+- Replace the mock with a real query: epic events for the campaign, ordered by `startOrdinal`, visibility-filtered (players see only public epic events).
+- Map `Event → TimelineEvent`: `calendarDate` = engine-formatted start-date string, `sessionName`/`summary` from title/content, `importance: 'major'` for epic, `isCurrent` when the event span contains the calendar's `currentDate`.
+- Keep the widget's render/props shape unchanged; only the data source changes. Add an empty state when no epic events exist.
+
+## Seed data — Calendar of Harptos (verified)
+
+Sources: realmshelps.net (Time and Seasons), Forgotten Realms Wiki (Calendar of Harptos).
+
+**Structure:** 12 months × 30 days (three 10-day tendays each); 5 festival days between specific months; Shieldmeet leap day after Midsummer every 4 years. 365 days/year, 366 in a Shieldmeet year. `weekdayMode: 'resetEachMonth'` (each month starts a fresh tenday; festival days have no tenday slot).
+
+**Internal `months` array (ordered, with `isIntercalary`):**
+
+| idx | name | days | intercalary |
+|----|------|------|----|
+| 0 | Hammer (Deepwinter) | 30 | |
+| 1 | Midwinter | 1 | ✓ |
+| 2 | Alturiak (Claw of Winter) | 30 | |
+| 3 | Ches (Claw of Sunsets) | 30 | |
+| 4 | Tarsakh (Claw of Storms) | 30 | |
+| 5 | Greengrass | 1 | ✓ |
+| 6 | Mirtul (The Melting) | 30 | |
+| 7 | Kythorn (Time of Flowers) | 30 | |
+| 8 | Flamerule (Summertide) | 30 | |
+| 9 | Midsummer | 1 | ✓ |
+| 10 | Shieldmeet | 0 (→1 leap) | ✓ |
+| 11 | Eleasis (Highsun) | 30 | |
+| 12 | Eleint (The Fading) | 30 | |
+| 13 | Highharvestide | 1 | ✓ |
+| 14 | Marpenoth (Leaffall) | 30 | |
+| 15 | Uktar (The Rotting) | 30 | |
+| 16 | Feast of the Moon | 1 | ✓ |
+| 17 | Nightal (Drawing Down) | 30 | |
+
+- **Leap rule:** `{ name:'Shieldmeet', monthIndex:10, interval:4, offset:0, addDays:1 }` (a day exists only when `year % 4 === 0`).
+- **weekdays:** 10 tenday day-names (e.g. "First"…"Tenth").
+- **yearSuffix:** `"DR"`. **namedYears:** a few canonical ones (e.g. 1358 "Year of Shadows", 1385 "Year of Blue Fire").
+- **moons:** Selûne, ~30-day cycle (display-only).
+- **seasons:** Winter / Spring / Summer / Autumn at reasonable month starts.
+- **holidays:** the five festivals (display markers; the festival days themselves).
+- **currentDate:** current era ~1491 DR (e.g. Mirtul 1491 DR). 1491 is not a Shieldmeet year, so the leap path is instead exercised by a seeded 1488 DR event.
+
+### Sample events (~10; Harptos dates; linked to existing seeded entities)
+Mix of public/private, a couple epic, one multi-day span, links across all 5 entity kinds + sessions:
+- **The Time of Troubles** — 1358 DR — epic, public (world-lore; Mystra falls)
+- **The Spellplague** — 1385 DR — epic, public (world-lore)
+- **Shieldmeet Grand Council** — 1488 DR (real Shieldmeet/leap year — exercises the leap day)
+- **Founding of Phandalin** — links Phandalin location + phandalin-history lore
+- **The Siege of Phandalin** — multi-day (start+end), epic — links Gundren, Redbrands, Phandalin
+- **Gundren's Disappearance** — private (GM-only) — links Gundren + Black Spider lore
+- **Wave Echo Cave Rediscovered** — links a location + dragon-legend lore
+- **Greengrass in Phandalin** — falls on the Greengrass festival day — links players
+- **+ ~2 more** covering a session link and a race link
+
+Ordinals are computed in the Python seed via a small port of `toOrdinal`; a test asserts the Python and TS engines agree on the seed dates (prevents drift). Event banner images via `scripts/gen_seed_event_images.mjs` (mirrors `gen_seed_lore_images.mjs`).
+
+## Testing strategy
+
+- **Engine (priority):** exhaustive unit + property tests in `tests/utils/calendarEngine.test.ts` — round-trip `fromOrdinal(toOrdinal(d)) === d` across thousands of dates incl. leap and negative years; month/leap boundaries; weekday continuity in both modes; intercalary-day handling; `validateDate` rejections; moon/season/holiday spot-checks vs hand-computed values; Harptos-specific assertions (365/366-day years, Shieldmeet only in `year % 4 === 0`).
+- **Server:** `tests/server/functions/{calendars,events}.test.ts` — visibility filtering (GM vs member), `gmContent` stripping, GM-only mutation guards, ordinal recompute on event write, and the calendar-edit re-validation/recompute transaction incl. invalid-date flag-back.
+- **Cross-language:** test asserting the Python seed's `toOrdinal` matches the TS engine for the seed dates.
+- **E2E:** `e2e/calendar/` — GM configures calendar + creates an event; player sees a public event on the list/grid but not a private one; an epic event appears on the dashboard timeline; drag an event onto a GM screen. Requires the `VITE_PUBLIC_FF_*` flags (per repo memory) so the Wiki/Calendar tabs render.
+
+## Build phasing (each phase independently shippable & tested)
+
+1. **Engine + types/schemas** — pure module, fully tested, before any UI or DB.
+2. **DB models + server functions + hooks** — with server tests.
+3. **Calendar viewing** (list + grid, read-only) + wiki "Calendar" category.
+4. **Calendar editor** (GM config) + **Events management** (GM CRUD, links).
+5. **Seed data** (Harptos calendar + sample events) + event seed images.
+6. **Epic timeline widget** swap to real epic events.
+7. **E2E** specs.
+
+## Risks & mitigations
+
+- **Leap-day / intercalary off-by-one (Kanka's #1 bug):** all math in one pure engine; round-trip property tests; Harptos seed exercises the leap path; festivals modeled as in-order intercalary months so ordinal math stays a simple sum.
+- **Stale event dates after a calendar edit:** server transaction re-validates + recomputes all ordinals; invalid dates flagged to the GM, never silently moved.
+- **Python/TS date drift in seed:** cross-language equality test on seed dates.
+- **Scope creep toward Kanka parity:** multiple calendars, recurring events, fuzzy dates, and time-of-day are explicit non-goals; schema leaves room for multiple calendars without migration.

--- a/e2e/calendar/calendar-events.spec.ts
+++ b/e2e/calendar/calendar-events.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * E2E: Calendar & Events.
+ *
+ * Proves that a GM can:
+ *   1. Open the Wiki tab, drill into the Calendar category, and see the seeded
+ *      events rendered in the calendar's default (list) view — including
+ *      "The Siege of Phandalin".
+ *   2. Open the GM-only Events category, click Create, fill in a title, submit
+ *      the EventModal, and see the new event appear.
+ *
+ * Mirrors e2e/lore/lore-editor.spec.ts (fixtures, PostHog/PartyKit mocks, GM
+ * session via globalSetup).
+ *
+ * Pre-conditions: `npm run dev:seed` must have run so that the GM session
+ * cookie + campaign data exist in the dev DB, AND the seed must have created a
+ * "Calendar of Harptos" with its events (Task 19). Do NOT run this spec against
+ * a production database.
+ */
+import { test, expect } from '../fixtures/tabletop-fixtures';
+import { mockPostHog, blockPartyKit } from '../fixtures/network-mocks';
+
+test.describe('Calendar & Events', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockPostHog(page);
+    await blockPartyKit(page);
+  });
+
+  test('GM sees seeded events on the calendar list', async ({ page, campaignUrl }) => {
+    await page.goto(campaignUrl);
+
+    // Open the Wiki tab in the InspectorSidebar.
+    await page.getByRole('tab', { name: 'Wiki' }).click();
+
+    // Drill into the Calendar category (visible to all members).
+    await page.getByRole('button', { name: 'Calendar' }).click();
+
+    // The calendar defaults to the list view, which renders event-list.
+    await expect(page.getByTestId('event-list')).toBeVisible({ timeout: 10_000 });
+
+    // The seeded epic event should be present in the list.
+    await expect(page.getByText('The Siege of Phandalin').first()).toBeVisible();
+  });
+
+  test('GM can create an event via the Events manager', async ({ page, campaignUrl }) => {
+    await page.goto(campaignUrl);
+
+    // Open the Wiki tab in the InspectorSidebar.
+    await page.getByRole('tab', { name: 'Wiki' }).click();
+
+    // Drill into the GM-only Events category.
+    await page.getByRole('button', { name: 'Events' }).click();
+
+    // Open the create modal.
+    await page.getByTestId('event-create-button').click();
+
+    // The EventModal renders as a dialog (the <form role="dialog">).
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    // Fill in the title using the stable testid on the FormInput.
+    await page.getByTestId('event-title-input').fill('E2E Festival');
+
+    // Submit. The start date defaults to the calendar's currentDate (a valid
+    // date), so title + submit is enough to create the event.
+    await page.getByRole('button', { name: /Create Event/i }).click();
+
+    // The new event should appear. .first() because re-runs accumulate events
+    // with the same title in the dev DB.
+    await expect(page.getByText('E2E Festival').first()).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/e2e/calendar/event-drag-drop.spec.ts
+++ b/e2e/calendar/event-drag-drop.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * E2E: Event card drag-and-drop onto the tabletop workspace.
+ *
+ * Proves that a GM can drag the first event card from the Wiki → Events panel
+ * onto the tabletop workspace and a floating event window appears on the surface.
+ *
+ * Drag technique: the same HTML5 dataTransfer dispatch approach used by
+ * tabletop-monster-tokens.spec.ts (dropOnMap).  Here we target
+ * `tabletop-workspace` instead of `active-map-stage` because event cards open
+ * as floating wiki windows, not as map tokens.
+ *
+ * Pre-conditions: `npm run dev:seed` must have run so that (a) the GM session
+ * cookie exists, (b) the campaign has at least one seeded event, and (c)
+ * a tabletop screen exists (globalSetup guarantees this).  Do NOT run against
+ * a production database.
+ */
+import { test, expect } from '../fixtures/tabletop-fixtures';
+import { mockPostHog, blockPartyKit } from '../fixtures/network-mocks';
+
+/**
+ * Dispatch a real HTML5 drop of a wiki document onto the tabletop workspace.
+ *
+ * Mirrors the `dropOnMap` helper in tabletop-monster-tokens.spec.ts exactly,
+ * with the only difference being the target testid (`tabletop-workspace`
+ * rather than `active-map-stage`).
+ */
+async function dropOnWorkspace(
+  page: import('@playwright/test').Page,
+  payload: { collection: string; documentId: string; title: string },
+  offset: { dx: number; dy: number } = { dx: 0, dy: 0 }
+): Promise<void> {
+  await page.evaluate(
+    ({ payload, offset }) => {
+      const workspace = document.querySelector(
+        '[data-testid="tabletop-workspace"]'
+      ) as HTMLElement | null;
+      if (!workspace) throw new Error('tabletop-workspace not found');
+      const rect = workspace.getBoundingClientRect();
+      const clientX = rect.left + rect.width / 2 + offset.dx;
+      const clientY = rect.top + rect.height / 2 + offset.dy;
+      const dt = new DataTransfer();
+      dt.setData('application/x-cartyx-document', JSON.stringify(payload));
+      for (const type of ['dragenter', 'dragover', 'drop'] as const) {
+        const event = new DragEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          clientX,
+          clientY,
+        });
+        // Chromium's DragEvent constructor ignores the dataTransfer init member,
+        // so force it on explicitly — otherwise handleDrop sees a null transfer.
+        Object.defineProperty(event, 'dataTransfer', { value: dt });
+        workspace.dispatchEvent(event);
+      }
+    },
+    { payload, offset }
+  );
+}
+
+test.describe('Event drag-and-drop onto tabletop', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockPostHog(page);
+    await blockPartyKit(page);
+  });
+
+  test('GM can drag an event card onto the workspace and an event window opens', async ({
+    page,
+    tabletopUrl,
+  }) => {
+    // Navigate to the tabletop tab — globalSetup ensures a screen exists.
+    await page.goto(tabletopUrl);
+
+    // Wait for the tabletop workspace to be ready.
+    const workspace = page.getByTestId('tabletop-workspace');
+    await expect(workspace).toBeVisible({ timeout: 20_000 });
+
+    // Open the Wiki sidebar panel.
+    await page.getByRole('tab', { name: 'Wiki' }).click();
+
+    // Drill into the GM-only Events category (EventsPanel lists all events to
+    // the GM as draggable EventCards).
+    await page.getByRole('button', { name: 'Events' }).click();
+
+    // Wait for the first event card to appear (requires seeded event data).
+    const firstCard = page.getByTestId('event-card').first();
+    await expect(firstCard).toBeVisible({ timeout: 10_000 });
+
+    // Read the documentId directly from the stable DOM attribute set on the
+    // card's root element.  This avoids the unreliable synthetic-dragstart
+    // approach — Chromium's DragEvent constructor silently ignores the
+    // dataTransfer init member outside a trusted drag gesture, causing getData
+    // to return '' and the payload to fall back to documentId: 'unknown'.
+    const documentId = await firstCard.getAttribute('data-event-id');
+    if (!documentId) throw new Error('data-event-id attribute missing from event-card');
+
+    // Read the title from the dedicated testid span — more stable than the
+    // fragile span.text-sm selector used previously.
+    const title = await firstCard.getByTestId('event-card-title').innerText();
+
+    // Build the drop payload the same way dropOnMap does in
+    // tabletop-monster-tokens.spec.ts: construct it directly rather than
+    // intercepting a dragstart event.
+    const payload = { collection: 'events', documentId, title };
+
+    // Drop onto the workspace centre.
+    await dropOnWorkspace(page, payload, { dx: 0, dy: 0 });
+
+    // A floating event window should appear on the workspace. Use .first() —
+    // the E2E screen persists across runs and may already hold event windows
+    // from earlier drops, so more than one event-window can be present.
+    await expect(page.getByTestId('event-window').first()).toBeVisible({ timeout: 10_000 });
+
+    // The FloatingWindow title bar should also contain the event's title
+    // (server now hydrates events so the title resolves, not "events:<id>").
+    await expect(page.getByText(title).first()).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/e2e/lore/lore-drag-drop.spec.ts
+++ b/e2e/lore/lore-drag-drop.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * E2E: Lore card drag-and-drop onto the tabletop workspace.
+ *
+ * Proves that a GM can drag the first lore card from the Wiki → Lore panel
+ * onto the tabletop workspace and a floating lore window appears on the surface.
+ *
+ * Drag technique: the same HTML5 dataTransfer dispatch approach used by
+ * tabletop-monster-tokens.spec.ts (dropOnMap).  Here we target
+ * `tabletop-workspace` instead of `active-map-stage` because lore cards open
+ * as floating wiki windows, not as map tokens.
+ *
+ * Pre-conditions: `npm run dev:seed` must have run so that (a) the GM session
+ * cookie exists, (b) the campaign has at least one seeded lore entry, and (c)
+ * a tabletop screen exists (globalSetup guarantees this).  Do NOT run against
+ * a production database.
+ */
+import { test, expect } from '../fixtures/tabletop-fixtures';
+import { mockPostHog, blockPartyKit } from '../fixtures/network-mocks';
+
+/**
+ * Dispatch a real HTML5 drop of a wiki document onto the tabletop workspace.
+ *
+ * Mirrors the `dropOnMap` helper in tabletop-monster-tokens.spec.ts exactly,
+ * with the only difference being the target testid (`tabletop-workspace`
+ * rather than `active-map-stage`).
+ */
+async function dropOnWorkspace(
+  page: import('@playwright/test').Page,
+  payload: { collection: string; documentId: string; title: string },
+  offset: { dx: number; dy: number } = { dx: 0, dy: 0 }
+): Promise<void> {
+  await page.evaluate(
+    ({ payload, offset }) => {
+      const workspace = document.querySelector(
+        '[data-testid="tabletop-workspace"]'
+      ) as HTMLElement | null;
+      if (!workspace) throw new Error('tabletop-workspace not found');
+      const rect = workspace.getBoundingClientRect();
+      const clientX = rect.left + rect.width / 2 + offset.dx;
+      const clientY = rect.top + rect.height / 2 + offset.dy;
+      const dt = new DataTransfer();
+      dt.setData('application/x-cartyx-document', JSON.stringify(payload));
+      for (const type of ['dragenter', 'dragover', 'drop'] as const) {
+        const event = new DragEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          clientX,
+          clientY,
+        });
+        // Chromium's DragEvent constructor ignores the dataTransfer init member,
+        // so force it on explicitly — otherwise handleDrop sees a null transfer.
+        Object.defineProperty(event, 'dataTransfer', { value: dt });
+        workspace.dispatchEvent(event);
+      }
+    },
+    { payload, offset }
+  );
+}
+
+test.describe('Lore drag-and-drop onto tabletop', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockPostHog(page);
+    await blockPartyKit(page);
+  });
+
+  test('GM can drag a lore card onto the workspace and a lore window opens', async ({
+    page,
+    tabletopUrl,
+  }) => {
+    // Navigate to the tabletop tab — globalSetup ensures a screen exists.
+    await page.goto(tabletopUrl);
+
+    // Wait for the tabletop workspace to be ready.
+    const workspace = page.getByTestId('tabletop-workspace');
+    await expect(workspace).toBeVisible({ timeout: 20_000 });
+
+    // Open the Wiki sidebar panel.
+    await page.getByRole('tab', { name: 'Wiki' }).click();
+
+    // Drill into the Lore category.
+    await page.getByRole('button', { name: 'Lore' }).click();
+
+    // Wait for the first lore card to appear (requires seeded lore data).
+    const firstCard = page.getByTestId('lore-card').first();
+    await expect(firstCard).toBeVisible({ timeout: 10_000 });
+
+    // Read the lore title from the card so we can assert it in the window header.
+    // The title is the first text-sm span inside the card.
+    const loreTitle = await firstCard.locator('span.text-sm').first().innerText();
+
+    // Extract the documentId from the card's drag payload — we need to do this
+    // by reading the data attribute set during onDragStart. The card sets the
+    // payload via JS, so we read it via evaluate.
+    const cardPayload = await firstCard.evaluate((el) => {
+      // Trigger a synthetic dragstart so the payload is set on a real DataTransfer,
+      // then read it back. We do not actually need to start a real drag; instead
+      // we intercept via a one-shot dragstart listener.
+      return new Promise<{ collection: string; documentId: string; title: string } | null>(
+        (resolve) => {
+          const handler = (e: DragEvent) => {
+            el.removeEventListener('dragstart', handler);
+            const raw = e.dataTransfer?.getData('application/x-cartyx-document') ?? null;
+            resolve(raw ? JSON.parse(raw) : null);
+          };
+          el.addEventListener('dragstart', handler);
+          el.dispatchEvent(
+            new DragEvent('dragstart', {
+              bubbles: true,
+              cancelable: true,
+              dataTransfer: new DataTransfer(),
+            })
+          );
+        }
+      );
+    });
+
+    // If we couldn't extract the payload from the dragstart event (some browsers
+    // restrict DataTransfer access outside the event), fall back to constructing
+    // the payload from what we know: collection is always "lore" and we use the
+    // title we already captured.
+    const payload: { collection: string; documentId: string; title: string } = cardPayload ?? {
+      collection: 'lore',
+      documentId: 'unknown',
+      title: loreTitle,
+    };
+
+    // Drop onto the workspace centre.
+    await dropOnWorkspace(page, payload, { dx: 0, dy: 0 });
+
+    // A floating lore window should appear on the workspace.  The FloatingWindow
+    // component renders the lore title in its title bar as a <span>.
+    // Also assert the LoreWindow content root (data-testid="lore-window") is present.
+    await expect(page.getByText(loreTitle).first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('lore-window')).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/e2e/lore/lore-drag-drop.spec.ts
+++ b/e2e/lore/lore-drag-drop.spec.ts
@@ -104,10 +104,13 @@ test.describe('Lore drag-and-drop onto tabletop', () => {
     // Drop onto the workspace centre.
     await dropOnWorkspace(page, payload, { dx: 0, dy: 0 });
 
-    // A floating lore window should appear on the workspace.
-    await expect(page.getByTestId('lore-window')).toBeVisible({ timeout: 10_000 });
+    // A floating lore window should appear on the workspace. Use .first() —
+    // the E2E screen persists across runs and may already hold lore windows
+    // from earlier drops, so more than one lore-window can be present.
+    await expect(page.getByTestId('lore-window').first()).toBeVisible({ timeout: 10_000 });
 
-    // The FloatingWindow title bar should also contain the lore entry's title.
+    // The FloatingWindow title bar should also contain the lore entry's title
+    // (server now hydrates lore so the title resolves, not "lore:<id>").
     await expect(page.getByText(title).first()).toBeVisible({ timeout: 10_000 });
   });
 });

--- a/e2e/lore/lore-drag-drop.spec.ts
+++ b/e2e/lore/lore-drag-drop.spec.ts
@@ -84,53 +84,30 @@ test.describe('Lore drag-and-drop onto tabletop', () => {
     const firstCard = page.getByTestId('lore-card').first();
     await expect(firstCard).toBeVisible({ timeout: 10_000 });
 
-    // Read the lore title from the card so we can assert it in the window header.
-    // The title is the first text-sm span inside the card.
-    const loreTitle = await firstCard.locator('span.text-sm').first().innerText();
+    // Read the documentId directly from the stable DOM attribute set on the
+    // card's root element.  This avoids the unreliable synthetic-dragstart
+    // approach — Chromium's DragEvent constructor silently ignores the
+    // dataTransfer init member outside a trusted drag gesture, causing getData
+    // to return '' and the payload to fall back to documentId: 'unknown'.
+    const documentId = await firstCard.getAttribute('data-lore-id');
+    if (!documentId) throw new Error('data-lore-id attribute missing from lore-card');
 
-    // Extract the documentId from the card's drag payload — we need to do this
-    // by reading the data attribute set during onDragStart. The card sets the
-    // payload via JS, so we read it via evaluate.
-    const cardPayload = await firstCard.evaluate((el) => {
-      // Trigger a synthetic dragstart so the payload is set on a real DataTransfer,
-      // then read it back. We do not actually need to start a real drag; instead
-      // we intercept via a one-shot dragstart listener.
-      return new Promise<{ collection: string; documentId: string; title: string } | null>(
-        (resolve) => {
-          const handler = (e: DragEvent) => {
-            el.removeEventListener('dragstart', handler);
-            const raw = e.dataTransfer?.getData('application/x-cartyx-document') ?? null;
-            resolve(raw ? JSON.parse(raw) : null);
-          };
-          el.addEventListener('dragstart', handler);
-          el.dispatchEvent(
-            new DragEvent('dragstart', {
-              bubbles: true,
-              cancelable: true,
-              dataTransfer: new DataTransfer(),
-            })
-          );
-        }
-      );
-    });
+    // Read the title from the dedicated testid span — more stable than the
+    // fragile span.text-sm selector used previously.
+    const title = await firstCard.getByTestId('lore-card-title').innerText();
 
-    // If we couldn't extract the payload from the dragstart event (some browsers
-    // restrict DataTransfer access outside the event), fall back to constructing
-    // the payload from what we know: collection is always "lore" and we use the
-    // title we already captured.
-    const payload: { collection: string; documentId: string; title: string } = cardPayload ?? {
-      collection: 'lore',
-      documentId: 'unknown',
-      title: loreTitle,
-    };
+    // Build the drop payload the same way dropOnMap does in
+    // tabletop-monster-tokens.spec.ts: construct it directly rather than
+    // intercepting a dragstart event.
+    const payload = { collection: 'lore', documentId, title };
 
     // Drop onto the workspace centre.
     await dropOnWorkspace(page, payload, { dx: 0, dy: 0 });
 
-    // A floating lore window should appear on the workspace.  The FloatingWindow
-    // component renders the lore title in its title bar as a <span>.
-    // Also assert the LoreWindow content root (data-testid="lore-window") is present.
-    await expect(page.getByText(loreTitle).first()).toBeVisible({ timeout: 10_000 });
+    // A floating lore window should appear on the workspace.
     await expect(page.getByTestId('lore-window')).toBeVisible({ timeout: 10_000 });
+
+    // The FloatingWindow title bar should also contain the lore entry's title.
+    await expect(page.getByText(title).first()).toBeVisible({ timeout: 10_000 });
   });
 });

--- a/e2e/lore/lore-editor.spec.ts
+++ b/e2e/lore/lore-editor.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * E2E: Lore editor (create flow).
+ *
+ * Proves that a GM can open the Lore panel, click Create, fill in a title,
+ * toggle the visibility to Public, submit the form, and see the newly created
+ * lore entry appear in the list.
+ *
+ * Pre-conditions: `npm run dev:seed` must have run so that the GM session
+ * cookie and campaign data exist in the dev DB.  Do NOT run this spec against
+ * a production database.
+ */
+import { test, expect } from '../fixtures/tabletop-fixtures';
+import { mockPostHog, blockPartyKit } from '../fixtures/network-mocks';
+
+const LORE_TITLE = 'E2E Lore Editor Fixture';
+
+/** Navigate to the campaign play page and drill down to the Lore panel. */
+async function openLorePanel(
+  page: import('@playwright/test').Page,
+  campaignUrl: string
+): Promise<void> {
+  await page.goto(campaignUrl);
+
+  // Open the Wiki tab in the InspectorSidebar.
+  await page.getByRole('tab', { name: 'Wiki' }).click();
+
+  // Drill into the Lore category.
+  await page.getByRole('button', { name: 'Lore' }).click();
+}
+
+test.describe('Lore editor (create flow)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockPostHog(page);
+    await blockPartyKit(page);
+  });
+
+  test('GM can create a new lore entry and see it in the list', async ({ page, campaignUrl }) => {
+    await openLorePanel(page, campaignUrl);
+
+    // Open the create modal.
+    await page.getByTestId('lore-create-button').click();
+
+    // The modal should be visible (identified by its heading).
+    await expect(page.getByRole('dialog', { name: /Create Lore/i })).toBeVisible();
+
+    // Fill in the title using the stable testid added to the FormInput.
+    await page.getByTestId('lore-title-input').fill(LORE_TITLE);
+
+    // Optionally type some content — target the CodeMirror editor's content
+    // region. Content is not required by the form, but exercising it is good.
+    const cmContent = page.locator('#lore-content-editor .cm-content').first();
+    if (await cmContent.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await cmContent.click();
+      await page.keyboard.type('A legendary account written for automated testing.');
+    }
+
+    // Toggle visibility to Public.
+    await page.getByRole('radio', { name: 'Public' }).click();
+
+    // Submit the form.
+    await page.getByRole('button', { name: 'Create Lore' }).click();
+
+    // The modal should close and the new entry should appear in the list.
+    await expect(page.getByRole('dialog', { name: /Create Lore/i })).toBeHidden({
+      timeout: 10_000,
+    });
+    await expect(page.getByText(LORE_TITLE)).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/e2e/lore/lore-editor.spec.ts
+++ b/e2e/lore/lore-editor.spec.ts
@@ -54,8 +54,13 @@ test.describe('Lore editor (create flow)', () => {
       await page.keyboard.type('A legendary account written for automated testing.');
     }
 
-    // Toggle visibility to Public.
-    await page.getByRole('radio', { name: 'Public' }).click();
+    // Toggle visibility to Public. The radio is an `sr-only` input behind a
+    // styled label, so click the visible label (native <label> toggles the
+    // wrapped input) rather than the offscreen radio itself.
+    await page
+      .getByRole('dialog', { name: /Create Lore/i })
+      .locator('label', { hasText: 'Public' })
+      .click();
 
     // Submit the form.
     await page.getByRole('button', { name: 'Create Lore' }).click();
@@ -64,6 +69,12 @@ test.describe('Lore editor (create flow)', () => {
     await expect(page.getByRole('dialog', { name: /Create Lore/i })).toBeHidden({
       timeout: 10_000,
     });
-    await expect(page.getByText(LORE_TITLE)).toBeVisible({ timeout: 10_000 });
+    // Assert the lore CARD (a button whose accessible name includes the title)
+    // is present — more robust than the title <h3>, which is truncate/min-w-0
+    // and can read as zero-width. .first() because re-runs accumulate fixtures
+    // with the same title in the dev DB.
+    await expect(page.getByRole('button', { name: new RegExp(LORE_TITLE) }).first()).toBeVisible({
+      timeout: 10_000,
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "db:verify": "tsx scripts/mongo-admin.ts verify",
     "db:sync": "tsx scripts/mongo-admin.ts sync",
     "dev:clear": "node scripts/run-python.cjs dev_clear.py",
-    "dev:seed": "node scripts/run-python.cjs dev_seed.py && node scripts/gen_seed_avatars.mjs",
+    "dev:seed": "node scripts/run-python.cjs dev_seed.py && node scripts/gen_seed_avatars.mjs && node scripts/gen_seed_lore_images.mjs",
     "dev:repair-images": "node scripts/run-python.cjs repair_seed_images.py && node scripts/gen_seed_avatars.mjs",
     "dev:gen-avatars": "node scripts/gen_seed_avatars.mjs",
     "fixture": "tsx scripts/dev-fixtures/cli.ts",

--- a/scripts/dev_seed.py
+++ b/scripts/dev_seed.py
@@ -1414,7 +1414,8 @@ def main() -> None:
                 now=now,
             )
             if lore_docs:
-                db.lore.insert_many(lore_docs)
+                # Mongoose pluralizes model('Lore') to the `lores` collection.
+                db.lores.insert_many(lore_docs)
             print(f"    lore       inserted {len(lore_docs)}")
 
         print()

--- a/scripts/dev_seed.py
+++ b/scripts/dev_seed.py
@@ -37,6 +37,7 @@ from pymongo.errors import ConfigurationError
 # focused on insertion logic.
 from seed_player_data import PLAYER_EMAILS, PLAYER_IMAGES, random_pc
 from seed_monster_data import build_monster_docs
+from seed_calendar_data import HARPTOS, to_ordinal
 
 
 def import_srd_races(db, *, campaign_id, gm_id, now) -> int:
@@ -744,6 +745,101 @@ def build_lore_docs(*, campaign_id, gm_id, player_ids, player_user_ids,
     return docs
 
 
+def build_calendar_doc(*, campaign_id, gm_id, now):
+    """One Calendar of Harptos document for the rich campaign.
+
+    Starts from the shared HARPTOS config (which mirrors app/utils/harptos.ts)
+    and stamps on the per-campaign ownership/timestamps. A shallow copy is fine
+    because we only add top-level keys; the nested month/season/etc. lists are
+    static reference data we never mutate.
+    """
+    doc = dict(HARPTOS)
+    doc.update({
+        "campaignId": campaign_id,
+        "createdBy": gm_id,
+        "createdAt": now,
+        "updatedAt": now,
+    })
+    return doc
+
+
+def build_event_docs(*, campaign_id, calendar_id, gm_id, now,
+                     character_ids, location_ids, race_ids, player_ids, session_ids):
+    """~10 sample events on the Harptos calendar, linked to seeded entities.
+
+    Arguments
+    ---------
+    character_ids : list of Character document ObjectIds (insertion order) —
+                    character_ids[0] is the first named NPC (Thorin Ironforge).
+    location_ids  : dict mapping location name → ObjectId (e.g. "Phandalin").
+    race_ids      : dict mapping race title → ObjectId (subset; may be empty).
+    player_ids    : list of Player document ObjectIds.
+    session_ids   : list of session ObjectIds (the first is linked from the
+                    Siege event). Pass [] when none are available — the link
+                    simply becomes None.
+
+    Every start/end date is valid under Harptos (see seed_calendar_data.py for
+    month lengths; Shieldmeet — monthIndex 10 — is only valid in leap years, and
+    1488 IS a leap year so day 1 resolves).
+    """
+    def ev(title, content, start, *, public, epic=False, end=None, links=None,
+           gm_content="", tags=None, session_id=None, day_offset=0):
+        ts = now - timedelta(days=day_offset)
+        return {
+            "title": title, "content": content, "gmContent": gm_content,
+            "isPublic": public, "isEpic": epic,
+            "start": start, "end": end,
+            "startOrdinal": to_ordinal(HARPTOS, start),
+            "endOrdinal": to_ordinal(HARPTOS, end or start),
+            "links": links or [], "sessionId": session_id, "images": [],
+            "tags": tags or [], "color": None,
+            "campaignId": campaign_id, "calendarId": calendar_id, "createdBy": gm_id,
+            "createdAt": ts, "updatedAt": ts,
+        }
+
+    # Resolve ids against the real seeded structures, falling back to a fresh
+    # ObjectId only when the collection is genuinely empty (keeps the builder
+    # usable in DB-free unit checks).
+    phandalin = location_ids.get("Phandalin") or (next(iter(location_ids.values())) if location_ids else ObjectId())
+    npc0 = character_ids[0] if character_ids else ObjectId()
+    player0 = player_ids[0] if player_ids else ObjectId()
+    elf = race_ids.get("Elf") or (next(iter(race_ids.values())) if race_ids else ObjectId())
+    session0 = session_ids[0] if session_ids else None
+
+    return [
+        ev("The Time of Troubles", "The gods walked Faerûn as mortals; Mystra fell at Mistmere.",
+           {"year": 1358, "monthIndex": 6, "day": 15}, public=True, epic=True, tags=["world", "history"]),
+        ev("The Spellplague", "Blue fire swept the Weave; magic itself convulsed across the Realms.",
+           {"year": 1385, "monthIndex": 8, "day": 1}, public=True, epic=True, tags=["world", "history"]),
+        ev("Shieldmeet Grand Council", "Rulers renewed pacts on the leap-day festival of Shieldmeet.",
+           {"year": 1488, "monthIndex": 10, "day": 1}, public=True, tags=["festival", "politics"]),
+        ev("Founding of Phandalin", "Settlers rebuilt the ruined town atop the old Phandelver pact lands.",
+           {"year": 1451, "monthIndex": 3, "day": 8}, public=True,
+           links=[{"kind": "location", "id": phandalin}], tags=["history"]),
+        ev("The Siege of Phandalin", "Redbrands stormed the town over two desperate days.",
+           {"year": 1491, "monthIndex": 4, "day": 11}, end={"year": 1491, "monthIndex": 4, "day": 12},
+           public=True, epic=True,
+           links=[{"kind": "location", "id": phandalin}, {"kind": "character", "id": npc0}],
+           tags=["campaign", "battle"], session_id=session0),
+        ev("Gundren's Disappearance", "Gundren Rockseeker vanished on the Triboar Trail.",
+           {"year": 1491, "monthIndex": 4, "day": 2}, public=False,
+           gm_content="Captured by Cragmaw goblins on the Black Spider's orders.",
+           links=[{"kind": "character", "id": npc0}], tags=["campaign", "secret"]),
+        ev("Wave Echo Cave Rediscovered", "The lost mine and its Forge of Spells came to light again.",
+           {"year": 1491, "monthIndex": 4, "day": 20}, public=True,
+           links=[{"kind": "location", "id": phandalin}], tags=["campaign"]),
+        ev("Greengrass in Phandalin", "The spring festival of Greengrass was kept with garlands and ale.",
+           {"year": 1491, "monthIndex": 5, "day": 1}, public=True,
+           links=[{"kind": "player", "id": player0}], tags=["festival"]),
+        ev("The Elven Retreat", "The elves withdrew to their hidden refuges as the age turned.",
+           {"year": 1344, "monthIndex": 12, "day": 20}, public=True,
+           links=[{"kind": "race", "id": elf}], tags=["history", "elf"]),
+        ev("Council Vote at Neverwinter", "A closed council set the season's trade compacts.",
+           {"year": 1491, "monthIndex": 6, "day": 10}, public=False,
+           gm_content="Sets up the next arc's politics.", tags=["politics", "secret"]),
+    ]
+
+
 def build_note_docs(*, campaign_id, session_ids, gm_id, party, now):
     """Return a realistic mix of Note docs for the rich campaign.
 
@@ -1417,6 +1513,24 @@ def main() -> None:
                 # Mongoose pluralizes model('Lore') to the `lores` collection.
                 db.lores.insert_many(lore_docs)
             print(f"    lore       inserted {len(lore_docs)}")
+
+            # Calendar of Harptos + sample events — inserted after lore so all
+            # entity ids (characters, locations, races, players, sessions) are
+            # available to link from events.
+            cal_doc = build_calendar_doc(campaign_id=campaign_id, gm_id=gm_id, now=now)
+            cal_result = db.calendars.insert_one(cal_doc)
+            calendar_id = cal_result.inserted_id
+            print(f"    calendar   inserted 1")
+
+            event_docs = build_event_docs(
+                campaign_id=campaign_id, calendar_id=calendar_id, gm_id=gm_id, now=now,
+                character_ids=character_ids, location_ids=location_ids, race_ids=race_ids,
+                player_ids=player_doc_ids, session_ids=list(session_ids.values()),
+            )
+            if event_docs:
+                # Mongoose pluralizes model('Event') to the `events` collection.
+                db.events.insert_many(event_docs)
+            print(f"    events     inserted {len(event_docs)}")
 
         print()
 

--- a/scripts/dev_seed.py
+++ b/scripts/dev_seed.py
@@ -568,6 +568,168 @@ CAMPAIGNS = [
 ]
 
 
+def build_lore_docs(*, campaign_id, gm_id, player_ids, character_ids,
+                    location_ids, race_ids, now):
+    """Return at least 5 Lore docs for the rich campaign.
+
+    Arguments
+    ---------
+    player_ids  : list of Player document ObjectIds (not userId)
+    character_ids : list of Character document ObjectIds (in insertion order)
+    location_ids  : dict mapping location name → ObjectId
+    race_ids      : dict mapping race title → ObjectId (subset; may be empty)
+    """
+    def image(slug, caption):
+        return {"url": f"/uploads/seed-lore/{slug}.png", "caption": caption, "crop": None}
+
+    def lore(title, content, *, public, author_id, links, images, tags,
+             gm_content="", day_offset=0):
+        ts = now - timedelta(days=day_offset)
+        return {
+            "title": title,
+            "content": content,
+            "gmContent": gm_content,
+            "isPublic": public,
+            "images": images,
+            "links": links,
+            "tags": tags,
+            "campaignId": campaign_id,
+            "createdBy": author_id,
+            "createdAt": ts,
+            "updatedAt": ts,
+        }
+
+    # Resolve ids — fall back gracefully when the collection is sparse.
+    elf_race_id   = race_ids.get("Elf") or (next(iter(race_ids.values())) if race_ids else ObjectId())
+    phandalin_id  = location_ids.get("Phandalin") or (next(iter(location_ids.values())) if location_ids else ObjectId())
+    # "Black Spider" NPC is Nezznar — use the first character id (Thorin) as a
+    # stand-in when no named-character lookup is available; see build_lore_docs
+    # call site where character_ids are indexed by insertion order.
+    npc_id        = character_ids[0] if character_ids else ObjectId()
+    # Second character (Elara Moonwhisper) for the dragon legend multi-link.
+    char2_id      = character_ids[1] if len(character_ids) > 1 else npc_id
+    # Player ids for the two player-linked lore docs.
+    player0_id    = player_ids[0] if player_ids else ObjectId()
+    player1_id    = player_ids[1] if len(player_ids) > 1 else player0_id
+
+    docs = [
+        # 1 — Race link (public, GM-authored)
+        lore(
+            "Origins of the Elves",
+            (
+                "Long before the rise of human kingdoms, the elves walked beneath "
+                "ancient stars. Born of the Feywild's raw magic, they carry the "
+                "memories of an age when gods still walked among mortals.\n\n"
+                "Their **Trance** meditation is not sleep but a waking reverie, "
+                "and their **Darkvision** a remnant of centuries spent in star-lit "
+                "forests far from any torch."
+            ),
+            public=True,
+            author_id=gm_id,
+            links=[{"kind": "race", "id": elf_race_id}],
+            images=[image("elf-origins", "Ancient elf ruins beneath a moonlit sky")],
+            tags=["lore", "race", "elf"],
+            day_offset=14,
+        ),
+        # 2 — Location link (public, GM-authored)
+        lore(
+            "A Short History of Phandalin",
+            (
+                "Phandalin was once a thriving human settlement that traded with "
+                "the dwarves of the Phandelver Pact. Orcs razed it to the ground "
+                "some five centuries ago, and only ruins remained until a generation "
+                "past when a wave of settlers began to rebuild.\n\n"
+                "Today it is a rough frontier town of a few hundred souls. The "
+                "Miner's Exchange controls much of the commerce, while Harbin Wester "
+                "serves as the largely ineffectual Townmaster."
+            ),
+            public=True,
+            author_id=gm_id,
+            links=[{"kind": "location", "id": phandalin_id}],
+            images=[image("phandalin-history", "Phandalin's main street at dusk")],
+            tags=["lore", "location", "history"],
+            day_offset=10,
+        ),
+        # 3 — Character link (private, GM-only gmContent)
+        lore(
+            "The Black Spider's Web",
+            (
+                "Rumours speak of a shadowy figure pulling strings across the "
+                "Sword Coast — a spymaster known only as the Black Spider. Caravans "
+                "have been ambushed, dwarven prospectors have gone missing, and at "
+                "the centre of each thread sits this unseen hand."
+            ),
+            public=False,
+            author_id=gm_id,
+            links=[{"kind": "character", "id": npc_id}],
+            images=[image("black-spider", "A spider-sigil wax seal on a torn letter")],
+            tags=["lore", "villain", "secret"],
+            gm_content=(
+                "**GM eyes only:** The Black Spider is Nezznar, a drow mage "
+                "who wants sole access to the Forge of Spells in Wave Echo Cave. "
+                "He has sent a doppelganger to impersonate one of the Rockseeker "
+                "brothers — reveal this when the party reaches area 12."
+            ),
+            day_offset=10,
+        ),
+        # 4 — Multi-link: location + character (public)
+        lore(
+            "Legend of the Sleeping Dragon",
+            (
+                "The peasants of the Triboar Trail tell of a dragon that once "
+                "laid waste to a city of mages, then curled beneath the mountains "
+                "to sleep for a thousand years. Some say the tremors that occasionally "
+                "shake Phandalin are its shallow breaths.\n\n"
+                "Scholars note that every fifty years or so, a silver-scaled form "
+                "is glimpsed above the Sword Mountains at dusk."
+            ),
+            public=True,
+            author_id=gm_id,
+            links=[
+                {"kind": "location", "id": phandalin_id},
+                {"kind": "character", "id": char2_id},
+            ],
+            images=[image("dragon-legend", "A silver dragon silhouetted against storm clouds")],
+            tags=["lore", "legend", "dragon"],
+            day_offset=7,
+        ),
+        # 5 — Player link (private — player + GM only)
+        lore(
+            "The Wanderer's Oath",
+            (
+                "Before joining the party, this adventurer swore an oath in a "
+                "roadside shrine to Tymora — Lady Luck. The exact words are known "
+                "only to them and to the goddess, but the party has glimpsed the "
+                "silver coin always turning between their fingers."
+            ),
+            public=False,
+            author_id=player0_id,
+            links=[{"kind": "player", "id": player0_id}],
+            images=[],
+            tags=["lore", "player", "backstory"],
+            day_offset=5,
+        ),
+        # 6 — Second player link (public) — ensures both visibility states
+        #     appear on the Player Lore tab.
+        lore(
+            "Songs of the Road",
+            (
+                "This adventurer keeps a travelling journal of the places the "
+                "party has passed through — sketches of Phandalin's crooked rooftops, "
+                "rubbings of goblin cave-carvings, the pressed flower from Conyberry. "
+                "Anyone who asks may read it at camp."
+            ),
+            public=True,
+            author_id=player1_id,
+            links=[{"kind": "player", "id": player1_id}],
+            images=[],
+            tags=["lore", "player", "journal"],
+            day_offset=3,
+        ),
+    ]
+    return docs
+
+
 def build_note_docs(*, campaign_id, session_ids, gm_id, party, now):
     """Return a realistic mix of Note docs for the rich campaign.
 
@@ -976,11 +1138,13 @@ def main() -> None:
         # Insert four players (one per player account), each with a unique
         # portrait + randomised name/race/class/backstory.
         party = []
+        # player_doc_ids: list of Player document _ids (used for lore links).
+        player_doc_ids: list = []
         for pu in player_users:
             pc = random_pc(rng)
             picture = PLAYER_IMAGES[image_cursor % len(PLAYER_IMAGES)]
             image_cursor += 1
-            db.players.insert_one({
+            p_result = db.players.insert_one({
                 "campaignId": campaign_id,
                 # `userId` is required by the unique index
                 # `{campaignId:1, userId:1}` — one player document per user
@@ -1012,6 +1176,7 @@ def main() -> None:
                 "createdAt": now,
                 "updatedAt": now,
             })
+            player_doc_ids.append(p_result.inserted_id)
             print(f"    player    {pc['firstName']} {pc['lastName']} "
                   f"({pc['race']} {pc['characterClass']}) — {pu['email']}")
             party.append({"name": f"{pc['firstName']} {pc['lastName']}",
@@ -1104,9 +1269,11 @@ def main() -> None:
         ])
         print(f"    location types  ({len(DEFAULT_LOCATION_TYPES)} defaults)")
 
-        # Insert any seed locations defined for this campaign
+        # Insert any seed locations defined for this campaign.
+        # location_ids: maps location name → inserted _id (for lore links).
+        location_ids: dict[str, object] = {}
         for loc in defn.get("locations", []):
-            db.location.insert_one({
+            loc_result = db.location.insert_one({
                 "campaignId": campaign_id,
                 "createdBy": gm_id,
                 "name": loc["name"],
@@ -1123,11 +1290,13 @@ def main() -> None:
                 "createdAt": now,
                 "updatedAt": now,
             })
+            location_ids[loc["name"]] = loc_result.inserted_id
             print(f"    location  {loc['name']} ({loc['locationType']})")
 
-        # Insert characters
+        # Insert characters; capture ids in insertion order for lore links.
+        character_ids: list = []
         for char in defn["characters"]:
-            db.characters.insert_one({
+            char_result = db.characters.insert_one({
                 "firstName": char["firstName"],
                 "lastName": char["lastName"],
                 "race": char["race"],
@@ -1147,17 +1316,25 @@ def main() -> None:
                 "createdAt": now,
                 "updatedAt": now,
             })
+            character_ids.append(char_result.inserted_id)
             print(f"    character  {char['firstName']} {char['lastName']} ({char['race']} {char['characterClass']})")
 
         # Bulk / stock test campaign — pile in SRD races, rules, hundreds
         # of monsters (base + variants), and hundreds of NPC characters so
         # every list page, search, filter, and drag-to-token surface is
         # exercisable at realistic scale from a fresh seed.
+        race_ids: dict[str, object] = {}
         if defn.get("bulk_test_campaign"):
             n_races = import_srd_races(db, campaign_id=campaign_id, gm_id=gm_id, now=now)
             n_rules = import_srd_rules(db, campaign_id=campaign_id, gm_id=gm_id, now=now)
             print(f"    SRD races  imported {n_races} from docs/srd/races")
             print(f"    SRD rules  imported {n_rules} from docs/srd/rules")
+            # Collect race ids for lore links (query back the titles we care about).
+            for race_doc in db.races.find(
+                {"campaignId": campaign_id, "title": {"$in": ["Elf", "Dwarf", "Human"]}},
+                {"_id": 1, "title": 1},
+            ):
+                race_ids[race_doc["title"]] = race_doc["_id"]
 
             # Bulk NPC characters — 200 generated names/classes/factions,
             # plus the two named characters already declared on the spec.
@@ -1208,6 +1385,22 @@ def main() -> None:
                 f"    monsters   imported {len(monster_docs)} stat blocks "
                 f"({'base+variants' if with_variants else 'base only'})"
             )
+
+        # Lore docs — rich campaign only, inserted last so all entity ids
+        # (races, locations, characters, players) are available.
+        if defn.get("rich_session_history"):
+            lore_docs = build_lore_docs(
+                campaign_id=campaign_id,
+                gm_id=gm_id,
+                player_ids=player_doc_ids,
+                character_ids=character_ids,
+                location_ids=location_ids,
+                race_ids=race_ids,
+                now=now,
+            )
+            if lore_docs:
+                db.lore.insert_many(lore_docs)
+            print(f"    lore       inserted {len(lore_docs)}")
 
         print()
 

--- a/scripts/dev_seed.py
+++ b/scripts/dev_seed.py
@@ -568,13 +568,19 @@ CAMPAIGNS = [
 ]
 
 
-def build_lore_docs(*, campaign_id, gm_id, player_ids, character_ids,
-                    location_ids, race_ids, now):
+def build_lore_docs(*, campaign_id, gm_id, player_ids, player_user_ids,
+                    character_ids, location_ids, race_ids, now):
     """Return at least 5 Lore docs for the rich campaign.
 
     Arguments
     ---------
-    player_ids  : list of Player document ObjectIds (not userId)
+    player_ids      : list of Player document ObjectIds (not userId) — used for
+                      the "player" link targets so the Lore tab can filter by
+                      player doc id.
+    player_user_ids : list of User ObjectIds, parallel to player_ids — used as
+                      createdBy so the server's ownership check
+                      (String(doc.createdBy) === member.userId) correctly
+                      identifies the owning player.
     character_ids : list of Character document ObjectIds (in insertion order)
     location_ids  : dict mapping location name → ObjectId
     race_ids      : dict mapping race title → ObjectId (subset; may be empty)
@@ -608,9 +614,13 @@ def build_lore_docs(*, campaign_id, gm_id, player_ids, character_ids,
     npc_id        = character_ids[0] if character_ids else ObjectId()
     # Second character (Elara Moonwhisper) for the dragon legend multi-link.
     char2_id      = character_ids[1] if len(character_ids) > 1 else npc_id
-    # Player ids for the two player-linked lore docs.
+    # Player *document* ids for the two player-linked lore docs (link targets).
     player0_id    = player_ids[0] if player_ids else ObjectId()
     player1_id    = player_ids[1] if len(player_ids) > 1 else player0_id
+    # Player *user* ids — used as createdBy so the server ownership check
+    # (String(doc.createdBy) === member.userId) recognises the owning player.
+    player0_user_id = player_user_ids[0] if player_user_ids else ObjectId()
+    player1_user_id = player_user_ids[1] if len(player_user_ids) > 1 else player0_user_id
 
     docs = [
         # 1 — Race link (public, GM-authored)
@@ -703,7 +713,10 @@ def build_lore_docs(*, campaign_id, gm_id, player_ids, character_ids,
                 "silver coin always turning between their fingers."
             ),
             public=False,
-            author_id=player0_id,
+            # createdBy must be the User _id (not the Player doc _id) so the
+            # server ownership check (String(doc.createdBy) === member.userId)
+            # lets the owning player read their own private lore.
+            author_id=player0_user_id,
             links=[{"kind": "player", "id": player0_id}],
             images=[],
             tags=["lore", "player", "backstory"],
@@ -720,7 +733,8 @@ def build_lore_docs(*, campaign_id, gm_id, player_ids, character_ids,
                 "Anyone who asks may read it at camp."
             ),
             public=True,
-            author_id=player1_id,
+            # Same reasoning: createdBy is the User _id, not the Player doc _id.
+            author_id=player1_user_id,
             links=[{"kind": "player", "id": player1_id}],
             images=[],
             tags=["lore", "player", "journal"],
@@ -1393,6 +1407,7 @@ def main() -> None:
                 campaign_id=campaign_id,
                 gm_id=gm_id,
                 player_ids=player_doc_ids,
+                player_user_ids=[pu["_id"] for pu in player_users],
                 character_ids=character_ids,
                 location_ids=location_ids,
                 race_ids=race_ids,

--- a/scripts/gen_seed_lore_images.mjs
+++ b/scripts/gen_seed_lore_images.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * Generate local PNG banner images for seeded lore entries.
+ *
+ * Each lore slug gets a deterministic banner: a gradient-style background
+ * derived from the slug hash, the entry's human title, and a book glyph (📖).
+ * Images are written to `public/uploads/seed-lore/<slug>.png`.
+ *
+ * Idempotent: files are always regenerated (overwritten) on each run, exactly
+ * like gen_seed_avatars.mjs. The public path the app references is:
+ *   /uploads/seed-lore/<slug>.png
+ *
+ * Usage:
+ *   node scripts/gen_seed_lore_images.mjs
+ *   npm run dev:seed   (called automatically as part of the chain)
+ *
+ * No database connection required — purely file I/O.
+ */
+import { createHash } from 'node:crypto';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Resvg } from '@resvg/resvg-js';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const LORE_SLUGS = [
+  { slug: 'elf-origins', title: 'Origins of the Elves' },
+  { slug: 'phandalin-history', title: 'A Short History of Phandalin' },
+  { slug: 'dragon-legend', title: 'Legend of the Sleeping Dragon' },
+  { slug: 'black-spider', title: "The Black Spider's Web" },
+];
+
+// ---------------------------------------------------------------------------
+// Deterministic banner SVG
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive a stable hue (0–359) and a secondary hue offset from the slug hash.
+ */
+function hashToHues(slug) {
+  const bytes = createHash('sha1').update(slug).digest();
+  const hue1 = bytes[0] % 360;
+  const hue2 = (hue1 + 40 + (bytes[1] % 60)) % 360;
+  return { hue1, hue2 };
+}
+
+/**
+ * Escape XML entities so title text is safe inside SVG.
+ */
+function escapeXml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * Wrap long title text into at most two lines, splitting on the last space
+ * before the midpoint so neither line is too long for the banner width.
+ */
+function wrapTitle(title) {
+  if (title.length <= 22) return [title];
+  // Try to find a space near the middle to split on.
+  const mid = Math.floor(title.length / 2);
+  const before = title.lastIndexOf(' ', mid);
+  const after = title.indexOf(' ', mid);
+  let splitAt;
+  if (before === -1 && after === -1) return [title];
+  if (before === -1) splitAt = after;
+  else if (after === -1) splitAt = before;
+  else splitAt = mid - before <= after - mid ? before : after;
+  return [title.slice(0, splitAt).trim(), title.slice(splitAt + 1).trim()];
+}
+
+/**
+ * Build a deterministic 320×160 banner SVG for a lore entry.
+ *
+ * Layout:
+ *   - Two-stop linear gradient background (hue1 → hue2, dark tones)
+ *   - Book glyph (unicode ᛒ rune-like circle initial) on the left
+ *   - Title text (one or two lines) centred in the right portion
+ *   - Subtle decorative rule line below the title
+ */
+function loreBannerSvg(slug, title) {
+  const { hue1, hue2 } = hashToHues(slug);
+  const W = 320;
+  const H = 160;
+
+  // Background gradient colours (dark, themed)
+  const bg1 = `hsl(${hue1} 38% 14%)`;
+  const bg2 = `hsl(${hue2} 28% 20%)`;
+  // Accent colour for glyph + rule
+  const accent = `hsl(${hue1} 62% 60%)`;
+  // Dim accent for secondary elements
+  const accentDim = `hsl(${hue1} 40% 40%)`;
+
+  const gradId = `g${slug.replace(/[^a-z0-9]/g, '')}`;
+
+  // Glyph circle — left side
+  const glyphCx = 60;
+  const glyphCy = H / 2;
+  const glyphR = 34;
+
+  // Pick a letter from the title for the glyph initial
+  const initial = escapeXml(title.charAt(0).toUpperCase());
+
+  // Title text lines
+  const lines = wrapTitle(title);
+  const titleX = 116;
+  const titleAreaWidth = W - titleX - 16;
+
+  let titleSvg = '';
+  if (lines.length === 1) {
+    titleSvg = `<text x="${titleX}" y="${H / 2 + 6}" font-family="Georgia, 'Times New Roman', serif" font-size="22" font-weight="bold" fill="white" dominant-baseline="middle">${escapeXml(lines[0])}</text>`;
+  } else {
+    const y1 = H / 2 - 12;
+    const y2 = H / 2 + 14;
+    titleSvg =
+      `<text x="${titleX}" y="${y1}" font-family="Georgia, 'Times New Roman', serif" font-size="20" font-weight="bold" fill="white">${escapeXml(lines[0])}</text>` +
+      `<text x="${titleX}" y="${y2}" font-family="Georgia, 'Times New Roman', serif" font-size="20" font-weight="bold" fill="white">${escapeXml(lines[1])}</text>`;
+  }
+
+  // Decorative rule under title text
+  const ruleY = lines.length === 1 ? H / 2 + 22 : H / 2 + 28;
+  const ruleX2 = titleX + titleAreaWidth;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
+  <defs>
+    <linearGradient id="${gradId}" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="${bg1}"/>
+      <stop offset="100%" stop-color="${bg2}"/>
+    </linearGradient>
+  </defs>
+  <!-- Background -->
+  <rect width="${W}" height="${H}" fill="url(#${gradId})"/>
+  <!-- Subtle corner ornament lines -->
+  <line x1="8" y1="8" x2="28" y2="8" stroke="${accentDim}" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="8" y1="8" x2="8" y2="28" stroke="${accentDim}" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="${W - 8}" y1="8" x2="${W - 28}" y2="8" stroke="${accentDim}" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="${W - 8}" y1="8" x2="${W - 8}" y2="28" stroke="${accentDim}" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- Glyph circle -->
+  <circle cx="${glyphCx}" cy="${glyphCy}" r="${glyphR}" fill="none" stroke="${accent}" stroke-width="2"/>
+  <circle cx="${glyphCx}" cy="${glyphCy}" r="${glyphR - 6}" fill="${accent}" fill-opacity="0.15"/>
+  <!-- Book pages icon: two overlapping rectangles to suggest an open book -->
+  <rect x="${glyphCx - 14}" y="${glyphCy - 14}" width="12" height="18" rx="2" fill="none" stroke="${accent}" stroke-width="1.8"/>
+  <rect x="${glyphCx + 2}" y="${glyphCy - 14}" width="12" height="18" rx="2" fill="none" stroke="${accent}" stroke-width="1.8"/>
+  <line x1="${glyphCx}" y1="${glyphCy - 14}" x2="${glyphCx}" y2="${glyphCy + 4}" stroke="${accent}" stroke-width="1.2"/>
+  <!-- Initial letter inside glyph -->
+  <text x="${glyphCx}" y="${glyphCy + 22}" font-family="Georgia, 'Times New Roman', serif" font-size="11" fill="${accent}" fill-opacity="0.7" text-anchor="middle">${initial}</text>
+  <!-- Vertical separator -->
+  <line x1="108" y1="28" x2="108" y2="${H - 28}" stroke="${accentDim}" stroke-width="1" stroke-dasharray="3,3"/>
+  <!-- Title -->
+  ${titleSvg}
+  <!-- Decorative rule -->
+  <line x1="${titleX}" y1="${ruleY}" x2="${ruleX2}" y2="${ruleY}" stroke="${accent}" stroke-width="1" stroke-opacity="0.5"/>
+</svg>`;
+}
+
+function renderPng(svg) {
+  return new Resvg(svg, { fitTo: { mode: 'width', value: 320 } }).render().asPng();
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const outDir = join(REPO_ROOT, 'public', 'uploads', 'seed-lore');
+  mkdirSync(outDir, { recursive: true });
+
+  for (const { slug, title } of LORE_SLUGS) {
+    const outPath = join(outDir, `${slug}.png`);
+    const svg = loreBannerSvg(slug, title);
+    writeFileSync(outPath, renderPng(svg));
+    console.log(`  wrote /uploads/seed-lore/${slug}.png  («${title}»)`);
+  }
+
+  console.log(
+    `\ngen_seed_lore_images: ${LORE_SLUGS.length} PNGs generated in public/uploads/seed-lore/`
+  );
+}
+
+main();

--- a/scripts/seed_calendar_data.py
+++ b/scripts/seed_calendar_data.py
@@ -1,0 +1,80 @@
+"""Calendar of Harptos seed config + a port of calendarEngine.toOrdinal.
+
+Mirrors app/utils/harptos.ts and app/utils/calendarEngine.ts EXACTLY. A vitest
+parity test (calendarEngine.parity.test.ts) asserts the TS engine and these
+numbers agree for the seeded dates, so the two ports cannot silently diverge.
+"""
+
+HARPTOS_MONTHS = [
+    {"name": "Hammer", "days": 30},
+    {"name": "Midwinter", "days": 1, "isIntercalary": True},
+    {"name": "Alturiak", "days": 30},
+    {"name": "Ches", "days": 30},
+    {"name": "Tarsakh", "days": 30},
+    {"name": "Greengrass", "days": 1, "isIntercalary": True},
+    {"name": "Mirtul", "days": 30},
+    {"name": "Kythorn", "days": 30},
+    {"name": "Flamerule", "days": 30},
+    {"name": "Midsummer", "days": 1, "isIntercalary": True},
+    {"name": "Shieldmeet", "days": 0, "isIntercalary": True},
+    {"name": "Eleasis", "days": 30},
+    {"name": "Eleint", "days": 30},
+    {"name": "Highharvestide", "days": 1, "isIntercalary": True},
+    {"name": "Marpenoth", "days": 30},
+    {"name": "Uktar", "days": 30},
+    {"name": "The Feast of the Moon", "days": 1, "isIntercalary": True},
+    {"name": "Nightal", "days": 30},
+]
+
+HARPTOS = {
+    "name": "Calendar of Harptos",
+    "description": "The calendar of the Forgotten Realms, devised by Harptos of Kaalinth.",
+    "months": HARPTOS_MONTHS,
+    "weekdays": ["First", "Second", "Third", "Fourth", "Fifth",
+                 "Sixth", "Seventh", "Eighth", "Ninth", "Tenth"],
+    "weekdayMode": "resetEachMonth",
+    "epoch": {"year": 1372, "weekdayIndex": 0},
+    "yearSuffix": "DR",
+    "namedYears": [
+        {"year": 1358, "name": "Year of Shadows"},
+        {"year": 1385, "name": "Year of Blue Fire"},
+    ],
+    "leapDays": [{"name": "Shieldmeet", "monthIndex": 10, "interval": 4, "offset": 0, "addDays": 1}],
+    "moons": [{"name": "Selûne", "cycleLength": 30, "offsetDays": 0}],
+    "seasons": [
+        {"name": "Winter", "startMonthIndex": 0, "startDay": 1},
+        {"name": "Spring", "startMonthIndex": 3, "startDay": 1},
+        {"name": "Summer", "startMonthIndex": 8, "startDay": 1},
+        {"name": "Autumn", "startMonthIndex": 13, "startDay": 1},
+    ],
+    "holidays": [],
+    "currentDate": {"year": 1491, "monthIndex": 6, "day": 15},
+}
+
+
+def _leap_applies(rule, year):
+    if rule["interval"] < 1:
+        return False
+    return (year - rule["offset"]) % rule["interval"] == 0
+
+
+def days_in_month(cfg, year, month_index):
+    base = cfg["months"][month_index]["days"]
+    extra = sum(r["addDays"] for r in cfg["leapDays"]
+                if r["monthIndex"] == month_index and _leap_applies(r, year))
+    return base + extra
+
+
+def days_in_year(cfg, year):
+    return sum(days_in_month(cfg, year, m) for m in range(len(cfg["months"])))
+
+
+def to_ordinal(cfg, date):
+    year, month_index, day = date["year"], date["monthIndex"], date["day"]
+    epoch_year = cfg["epoch"]["year"]
+    if year >= epoch_year:
+        year_start = sum(days_in_year(cfg, y) for y in range(epoch_year, year))
+    else:
+        year_start = -sum(days_in_year(cfg, y) for y in range(year, epoch_year))
+    before_month = sum(days_in_month(cfg, year, m) for m in range(month_index))
+    return year_start + before_month + (day - 1)

--- a/scripts/verify_session_seed.py
+++ b/scripts/verify_session_seed.py
@@ -157,17 +157,20 @@ def test_dice_log_deterministic():
 
 
 def test_lore_docs():
-    race_id     = ObjectId()
-    location_id = ObjectId()
-    char_id0    = ObjectId()
-    char_id1    = ObjectId()
-    player_id0  = ObjectId()
-    player_id1  = ObjectId()
+    race_id        = ObjectId()
+    location_id    = ObjectId()
+    char_id0       = ObjectId()
+    char_id1       = ObjectId()
+    player_id0     = ObjectId()   # Player document _id
+    player_id1     = ObjectId()
+    player_user_id0 = ObjectId()  # User _id for the owning player
+    player_user_id1 = ObjectId()
 
     docs = seed.build_lore_docs(
         campaign_id=CAMPAIGN_ID,
         gm_id=GM_ID,
         player_ids=[player_id0, player_id1],
+        player_user_ids=[player_user_id0, player_user_id1],
         character_ids=[char_id0, char_id1],
         location_ids={"Phandalin": location_id},
         race_ids={"Elf": race_id},
@@ -231,11 +234,33 @@ def test_lore_docs():
     assert player_id0 in linked_player_ids or player_id1 in linked_player_ids, \
         "player links must use the supplied player_ids"
 
+    # ── Player-linked private lore must use the User _id as createdBy ──────────
+    # The server checks String(doc.createdBy) === member.userId where
+    # member.userId is the authenticated User's DB _id — NOT the Player doc _id.
+    player_private = [
+        d for d in docs
+        if not d["isPublic"]
+        and any(lnk["kind"] == "player" for lnk in d["links"])
+    ]
+    assert player_private, "need at least one private player-linked lore doc"
+    player_user_ids_set = {player_user_id0, player_user_id1}
+    player_doc_ids_set  = {player_id0, player_id1}
+    for d in player_private:
+        assert d["createdBy"] in player_user_ids_set, (
+            f"Private player lore {d['title']!r} createdBy={d['createdBy']} "
+            f"must be a User _id {player_user_ids_set}, not a Player doc _id"
+        )
+        assert d["createdBy"] not in player_doc_ids_set, (
+            f"Private player lore {d['title']!r} createdBy must NOT be the "
+            f"Player document _id {player_doc_ids_set}"
+        )
+
     # ── Graceful fallback when race_ids is empty ─────────────────────────────
     docs_no_races = seed.build_lore_docs(
         campaign_id=CAMPAIGN_ID,
         gm_id=GM_ID,
         player_ids=[player_id0, player_id1],
+        player_user_ids=[player_user_id0, player_user_id1],
         character_ids=[char_id0, char_id1],
         location_ids={"Phandalin": location_id},
         race_ids={},  # empty — should still produce docs without crashing

--- a/scripts/verify_session_seed.py
+++ b/scripts/verify_session_seed.py
@@ -156,6 +156,94 @@ def test_dice_log_deterministic():
     assert [d["id"] for d in a] == [d["id"] for d in b], "dice ids must be deterministic"
 
 
+def test_lore_docs():
+    race_id     = ObjectId()
+    location_id = ObjectId()
+    char_id0    = ObjectId()
+    char_id1    = ObjectId()
+    player_id0  = ObjectId()
+    player_id1  = ObjectId()
+
+    docs = seed.build_lore_docs(
+        campaign_id=CAMPAIGN_ID,
+        gm_id=GM_ID,
+        player_ids=[player_id0, player_id1],
+        character_ids=[char_id0, char_id1],
+        location_ids={"Phandalin": location_id},
+        race_ids={"Elf": race_id},
+        now=NOW,
+    )
+
+    # ── Volume ──────────────────────────────────────────────────────────────
+    assert len(docs) >= 5, f"expected >=5 lore docs, got {len(docs)}"
+
+    # ── Required fields present on every doc ────────────────────────────────
+    required = {
+        "title", "content", "gmContent", "isPublic", "images",
+        "links", "tags", "campaignId", "createdBy", "createdAt", "updatedAt",
+    }
+    for d in docs:
+        assert required.issubset(d), f"missing fields in {d.get('title')!r}: {required - d.keys()}"
+        assert d["campaignId"] == CAMPAIGN_ID
+        assert isinstance(d["isPublic"], bool)
+        assert isinstance(d["tags"], list)
+        assert isinstance(d["links"], list)
+        assert isinstance(d["images"], list)
+
+    # ── All four link kinds must appear at least once ────────────────────────
+    link_kinds = {lnk["kind"] for d in docs for lnk in d["links"]}
+    for kind in ("race", "location", "character", "player"):
+        assert kind in link_kinds, f"no link of kind={kind!r} found"
+
+    # ── Links must carry real (non-falsy) ids ────────────────────────────────
+    for d in docs:
+        for lnk in d["links"]:
+            assert lnk.get("id"), f"link missing id in doc {d.get('title')!r}"
+            assert lnk.get("kind") in ("race", "location", "character", "player"), \
+                f"unexpected link kind {lnk.get('kind')!r}"
+
+    # ── At least one private doc with non-empty gmContent ───────────────────
+    private_with_gm = [d for d in docs if not d["isPublic"] and d.get("gmContent")]
+    assert private_with_gm, "need at least one private doc with gmContent"
+
+    # ── At least one public and one private doc ──────────────────────────────
+    assert any(d["isPublic"] for d in docs), "need at least one public doc"
+    assert any(not d["isPublic"] for d in docs), "need at least one private doc"
+
+    # ── Images carry the expected slug-based URL pattern ────────────────────
+    img_urls = [img["url"] for d in docs for img in d["images"]]
+    assert any(u.startswith("/uploads/seed-lore/") for u in img_urls), \
+        "image urls should be under /uploads/seed-lore/"
+
+    # ── The race link uses the supplied race_id ──────────────────────────────
+    race_links = [lnk for d in docs for lnk in d["links"] if lnk["kind"] == "race"]
+    assert any(lnk["id"] == race_id for lnk in race_links), \
+        "race link must use the supplied race_id"
+
+    # ── The location link uses the supplied location_id ──────────────────────
+    loc_links = [lnk for d in docs for lnk in d["links"] if lnk["kind"] == "location"]
+    assert any(lnk["id"] == location_id for lnk in loc_links), \
+        "location link must use the supplied location_id"
+
+    # ── Player links use the supplied player doc ids ─────────────────────────
+    player_links = [lnk for d in docs for lnk in d["links"] if lnk["kind"] == "player"]
+    linked_player_ids = {lnk["id"] for lnk in player_links}
+    assert player_id0 in linked_player_ids or player_id1 in linked_player_ids, \
+        "player links must use the supplied player_ids"
+
+    # ── Graceful fallback when race_ids is empty ─────────────────────────────
+    docs_no_races = seed.build_lore_docs(
+        campaign_id=CAMPAIGN_ID,
+        gm_id=GM_ID,
+        player_ids=[player_id0, player_id1],
+        character_ids=[char_id0, char_id1],
+        location_ids={"Phandalin": location_id},
+        race_ids={},  # empty — should still produce docs without crashing
+        now=NOW,
+    )
+    assert len(docs_no_races) >= 5, "build_lore_docs must work even when race_ids is empty"
+
+
 def test_chat_transcript_spine_per_session():
     start = NOW
     end = start + timedelta(hours=4)

--- a/scripts/verify_session_seed.py
+++ b/scripts/verify_session_seed.py
@@ -315,6 +315,114 @@ def test_transcript_ids_are_session_scoped():
             "ids must not collide across runs with different session ids"
 
 
+def test_calendar_doc():
+    doc = seed.build_calendar_doc(campaign_id=CAMPAIGN_ID, gm_id=GM_ID, now=NOW)
+    assert doc["name"] == "Calendar of Harptos"
+    assert doc["campaignId"] == CAMPAIGN_ID
+    assert doc["createdBy"] == GM_ID
+    assert doc["createdAt"] == NOW and doc["updatedAt"] == NOW
+    # Reference data carried through from the shared HARPTOS config.
+    assert isinstance(doc["months"], list) and len(doc["months"]) == 18
+    assert isinstance(doc["weekdays"], list) and doc["weekdays"]
+    assert doc["epoch"]["year"] == 1372
+    # Building twice must not mutate the shared HARPTOS dict (no campaignId leak).
+    from seed_calendar_data import HARPTOS
+    assert "campaignId" not in HARPTOS, "build_calendar_doc must not mutate HARPTOS"
+
+
+def test_event_docs():
+    location_id = ObjectId()
+    char_id0 = ObjectId()
+    char_id1 = ObjectId()
+    elf_race_id = ObjectId()
+    player_id0 = ObjectId()
+    session_id0 = ObjectId()
+    calendar_id = ObjectId()
+
+    docs = seed.build_event_docs(
+        campaign_id=CAMPAIGN_ID, calendar_id=calendar_id, gm_id=GM_ID, now=NOW,
+        character_ids=[char_id0, char_id1],
+        location_ids={"Phandalin": location_id},
+        race_ids={"Elf": elf_race_id},
+        player_ids=[player_id0],
+        session_ids=[session_id0],
+    )
+
+    # ── Volume ──────────────────────────────────────────────────────────────
+    assert len(docs) == 10, f"expected exactly 10 events, got {len(docs)}"
+
+    # ── Required fields on every doc ─────────────────────────────────────────
+    required = {
+        "title", "content", "gmContent", "isPublic", "isEpic", "start", "end",
+        "startOrdinal", "endOrdinal", "links", "sessionId", "images", "tags",
+        "color", "campaignId", "calendarId", "createdBy", "createdAt", "updatedAt",
+    }
+    for d in docs:
+        assert required.issubset(d), f"missing fields in {d.get('title')!r}: {required - d.keys()}"
+        assert d["campaignId"] == CAMPAIGN_ID
+        assert d["calendarId"] == calendar_id
+        assert d["createdBy"] == GM_ID
+        assert isinstance(d["isPublic"], bool)
+        assert isinstance(d["isEpic"], bool)
+        assert isinstance(d["tags"], list)
+        assert isinstance(d["links"], list)
+        assert isinstance(d["images"], list)
+        # Ordinals MUST be integers (the wire/index field is a Number).
+        assert isinstance(d["startOrdinal"], int), f"startOrdinal not int in {d['title']!r}"
+        assert isinstance(d["endOrdinal"], int), f"endOrdinal not int in {d['title']!r}"
+        # start is a {year, monthIndex, day} dict; end is that or None.
+        assert set(d["start"].keys()) == {"year", "monthIndex", "day"}
+        assert d["end"] is None or set(d["end"].keys()) == {"year", "monthIndex", "day"}
+        # endOrdinal defaults to startOrdinal when there's no end.
+        if d["end"] is None:
+            assert d["endOrdinal"] == d["startOrdinal"]
+        else:
+            assert d["endOrdinal"] >= d["startOrdinal"]
+
+    # ── Ordinal correctness — must equal the engine's to_ordinal ─────────────
+    from seed_calendar_data import HARPTOS, to_ordinal
+    for d in docs:
+        assert d["startOrdinal"] == to_ordinal(HARPTOS, d["start"])
+        assert d["endOrdinal"] == to_ordinal(HARPTOS, d["end"] or d["start"])
+
+    # ── Public/private + epic mix ────────────────────────────────────────────
+    assert any(d["isPublic"] for d in docs), "need a public event"
+    assert any(not d["isPublic"] for d in docs), "need a private event"
+    assert any(d["isEpic"] for d in docs), "need an epic event"
+    # Private events carry GM-only content.
+    assert any(not d["isPublic"] and d["gmContent"] for d in docs), \
+        "need a private event with gmContent"
+
+    # ── Links resolve to the supplied real ids ───────────────────────────────
+    link_kinds = {lnk["kind"] for d in docs for lnk in d["links"]}
+    for kind in ("location", "character", "race", "player"):
+        assert kind in link_kinds, f"no event link of kind={kind!r}"
+    all_link_ids = {lnk["id"] for d in docs for lnk in d["links"]}
+    assert location_id in all_link_ids, "location link must use supplied location_id"
+    assert char_id0 in all_link_ids, "character link must use supplied character id"
+    assert elf_race_id in all_link_ids, "race link must use supplied Elf race id"
+    assert player_id0 in all_link_ids, "player link must use supplied player id"
+    # The two-day Siege event links the first session.
+    assert any(d["sessionId"] == session_id0 for d in docs), \
+        "the multi-day Siege event must link the first session"
+
+    # ── A multi-day event exists (end != start) ──────────────────────────────
+    assert any(d["end"] is not None for d in docs), "need at least one multi-day event"
+
+    # ── Graceful fallback when collections are empty ─────────────────────────
+    docs_empty = seed.build_event_docs(
+        campaign_id=CAMPAIGN_ID, calendar_id=calendar_id, gm_id=GM_ID, now=NOW,
+        character_ids=[], location_ids={}, race_ids={}, player_ids=[], session_ids=[],
+    )
+    assert len(docs_empty) == 10, "build_event_docs must work with empty id collections"
+    # With no sessions, the session link falls back to None.
+    assert all(d["sessionId"] is None for d in docs_empty), \
+        "sessionId must be None when no session ids are supplied"
+    # Ordinals still integers in the fallback path.
+    for d in docs_empty:
+        assert isinstance(d["startOrdinal"], int) and isinstance(d["endOrdinal"], int)
+
+
 def run():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     for t in tests:

--- a/tests/components/mainview/WikiPanel.test.tsx
+++ b/tests/components/mainview/WikiPanel.test.tsx
@@ -73,6 +73,22 @@ vi.mock('~/components/wiki/monsters/MonstersPanel', () => ({
   ),
 }));
 
+vi.mock('~/components/wiki/calendar/CalendarPanel', () => ({
+  CalendarPanel: ({ onBack }: { onBack: () => void }) => (
+    <div data-testid="calendar-panel-stub">
+      <button onClick={onBack}>Back</button>
+    </div>
+  ),
+}));
+
+vi.mock('~/components/wiki/calendar/EventsPanel', () => ({
+  EventsPanel: ({ onBack }: { onBack: () => void }) => (
+    <div data-testid="events-panel-stub">
+      <button onClick={onBack}>Back</button>
+    </div>
+  ),
+}));
+
 describe('WikiPanel', () => {
   it('renders the Characters category button (non-GM)', () => {
     useCampaignMock.mockReturnValue({ campaign: { isGM: false } });
@@ -80,11 +96,11 @@ describe('WikiPanel', () => {
     expect(screen.getByRole('button', { name: 'Characters' })).toBeInTheDocument();
   });
 
-  it('shows only the six player categories when not GM (no Maps, no Monsters)', () => {
+  it('shows only the seven player categories when not GM (no Maps, no Monsters, no Events)', () => {
     useCampaignMock.mockReturnValue({ campaign: { isGM: false } });
     render(<WikiPanel />);
 
-    expect(screen.getAllByRole('button')).toHaveLength(6);
+    expect(screen.getAllByRole('button')).toHaveLength(7);
     expect(screen.getByRole('button', { name: 'Characters' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Players' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Races' })).toBeInTheDocument();
@@ -92,18 +108,48 @@ describe('WikiPanel', () => {
     expect(screen.getByRole('button', { name: 'Locations' })).toBeInTheDocument();
     // Lore is visible to all members.
     expect(screen.getByRole('button', { name: 'Lore' })).toBeInTheDocument();
-    // Maps + Monsters are GM-only.
+    // Calendar is visible to all members.
+    expect(screen.getByRole('button', { name: 'Calendar' })).toBeInTheDocument();
+    // Maps + Monsters + Events are GM-only.
     expect(screen.queryByRole('button', { name: 'Maps' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Monsters' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Events' })).not.toBeInTheDocument();
   });
 
-  it('shows the GM-only Maps + Monsters categories when viewer is GM', () => {
+  it('shows the GM-only Maps + Monsters + Events categories when viewer is GM', () => {
     useCampaignMock.mockReturnValue({ campaign: { isGM: true } });
     render(<WikiPanel />);
 
-    expect(screen.getAllByRole('button')).toHaveLength(8);
+    expect(screen.getAllByRole('button')).toHaveLength(10);
     expect(screen.getByRole('button', { name: 'Maps' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Monsters' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Events' })).toBeInTheDocument();
+  });
+
+  it('Calendar category is visible to non-GM members', () => {
+    useCampaignMock.mockReturnValue({ campaign: { isGM: false } });
+    render(<WikiPanel />);
+    expect(screen.getByRole('button', { name: 'Calendar' })).toBeInTheDocument();
+  });
+
+  it('clicking Calendar shows CalendarPanel', async () => {
+    useCampaignMock.mockReturnValue({ campaign: { isGM: false } });
+    const user = userEvent.setup();
+    render(<WikiPanel />);
+
+    await user.click(screen.getByRole('button', { name: 'Calendar' }));
+
+    expect(screen.getByTestId('calendar-panel-stub')).toBeInTheDocument();
+  });
+
+  it('clicking Events shows EventsPanel for GM', async () => {
+    useCampaignMock.mockReturnValue({ campaign: { isGM: true } });
+    const user = userEvent.setup();
+    render(<WikiPanel />);
+
+    await user.click(screen.getByRole('button', { name: 'Events' }));
+
+    expect(screen.getByTestId('events-panel-stub')).toBeInTheDocument();
   });
 
   it('clicking Lore shows LorePanel', async () => {

--- a/tests/components/mainview/WikiPanel.test.tsx
+++ b/tests/components/mainview/WikiPanel.test.tsx
@@ -49,6 +49,14 @@ vi.mock('~/components/wiki/locations/LocationsPanel', () => ({
   ),
 }));
 
+vi.mock('~/components/wiki/lore/LorePanel', () => ({
+  LorePanel: ({ onBack }: { onBack: () => void }) => (
+    <div data-testid="lore-panel">
+      <button onClick={onBack}>Back</button>
+    </div>
+  ),
+}));
+
 vi.mock('~/components/wiki/maps/MapsPanel', () => ({
   MapsPanel: ({ onBack }: { onBack: () => void }) => (
     <div data-testid="maps-panel">
@@ -72,16 +80,18 @@ describe('WikiPanel', () => {
     expect(screen.getByRole('button', { name: 'Characters' })).toBeInTheDocument();
   });
 
-  it('shows only the five player categories when not GM (no Maps, no Monsters)', () => {
+  it('shows only the six player categories when not GM (no Maps, no Monsters)', () => {
     useCampaignMock.mockReturnValue({ campaign: { isGM: false } });
     render(<WikiPanel />);
 
-    expect(screen.getAllByRole('button')).toHaveLength(5);
+    expect(screen.getAllByRole('button')).toHaveLength(6);
     expect(screen.getByRole('button', { name: 'Characters' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Players' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Races' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Rules' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Locations' })).toBeInTheDocument();
+    // Lore is visible to all members.
+    expect(screen.getByRole('button', { name: 'Lore' })).toBeInTheDocument();
     // Maps + Monsters are GM-only.
     expect(screen.queryByRole('button', { name: 'Maps' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Monsters' })).not.toBeInTheDocument();
@@ -91,9 +101,19 @@ describe('WikiPanel', () => {
     useCampaignMock.mockReturnValue({ campaign: { isGM: true } });
     render(<WikiPanel />);
 
-    expect(screen.getAllByRole('button')).toHaveLength(7);
+    expect(screen.getAllByRole('button')).toHaveLength(8);
     expect(screen.getByRole('button', { name: 'Maps' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Monsters' })).toBeInTheDocument();
+  });
+
+  it('clicking Lore shows LorePanel', async () => {
+    useCampaignMock.mockReturnValue({ campaign: { isGM: false } });
+    const user = userEvent.setup();
+    render(<WikiPanel />);
+
+    await user.click(screen.getByRole('button', { name: 'Lore' }));
+
+    expect(screen.getByTestId('lore-panel')).toBeInTheDocument();
   });
 
   it('clicking Characters shows CharactersPanel', async () => {

--- a/tests/components/mainview/WikiPanel.test.tsx
+++ b/tests/components/mainview/WikiPanel.test.tsx
@@ -75,7 +75,7 @@ vi.mock('~/components/wiki/monsters/MonstersPanel', () => ({
 
 vi.mock('~/components/wiki/calendar/CalendarPanel', () => ({
   CalendarPanel: ({ onBack }: { onBack: () => void }) => (
-    <div data-testid="calendar-panel-stub">
+    <div data-testid="calendar-panel">
       <button onClick={onBack}>Back</button>
     </div>
   ),
@@ -139,7 +139,7 @@ describe('WikiPanel', () => {
 
     await user.click(screen.getByRole('button', { name: 'Calendar' }));
 
-    expect(screen.getByTestId('calendar-panel-stub')).toBeInTheDocument();
+    expect(screen.getByTestId('calendar-panel')).toBeInTheDocument();
   });
 
   it('clicking Events shows EventsPanel for GM', async () => {

--- a/tests/components/wiki/lore/LoreCard.test.tsx
+++ b/tests/components/wiki/lore/LoreCard.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LoreCard } from '~/components/wiki/lore/LoreCard';
+
+// setTokenDragImage uses document.createElement / document.body.appendChild
+// and e.dataTransfer.setDragImage — stub it to avoid happy-dom canvas issues.
+vi.mock('~/utils/setTokenDragImage', () => ({
+  setTokenDragImage: vi.fn(),
+}));
+
+const lore = {
+  id: 'l1',
+  title: 'The Fall of Phandalin',
+  isPublic: true,
+  tags: [],
+  images: [],
+  links: [],
+  campaignId: 'c1',
+  createdBy: 'u1',
+  content: '',
+  createdAt: '',
+  updatedAt: '',
+  canEdit: true,
+};
+
+describe('LoreCard', () => {
+  it('sets the drag payload with collection lore', () => {
+    render(<LoreCard lore={lore as never} onClick={vi.fn()} />);
+    const card = screen.getByTestId('lore-card');
+    const setData = vi.fn();
+    fireEvent.dragStart(card, {
+      dataTransfer: { setData, setDragImage: vi.fn() } as never,
+    });
+    const payload = JSON.parse(
+      setData.mock.calls.find((c) => c[0] === 'application/x-cartyx-document')![1]
+    );
+    expect(payload).toMatchObject({
+      collection: 'lore',
+      documentId: 'l1',
+      title: 'The Fall of Phandalin',
+    });
+  });
+
+  it('renders the title', () => {
+    render(<LoreCard lore={lore as never} onClick={vi.fn()} />);
+    expect(screen.getByText('The Fall of Phandalin')).toBeInTheDocument();
+  });
+
+  it('shows public icon when isPublic=true', () => {
+    render(<LoreCard lore={lore as never} onClick={vi.fn()} />);
+    expect(screen.getByLabelText('Public')).toBeInTheDocument();
+  });
+
+  it('shows private icon when isPublic=false', () => {
+    render(<LoreCard lore={{ ...lore, isPublic: false } as never} onClick={vi.fn()} />);
+    expect(screen.getByLabelText('Private')).toBeInTheDocument();
+  });
+
+  it('fires onClick when clicked', () => {
+    const onClick = vi.fn();
+    render(<LoreCard lore={lore as never} onClick={onClick} />);
+    fireEvent.click(screen.getByTestId('lore-card'));
+    expect(onClick).toHaveBeenCalledWith(lore);
+  });
+
+  it('fires onClick on Enter key', () => {
+    const onClick = vi.fn();
+    render(<LoreCard lore={lore as never} onClick={onClick} />);
+    fireEvent.keyDown(screen.getByTestId('lore-card'), { key: 'Enter' });
+    expect(onClick).toHaveBeenCalledWith(lore);
+  });
+
+  it('fires onClick on Space key', () => {
+    const onClick = vi.fn();
+    render(<LoreCard lore={lore as never} onClick={onClick} />);
+    fireEvent.keyDown(screen.getByTestId('lore-card'), { key: ' ' });
+    expect(onClick).toHaveBeenCalledWith(lore);
+  });
+
+  it('renders tags', () => {
+    const loreWithTags = { ...lore, tags: ['history', 'magic'] };
+    render(<LoreCard lore={loreWithTags as never} onClick={vi.fn()} />);
+    expect(screen.getByText('#history')).toBeInTheDocument();
+    expect(screen.getByText('#magic')).toBeInTheDocument();
+  });
+
+  it('renders link count when links are present', () => {
+    const loreWithLinks = {
+      ...lore,
+      links: [
+        { kind: 'character', id: 'c1', label: 'Hero' },
+        { kind: 'location', id: 'loc1', label: 'Town' },
+      ],
+    };
+    render(<LoreCard lore={loreWithLinks as never} onClick={vi.fn()} />);
+    expect(screen.getByText('2 links')).toBeInTheDocument();
+  });
+});

--- a/tests/components/wiki/lore/LoreModal.test.tsx
+++ b/tests/components/wiki/lore/LoreModal.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, within } from '@testing-library/react';
 import { LoreModal } from '~/components/wiki/lore/LoreModal';
 
 vi.mock('~/hooks/useLore', () => ({
@@ -88,5 +88,18 @@ describe('LoreModal', () => {
       fireEvent.submit(screen.getByRole('dialog'));
     });
     expect(screen.getByText(/title is required/i)).toBeInTheDocument();
+  });
+
+  it('pre-seeds the links editor with initialLinks in create mode', () => {
+    render(
+      <LoreModal
+        isOpen
+        onClose={() => {}}
+        campaignId="c1"
+        initialLinks={[{ kind: 'character', id: 'ch1', label: 'Gandalf' }]}
+      />
+    );
+    const linksEditor = screen.getByTestId('lore-links-editor');
+    expect(within(linksEditor).getByText('Gandalf')).toBeInTheDocument();
   });
 });

--- a/tests/components/wiki/lore/LoreModal.test.tsx
+++ b/tests/components/wiki/lore/LoreModal.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { LoreModal } from '~/components/wiki/lore/LoreModal';
+
+vi.mock('~/hooks/useLore', () => ({
+  useLoreEntry: () => ({ lore: null, isLoading: false }),
+  useCreateLore: () => ({ create: vi.fn(), isLoading: false, error: null }),
+  useUpdateLore: () => ({ update: vi.fn(), isLoading: false, error: null }),
+}));
+vi.mock('~/hooks/useCampaigns', () => ({ useCampaign: () => ({ campaign: { isGM: true } }) }));
+vi.mock('~/hooks/useCharacters', () => ({ useCharacters: () => ({ characters: [] }) }));
+vi.mock('~/hooks/usePlayers', () => ({ usePlayers: () => ({ players: [] }) }));
+vi.mock('~/hooks/useLocations', () => ({ useLocations: () => ({ locations: [] }) }));
+vi.mock('~/hooks/useRaces', () => ({ useRaces: () => ({ races: [] }) }));
+vi.mock('~/hooks/useTags', () => ({ useTags: () => ({ tags: [] }) }));
+vi.mock('~/hooks/useTabletopScreens', () => ({
+  useTabletopScreenList: () => ({ screens: [] }),
+  useTabletopMutations: () => ({
+    openWindow: { mutate: vi.fn(), isPending: false },
+  }),
+}));
+
+// Mock CodeMirror so MarkdownEditor renders without DOM issues
+vi.mock('@codemirror/view', () => {
+  class FakeEditorView {
+    dom: HTMLDivElement;
+    contentDOM: HTMLDivElement;
+    state = { doc: { toString: () => '' } };
+    constructor(opts: { state: { doc: string }; parent: HTMLElement }) {
+      this.dom = document.createElement('div');
+      this.contentDOM = document.createElement('div');
+      this.dom.appendChild(this.contentDOM);
+      opts.parent.appendChild(this.dom);
+    }
+    dispatch() {}
+    focus() {}
+    destroy() {}
+  }
+  return {
+    EditorView: Object.assign(FakeEditorView, {
+      theme: () => [],
+      updateListener: {
+        of: () => [],
+      },
+      lineWrapping: [],
+    }),
+    placeholder: () => [],
+    keymap: { of: () => [] },
+  };
+});
+vi.mock('@codemirror/state', () => {
+  class FakeCompartment {
+    of(ext: unknown) {
+      return ext;
+    }
+    reconfigure(ext: unknown) {
+      return ext;
+    }
+  }
+  return {
+    EditorState: {
+      create: (opts: { doc: string }) => ({ doc: opts.doc }),
+      readOnly: { of: () => [] },
+    },
+    Compartment: FakeCompartment,
+  };
+});
+vi.mock('@codemirror/lang-markdown', () => ({ markdown: () => [], markdownLanguage: {} }));
+vi.mock('@codemirror/commands', () => ({
+  defaultKeymap: [],
+  history: () => [],
+  historyKeymap: [],
+}));
+vi.mock('@codemirror/language', () => ({ syntaxHighlighting: () => [] }));
+vi.mock('@codemirror/theme-one-dark', () => ({ oneDarkHighlightStyle: {} }));
+
+describe('LoreModal', () => {
+  it('renders a title input and the links editor in create mode', () => {
+    render(<LoreModal isOpen onClose={() => {}} campaignId="c1" />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByTestId('lore-links-editor')).toBeInTheDocument();
+  });
+
+  it('requires a title before saving', async () => {
+    render(<LoreModal isOpen onClose={() => {}} campaignId="c1" />);
+    await act(async () => {
+      fireEvent.submit(screen.getByRole('dialog'));
+    });
+    expect(screen.getByText(/title is required/i)).toBeInTheDocument();
+  });
+});

--- a/tests/components/wiki/lore/LorePanel.test.tsx
+++ b/tests/components/wiki/lore/LorePanel.test.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { LorePanel } from '~/components/wiki/lore/LorePanel';
+import { useLore } from '~/hooks/useLore';
+import { useCampaign } from '~/hooks/useCampaigns';
+
+// Stub the modal components to avoid portal / query-client complexity.
+vi.mock('~/components/wiki/lore/LoreModal', () => ({
+  LoreModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div role="dialog" aria-label="lore-modal" /> : null,
+}));
+vi.mock('~/components/wiki/lore/LoreViewModal', () => ({
+  LoreViewModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div role="dialog" aria-label="lore-view-modal" /> : null,
+}));
+
+vi.mock('~/hooks/useLore');
+vi.mock('~/hooks/useCampaigns');
+vi.mock('~/hooks/useTags', () => ({
+  useTags: () => ({ tags: [], isLoading: false, error: null }),
+}));
+vi.mock('~/hooks/useTabletopScreens', () => ({
+  useTabletopScreenList: () => ({ screens: [], isLoading: false, error: null }),
+  useTabletopMutations: () => ({
+    openWindow: { mutate: vi.fn(), isPending: false },
+  }),
+}));
+vi.mock('@tanstack/react-router', () => ({
+  useParams: () => ({ campaignId: 'campaign-123' }),
+}));
+// Stub setTokenDragImage used by LoreCard
+vi.mock('~/utils/setTokenDragImage', () => ({
+  setTokenDragImage: vi.fn(),
+}));
+
+const mockLore = [
+  {
+    id: 'lore-1',
+    campaignId: 'campaign-123',
+    title: 'The Ancient Prophecy',
+    tags: ['prophecy', 'magic'],
+    isPublic: true,
+    images: [],
+    links: [],
+    createdBy: 'user-1',
+    content: '',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    canEdit: true,
+  },
+];
+
+function setupMocks(overrides: { isGM?: boolean; lore?: typeof mockLore } = {}) {
+  const { isGM = true, lore = mockLore } = overrides;
+  (useCampaign as ReturnType<typeof vi.fn>).mockReturnValue({
+    campaign: { isGM, sessions: [] },
+    isLoading: false,
+    error: null,
+  });
+  (useLore as ReturnType<typeof vi.fn>).mockReturnValue({
+    lore,
+    isLoading: false,
+    error: null,
+  });
+}
+
+describe('LorePanel', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('renders the "Lore" header', () => {
+    setupMocks();
+    render(<LorePanel onBack={vi.fn()} />);
+    expect(screen.getByText('Lore')).toBeInTheDocument();
+  });
+
+  it('shows the create button for GM', () => {
+    setupMocks({ isGM: true });
+    render(<LorePanel onBack={vi.fn()} />);
+    expect(screen.getByTestId('lore-create-button')).toBeInTheDocument();
+  });
+
+  it('hides the create button for non-GM players', () => {
+    setupMocks({ isGM: false });
+    render(<LorePanel onBack={vi.fn()} />);
+    expect(screen.queryByTestId('lore-create-button')).not.toBeInTheDocument();
+  });
+
+  it('renders a lore card for each item', async () => {
+    setupMocks();
+    render(<LorePanel onBack={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText('The Ancient Prophecy')).toBeInTheDocument();
+    });
+  });
+
+  it('GM clicking create button opens LoreModal', async () => {
+    setupMocks({ isGM: true });
+    const user = userEvent.setup();
+    render(<LorePanel onBack={vi.fn()} />);
+    await user.click(screen.getByTestId('lore-create-button'));
+    expect(screen.getByRole('dialog', { name: 'lore-modal' })).toBeInTheDocument();
+  });
+
+  it('clicking a canEdit lore card opens LoreModal (edit)', async () => {
+    setupMocks({ isGM: true });
+    const user = userEvent.setup();
+    render(<LorePanel onBack={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText('The Ancient Prophecy')).toBeInTheDocument();
+    });
+    await user.click(screen.getByText('The Ancient Prophecy'));
+    expect(screen.getByRole('dialog', { name: 'lore-modal' })).toBeInTheDocument();
+  });
+
+  it('clicking a non-editable lore card opens LoreViewModal', async () => {
+    setupMocks({
+      isGM: false,
+      lore: [{ ...mockLore[0]!, canEdit: false }],
+    });
+    const user = userEvent.setup();
+    render(<LorePanel onBack={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText('The Ancient Prophecy')).toBeInTheDocument();
+    });
+    await user.click(screen.getByText('The Ancient Prophecy'));
+    expect(screen.getByRole('dialog', { name: 'lore-view-modal' })).toBeInTheDocument();
+  });
+
+  it('shows loading state', () => {
+    setupMocks();
+    (useLore as ReturnType<typeof vi.fn>).mockReturnValue({
+      lore: [],
+      isLoading: true,
+      error: null,
+    });
+    render(<LorePanel onBack={vi.fn()} />);
+    expect(screen.getByText('Loading lore...')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no lore found', () => {
+    setupMocks({ lore: [] });
+    render(<LorePanel onBack={vi.fn()} />);
+    expect(screen.getByText('No lore found matching your filters.')).toBeInTheDocument();
+  });
+
+  it('shows error state', () => {
+    setupMocks();
+    (useLore as ReturnType<typeof vi.fn>).mockReturnValue({
+      lore: [],
+      isLoading: false,
+      error: 'Failed to fetch lore',
+    });
+    render(<LorePanel onBack={vi.fn()} />);
+    expect(screen.getByText('Failed to fetch lore')).toBeInTheDocument();
+  });
+
+  it('calls onBack when header back button is clicked', async () => {
+    setupMocks();
+    const onBack = vi.fn();
+    const user = userEvent.setup();
+    render(<LorePanel onBack={onBack} />);
+    await user.click(screen.getByLabelText('Back'));
+    expect(onBack).toHaveBeenCalled();
+  });
+});

--- a/tests/components/wiki/lore/LorePanel.test.tsx
+++ b/tests/components/wiki/lore/LorePanel.test.tsx
@@ -83,10 +83,10 @@ describe('LorePanel', () => {
     expect(screen.getByTestId('lore-create-button')).toBeInTheDocument();
   });
 
-  it('hides the create button for non-GM players', () => {
+  it('shows the create button for non-GM members', () => {
     setupMocks({ isGM: false });
     render(<LorePanel onBack={vi.fn()} />);
-    expect(screen.queryByTestId('lore-create-button')).not.toBeInTheDocument();
+    expect(screen.getByTestId('lore-create-button')).toBeInTheDocument();
   });
 
   it('renders a lore card for each item', async () => {
@@ -107,6 +107,17 @@ describe('LorePanel', () => {
 
   it('clicking a canEdit lore card opens LoreModal (edit)', async () => {
     setupMocks({ isGM: true });
+    const user = userEvent.setup();
+    render(<LorePanel onBack={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText('The Ancient Prophecy')).toBeInTheDocument();
+    });
+    await user.click(screen.getByText('The Ancient Prophecy'));
+    expect(screen.getByRole('dialog', { name: 'lore-modal' })).toBeInTheDocument();
+  });
+
+  it('non-GM clicking a canEdit lore card opens LoreModal (edit)', async () => {
+    setupMocks({ isGM: false, lore: [{ ...mockLore[0]!, canEdit: true }] });
     const user = userEvent.setup();
     render(<LorePanel onBack={vi.fn()} />);
     await waitFor(() => {

--- a/tests/components/wiki/players/PlayerWindowLoreTab.test.tsx
+++ b/tests/components/wiki/players/PlayerWindowLoreTab.test.tsx
@@ -1,0 +1,104 @@
+import React, { type ReactNode } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { PlayerLoreTab } from '~/components/wiki/players/PlayerLoreTab';
+import type { LoreListItem } from '~/types/lore';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockRemove = vi.fn();
+
+vi.mock('~/hooks/useLore', () => ({
+  useLinkedLore: () => ({
+    lore: [
+      {
+        id: 'l1',
+        title: 'Oath of the Dawn',
+        isPublic: true,
+        tags: [],
+        images: [],
+        links: [],
+        campaignId: 'c1',
+        createdBy: 'u1',
+        content: '',
+        createdAt: '',
+        updatedAt: '',
+        canEdit: false,
+      } satisfies LoreListItem,
+    ],
+    isLoading: false,
+    error: null,
+  }),
+  useDeleteLore: () => ({ remove: mockRemove, isLoading: false, error: null }),
+}));
+
+// Stub heavy modals to avoid query-client / portal complexity
+vi.mock('~/components/wiki/lore/LoreModal', () => ({
+  LoreModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="lore-modal-stub" /> : null,
+}));
+
+vi.mock('~/components/wiki/lore/LoreViewModal', () => ({
+  LoreViewModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="lore-view-modal-stub" /> : null,
+}));
+
+// ---------------------------------------------------------------------------
+// Wrapper
+// ---------------------------------------------------------------------------
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const [queryClient] = React.useState(
+    () => new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  );
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+function customRender(ui: React.ReactNode) {
+  return render(ui, { wrapper: Wrapper });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PlayerLoreTab', () => {
+  const baseProps = {
+    campaignId: 'c1',
+    playerId: 'p1',
+    canManage: false,
+  };
+
+  it('renders the linked lore title', () => {
+    customRender(<PlayerLoreTab {...baseProps} />);
+    expect(screen.getByText('Oath of the Dawn')).toBeInTheDocument();
+  });
+
+  it('does not show Add lore button when canManage is false', () => {
+    customRender(<PlayerLoreTab {...baseProps} />);
+    expect(screen.queryByText(/add lore/i)).not.toBeInTheDocument();
+  });
+
+  it('shows Add lore button when canManage is true', () => {
+    customRender(<PlayerLoreTab {...baseProps} canManage />);
+    expect(screen.getByText(/add lore/i)).toBeInTheDocument();
+  });
+
+  it('opens LoreModal stub when Add lore is clicked', async () => {
+    const user = userEvent.setup();
+    customRender(<PlayerLoreTab {...baseProps} canManage />);
+    await user.click(screen.getByText(/add lore/i));
+    expect(screen.getByTestId('lore-modal-stub')).toBeInTheDocument();
+  });
+
+  it('opens LoreViewModal stub when a lore entry is clicked', async () => {
+    const user = userEvent.setup();
+    customRender(<PlayerLoreTab {...baseProps} />);
+    await user.click(screen.getByText('Oath of the Dawn'));
+    expect(screen.getByTestId('lore-view-modal-stub')).toBeInTheDocument();
+  });
+});

--- a/tests/server/db/lore-model.test.ts
+++ b/tests/server/db/lore-model.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+
+/*
+ * The global setup.ts mocks mongoose with a MockSchema that does not track
+ * paths. Schema-level tests need real mongoose, so we unmock + reset modules
+ * and dynamically import the real Lore model — the same approach used in
+ * tests/server/db/gmscreen.test.ts.
+ */
+describe('Lore model', () => {
+   
+  let RealLore: any;
+
+  beforeAll(async () => {
+    vi.unmock('mongoose');
+    vi.resetModules();
+    const mod = await import('~/server/db/models/Lore');
+    RealLore = mod.Lore;
+  });
+
+  afterAll(() => {
+    // Restore the global mongoose mock so other tests in this worker are unaffected.
+    vi.doMock('mongoose', () => {
+      class MockSchema {
+        constructor(_def?: unknown) {}
+        static Types = { ObjectId: String };
+        pre(_hook: string, _fn: unknown) {}
+      }
+      const mockModel = vi.fn(() => ({
+        findOne: vi.fn(),
+        findOneAndUpdate: vi.fn(),
+        findById: vi.fn(),
+        find: vi.fn(),
+        create: vi.fn(),
+        exists: vi.fn(),
+        save: vi.fn(),
+        updateOne: vi.fn(),
+      }));
+      return {
+        default: {
+          connect: vi.fn(),
+          connection: { readyState: 0 },
+          Schema: MockSchema,
+          model: mockModel,
+          models: {},
+        },
+        Schema: MockSchema,
+        model: mockModel,
+        models: {},
+        connection: { readyState: 0 },
+      };
+    });
+    vi.resetModules();
+  });
+
+  it('defines the expected paths', () => {
+    const paths = Object.keys(RealLore.schema.paths);
+    expect(paths).toEqual(
+      expect.arrayContaining([
+        'title',
+        'content',
+        'gmContent',
+        'isPublic',
+        'images',
+        'links',
+        'tags',
+        'campaignId',
+        'createdBy',
+        'createdAt',
+        'updatedAt',
+      ])
+    );
+  });
+
+  it('links require a kind enum and an id', () => {
+    const linkPath = RealLore.schema.path('links');
+    // SchemaDocumentArray exposes the sub-schema directly on .schema (not .caster.schema)
+     
+    const sub = (linkPath as any).schema;
+    expect(sub.path('kind').options.enum).toEqual(['race', 'character', 'player', 'location']);
+    expect(sub.path('id').options.required).toBeTruthy();
+  });
+});

--- a/tests/server/functions/calendars.test.ts
+++ b/tests/server/functions/calendars.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tanstack/react-start', () => ({
+  createServerFn: () => ({
+    inputValidator: () => ({ handler: (fn: unknown) => fn }),
+    handler: (fn: unknown) => fn,
+  }),
+}));
+vi.mock('~/server/session', () => ({ getSession: vi.fn() }));
+vi.mock('~/server/db/connection', () => ({ connectDB: vi.fn(), isDBConnected: vi.fn(() => true) }));
+vi.mock('~/server/db/models/User', () => ({ User: { findOne: vi.fn() } }));
+vi.mock('~/server/db/models/Campaign', () => ({ Campaign: { findById: vi.fn() } }));
+vi.mock('~/server/db/models/Calendar', () => ({
+  Calendar: { findOne: vi.fn(), findOneAndUpdate: vi.fn(), deleteOne: vi.fn() },
+}));
+vi.mock('~/server/db/models/Event', () => ({ Event: { find: vi.fn(), bulkWrite: vi.fn() } }));
+vi.mock('~/server/utils/posthog', () => ({
+  serverCaptureException: vi.fn(),
+  serverCaptureEvent: vi.fn(),
+}));
+
+import { getSession } from '~/server/session';
+import { User } from '~/server/db/models/User';
+import { Campaign } from '~/server/db/models/Campaign';
+import { Calendar } from '~/server/db/models/Calendar';
+import { Event } from '~/server/db/models/Event';
+import {
+  upsertCalendar,
+  getCalendar,
+  setCurrentDate,
+  deleteCalendar,
+} from '~/server/functions/calendars';
+
+const session = { id: 'sess-1' } as never;
+const gmCampaign = {
+  _id: 'camp-1',
+  gameMasterId: 'user-1',
+  members: [{ userId: 'user-1', role: 'gm' }],
+};
+const playerCampaign = {
+  _id: 'camp-1',
+  gameMasterId: 'gm-x',
+  members: [{ userId: 'user-1', role: 'player' }],
+};
+
+const _upsert = upsertCalendar as unknown as (a: {
+  data: Record<string, unknown>;
+}) => Promise<unknown>;
+const _get = getCalendar as unknown as (a: { data: Record<string, unknown> }) => Promise<unknown>;
+const _setDate = setCurrentDate as unknown as (a: {
+  data: Record<string, unknown>;
+}) => Promise<unknown>;
+const _delete = deleteCalendar as unknown as (a: {
+  data: Record<string, unknown>;
+}) => Promise<unknown>;
+
+const baseInput = {
+  campaignId: 'camp-1',
+  name: 'Harptos',
+  description: '',
+  months: [{ name: 'Hammer', days: 30 }],
+  weekdays: ['d1', 'd2', 'd3', 'd4', 'd5', 'd6', 'd7'],
+  weekdayMode: 'continuous',
+  epoch: { year: 1, weekdayIndex: 0 },
+  yearSuffix: 'DR',
+  namedYears: [],
+  leapDays: [],
+  moons: [],
+  seasons: [],
+  holidays: [],
+  currentDate: { year: 1, monthIndex: 0, day: 1 },
+};
+
+const calDoc = {
+  _id: 'cal-1',
+  createdBy: 'user-1',
+  ...baseInput,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getSession).mockResolvedValue(session);
+  vi.mocked(User.findOne).mockResolvedValue({ _id: 'user-1' } as never);
+  vi.mocked(Campaign.findById).mockResolvedValue(gmCampaign as never);
+});
+
+describe('upsertCalendar', () => {
+  it('forbids a non-GM from saving', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    await expect(_upsert({ data: baseInput })).rejects.toThrow('Forbidden');
+  });
+
+  it('upserts for a GM and returns success with empty event list', async () => {
+    vi.mocked(Calendar.findOneAndUpdate).mockResolvedValue(calDoc as never);
+    vi.mocked(Event.find).mockReturnValue({
+      lean: vi.fn().mockResolvedValue([]),
+    } as never);
+    const res = (await _upsert({ data: baseInput })) as Record<string, unknown>;
+    expect(res.success).toBe(true);
+    expect(res.invalidEventIds).toEqual([]);
+  });
+});
+
+describe('getCalendar', () => {
+  it('returns null when no calendar exists', async () => {
+    vi.mocked(Calendar.findOne).mockReturnValue({
+      lean: vi.fn().mockResolvedValue(null),
+    } as never);
+    const res = await _get({ data: { campaignId: 'camp-1' } });
+    expect(res).toBeNull();
+  });
+
+  it('returns serialized calendar for a member', async () => {
+    vi.mocked(Calendar.findOne).mockReturnValue({
+      lean: vi.fn().mockResolvedValue(calDoc),
+    } as never);
+    const res = (await _get({ data: { campaignId: 'camp-1' } })) as Record<string, unknown>;
+    expect(res).not.toBeNull();
+    expect(res.name).toBe('Harptos');
+    expect(res.canEdit).toBe(true); // GM
+  });
+
+  it('canEdit is false for a non-GM member', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    vi.mocked(Calendar.findOne).mockReturnValue({
+      lean: vi.fn().mockResolvedValue(calDoc),
+    } as never);
+    const res = (await _get({ data: { campaignId: 'camp-1' } })) as Record<string, unknown>;
+    expect(res.canEdit).toBe(false);
+  });
+});
+
+describe('setCurrentDate', () => {
+  it('forbids a non-GM', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    await expect(
+      _setDate({ data: { campaignId: 'camp-1', currentDate: { year: 1, monthIndex: 0, day: 2 } } })
+    ).rejects.toThrow('Forbidden');
+  });
+
+  it('updates currentDate for a GM', async () => {
+    vi.mocked(Calendar.findOneAndUpdate).mockResolvedValue({
+      ...calDoc,
+      currentDate: { year: 1, monthIndex: 0, day: 2 },
+    } as never);
+    const res = (await _setDate({
+      data: { campaignId: 'camp-1', currentDate: { year: 1, monthIndex: 0, day: 2 } },
+    })) as Record<string, Record<string, unknown>>;
+    expect(res.success).toBe(true);
+    expect(res.calendar.currentDate).toEqual({ year: 1, monthIndex: 0, day: 2 });
+  });
+});
+
+describe('deleteCalendar', () => {
+  it('forbids a non-GM', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    await expect(_delete({ data: { campaignId: 'camp-1' } })).rejects.toThrow('Forbidden');
+  });
+
+  it('deletes for a GM', async () => {
+    vi.mocked(Calendar.deleteOne).mockResolvedValue({ deletedCount: 1 } as never);
+    const res = await _delete({ data: { campaignId: 'camp-1' } });
+    expect(res).toEqual({ success: true });
+    expect(Calendar.deleteOne).toHaveBeenCalledWith({ campaignId: 'camp-1' });
+  });
+});

--- a/tests/server/functions/calendars.test.ts
+++ b/tests/server/functions/calendars.test.ts
@@ -102,6 +102,16 @@ describe('upsertCalendar', () => {
     expect(res.invalidEventIds).toEqual([]);
   });
 
+  it('rejects when the incoming currentDate is invalid for the new config', async () => {
+    vi.mocked(Event.find).mockReturnValue({
+      lean: vi.fn().mockResolvedValue([]),
+    } as never);
+    // baseInput has months=[{name:'Hammer', days:30}] — monthIndex 5 is out of range (only index 0 exists)
+    await expect(
+      _upsert({ data: { ...baseInput, currentDate: { year: 1, monthIndex: 5, day: 1 } } })
+    ).rejects.toThrow();
+  });
+
   it('re-validates events against the new config: flags invalid, recomputes valid ordinals', async () => {
     // baseInput config: months=[{name:'Hammer', days:30}], epoch={year:1, weekdayIndex:0}
     // ev-valid: start={year:1, monthIndex:0, day:5} => day 5 <= 30, valid
@@ -177,6 +187,9 @@ describe('setCurrentDate', () => {
   });
 
   it('updates currentDate for a GM', async () => {
+    vi.mocked(Calendar.findOne).mockReturnValue({
+      lean: vi.fn().mockResolvedValue(calDoc),
+    } as never);
     vi.mocked(Calendar.findOneAndUpdate).mockResolvedValue({
       ...calDoc,
       currentDate: { year: 1, monthIndex: 0, day: 2 },
@@ -186,6 +199,15 @@ describe('setCurrentDate', () => {
     })) as Record<string, Record<string, unknown>>;
     expect(res.success).toBe(true);
     expect(res.calendar.currentDate).toEqual({ year: 1, monthIndex: 0, day: 2 });
+  });
+
+  it('rejects a currentDate out of range for the calendar', async () => {
+    vi.mocked(Calendar.findOne).mockReturnValue({
+      lean: vi.fn().mockResolvedValue(calDoc),
+    } as never);
+    await expect(
+      _setDate({ data: { campaignId: 'camp-1', currentDate: { year: 1, monthIndex: 0, day: 99 } } })
+    ).rejects.toThrow();
   });
 });
 

--- a/tests/server/functions/calendars.test.ts
+++ b/tests/server/functions/calendars.test.ts
@@ -101,6 +101,42 @@ describe('upsertCalendar', () => {
     expect(res.success).toBe(true);
     expect(res.invalidEventIds).toEqual([]);
   });
+
+  it('re-validates events against the new config: flags invalid, recomputes valid ordinals', async () => {
+    // baseInput config: months=[{name:'Hammer', days:30}], epoch={year:1, weekdayIndex:0}
+    // ev-valid: start={year:1, monthIndex:0, day:5} => day 5 <= 30, valid
+    //   toOrdinal = yearStartOrdinal(year=1, epoch=1)=0 + daysBeforeMonth(monthIndex=0)=0 + (day-1)=4 => 4
+    // ev-invalid: start={year:1, monthIndex:0, day:99} => day 99 > 30, invalid
+    vi.mocked(Event.find).mockReturnValue({
+      lean: vi.fn().mockResolvedValue([
+        { _id: 'ev-valid', start: { year: 1, monthIndex: 0, day: 5 }, end: null },
+        { _id: 'ev-invalid', start: { year: 1, monthIndex: 0, day: 99 }, end: null },
+      ]),
+    } as never);
+    vi.mocked(Event.bulkWrite).mockResolvedValue({} as never);
+    vi.mocked(Calendar.findOneAndUpdate).mockResolvedValue({ _id: 'cal-1', ...baseInput } as never);
+
+    const res = (await _upsert({ data: baseInput })) as Record<string, unknown>;
+
+    // Invalid event is flagged, valid event is not
+    const invalidIds = res.invalidEventIds as string[];
+    expect(invalidIds).toContain('ev-invalid');
+    expect(invalidIds).not.toContain('ev-valid');
+
+    // bulkWrite called once with only the valid event's op
+    expect(Event.bulkWrite).toHaveBeenCalledOnce();
+    const ops = vi.mocked(Event.bulkWrite).mock.calls[0][0] as Array<{
+      updateOne: {
+        filter: { _id: string };
+        update: { $set: { startOrdinal: number; endOrdinal: number } };
+      };
+    }>;
+    expect(ops).toHaveLength(1);
+    expect(ops[0].updateOne.filter._id).toBe('ev-valid');
+    // startOrdinal and endOrdinal both 4: toOrdinal({year:1,monthIndex:0,day:5}) = 0+0+(5-1) = 4
+    expect(ops[0].updateOne.update.$set.startOrdinal).toBe(4);
+    expect(ops[0].updateOne.update.$set.endOrdinal).toBe(4);
+  });
 });
 
 describe('getCalendar', () => {

--- a/tests/server/functions/events.test.ts
+++ b/tests/server/functions/events.test.ts
@@ -36,6 +36,7 @@ import { User } from '~/server/db/models/User';
 import { Campaign } from '~/server/db/models/Campaign';
 import { Calendar } from '~/server/db/models/Calendar';
 import { Event } from '~/server/db/models/Event';
+import { removeDocumentRefsFromScreens } from '~/server/functions/gmscreens-helpers';
 import {
   listEvents,
   createEvent,
@@ -295,5 +296,18 @@ describe('deleteEvent', () => {
     await expect(_delete({ data: { id: 'e1', campaignId: 'camp-1' } })).rejects.toThrow(
       'Forbidden'
     );
+  });
+
+  it('GM deletes an event and removeDocumentRefsFromScreens is called', async () => {
+    vi.mocked(Event.findById).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({ _id: 'e1', campaignId: 'camp-1' }),
+    } as never);
+    vi.mocked(Event.deleteOne).mockResolvedValue({ deletedCount: 1 } as never);
+
+    const result = await _delete({ data: { id: 'e1', campaignId: 'camp-1' } });
+
+    expect(vi.mocked(removeDocumentRefsFromScreens)).toHaveBeenCalledOnce();
+    expect(vi.mocked(removeDocumentRefsFromScreens)).toHaveBeenCalledWith('camp-1', 'events', 'e1');
+    expect(result.success).toBe(true);
   });
 });

--- a/tests/server/functions/events.test.ts
+++ b/tests/server/functions/events.test.ts
@@ -170,6 +170,19 @@ describe('createEvent', () => {
       })
     ).rejects.toThrow(/Day/);
   });
+  it('rejects an end date before the start date', async () => {
+    await expect(
+      _create({
+        data: {
+          campaignId: 'camp-1',
+          title: 'T',
+          start: { year: 1, monthIndex: 0, day: 5 },
+          end: { year: 1, monthIndex: 0, day: 2 },
+        },
+      })
+    ).rejects.toThrow(/on or after the start date/);
+    expect(Event.create).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -269,6 +282,24 @@ describe('updateEvent', () => {
     >;
     expect(updateArg.$set.startOrdinal).toBe(2);
     expect(updateArg.$set.endOrdinal).toBe(2);
+  });
+
+  it('rejects an end date before the start date', async () => {
+    vi.mocked(Event.findById).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({ _id: 'e1', campaignId: 'camp-1' }),
+    } as never);
+    await expect(
+      _update({
+        data: {
+          id: 'e1',
+          campaignId: 'camp-1',
+          title: 'T',
+          start: { year: 1, monthIndex: 0, day: 5 },
+          end: { year: 1, monthIndex: 0, day: 2 },
+        },
+      })
+    ).rejects.toThrow(/on or after the start date/);
+    expect(Event.findOneAndUpdate).not.toHaveBeenCalled();
   });
 
   it('rejects a non-GM', async () => {

--- a/tests/server/functions/events.test.ts
+++ b/tests/server/functions/events.test.ts
@@ -36,7 +36,13 @@ import { User } from '~/server/db/models/User';
 import { Campaign } from '~/server/db/models/Campaign';
 import { Calendar } from '~/server/db/models/Calendar';
 import { Event } from '~/server/db/models/Event';
-import { listEvents, createEvent } from '~/server/functions/events';
+import {
+  listEvents,
+  createEvent,
+  getEvent,
+  updateEvent,
+  deleteEvent,
+} from '~/server/functions/events';
 
 const gmCampaign = {
   _id: 'camp-1',
@@ -63,6 +69,15 @@ const calDoc = {
 
 const _list = listEvents as unknown as (a: { data: Record<string, unknown> }) => Promise<unknown[]>;
 const _create = createEvent as unknown as (a: {
+  data: Record<string, unknown>;
+}) => Promise<Record<string, unknown>>;
+const _get = getEvent as unknown as (a: {
+  data: Record<string, unknown>;
+}) => Promise<Record<string, unknown> | null>;
+const _update = updateEvent as unknown as (a: {
+  data: Record<string, unknown>;
+}) => Promise<Record<string, unknown>>;
+const _delete = deleteEvent as unknown as (a: {
   data: Record<string, unknown>;
 }) => Promise<Record<string, unknown>>;
 
@@ -153,5 +168,132 @@ describe('createEvent', () => {
         data: { campaignId: 'camp-1', title: 'T', start: { year: 1, monthIndex: 0, day: 99 } },
       })
     ).rejects.toThrow(/Day/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEvent
+// ---------------------------------------------------------------------------
+
+const publicEventDoc = {
+  _id: 'e1',
+  campaignId: 'camp-1',
+  calendarId: 'cal-1',
+  createdBy: 'user-1',
+  title: 'T',
+  content: 'pub',
+  gmContent: 'secret',
+  isPublic: true,
+  isEpic: false,
+  start: { year: 1, monthIndex: 0, day: 1 },
+  end: null,
+  startOrdinal: 0,
+  endOrdinal: 0,
+  links: [],
+  images: [],
+  tags: [],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('getEvent', () => {
+  it('strips gmContent for a non-GM member', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    vi.mocked(Event.findById).mockReturnValue({
+      lean: vi.fn().mockResolvedValue(publicEventDoc),
+    } as never);
+    const res = await _get({ data: { id: 'e1', campaignId: 'camp-1' } });
+    expect(res).not.toBeNull();
+    expect(res!.gmContent).toBe('');
+    expect(res!.content).toBe('pub');
+  });
+
+  it('returns gmContent for a GM member', async () => {
+    // gmCampaign is already the default from beforeEach
+    vi.mocked(Event.findById).mockReturnValue({
+      lean: vi.fn().mockResolvedValue(publicEventDoc),
+    } as never);
+    const res = await _get({ data: { id: 'e1', campaignId: 'camp-1' } });
+    expect(res).not.toBeNull();
+    expect(res!.gmContent).toBe('secret');
+  });
+
+  it('hides a non-public event from a non-GM', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    vi.mocked(Event.findById).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({ ...publicEventDoc, isPublic: false }),
+    } as never);
+    const res = await _get({ data: { id: 'e1', campaignId: 'camp-1' } });
+    expect(res).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateEvent
+// ---------------------------------------------------------------------------
+
+describe('updateEvent', () => {
+  it('recomputes startOrdinal and endOrdinal from the calendar', async () => {
+    // gmCampaign + calDoc are set up in beforeEach
+    vi.mocked(Event.findById).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({ _id: 'e1', campaignId: 'camp-1' }),
+    } as never);
+    vi.mocked(Event.findOneAndUpdate).mockResolvedValue({
+      _id: 'e1',
+      campaignId: 'camp-1',
+      calendarId: 'cal-1',
+      createdBy: 'user-1',
+      start: { year: 1, monthIndex: 0, day: 3 },
+      end: null,
+      startOrdinal: 2,
+      endOrdinal: 2,
+      links: [],
+      images: [],
+      tags: [],
+    } as never);
+
+    await _update({
+      data: {
+        id: 'e1',
+        campaignId: 'camp-1',
+        title: 'T',
+        start: { year: 1, monthIndex: 0, day: 3 },
+        end: null,
+      },
+    });
+
+    const updateArg = vi.mocked(Event.findOneAndUpdate).mock.calls[0][1] as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(updateArg.$set.startOrdinal).toBe(2);
+    expect(updateArg.$set.endOrdinal).toBe(2);
+  });
+
+  it('rejects a non-GM', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    await expect(
+      _update({
+        data: {
+          id: 'e1',
+          campaignId: 'camp-1',
+          title: 'T',
+          start: { year: 1, monthIndex: 0, day: 1 },
+        },
+      })
+    ).rejects.toThrow('Forbidden');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteEvent
+// ---------------------------------------------------------------------------
+
+describe('deleteEvent', () => {
+  it('rejects a non-GM', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    await expect(_delete({ data: { id: 'e1', campaignId: 'camp-1' } })).rejects.toThrow(
+      'Forbidden'
+    );
   });
 });

--- a/tests/server/functions/events.test.ts
+++ b/tests/server/functions/events.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tanstack/react-start', () => ({
+  createServerFn: () => ({
+    inputValidator: () => ({ handler: (fn: unknown) => fn }),
+    handler: (fn: unknown) => fn,
+  }),
+}));
+vi.mock('~/server/session', () => ({ getSession: vi.fn() }));
+vi.mock('~/server/db/connection', () => ({ connectDB: vi.fn(), isDBConnected: vi.fn(() => true) }));
+vi.mock('~/server/db/models/User', () => ({ User: { findOne: vi.fn() } }));
+vi.mock('~/server/db/models/Campaign', () => ({ Campaign: { findById: vi.fn() } }));
+vi.mock('~/server/db/models/Calendar', () => ({ Calendar: { findOne: vi.fn() } }));
+vi.mock('~/server/db/models/Event', () => ({
+  Event: {
+    find: vi.fn(),
+    findById: vi.fn(),
+    create: vi.fn(),
+    findOneAndUpdate: vi.fn(),
+    deleteOne: vi.fn(),
+  },
+}));
+vi.mock('~/server/functions/gmscreens-helpers', () => ({ removeDocumentRefsFromScreens: vi.fn() }));
+vi.mock('~/server/utils/posthog', () => ({
+  serverCaptureException: vi.fn(),
+  serverCaptureEvent: vi.fn(),
+}));
+vi.mock('~/server/db/models/Character', () => ({ Character: { findById: vi.fn() } }));
+vi.mock('~/server/db/models/Player', () => ({ Player: { findById: vi.fn() } }));
+vi.mock('~/server/db/models/Location', () => ({ Location: { findById: vi.fn() } }));
+vi.mock('~/server/db/models/Race', () => ({ Race: { findById: vi.fn() } }));
+vi.mock('~/server/db/models/Lore', () => ({ Lore: { findById: vi.fn() } }));
+
+import { getSession } from '~/server/session';
+import { User } from '~/server/db/models/User';
+import { Campaign } from '~/server/db/models/Campaign';
+import { Calendar } from '~/server/db/models/Calendar';
+import { Event } from '~/server/db/models/Event';
+import { listEvents, createEvent } from '~/server/functions/events';
+
+const gmCampaign = {
+  _id: 'camp-1',
+  gameMasterId: 'user-1',
+  members: [{ userId: 'user-1', role: 'gm' }],
+};
+const playerCampaign = {
+  _id: 'camp-1',
+  gameMasterId: 'gm-x',
+  members: [{ userId: 'user-1', role: 'player' }],
+};
+const calDoc = {
+  months: [{ name: 'A', days: 30 }],
+  weekdays: ['d1'],
+  weekdayMode: 'continuous',
+  epoch: { year: 1, weekdayIndex: 0 },
+  yearSuffix: 'DR',
+  leapDays: [],
+  moons: [],
+  seasons: [],
+  holidays: [],
+  _id: 'cal-1',
+};
+
+const _list = listEvents as unknown as (a: { data: Record<string, unknown> }) => Promise<unknown[]>;
+const _create = createEvent as unknown as (a: {
+  data: Record<string, unknown>;
+}) => Promise<Record<string, unknown>>;
+
+function mockEventFind(docs: unknown[]) {
+  vi.mocked(Event.find).mockReturnValue({
+    sort: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue(docs) }),
+  } as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getSession).mockResolvedValue({ id: 'sess-1' } as never);
+  vi.mocked(User.findOne).mockResolvedValue({ _id: 'user-1' } as never);
+  vi.mocked(Campaign.findById).mockResolvedValue(gmCampaign as never);
+  vi.mocked(Calendar.findOne).mockReturnValue({ lean: vi.fn().mockResolvedValue(calDoc) } as never);
+});
+
+describe('listEvents', () => {
+  it('restricts non-GM to public events', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    mockEventFind([]);
+    await _list({ data: { campaignId: 'camp-1' } });
+    const filter = vi.mocked(Event.find).mock.calls[0][0] as unknown as Record<string, unknown>;
+    expect(filter.isPublic).toBe(true);
+  });
+  it('adds epicOnly filter', async () => {
+    mockEventFind([]);
+    await _list({ data: { campaignId: 'camp-1', epicOnly: true } });
+    const filter = vi.mocked(Event.find).mock.calls[0][0] as unknown as Record<string, unknown>;
+    expect(filter.isEpic).toBe(true);
+  });
+  it('never returns gmContent', async () => {
+    mockEventFind([
+      {
+        _id: 'e1',
+        title: 'T',
+        content: 'c',
+        gmContent: 'secret',
+        isPublic: true,
+        isEpic: false,
+        start: { year: 1, monthIndex: 0, day: 1 },
+        end: null,
+        startOrdinal: 0,
+        endOrdinal: 0,
+        links: [],
+        images: [],
+        tags: [],
+        campaignId: 'camp-1',
+        calendarId: 'cal-1',
+        createdBy: 'user-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+    const res = (await _list({ data: { campaignId: 'camp-1' } })) as Record<string, unknown>[];
+    expect(res[0]).not.toHaveProperty('gmContent');
+  });
+});
+
+describe('createEvent', () => {
+  it('forbids a non-GM', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    await expect(
+      _create({
+        data: { campaignId: 'camp-1', title: 'T', start: { year: 1, monthIndex: 0, day: 1 } },
+      })
+    ).rejects.toThrow('Forbidden');
+  });
+  it('computes startOrdinal/endOrdinal from the calendar', async () => {
+    vi.mocked(Event.create).mockImplementation(
+      async (doc: Record<string, unknown>) => ({ _id: 'e1', ...doc }) as never
+    );
+    await _create({
+      data: {
+        campaignId: 'camp-1',
+        title: 'T',
+        start: { year: 1, monthIndex: 0, day: 2 },
+        end: null,
+      },
+    });
+    const arg = vi.mocked(Event.create).mock.calls[0][0] as Record<string, unknown>;
+    expect(arg.startOrdinal).toBe(1);
+    expect(arg.endOrdinal).toBe(1);
+  });
+  it('rejects an out-of-range date', async () => {
+    await expect(
+      _create({
+        data: { campaignId: 'camp-1', title: 'T', start: { year: 1, monthIndex: 0, day: 99 } },
+      })
+    ).rejects.toThrow(/Day/);
+  });
+});

--- a/tests/server/functions/lore.test.ts
+++ b/tests/server/functions/lore.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tanstack/react-start', () => ({
+  createServerFn: () => ({
+    inputValidator: () => ({ handler: (fn: unknown) => fn }),
+    handler: (fn: unknown) => fn,
+  }),
+}));
+vi.mock('~/server/session', () => ({ getSession: vi.fn() }));
+vi.mock('~/server/db/connection', () => ({ connectDB: vi.fn(), isDBConnected: vi.fn(() => true) }));
+vi.mock('~/server/db/models/User', () => ({ User: { findOne: vi.fn() } }));
+vi.mock('~/server/db/models/Campaign', () => ({ Campaign: { findById: vi.fn() } }));
+vi.mock('~/server/db/models/Lore', () => ({
+  Lore: {
+    find: vi.fn(),
+    findById: vi.fn(),
+    create: vi.fn(),
+    findOneAndUpdate: vi.fn(),
+    deleteOne: vi.fn(),
+  },
+}));
+// The real removeDocumentRefsFromScreens lives in gmscreens-helpers, not a separate utils file
+vi.mock('~/server/functions/gmscreens-helpers', () => ({
+  removeDocumentRefsFromScreens: vi.fn(),
+}));
+vi.mock('~/server/utils/posthog', () => ({
+  serverCaptureException: vi.fn(),
+  serverCaptureEvent: vi.fn(),
+}));
+// Mock the entity models used for link-label resolution
+vi.mock('~/server/db/models/Character', () => ({ Character: { findById: vi.fn() } }));
+vi.mock('~/server/db/models/Player', () => ({ Player: { findById: vi.fn() } }));
+vi.mock('~/server/db/models/Location', () => ({ Location: { findById: vi.fn() } }));
+vi.mock('~/server/db/models/Race', () => ({ Race: { findById: vi.fn() } }));
+
+import { getSession } from '~/server/session';
+import { User } from '~/server/db/models/User';
+import { Campaign } from '~/server/db/models/Campaign';
+import { Lore } from '~/server/db/models/Lore';
+import { removeDocumentRefsFromScreens } from '~/server/functions/gmscreens-helpers';
+import { listLore, getLore, createLore, updateLore, deleteLore } from '~/server/functions/lore';
+
+const session = { id: 'sess-1' } as never;
+const dbUser = { _id: 'user-1' };
+const gmCampaign = {
+  _id: 'camp-1',
+  gameMasterId: 'user-1',
+  members: [{ userId: 'user-1', role: 'gm' }],
+};
+const playerCampaign = {
+  _id: 'camp-1',
+  gameMasterId: 'gm-x',
+  members: [{ userId: 'user-1', role: 'player' }],
+};
+
+const _list = listLore as unknown as (a: { data: Record<string, unknown> }) => Promise<unknown[]>;
+const _get = getLore as unknown as (a: {
+  data: Record<string, unknown>;
+}) => Promise<Record<string, unknown> | null>;
+const _create = createLore as unknown as (a: { data: Record<string, unknown> }) => Promise<unknown>;
+const _update = updateLore as unknown as (a: { data: Record<string, unknown> }) => Promise<unknown>;
+const _delete = deleteLore as unknown as (a: { data: Record<string, unknown> }) => Promise<unknown>;
+
+function mockFindReturning(docs: unknown[]) {
+  vi.mocked(Lore.find).mockReturnValue({
+    sort: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue(docs) }),
+  } as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getSession).mockResolvedValue(session);
+  vi.mocked(User.findOne).mockResolvedValue(dbUser as never);
+  vi.mocked(Campaign.findById).mockResolvedValue(gmCampaign as never);
+});
+
+describe('listLore', () => {
+  it('restricts non-GM members to public or own lore', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    mockFindReturning([]);
+    await _list({ data: { campaignId: 'camp-1' } });
+    const filter = vi.mocked(Lore.find).mock.calls[0][0] as unknown as Record<string, unknown>;
+    expect(filter).toMatchObject({ campaignId: 'camp-1' });
+    expect(JSON.stringify(filter)).toContain('$or'); // isPublic OR createdBy === user
+  });
+
+  it('adds a links filter when linkedKind/linkedId provided', async () => {
+    mockFindReturning([]);
+    await _list({ data: { campaignId: 'camp-1', linkedKind: 'player', linkedId: 'p-1' } });
+    const filter = vi.mocked(Lore.find).mock.calls[0][0] as unknown as Record<string, unknown>;
+    expect(filter.links).toEqual({ $elemMatch: { kind: 'player', id: 'p-1' } });
+  });
+
+  it('never returns gmContent', async () => {
+    mockFindReturning([
+      {
+        _id: 'l1',
+        title: 'T',
+        content: 'c',
+        gmContent: 'secret',
+        isPublic: true,
+        images: [],
+        links: [],
+        tags: [],
+        campaignId: 'camp-1',
+        createdBy: 'user-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+    const res = (await _list({ data: { campaignId: 'camp-1' } })) as Record<string, unknown>[];
+    expect(res[0]).not.toHaveProperty('gmContent');
+  });
+});
+
+describe('getLore', () => {
+  it('strips gmContent for non-GM viewers', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    vi.mocked(Lore.findById).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        _id: 'l1',
+        title: 'T',
+        content: 'c',
+        gmContent: 'secret',
+        isPublic: true,
+        images: [],
+        links: [],
+        tags: [],
+        campaignId: 'camp-1',
+        createdBy: 'someone',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+    } as never);
+    const res = await _get({ data: { id: 'l1', campaignId: 'camp-1' } });
+    expect(res?.gmContent).toBe('');
+    expect(res?.canEdit).toBe(false);
+  });
+
+  it('returns null for a private lore a non-owner non-GM requests', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    vi.mocked(Lore.findById).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        _id: 'l1',
+        isPublic: false,
+        createdBy: 'someone-else',
+        campaignId: 'camp-1',
+        title: 'T',
+        content: '',
+        gmContent: '',
+        images: [],
+        links: [],
+        tags: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+    } as never);
+    const res = await _get({ data: { id: 'l1', campaignId: 'camp-1' } });
+    expect(res).toBeNull();
+  });
+});
+
+describe('updateLore / deleteLore permissions', () => {
+  it('forbids a non-creator non-GM from updating', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    vi.mocked(Lore.findById).mockResolvedValue({
+      _id: 'l1',
+      campaignId: 'camp-1',
+      createdBy: 'someone-else',
+    } as never);
+    await expect(_update({ data: { id: 'l1', campaignId: 'camp-1', title: 'X' } })).rejects.toThrow(
+      'Forbidden'
+    );
+  });
+
+  it('lets the creator delete and clears screen refs', async () => {
+    vi.mocked(Lore.findById).mockResolvedValue({
+      _id: 'l1',
+      campaignId: 'camp-1',
+      createdBy: 'user-1',
+    } as never);
+    vi.mocked(Lore.deleteOne).mockResolvedValue({ deletedCount: 1 } as never);
+    const res = await _delete({ data: { id: 'l1', campaignId: 'camp-1' } });
+    expect(res).toEqual({ success: true });
+    // Real signature: removeDocumentRefsFromScreens(campaignId, collection, documentId)
+    expect(removeDocumentRefsFromScreens).toHaveBeenCalledWith('camp-1', 'lore', 'l1');
+  });
+});
+
+describe('createLore', () => {
+  it('allows any member to create', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    vi.mocked(Lore.create).mockResolvedValue({
+      _id: 'new',
+      title: 'T',
+      content: '',
+      gmContent: '',
+      isPublic: false,
+      images: [],
+      links: [],
+      tags: [],
+      campaignId: 'camp-1',
+      createdBy: 'user-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as never);
+    const res = (await _create({ data: { campaignId: 'camp-1', title: 'T' } })) as Record<
+      string,
+      unknown
+    >;
+    expect(res.success).toBe(true);
+  });
+});

--- a/tests/server/functions/lore.test.ts
+++ b/tests/server/functions/lore.test.ts
@@ -284,7 +284,7 @@ describe('updateLore GM gmContent', () => {
     expect(res.lore.gmContent).toBe('gm notes');
   });
 
-  it('does NOT persist gmContent when a non-GM creator updates lore', async () => {
+  it('does NOT write gmContent when a non-GM creator updates lore (preserves stored GM notes)', async () => {
     vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
     // non-GM must be the creator to pass the permission check
     vi.mocked(Lore.findById).mockReturnValue({
@@ -292,13 +292,16 @@ describe('updateLore GM gmContent', () => {
         _id: 'l1',
         campaignId: 'camp-1',
         createdBy: 'user-1',
+        // A GM previously attached private notes to this doc.
+        gmContent: 'gm-only secret',
       }),
     } as never);
     vi.mocked(Lore.findOneAndUpdate).mockResolvedValue({
       _id: 'l1',
       title: 'Updated',
       content: 'body',
-      gmContent: '',
+      // Stored value is untouched because the update omitted the field.
+      gmContent: 'gm-only secret',
       isPublic: false,
       images: [],
       links: [],
@@ -308,13 +311,17 @@ describe('updateLore GM gmContent', () => {
       createdAt: new Date(),
       updatedAt: new Date(),
     } as never);
-    await _update({
-      data: { id: 'l1', campaignId: 'camp-1', title: 'Updated', gmContent: 'secret' },
-    });
+    const res = (await _update({
+      data: { id: 'l1', campaignId: 'camp-1', title: 'Updated', gmContent: 'injected' },
+    })) as Record<string, Record<string, unknown>>;
     const updateArg = vi.mocked(Lore.findOneAndUpdate).mock.calls[0][1] as Record<
       string,
       Record<string, unknown>
     >;
-    expect(updateArg.$set.gmContent).toBe('');
+    // The non-GM's gmContent input is neither trusted nor persisted: the field
+    // must be absent from $set so the GM's stored notes survive the edit...
+    expect(updateArg.$set).not.toHaveProperty('gmContent');
+    // ...and a non-GM never receives gmContent back in the response.
+    expect(res.lore.gmContent).toBe('');
   });
 });

--- a/tests/server/functions/lore.test.ts
+++ b/tests/server/functions/lore.test.ts
@@ -32,6 +32,7 @@ vi.mock('~/server/db/models/Character', () => ({ Character: { findById: vi.fn() 
 vi.mock('~/server/db/models/Player', () => ({ Player: { findById: vi.fn() } }));
 vi.mock('~/server/db/models/Location', () => ({ Location: { findById: vi.fn() } }));
 vi.mock('~/server/db/models/Race', () => ({ Race: { findById: vi.fn() } }));
+vi.mock('~/server/db/models/Event', () => ({ Event: { updateMany: vi.fn() } }));
 
 import { getSession } from '~/server/session';
 import { User } from '~/server/db/models/User';

--- a/tests/server/functions/lore.test.ts
+++ b/tests/server/functions/lore.test.ts
@@ -214,6 +214,27 @@ describe('createLore', () => {
     >;
     expect(res.success).toBe(true);
   });
+
+  it('does NOT persist gmContent when a non-GM creates lore', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    vi.mocked(Lore.create).mockResolvedValue({
+      _id: 'new',
+      title: 'T',
+      content: '',
+      gmContent: '',
+      isPublic: false,
+      images: [],
+      links: [],
+      tags: [],
+      campaignId: 'camp-1',
+      createdBy: 'user-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as never);
+    await _create({ data: { campaignId: 'camp-1', title: 'T', gmContent: 'secret' } });
+    const createArg = vi.mocked(Lore.create).mock.calls[0][0] as Record<string, unknown>;
+    expect(createArg.gmContent).toBe('');
+  });
 });
 
 describe('listLore GM visibility filter', () => {
@@ -260,5 +281,39 @@ describe('updateLore GM gmContent', () => {
     })) as Record<string, Record<string, unknown>>;
     expect(res.success).toBe(true);
     expect(res.lore.gmContent).toBe('gm notes');
+  });
+
+  it('does NOT persist gmContent when a non-GM creator updates lore', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    // non-GM must be the creator to pass the permission check
+    vi.mocked(Lore.findById).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        _id: 'l1',
+        campaignId: 'camp-1',
+        createdBy: 'user-1',
+      }),
+    } as never);
+    vi.mocked(Lore.findOneAndUpdate).mockResolvedValue({
+      _id: 'l1',
+      title: 'Updated',
+      content: 'body',
+      gmContent: '',
+      isPublic: false,
+      images: [],
+      links: [],
+      tags: [],
+      campaignId: 'camp-1',
+      createdBy: 'user-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as never);
+    await _update({
+      data: { id: 'l1', campaignId: 'camp-1', title: 'Updated', gmContent: 'secret' },
+    });
+    const updateArg = vi.mocked(Lore.findOneAndUpdate).mock.calls[0][1] as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(updateArg.$set.gmContent).toBe('');
   });
 });

--- a/tests/server/functions/lore.test.ts
+++ b/tests/server/functions/lore.test.ts
@@ -163,10 +163,12 @@ describe('getLore', () => {
 describe('updateLore / deleteLore permissions', () => {
   it('forbids a non-creator non-GM from updating', async () => {
     vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
-    vi.mocked(Lore.findById).mockResolvedValue({
-      _id: 'l1',
-      campaignId: 'camp-1',
-      createdBy: 'someone-else',
+    vi.mocked(Lore.findById).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        _id: 'l1',
+        campaignId: 'camp-1',
+        createdBy: 'someone-else',
+      }),
     } as never);
     await expect(_update({ data: { id: 'l1', campaignId: 'camp-1', title: 'X' } })).rejects.toThrow(
       'Forbidden'
@@ -174,10 +176,12 @@ describe('updateLore / deleteLore permissions', () => {
   });
 
   it('lets the creator delete and clears screen refs', async () => {
-    vi.mocked(Lore.findById).mockResolvedValue({
-      _id: 'l1',
-      campaignId: 'camp-1',
-      createdBy: 'user-1',
+    vi.mocked(Lore.findById).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        _id: 'l1',
+        campaignId: 'camp-1',
+        createdBy: 'user-1',
+      }),
     } as never);
     vi.mocked(Lore.deleteOne).mockResolvedValue({ deletedCount: 1 } as never);
     const res = await _delete({ data: { id: 'l1', campaignId: 'camp-1' } });
@@ -209,5 +213,52 @@ describe('createLore', () => {
       unknown
     >;
     expect(res.success).toBe(true);
+  });
+});
+
+describe('listLore GM visibility filter', () => {
+  it('adds isPublic:true filter when GM requests visibility=public', async () => {
+    mockFindReturning([]);
+    await _list({ data: { campaignId: 'camp-1', visibility: 'public' } });
+    const filter = vi.mocked(Lore.find).mock.calls[0][0] as unknown as Record<string, unknown>;
+    expect(filter.isPublic).toBe(true);
+  });
+
+  it('adds isPublic:false filter when GM requests visibility=private', async () => {
+    mockFindReturning([]);
+    await _list({ data: { campaignId: 'camp-1', visibility: 'private' } });
+    const filter = vi.mocked(Lore.find).mock.calls[0][0] as unknown as Record<string, unknown>;
+    expect(filter.isPublic).toBe(false);
+  });
+});
+
+describe('updateLore GM gmContent', () => {
+  it('returns gmContent populated when a GM updates lore', async () => {
+    vi.mocked(Lore.findById).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        _id: 'l1',
+        campaignId: 'camp-1',
+        createdBy: 'someone-else',
+      }),
+    } as never);
+    vi.mocked(Lore.findOneAndUpdate).mockResolvedValue({
+      _id: 'l1',
+      title: 'Updated',
+      content: 'body',
+      gmContent: 'gm notes',
+      isPublic: true,
+      images: [],
+      links: [],
+      tags: [],
+      campaignId: 'camp-1',
+      createdBy: 'someone-else',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as never);
+    const res = (await _update({
+      data: { id: 'l1', campaignId: 'camp-1', title: 'Updated', gmContent: 'gm notes' },
+    })) as Record<string, Record<string, unknown>>;
+    expect(res.success).toBe(true);
+    expect(res.lore.gmContent).toBe('gm notes');
   });
 });

--- a/tests/server/functions/players.test.ts
+++ b/tests/server/functions/players.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tanstack/react-start', () => ({
+  createServerFn: () => ({
+    inputValidator: () => ({ handler: (fn: unknown) => fn }),
+    handler: (fn: unknown) => fn,
+  }),
+}));
+vi.mock('~/server/session', () => ({ getSession: vi.fn() }));
+vi.mock('~/server/db/connection', () => ({ connectDB: vi.fn(), isDBConnected: vi.fn(() => true) }));
+vi.mock('~/server/db/models/User', () => ({ User: { findOne: vi.fn(), updateOne: vi.fn() } }));
+vi.mock('~/server/db/models/Campaign', () => ({
+  Campaign: { findOneAndUpdate: vi.fn() },
+}));
+vi.mock('~/server/db/models/Player', () => ({
+  Player: {
+    findOne: vi.fn(),
+    create: vi.fn(),
+    updateOne: vi.fn(),
+    findById: vi.fn(),
+  },
+}));
+vi.mock('~/server/db/models/Character', () => ({
+  Character: { create: vi.fn() },
+}));
+vi.mock('~/server/db/models/Lore', () => ({
+  Lore: { create: vi.fn() },
+}));
+vi.mock('~/server/functions/gmscreens-helpers', () => ({
+  removeDocumentRefsFromScreens: vi.fn(),
+}));
+vi.mock('~/server/utils/pruneLoreLinks', () => ({
+  pruneLoreLinks: vi.fn(),
+}));
+vi.mock('~/server/utils/requireCampaignMember', () => ({
+  requireCampaignMember: vi.fn(),
+}));
+vi.mock('~/server/utils/posthog', () => ({
+  serverCaptureException: vi.fn(),
+  serverCaptureEvent: vi.fn(),
+}));
+
+import { getSession } from '~/server/session';
+import { User } from '~/server/db/models/User';
+import { Campaign } from '~/server/db/models/Campaign';
+import { Player } from '~/server/db/models/Player';
+import { Character } from '~/server/db/models/Character';
+import { Lore } from '~/server/db/models/Lore';
+import { completeJoinWizard } from '~/server/functions/players';
+
+const _completeJoinWizard = completeJoinWizard as unknown as (a: {
+  data: Record<string, unknown>;
+}) => Promise<Record<string, unknown>>;
+
+const mockSession = { id: 'sess-user-1' };
+const mockDbUser = { _id: 'dbuser-1' };
+const mockCampaign = { _id: 'camp-1', name: 'Test Campaign', maxPlayers: 4, members: [] };
+const mockPlayerDoc = { _id: 'player-id-1' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getSession).mockResolvedValue(mockSession as never);
+  vi.mocked(User.findOne).mockResolvedValue(mockDbUser as never);
+  vi.mocked(User.updateOne).mockResolvedValue({} as never);
+  vi.mocked(Campaign.findOneAndUpdate).mockResolvedValue(mockCampaign as never);
+  vi.mocked(Player.findOne).mockResolvedValue(null); // no existing player
+  vi.mocked(Player.create).mockResolvedValue(mockPlayerDoc as never);
+  vi.mocked(Player.updateOne).mockResolvedValue({} as never);
+  vi.mocked(Character.create).mockResolvedValue({ _id: 'char-id-1' } as never);
+  vi.mocked(Lore.create).mockResolvedValue({} as never);
+});
+
+const basePlayerInput = {
+  firstName: 'Aria',
+  lastName: 'Brightblade',
+  race: 'Elf',
+  characterClass: 'Ranger',
+  age: 25,
+  gender: 'Female',
+  location: '',
+  link: '',
+  picture: '',
+  pictureCrop: null,
+  description: '',
+  backstory: '',
+  color: '#3498db',
+  eyeColor: '',
+  hairColor: '',
+  weight: null,
+  height: '',
+  size: '',
+  appearance: '',
+};
+
+describe('completeJoinWizard', () => {
+  it('creates the player and returns success with playerId', async () => {
+    const result = await _completeJoinWizard({
+      data: { campaignId: 'camp-1', player: basePlayerInput, characters: [], lore: [] },
+    });
+    expect(result.success).toBe(true);
+    expect(result.playerId).toBe('player-id-1');
+    expect(Player.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates Lore docs linked to the new player when lore entries are provided', async () => {
+    const result = await _completeJoinWizard({
+      data: {
+        campaignId: 'camp-1',
+        player: basePlayerInput,
+        characters: [],
+        lore: [
+          { title: 'A', content: 'x', isPublic: true },
+          { title: 'B', content: '', isPublic: false },
+        ],
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(Lore.create).toHaveBeenCalledTimes(2);
+
+    const firstCall = vi.mocked(Lore.create).mock.calls[0][0] as Record<string, unknown>;
+    expect(firstCall.title).toBe('A');
+    expect(firstCall.content).toBe('x');
+    expect(firstCall.isPublic).toBe(true);
+    expect(firstCall.campaignId).toBe('camp-1');
+    expect(firstCall.createdBy).toBe('dbuser-1');
+    expect(firstCall.links).toEqual([{ kind: 'player', id: 'player-id-1' }]);
+
+    const secondCall = vi.mocked(Lore.create).mock.calls[1][0] as Record<string, unknown>;
+    expect(secondCall.title).toBe('B');
+    expect(secondCall.content).toBe('');
+    expect(secondCall.isPublic).toBe(false);
+    expect(secondCall.links).toEqual([{ kind: 'player', id: 'player-id-1' }]);
+  });
+
+  it('does NOT call Lore.create when lore array is empty', async () => {
+    await _completeJoinWizard({
+      data: { campaignId: 'camp-1', player: basePlayerInput, characters: [], lore: [] },
+    });
+    expect(Lore.create).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call Lore.create when lore is omitted', async () => {
+    await _completeJoinWizard({
+      data: { campaignId: 'camp-1', player: basePlayerInput, characters: [] },
+    });
+    expect(Lore.create).not.toHaveBeenCalled();
+  });
+
+  it('throws when campaign is full', async () => {
+    vi.mocked(Campaign.findOneAndUpdate).mockResolvedValue(null);
+    await expect(
+      _completeJoinWizard({
+        data: { campaignId: 'camp-1', player: basePlayerInput, characters: [] },
+      })
+    ).rejects.toThrow('Campaign is full');
+  });
+
+  it('throws when player already exists for this campaign', async () => {
+    vi.mocked(Player.findOne).mockResolvedValue({ _id: 'existing' } as never);
+    await expect(
+      _completeJoinWizard({
+        data: { campaignId: 'camp-1', player: basePlayerInput, characters: [] },
+      })
+    ).rejects.toThrow('Player already exists for this campaign');
+  });
+});

--- a/tests/server/functions/tabletop-hydration.test.ts
+++ b/tests/server/functions/tabletop-hydration.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// hydrateRefs lazily `await import`s the Event model, so mock it up front.
+vi.mock('~/server/db/models/Note', () => ({ Note: { find: vi.fn() } }));
+vi.mock('~/server/db/models/Character', () => ({ Character: { find: vi.fn() } }));
+vi.mock('~/server/db/models/Race', () => ({ Race: { find: vi.fn() } }));
+vi.mock('~/server/db/models/Rule', () => ({ Rule: { find: vi.fn() } }));
+vi.mock('~/server/db/models/Event', () => ({ Event: { find: vi.fn() } }));
+
+import { Event } from '~/server/db/models/Event';
+import { hydrateRefs } from '~/server/functions/tabletop-hydration';
+
+const eventDocs = [
+  { _id: 'pub', title: 'Public Feast', content: 'open to all', isPublic: true },
+  { _id: 'priv', title: 'Secret Plot', content: 'GM eyes only', isPublic: false },
+];
+
+function mockEventFind() {
+  vi.mocked(Event.find).mockReturnValue({
+    lean: vi.fn().mockResolvedValue(eventDocs),
+  } as never);
+}
+
+describe('hydrateRefs — event privacy on shared screens', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEventFind();
+  });
+
+  const refs = [
+    { collection: 'events', documentId: 'pub' },
+    { collection: 'events', documentId: 'priv' },
+  ];
+
+  it('omits non-public events for a non-GM viewer', async () => {
+    const hydrated = await hydrateRefs(refs, 'camp-1', { isGM: false });
+    expect(hydrated['events:pub']).toBeDefined();
+    expect(hydrated['events:pub'].title).toBe('Public Feast');
+    // Private event must not leak its title/content to a player.
+    expect(hydrated['events:priv']).toBeUndefined();
+  });
+
+  it('hydrates private events for a GM viewer', async () => {
+    const hydrated = await hydrateRefs(refs, 'camp-1', { isGM: true });
+    expect(hydrated['events:priv']).toBeDefined();
+    expect(hydrated['events:priv'].content).toBe('GM eyes only');
+  });
+
+  it('defaults to GM (no redaction) when no viewer role is provided', async () => {
+    const hydrated = await hydrateRefs(refs, 'camp-1');
+    expect(hydrated['events:priv']).toBeDefined();
+  });
+});

--- a/tests/server/utils/oauth.test.ts
+++ b/tests/server/utils/oauth.test.ts
@@ -234,6 +234,31 @@ describe('upsertUser', () => {
     });
   });
 
+  it('captures and rethrows when the DB is not connected (no broken session)', async () => {
+    mockIsDBConnected.mockReturnValue(false);
+
+    const { upsertUser } = await import('~/server/utils/oauth');
+    const profile = {
+      id: 'google_offline',
+      provider: 'google' as const,
+      name: 'Test User',
+      email: 'test@example.com',
+      avatar: null,
+      accessToken: 'tok',
+      refreshToken: null,
+      tokenIssuedAt: Date.now(),
+    };
+
+    // No DB means we can't persist the account: auth must fail rather than mint
+    // an unpersisted "unknown" session.
+    await expect(upsertUser(profile)).rejects.toThrow(/not connected/);
+    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+    expect(mockServerCaptureException).toHaveBeenCalledWith(expect.any(Error), 'google_offline', {
+      action: 'upsertUser',
+      provider: 'google',
+    });
+  });
+
   it('does not capture exception on successful upsert', async () => {
     mockFindOneAndUpdate.mockResolvedValue({
       email: 'test@example.com',

--- a/tests/server/utils/oauth.test.ts
+++ b/tests/server/utils/oauth.test.ts
@@ -207,7 +207,7 @@ describe('upsertUser', () => {
     mockIsDBConnected.mockReturnValue(true);
   });
 
-  it('captures exception to PostHog when DB upsert fails', async () => {
+  it('captures the exception to PostHog and rethrows when the DB upsert fails', async () => {
     const dbError = new Error('MongoDB connection lost');
     mockFindOneAndUpdate.mockRejectedValue(dbError);
 
@@ -223,14 +223,15 @@ describe('upsertUser', () => {
       tokenIssuedAt: Date.now(),
     };
 
-    const result = await upsertUser(profile);
+    // A persistence failure must surface, not be swallowed into a broken session:
+    // the OAuth callback relies on this throw to redirect to an error page rather
+    // than logging the user in with an unpersisted "unknown" session.
+    await expect(upsertUser(profile)).rejects.toThrow(dbError);
 
     expect(mockServerCaptureException).toHaveBeenCalledWith(dbError, 'google_123', {
       action: 'upsertUser',
       provider: 'google',
     });
-    // Should still return fallback session user with role 'unknown'
-    expect(result.role).toBe('unknown');
   });
 
   it('does not capture exception on successful upsert', async () => {

--- a/tests/server/utils/pruneLoreLinks.test.ts
+++ b/tests/server/utils/pruneLoreLinks.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+vi.mock('~/server/db/models/Lore', () => ({ Lore: { updateMany: vi.fn() } }));
+import { Lore } from '~/server/db/models/Lore';
+import { pruneLoreLinks } from '~/server/utils/pruneLoreLinks';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('pruneLoreLinks', () => {
+  it('pulls matching links from all lore in the campaign', async () => {
+    vi.mocked(Lore.updateMany).mockResolvedValue({ modifiedCount: 2 } as never);
+    await pruneLoreLinks('character', 'c-1', 'camp-1');
+    expect(Lore.updateMany).toHaveBeenCalledWith(
+      { campaignId: 'camp-1', 'links.id': 'c-1' },
+      { $pull: { links: { kind: 'character', id: 'c-1' } } }
+    );
+  });
+});

--- a/tests/services/eventsTimeline.test.ts
+++ b/tests/services/eventsTimeline.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { eventsToTimeline } from '~/services/eventsTimeline';
+import { HARPTOS_CONFIG } from '~/utils/harptos';
+import type { EventListItem } from '~/types/event';
+
+const cfg = HARPTOS_CONFIG;
+const base: EventListItem = {
+  id: 'e1',
+  campaignId: 'c',
+  calendarId: 'cal',
+  createdBy: 'u',
+  title: 'Siege',
+  content: 'A great siege',
+  isPublic: true,
+  isEpic: true,
+  start: { year: 1491, monthIndex: 4, day: 11 },
+  end: { year: 1491, monthIndex: 4, day: 12 },
+  startOrdinal: 0,
+  endOrdinal: 0,
+  links: [],
+  sessionId: null,
+  images: [],
+  tags: [],
+  color: null,
+  createdAt: '',
+  updatedAt: '',
+  canEdit: false,
+};
+
+describe('eventsToTimeline', () => {
+  it('maps an epic event to a major TimelineEvent, newest first', () => {
+    const older = { ...base, id: 'e0', start: { year: 1358, monthIndex: 0, day: 1 }, end: null };
+    const out = eventsToTimeline(cfg, [base, older], { year: 1491, monthIndex: 4, day: 11 });
+    expect(out[0].id).toBe('e1'); // newest first
+    expect(out[0].importance).toBe('major');
+    expect(out[0].calendarDate).toContain('Tarsakh');
+    expect(out[0].isCurrent).toBe(true); // currentDate within the span
+    expect(out[1].isCurrent).toBeUndefined();
+  });
+});

--- a/tests/types/schemas/lore-window-collection.test.ts
+++ b/tests/types/schemas/lore-window-collection.test.ts
@@ -31,3 +31,31 @@ describe('lore is an accepted tabletop/GM-screen window collection', () => {
     expect(result.success).toBe(true);
   });
 });
+
+/**
+ * Regression guard: `'events'` must be an accepted window collection so that
+ * dragging an event card onto the tabletop / GM screens opens a window.
+ */
+describe('events is an accepted tabletop/GM-screen window collection', () => {
+  it('openTabletopWindowSchema accepts collection "events"', () => {
+    const result = openTabletopWindowSchema.safeParse({
+      screenId: 's1',
+      campaignId: 'c1',
+      collection: 'events',
+      documentId: 'e1',
+      x: 0,
+      y: 0,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('gmscreens openWindowSchema accepts collection "events"', () => {
+    const result = openWindowSchema.safeParse({
+      screenId: 's1',
+      campaignId: 'c1',
+      collection: 'events',
+      documentId: 'e1',
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/tests/types/schemas/lore-window-collection.test.ts
+++ b/tests/types/schemas/lore-window-collection.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { openTabletopWindowSchema } from '~/types/schemas/tabletop';
+import { openWindowSchema } from '~/types/schemas/gmscreens';
+
+/**
+ * Regression guard: `'lore'` must be an accepted window collection so that
+ * dragging a lore card onto the tabletop / GM screens opens a window. This was
+ * missing from both allowlists (TABLETOP_COLLECTIONS / SUPPORTED_COLLECTIONS),
+ * which silently rejected lore drops server-side — caught by e2e, not units.
+ */
+describe('lore is an accepted tabletop/GM-screen window collection', () => {
+  it('openTabletopWindowSchema accepts collection "lore"', () => {
+    const result = openTabletopWindowSchema.safeParse({
+      screenId: 's1',
+      campaignId: 'c1',
+      collection: 'lore',
+      documentId: 'l1',
+      x: 0,
+      y: 0,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('gmscreens openWindowSchema accepts collection "lore"', () => {
+    const result = openWindowSchema.safeParse({
+      screenId: 's1',
+      campaignId: 'c1',
+      collection: 'lore',
+      documentId: 'l1',
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/tests/utils/calendarEngine.parity.test.ts
+++ b/tests/utils/calendarEngine.parity.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { toOrdinal } from '~/utils/calendarEngine';
+import { HARPTOS_CONFIG } from '~/utils/harptos';
+
+// These ordinals are produced by scripts/seed_calendar_data.py:to_ordinal for the
+// seeded sample-event dates. If the TS engine and Python port diverge, this fails.
+const EXPECTED: Array<[{ year: number; monthIndex: number; day: number }, number]> = [
+  [{ year: 1491, monthIndex: 6, day: 15 }, 43601],
+  [{ year: 1488, monthIndex: 10, day: 1 }, 42582],
+  [{ year: 1358, monthIndex: 0, day: 1 }, -5113],
+];
+
+describe('calendar engine parity (TS vs Python seed port)', () => {
+  it('matches the Python to_ordinal for seed dates', () => {
+    for (const [date, expected] of EXPECTED) {
+      expect(toOrdinal(HARPTOS_CONFIG, date)).toBe(expected);
+    }
+  });
+});

--- a/tests/utils/calendarEngine.test.ts
+++ b/tests/utils/calendarEngine.test.ts
@@ -60,13 +60,19 @@ describe('toOrdinal / fromOrdinal', () => {
       }
     }
   });
+
+  it('fromOrdinal throws on a degenerate zero-length-year config', () => {
+    const zeroCfg: CalendarConfig = {
+      months: [{ name: 'Z', days: 0 }],
+      weekdays: ['d1'],
+      weekdayMode: 'continuous',
+      epoch: { year: 1, weekdayIndex: 0 },
+      leapDays: [],
+    };
+    expect(() => fromOrdinal(zeroCfg, 5)).toThrow();
+  });
 });
 
 function daysInMonthHelper(year: number, m: number): number {
-  // mirror engine for the loop bound
-  const base = cfg.months[m]!.days;
-  const leap = cfg.leapDays.some(
-    (r) => r.monthIndex === m && (((year - r.offset) % r.interval) + r.interval) % r.interval === 0
-  );
-  return base + (leap ? 1 : 0);
+  return daysInMonth(cfg, year, m);
 }

--- a/tests/utils/calendarEngine.test.ts
+++ b/tests/utils/calendarEngine.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { daysInMonth, daysInYear, type CalendarConfig } from '~/utils/calendarEngine';
+
+// Minimal config: 2 months (30, 30), 5-day week, leap +1 to month 1 every 4 years.
+const cfg: CalendarConfig = {
+  months: [
+    { name: 'Alpha', days: 30 },
+    { name: 'Beta', days: 30 },
+  ],
+  weekdays: ['d1', 'd2', 'd3', 'd4', 'd5'],
+  weekdayMode: 'continuous',
+  epoch: { year: 1, weekdayIndex: 0 },
+  leapDays: [{ name: 'Leap', monthIndex: 1, interval: 4, offset: 0, addDays: 1 }],
+};
+
+describe('daysInMonth / daysInYear', () => {
+  it('returns base length in a non-leap year', () => {
+    expect(daysInMonth(cfg, 1, 1)).toBe(30); // year 1 % 4 !== 0
+    expect(daysInYear(cfg, 1)).toBe(60);
+  });
+  it('adds leap days in a matching year', () => {
+    expect(daysInMonth(cfg, 4, 1)).toBe(31); // 4 % 4 === 0
+    expect(daysInYear(cfg, 4)).toBe(61);
+  });
+  it('handles negative years for leap matching', () => {
+    expect(daysInMonth(cfg, -4, 1)).toBe(31);
+    expect(daysInMonth(cfg, -1, 1)).toBe(30);
+  });
+});

--- a/tests/utils/calendarEngine.test.ts
+++ b/tests/utils/calendarEngine.test.ts
@@ -169,11 +169,17 @@ describe('monthGrid', () => {
     expect(grid[5]).toEqual([26, 27, 28, 29, 30]);
   });
   it('adds leading blanks in continuous mode when day 1 is mid-week', () => {
-    // month 1 of year 1 starts at ordinal 30 -> weekday 30 % 5 = 0; force offset
+    // epoch weekdayIndex:2 -> day 1 of year 1 (ordinal 0) is weekday 2 -> 2 leading nulls
     const off: CalendarConfig = { ...cfg, epoch: { year: 1, weekdayIndex: 2 } };
     const grid = monthGrid(off, 1, 0);
     expect(grid[0]!.slice(0, 2)).toEqual([null, null]);
     expect(grid[0]![2]).toBe(1);
+  });
+  it('pads the final row with trailing nulls when days do not fill a week', () => {
+    // 31-day month, 5-day week, continuous, day1 weekday 0 -> last row [31, null, null, null, null]
+    const c31: CalendarConfig = { ...cfg, months: [{ name: 'Long', days: 31 }] };
+    const grid = monthGrid(c31, 1, 0);
+    expect(grid[grid.length - 1]).toEqual([31, null, null, null, null]);
   });
 });
 
@@ -195,6 +201,23 @@ describe('moonPhase / seasonOf / holidaysOn / formatDate', () => {
   it('seasonOf picks the active season', () => {
     expect(seasonOf(dcfg, toOrdinal(dcfg, { year: 1, monthIndex: 0, day: 5 }))?.name).toBe('Cold');
     expect(seasonOf(dcfg, toOrdinal(dcfg, { year: 1, monthIndex: 1, day: 5 }))?.name).toBe('Warm');
+  });
+  it("seasonOf wraps the previous year's last season before the first season start", () => {
+    const wrapCfg: CalendarConfig = {
+      ...cfg,
+      seasons: [
+        { name: 'Spring', startMonthIndex: 0, startDay: 10 },
+        { name: 'Autumn', startMonthIndex: 1, startDay: 10 },
+      ],
+    };
+    // year 1, month 0, day 1 is before Spring's day-10 start -> should carry over Autumn (last season)
+    expect(seasonOf(wrapCfg, toOrdinal(wrapCfg, { year: 1, monthIndex: 0, day: 1 }))?.name).toBe(
+      'Autumn'
+    );
+    // and a date after Spring start but before Autumn is Spring
+    expect(seasonOf(wrapCfg, toOrdinal(wrapCfg, { year: 1, monthIndex: 0, day: 15 }))?.name).toBe(
+      'Spring'
+    );
   });
   it('holidaysOn returns matching holidays', () => {
     expect(holidaysOn(dcfg, 1, 0, 15).map((h) => h.name)).toEqual(['Feast']);

--- a/tests/utils/calendarEngine.test.ts
+++ b/tests/utils/calendarEngine.test.ts
@@ -4,6 +4,10 @@ import {
   daysInYear,
   toOrdinal,
   fromOrdinal,
+  validateDate,
+  compareDates,
+  addDays,
+  weekdayOf,
   type CalendarConfig,
 } from '~/utils/calendarEngine';
 
@@ -76,3 +80,63 @@ describe('toOrdinal / fromOrdinal', () => {
 function daysInMonthHelper(year: number, m: number): number {
   return daysInMonth(cfg, year, m);
 }
+
+describe('validateDate', () => {
+  it('accepts an in-range date', () => {
+    expect(validateDate(cfg, { year: 1, monthIndex: 0, day: 30 }).ok).toBe(true);
+  });
+  it('rejects a day beyond the month length', () => {
+    expect(validateDate(cfg, { year: 1, monthIndex: 0, day: 31 }).ok).toBe(false);
+  });
+  it('rejects an out-of-range month', () => {
+    expect(validateDate(cfg, { year: 1, monthIndex: 9, day: 1 }).ok).toBe(false);
+  });
+  it('rejects a day in a zero-length (non-leap) month', () => {
+    const z: CalendarConfig = {
+      ...cfg,
+      months: [
+        { name: 'A', days: 30 },
+        { name: 'Z', days: 0 },
+      ],
+    };
+    expect(validateDate(z, { year: 1, monthIndex: 1, day: 1 }).ok).toBe(false);
+  });
+});
+
+describe('compareDates / addDays', () => {
+  it('orders dates', () => {
+    expect(
+      compareDates(cfg, { year: 1, monthIndex: 0, day: 1 }, { year: 1, monthIndex: 0, day: 2 })
+    ).toBe(-1);
+    expect(
+      compareDates(cfg, { year: 2, monthIndex: 0, day: 1 }, { year: 1, monthIndex: 0, day: 1 })
+    ).toBe(1);
+  });
+  it('adds days across a month boundary', () => {
+    expect(addDays(cfg, { year: 1, monthIndex: 0, day: 30 }, 1)).toEqual({
+      year: 1,
+      monthIndex: 1,
+      day: 1,
+    });
+  });
+});
+
+describe('weekdayOf', () => {
+  it('continuous mode flows across months', () => {
+    expect(weekdayOf(cfg, { year: 1, monthIndex: 0, day: 1 })).toBe(0);
+    expect(weekdayOf(cfg, { year: 1, monthIndex: 0, day: 6 })).toBe(0); // 5-day week
+  });
+  it('resetEachMonth mode resets day 1 to weekday 0 and returns -1 for intercalary', () => {
+    const r: CalendarConfig = {
+      ...cfg,
+      weekdayMode: 'resetEachMonth',
+      months: [
+        { name: 'A', days: 30 },
+        { name: 'Fest', days: 1, isIntercalary: true },
+      ],
+    };
+    expect(weekdayOf(r, { year: 1, monthIndex: 0, day: 1 })).toBe(0);
+    expect(weekdayOf(r, { year: 1, monthIndex: 0, day: 7 })).toBe(1);
+    expect(weekdayOf(r, { year: 1, monthIndex: 1, day: 1 })).toBe(-1);
+  });
+});

--- a/tests/utils/calendarEngine.test.ts
+++ b/tests/utils/calendarEngine.test.ts
@@ -15,6 +15,7 @@ import {
   formatDate,
   type CalendarConfig,
 } from '~/utils/calendarEngine';
+import { HARPTOS_CONFIG } from '~/utils/harptos';
 
 // Minimal config: 2 months (30, 30), 5-day week, leap +1 to month 1 every 4 years.
 const cfg: CalendarConfig = {
@@ -230,5 +231,28 @@ describe('moonPhase / seasonOf / holidaysOn / formatDate', () => {
       months: [{ name: 'Midsummer', days: 1, isIntercalary: true }],
     };
     expect(formatDate(ic, { year: 1482, monthIndex: 0, day: 1 })).toBe('Midsummer, 1482 DR');
+  });
+});
+
+describe('Harptos', () => {
+  it('a normal year has 365 days', () => {
+    expect(daysInYear(HARPTOS_CONFIG, 1373)).toBe(365); // 1373 % 4 !== 0
+  });
+  it('a Shieldmeet year has 366 days', () => {
+    expect(daysInYear(HARPTOS_CONFIG, 1372)).toBe(366); // 1372 % 4 === 0
+  });
+  it('Shieldmeet has no placeable day in a non-leap year', () => {
+    expect(validateDate(HARPTOS_CONFIG, { year: 1373, monthIndex: 10, day: 1 }).ok).toBe(false);
+  });
+  it('Shieldmeet day 1 is valid in a leap year', () => {
+    expect(validateDate(HARPTOS_CONFIG, { year: 1488, monthIndex: 10, day: 1 }).ok).toBe(true);
+  });
+  it('round-trips across a Shieldmeet year', () => {
+    for (let m = 0; m < HARPTOS_CONFIG.months.length; m++) {
+      for (let day = 1; day <= daysInMonth(HARPTOS_CONFIG, 1488, m); day++) {
+        const d = { year: 1488, monthIndex: m, day };
+        expect(fromOrdinal(HARPTOS_CONFIG, toOrdinal(HARPTOS_CONFIG, d))).toEqual(d);
+      }
+    }
   });
 });

--- a/tests/utils/calendarEngine.test.ts
+++ b/tests/utils/calendarEngine.test.ts
@@ -8,6 +8,11 @@ import {
   compareDates,
   addDays,
   weekdayOf,
+  monthGrid,
+  moonPhase,
+  seasonOf,
+  holidaysOn,
+  formatDate,
   type CalendarConfig,
 } from '~/utils/calendarEngine';
 
@@ -153,5 +158,54 @@ describe('weekdayOf', () => {
     expect(weekdayOf(r, { year: 1, monthIndex: 0, day: 1 })).toBe(0);
     expect(weekdayOf(r, { year: 1, monthIndex: 0, day: 7 })).toBe(1);
     expect(weekdayOf(r, { year: 1, monthIndex: 1, day: 1 })).toBe(-1);
+  });
+});
+
+describe('monthGrid', () => {
+  it('chunks days into week rows, padding the last row with null', () => {
+    const grid = monthGrid(cfg, 1, 0); // 30 days, 5-day week, continuous, day1 weekday 0
+    expect(grid.length).toBe(6);
+    expect(grid[0]).toEqual([1, 2, 3, 4, 5]);
+    expect(grid[5]).toEqual([26, 27, 28, 29, 30]);
+  });
+  it('adds leading blanks in continuous mode when day 1 is mid-week', () => {
+    // month 1 of year 1 starts at ordinal 30 -> weekday 30 % 5 = 0; force offset
+    const off: CalendarConfig = { ...cfg, epoch: { year: 1, weekdayIndex: 2 } };
+    const grid = monthGrid(off, 1, 0);
+    expect(grid[0]!.slice(0, 2)).toEqual([null, null]);
+    expect(grid[0]![2]).toBe(1);
+  });
+});
+
+describe('moonPhase / seasonOf / holidaysOn / formatDate', () => {
+  const dcfg: CalendarConfig = {
+    ...cfg,
+    moons: [{ name: 'Luna', cycleLength: 10, offsetDays: 0 }],
+    seasons: [
+      { name: 'Cold', startMonthIndex: 0, startDay: 1 },
+      { name: 'Warm', startMonthIndex: 1, startDay: 1 },
+    ],
+    holidays: [{ name: 'Feast', monthIndex: 0, day: 15 }],
+    yearSuffix: 'DR',
+  };
+  it('moonPhase returns a 0..1 fraction', () => {
+    expect(moonPhase(dcfg, dcfg.moons![0]!, 0)).toBeCloseTo(0, 5);
+    expect(moonPhase(dcfg, dcfg.moons![0]!, 5)).toBeCloseTo(0.5, 5);
+  });
+  it('seasonOf picks the active season', () => {
+    expect(seasonOf(dcfg, toOrdinal(dcfg, { year: 1, monthIndex: 0, day: 5 }))?.name).toBe('Cold');
+    expect(seasonOf(dcfg, toOrdinal(dcfg, { year: 1, monthIndex: 1, day: 5 }))?.name).toBe('Warm');
+  });
+  it('holidaysOn returns matching holidays', () => {
+    expect(holidaysOn(dcfg, 1, 0, 15).map((h) => h.name)).toEqual(['Feast']);
+    expect(holidaysOn(dcfg, 1, 0, 16)).toEqual([]);
+  });
+  it('formatDate renders normal vs intercalary', () => {
+    expect(formatDate(dcfg, { year: 1482, monthIndex: 0, day: 11 })).toBe('11th Alpha, 1482 DR');
+    const ic: CalendarConfig = {
+      ...dcfg,
+      months: [{ name: 'Midsummer', days: 1, isIntercalary: true }],
+    };
+    expect(formatDate(ic, { year: 1482, monthIndex: 0, day: 1 })).toBe('Midsummer, 1482 DR');
   });
 });

--- a/tests/utils/calendarEngine.test.ts
+++ b/tests/utils/calendarEngine.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { daysInMonth, daysInYear, type CalendarConfig } from '~/utils/calendarEngine';
+import {
+  daysInMonth,
+  daysInYear,
+  toOrdinal,
+  fromOrdinal,
+  type CalendarConfig,
+} from '~/utils/calendarEngine';
 
 // Minimal config: 2 months (30, 30), 5-day week, leap +1 to month 1 every 4 years.
 const cfg: CalendarConfig = {
@@ -27,3 +33,40 @@ describe('daysInMonth / daysInYear', () => {
     expect(daysInMonth(cfg, -1, 1)).toBe(30);
   });
 });
+
+describe('toOrdinal / fromOrdinal', () => {
+  it('epoch first day is ordinal 0', () => {
+    expect(toOrdinal(cfg, { year: 1, monthIndex: 0, day: 1 })).toBe(0);
+  });
+  it('counts within a year', () => {
+    expect(toOrdinal(cfg, { year: 1, monthIndex: 0, day: 2 })).toBe(1);
+    expect(toOrdinal(cfg, { year: 1, monthIndex: 1, day: 1 })).toBe(30);
+  });
+  it('crosses a leap year boundary', () => {
+    // year 1,2,3 are 60 days; year 4 (leap) is 61. Start of year 5:
+    expect(toOrdinal(cfg, { year: 5, monthIndex: 0, day: 1 })).toBe(60 * 3 + 61);
+  });
+  it('handles negative ordinals (before epoch)', () => {
+    // year 0 IS a leap year (0 % 4 === 0, offset=0) → 61 days; last day is monthIndex=1, day=31
+    expect(toOrdinal(cfg, { year: 0, monthIndex: 1, day: 31 })).toBe(-1);
+  });
+  it('round-trips fromOrdinal(toOrdinal(d)) === d across many dates', () => {
+    for (let year = -6; year <= 8; year++) {
+      for (let m = 0; m < cfg.months.length; m++) {
+        for (let day = 1; day <= daysInMonthHelper(year, m); day++) {
+          const d = { year, monthIndex: m, day };
+          expect(fromOrdinal(cfg, toOrdinal(cfg, d))).toEqual(d);
+        }
+      }
+    }
+  });
+});
+
+function daysInMonthHelper(year: number, m: number): number {
+  // mirror engine for the loop bound
+  const base = cfg.months[m]!.days;
+  const leap = cfg.leapDays.some(
+    (r) => r.monthIndex === m && (((year - r.offset) % r.interval) + r.interval) % r.interval === 0
+  );
+  return base + (leap ? 1 : 0);
+}

--- a/tests/utils/calendarEngine.test.ts
+++ b/tests/utils/calendarEngine.test.ts
@@ -101,6 +101,9 @@ describe('validateDate', () => {
     };
     expect(validateDate(z, { year: 1, monthIndex: 1, day: 1 }).ok).toBe(false);
   });
+  it('rejects a non-integer year', () => {
+    expect(validateDate(cfg, { year: 1.5, monthIndex: 0, day: 1 }).ok).toBe(false);
+  });
 });
 
 describe('compareDates / addDays', () => {
@@ -112,11 +115,23 @@ describe('compareDates / addDays', () => {
       compareDates(cfg, { year: 2, monthIndex: 0, day: 1 }, { year: 1, monthIndex: 0, day: 1 })
     ).toBe(1);
   });
+  it('returns 0 for equal dates', () => {
+    expect(
+      compareDates(cfg, { year: 1, monthIndex: 0, day: 5 }, { year: 1, monthIndex: 0, day: 5 })
+    ).toBe(0);
+  });
   it('adds days across a month boundary', () => {
     expect(addDays(cfg, { year: 1, monthIndex: 0, day: 30 }, 1)).toEqual({
       year: 1,
       monthIndex: 1,
       day: 1,
+    });
+  });
+  it('subtracts days across a month boundary (negative n)', () => {
+    expect(addDays(cfg, { year: 1, monthIndex: 1, day: 1 }, -1)).toEqual({
+      year: 1,
+      monthIndex: 0,
+      day: 30,
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds **Lore**: a campaign-scoped wiki entity capturing history/stories/flavor, with public + GM-only Markdown and images, linkable to any number of **Race / Character / Player / Location** entities. Lore behaves like Characters — GM (or creator) edits it, it drags out onto the tabletop and GM screens, and lore linked to a Player surfaces in a **Lore tab** on the player window. Players can author lore (public/private) during character creation and while editing.

Built per `docs/specs/2026-06-16-lore-design.md` and `docs/specs/2026-06-16-lore-plan.md` (21-task TDD plan, each task spec- and quality-reviewed).

## What's included
- **Data/server**: `Lore` model, Zod schemas, types; `lore.ts` server fns gated by `requireCampaignMember` — any member creates, creator-or-GM edits; visibility = `isPublic` OR creator, `gmContent` GM-only at read **and write**; polymorphic `links: [{kind,id}]` with read-time labels; `pruneLoreLinks` on entity deletes; `'lore'` added to the tabletop/GM-screen window allowlists + hydration registries.
- **Hooks**: `useLore` / `useLoreEntry` / `useLinkedLore` + mutations.
- **Wiki UI**: `LorePanel`, draggable `LoreCard`, `LoreModal` (+ `LoreLinksEditor`), `LoreViewModal`, `LoreWindow`, wrappers; registered in `WikiPanel` (all members).
- **Drag-out**: `'lore'` rendered as a window in `TabletopView` + `GMScreensView`.
- **Player integration**: Lore tab in `PlayerWindow`, lore section in `PlayerModal` edit, `StepLore` in the join wizard (persists player-linked lore via `completeJoinWizard`).
- **Seed**: 6 sample lore docs (race/location/character/player links, public + private + GM-only, multi-link) into the `lores` collection + a deterministic lore-image generator wired into `dev:seed`.

## Testing
- **1308 unit/component/server tests pass; tsc clean.**
- Seed harness (ephemeral Mongo): `test_lore_docs` asserts >=5 docs, all 4 link kinds, a private+`gmContent` doc, correct `createdBy`.
- **E2E (Playwright): both `e2e/lore/lore-editor.spec.ts` and `e2e/lore/lore-drag-drop.spec.ts` PASS** against the reseeded dev DB (GM creates a lore entry and sees it; drags a lore card onto the tabletop and a lore window opens).
- Dev environment wiped and reseeded with the new lore data (6 docs + 4 images), verified in the `lores` collection.

## Bugs the e2e caught (and this PR fixes)
The browser e2e surfaced three integration gaps the unit suite mocked past:
1. `'lore'` was missing from the `openWindow` collection allowlists (`TABLETOP_COLLECTIONS` / `SUPPORTED_COLLECTIONS`) — lore drops were rejected server-side.
2. `'lore'` was missing from the window-hydration registries — a dropped lore window's title bar showed `lore:<id>` instead of the title.
3. `dev_seed.py` inserted lore into the `lore` collection, but Mongoose pluralizes `model('Lore')` to `lores` — so seeded lore was invisible to the app. Fixed to write `lores`. A schema regression test now guards the allowlist.

## Notes
- Player Lore tab is always visible (matches the Relationships-tab convention) rather than hidden-when-empty — a minor, intentional deviation from spec section 8.
- Branch also carries a separate, pre-existing `fix(auth)` commit (`b3447a1`).
- The 4 Dependabot alerts on the default branch are unrelated (separate deferred dep-fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)