### PR TITLE
fix(dev-env): seed images 404 + tabletop PartyKit sockets never connect

### DIFF
--- a/app/hooks/useTabletopMapParty.ts
+++ b/app/hooks/useTabletopMapParty.ts
@@ -91,7 +91,10 @@ export function useTabletopMapParty(
   const socket = usePartySocket({
     host: PARTYKIT_HOST,
     room: roomId,
-    party: 'tabletop-map',
+    // Party names must be valid JS identifiers (PartyKit interpolates them
+    // into generated code) AND match its /^[a-z0-9_-]+$/ config schema, so
+    // underscore is the only separator that satisfies both.
+    party: 'tabletop_map',
     query: campaignId ? async () => ({ token: await getToken() }) : () => ({ token: '' }),
     onOpen() {
       console.info(`[TabletopMapParty] Connected to room ${roomId}`);

--- a/app/server/functions/maps.ts
+++ b/app/server/functions/maps.ts
@@ -110,8 +110,9 @@ async function broadcastActiveMapChanged(
   if (!host) return;
   const isLocal = host.startsWith('localhost') || host.startsWith('127.0.0.1');
   const protocol = isLocal ? 'http' : 'https';
-  // Mirrors `useTabletopMapParty`: party `tabletop-map`, room `tabletop-map-<campaignId>`.
-  const url = `${protocol}://${host}/parties/tabletop-map/tabletop-map-${campaignId}`;
+  // Mirrors `useTabletopMapParty`: party `tabletop_map` (underscore — the
+  // partykit.json key), room `tabletop-map-<campaignId>`.
+  const url = `${protocol}://${host}/parties/tabletop_map/tabletop-map-${campaignId}`;
   try {
     const { createPartyBroadcastToken } = await import('../session');
     const broadcastToken = await createPartyBroadcastToken();

--- a/party/tabletop.ts
+++ b/party/tabletop.ts
@@ -1,7 +1,49 @@
 import type * as Party from 'partykit/server';
+import { jwtVerify } from 'jose';
 
 export default class TabletopParty implements Party.Server {
   constructor(readonly room: Party.Room) {}
+
+  // Authenticate and room-bind connections exactly like `tabletop-map.ts`:
+  // without this, anyone with a campaign id could join the relay tokenless
+  // and read/inject tabletop UI events for every connected player.
+  static async onBeforeConnect(request: Party.Request, lobby: Party.Lobby) {
+    const token = new URL(request.url).searchParams.get('token');
+    if (!token) return new Response('Unauthorized', { status: 401 });
+
+    const sessionSecret = lobby.env.SESSION_SECRET;
+    if (typeof sessionSecret !== 'string' || sessionSecret.trim() === '') {
+      return new Response('Unauthorized', { status: 401 });
+    }
+
+    try {
+      const { payload } = await jwtVerify(token, new TextEncoder().encode(sessionSecret), {
+        algorithms: ['HS256'],
+      });
+      const userId = typeof payload.sub === 'string' ? payload.sub.trim() : '';
+      if (!userId) return new Response('Unauthorized', { status: 401 });
+
+      // The token's sessionId claim carries the campaign id; the room is
+      // exactly `tabletop-<campaignId>` (see useTabletopParty). Require the
+      // claim and match the room exactly so an empty claim can't join any
+      // room and a suffix collision can't cross campaigns.
+      const campaignId = typeof payload.sessionId === 'string' ? payload.sessionId.trim() : '';
+      if (!campaignId) return new Response('Forbidden', { status: 403 });
+      const roomId = new URL(request.url).pathname.split('/').pop() ?? '';
+      if (roomId !== `tabletop-${campaignId}`) {
+        return new Response('Forbidden', { status: 403 });
+      }
+
+      request.headers.set('X-User-ID', userId);
+      request.headers.set(
+        'X-User-Role',
+        typeof payload.role === 'string' ? payload.role : 'player'
+      );
+      return request;
+    } catch {
+      return new Response('Unauthorized', { status: 401 });
+    }
+  }
 
   onConnect(conn: Party.Connection) {
     console.info(`[Tabletop] ${conn.id} connected to room ${this.room.id}`);

--- a/partykit.json
+++ b/partykit.json
@@ -1,4 +1,8 @@
 {
   "name": "cartyx-party",
-  "main": "party/index.ts"
+  "main": "party/index.ts",
+  "parties": {
+    "tabletop": "party/tabletop.ts",
+    "tabletop_map": "party/tabletop-map.ts"
+  }
 }

--- a/scripts/dev_clear.py
+++ b/scripts/dev_clear.py
@@ -36,6 +36,8 @@ from dotenv import load_dotenv
 from pymongo import MongoClient
 from pymongo.errors import ConfigurationError
 
+from r2_util import get_r2_client, r2_env
+
 load_dotenv()
 
 # Repo root anchored to this script's location (scripts/ is one level down)
@@ -115,25 +117,13 @@ def clear_local_uploads() -> int:
 
 def clear_r2_bucket() -> int:
     """Delete every object in the R2 bucket. No-op if R2 isn't configured."""
-    account_id = os.environ.get("R2_ACCOUNT_ID")
-    access_key = os.environ.get("R2_ACCESS_KEY_ID")
-    secret_key = os.environ.get("R2_SECRET_ACCESS_KEY")
-    bucket = os.environ.get("R2_BUCKET")
-    if not all([account_id, access_key, secret_key, bucket]):
+    env = r2_env()  # shared env detection + prod-bucket guard (r2_util)
+    if not env:
         print("  skip  R2 (not configured — R2_* env vars missing)")
         return 0
-    if re.search(r"prod", bucket, re.IGNORECASE):
-        sys.exit("R2_BUCKET looks like a production bucket. Aborting.")
+    bucket = env["R2_BUCKET"]
 
-    import boto3  # local import: only needed when R2 is configured
-
-    s3 = boto3.client(
-        "s3",
-        endpoint_url=f"https://{account_id}.r2.cloudflarestorage.com",
-        aws_access_key_id=access_key,
-        aws_secret_access_key=secret_key,
-        region_name="auto",
-    )
+    s3 = get_r2_client(env)
     deleted = 0
     for page in s3.get_paginator("list_objects_v2").paginate(Bucket=bucket):
         objs = page.get("Contents", [])

--- a/scripts/dev_seed.py
+++ b/scripts/dev_seed.py
@@ -193,78 +193,16 @@ def require_mongo_uri() -> str:
 # documents store full CDN URLs — exactly like a real user upload through the
 # app (see app/server/functions/uploads.ts). Without CDN config everything
 # falls back to local public/uploads/ writes for plain-localhost dev and CI.
+# The shared implementation lives in r2_util (also used by dev_clear.py and
+# repair_seed_images.py) so the guards and endpoint can't drift.
 
-def _r2_env() -> dict[str, str] | None:
-    """The app's CDN/R2 env vars, or None unless ALL are present."""
-    keys = ("CDN_URL", "R2_ACCOUNT_ID", "R2_ACCESS_KEY_ID",
-            "R2_SECRET_ACCESS_KEY", "R2_BUCKET")
-    env = {k: os.environ.get(k) or "" for k in keys}
-    if not all(env.values()):
-        return None
-    if re.search(r"prod", env["R2_BUCKET"], re.IGNORECASE):
-        sys.exit("R2_BUCKET looks like a production bucket. Aborting.")
-    return env
-
-
-_r2_client = None
-
-
-def cdn_base() -> str | None:
-    """Normalized CDN origin (no trailing slash) when fully configured."""
-    env = _r2_env()
-    return env["CDN_URL"].rstrip("/") if env else None
-
-
-def public_url(rel_path: str) -> str:
-    """Where the app will serve `rel_path` from: the CDN when configured
-    (matching the validation in campaigns.ts — origin must be CDN_URL and the
-    path must start with /uploads/), else the path itself for local Vite."""
-    base = cdn_base()
-    return f"{base}{rel_path}" if base else rel_path
-
-
-def _get_r2_client(env: dict[str, str]):
-    """Lazily-constructed shared boto3 S3 client for the R2 endpoint."""
-    global _r2_client
-    if _r2_client is None:
-        import boto3  # local import: only needed when R2 is configured
-
-        _r2_client = boto3.client(
-            "s3",
-            endpoint_url=f"https://{env['R2_ACCOUNT_ID']}.r2.cloudflarestorage.com",
-            aws_access_key_id=env["R2_ACCESS_KEY_ID"],
-            aws_secret_access_key=env["R2_SECRET_ACCESS_KEY"],
-            region_name="auto",
-        )
-    return _r2_client
-
-
-def upload_to_r2(rel_path: str, body: bytes, content_type: str) -> None:
-    """Put `body` at the R2 key matching `rel_path` (leading slash stripped),
-    so `{CDN_URL}{rel_path}` serves it. Requires CDN/R2 to be configured."""
-    env = _r2_env()
-    if not env:
-        sys.exit("upload_to_r2 called without full CDN/R2 configuration")
-    _get_r2_client(env).put_object(
-        Bucket=env["R2_BUCKET"],
-        Key=rel_path.lstrip("/"),
-        Body=body,
-        ContentType=content_type,
-    )
-
-
-def list_r2_keys(prefix: str) -> set[str]:
-    """Existing R2 keys under `prefix` (used by repair_seed_images.py to spot
-    dangling CDN references). Requires CDN/R2 to be configured."""
-    env = _r2_env()
-    if not env:
-        sys.exit("list_r2_keys called without full CDN/R2 configuration")
-    keys: set[str] = set()
-    paginator = _get_r2_client(env).get_paginator("list_objects_v2")
-    for page in paginator.paginate(Bucket=env["R2_BUCKET"], Prefix=prefix):
-        for obj in page.get("Contents", []):
-            keys.add(obj["Key"])
-    return keys
+from r2_util import (  # noqa: F401 — re-exported for repair/verify scripts
+    CDN_ENV_KEYS,
+    cdn_base,
+    list_r2_keys,
+    public_url,
+    upload_to_r2,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -314,12 +252,14 @@ def copy_player_portraits() -> None:
     files live in `assets/` (not web-served). CDN configured → upload each to
     R2 under uploads/seed-players/; otherwise copy into
     `public/uploads/seed-players/` for the local Vite server. Idempotent —
-    overwrites on every seed."""
+    R2 keys already present are skipped (the portraits are committed assets
+    that never change); local copies are overwritten."""
     src_dir = REPO_ROOT / "assets"
     use_cdn = bool(cdn_base())
     dst_dir = REPO_ROOT / "public" / "uploads" / "seed-players"
     if not use_cdn:
         dst_dir.mkdir(parents=True, exist_ok=True)
+    existing = list_r2_keys("uploads/seed-players/") if use_cdn else set()
     copied = 0
     missing = []
     for i in range(1, 13):
@@ -328,8 +268,9 @@ def copy_player_portraits() -> None:
             missing.append(src.name)
             continue
         if use_cdn:
-            upload_to_r2(f"/uploads/seed-players/player{i}.jpg",
-                         src.read_bytes(), "image/jpeg")
+            if f"uploads/seed-players/player{i}.jpg" not in existing:
+                upload_to_r2(f"/uploads/seed-players/player{i}.jpg",
+                             src.read_bytes(), "image/jpeg")
         else:
             shutil.copyfile(src, dst_dir / f"player{i}.jpg")
         copied += 1
@@ -1303,13 +1244,9 @@ def main() -> None:
                 gm_id=gm_id,
                 now=now,
                 with_variants=with_variants,
+                map_picture=public_url,
             )
             if monster_docs:
-                # seed_monster_data records served-relative avatar paths; map
-                # them to the CDN when configured (same as local_avatar_path).
-                for m in monster_docs:
-                    if m.get("picture"):
-                        m["picture"] = public_url(m["picture"])
                 db.monsters.insert_many(monster_docs)
             print(
                 f"    monsters   imported {len(monster_docs)} stat blocks "

--- a/scripts/dev_seed.py
+++ b/scripts/dev_seed.py
@@ -145,17 +145,18 @@ def ensure_player_users(db, now) -> list[dict]:
 
 
 def local_avatar_path(kind: str, name: str) -> str:
-    """Deterministic served path for a generated local avatar.
+    """Deterministic served URL for a generated seed avatar.
 
     The PNG itself is produced by `scripts/gen_seed_avatars.mjs` (run via
     `npm run dev:gen-avatars`) — Python has no SVG rasteriser, so the seed only
-    records the path and the Node generator renders the identicon there. The
-    hash MUST stay in sync with that script: sha1("{kind}:{name}")[:16].
-    Local files avoid DiceBear's CDN rate limit (which 429s the burst of ~350
-    avatar requests the wiki fires on load) and work offline.
+    records the URL and the Node generator renders (and, when the CDN is
+    configured, uploads) the identicon there. The hash MUST stay in sync with
+    that script: sha1("{kind}:{name}")[:16]. Generated files avoid DiceBear's
+    CDN rate limit (which 429s the burst of ~350 avatar requests the wiki
+    fires on load) and work offline.
     """
     digest = hashlib.sha1(f"{kind}:{name}".encode("utf-8")).hexdigest()[:16]
-    return f"/uploads/seed-avatars/{kind}/{digest}.png"
+    return public_url(f"/uploads/seed-avatars/{kind}/{digest}.png")
 
 
 def adventurer_avatar(first_name: str, last_name: str) -> str:
@@ -180,6 +181,90 @@ def require_mongo_uri() -> str:
     if re.search(r"prod", uri, re.IGNORECASE):
         sys.exit("MONGODB_URI looks like a production connection string. Aborting.")
     return uri
+
+
+# ---------------------------------------------------------------------------
+# CDN / R2 uploads
+# ---------------------------------------------------------------------------
+# The deployed dev environment (Vercel) cannot serve files written to a local
+# public/uploads/ — its filesystem is baked from git at build time and
+# public/uploads/ is gitignored. When the CDN is configured (CDN_URL + R2_*
+# env vars, same ones the app uses), seed images are uploaded to R2 and the
+# documents store full CDN URLs — exactly like a real user upload through the
+# app (see app/server/functions/uploads.ts). Without CDN config everything
+# falls back to local public/uploads/ writes for plain-localhost dev and CI.
+
+def _r2_env() -> dict[str, str] | None:
+    """The app's CDN/R2 env vars, or None unless ALL are present."""
+    keys = ("CDN_URL", "R2_ACCOUNT_ID", "R2_ACCESS_KEY_ID",
+            "R2_SECRET_ACCESS_KEY", "R2_BUCKET")
+    env = {k: os.environ.get(k) or "" for k in keys}
+    if not all(env.values()):
+        return None
+    if re.search(r"prod", env["R2_BUCKET"], re.IGNORECASE):
+        sys.exit("R2_BUCKET looks like a production bucket. Aborting.")
+    return env
+
+
+_r2_client = None
+
+
+def cdn_base() -> str | None:
+    """Normalized CDN origin (no trailing slash) when fully configured."""
+    env = _r2_env()
+    return env["CDN_URL"].rstrip("/") if env else None
+
+
+def public_url(rel_path: str) -> str:
+    """Where the app will serve `rel_path` from: the CDN when configured
+    (matching the validation in campaigns.ts — origin must be CDN_URL and the
+    path must start with /uploads/), else the path itself for local Vite."""
+    base = cdn_base()
+    return f"{base}{rel_path}" if base else rel_path
+
+
+def _get_r2_client(env: dict[str, str]):
+    """Lazily-constructed shared boto3 S3 client for the R2 endpoint."""
+    global _r2_client
+    if _r2_client is None:
+        import boto3  # local import: only needed when R2 is configured
+
+        _r2_client = boto3.client(
+            "s3",
+            endpoint_url=f"https://{env['R2_ACCOUNT_ID']}.r2.cloudflarestorage.com",
+            aws_access_key_id=env["R2_ACCESS_KEY_ID"],
+            aws_secret_access_key=env["R2_SECRET_ACCESS_KEY"],
+            region_name="auto",
+        )
+    return _r2_client
+
+
+def upload_to_r2(rel_path: str, body: bytes, content_type: str) -> None:
+    """Put `body` at the R2 key matching `rel_path` (leading slash stripped),
+    so `{CDN_URL}{rel_path}` serves it. Requires CDN/R2 to be configured."""
+    env = _r2_env()
+    if not env:
+        sys.exit("upload_to_r2 called without full CDN/R2 configuration")
+    _get_r2_client(env).put_object(
+        Bucket=env["R2_BUCKET"],
+        Key=rel_path.lstrip("/"),
+        Body=body,
+        ContentType=content_type,
+    )
+
+
+def list_r2_keys(prefix: str) -> set[str]:
+    """Existing R2 keys under `prefix` (used by repair_seed_images.py to spot
+    dangling CDN references). Requires CDN/R2 to be configured."""
+    env = _r2_env()
+    if not env:
+        sys.exit("list_r2_keys called without full CDN/R2 configuration")
+    keys: set[str] = set()
+    paginator = _get_r2_client(env).get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=env["R2_BUCKET"], Prefix=prefix):
+        for obj in page.get("Contents", []):
+            keys.add(obj["Key"])
+    return keys
 
 
 # ---------------------------------------------------------------------------
@@ -208,21 +293,33 @@ def generate_campaign_svg(title: str, colors: dict[str, str]) -> str:
 
 
 def save_image(svg_content: str, filename: str) -> str:
+    """Store a generated campaign image where the app will serve it.
+
+    CDN configured → upload to R2 under uploads/campaigns/ and return the full
+    CDN URL, matching a real user upload. Otherwise → write to the local
+    public/uploads/ fallback and return the relative path."""
+    rel = f"/uploads/campaigns/{filename}"
+    if cdn_base():
+        upload_to_r2(rel, svg_content.encode("utf-8"), "image/svg+xml")
+        return public_url(rel)
     uploads_dir = REPO_ROOT / "public" / "uploads" / "campaigns"
     uploads_dir.mkdir(parents=True, exist_ok=True)
     (uploads_dir / filename).write_text(svg_content, encoding="utf-8")
-    return f"/uploads/campaigns/{filename}"
+    return rel
 
 
 def copy_player_portraits() -> None:
     """Publish the 12 committed player portraits so the URLs the player docs
-    reference (`/uploads/seed-players/playerN.jpg`, see PLAYER_IMAGES) actually
-    resolve. The source files live in `assets/` (not web-served); Vite only
-    serves `public/` at the site root, so each portrait is copied into
-    `public/uploads/seed-players/`. Idempotent — overwrites on every seed."""
+    reference (PLAYER_IMAGES via public_url) actually resolve. The source
+    files live in `assets/` (not web-served). CDN configured → upload each to
+    R2 under uploads/seed-players/; otherwise copy into
+    `public/uploads/seed-players/` for the local Vite server. Idempotent —
+    overwrites on every seed."""
     src_dir = REPO_ROOT / "assets"
+    use_cdn = bool(cdn_base())
     dst_dir = REPO_ROOT / "public" / "uploads" / "seed-players"
-    dst_dir.mkdir(parents=True, exist_ok=True)
+    if not use_cdn:
+        dst_dir.mkdir(parents=True, exist_ok=True)
     copied = 0
     missing = []
     for i in range(1, 13):
@@ -230,9 +327,14 @@ def copy_player_portraits() -> None:
         if not src.exists():
             missing.append(src.name)
             continue
-        shutil.copyfile(src, dst_dir / f"player{i}.jpg")
+        if use_cdn:
+            upload_to_r2(f"/uploads/seed-players/player{i}.jpg",
+                         src.read_bytes(), "image/jpeg")
+        else:
+            shutil.copyfile(src, dst_dir / f"player{i}.jpg")
         copied += 1
-    print(f"Player portraits: copied {copied}/12 → public/uploads/seed-players/")
+    dest = "R2 uploads/seed-players/" if use_cdn else "public/uploads/seed-players/"
+    print(f"Player portraits: published {copied}/12 → {dest}")
     if missing:
         print(f"  WARNING missing portrait sources: {', '.join(missing)}")
 
@@ -978,7 +1080,7 @@ def main() -> None:
         party = []
         for pu in player_users:
             pc = random_pc(rng)
-            picture = PLAYER_IMAGES[image_cursor % len(PLAYER_IMAGES)]
+            picture = public_url(PLAYER_IMAGES[image_cursor % len(PLAYER_IMAGES)])
             image_cursor += 1
             db.players.insert_one({
                 "campaignId": campaign_id,
@@ -1203,6 +1305,11 @@ def main() -> None:
                 with_variants=with_variants,
             )
             if monster_docs:
+                # seed_monster_data records served-relative avatar paths; map
+                # them to the CDN when configured (same as local_avatar_path).
+                for m in monster_docs:
+                    if m.get("picture"):
+                        m["picture"] = public_url(m["picture"])
                 db.monsters.insert_many(monster_docs)
             print(
                 f"    monsters   imported {len(monster_docs)} stat blocks "

--- a/scripts/gen_seed_avatars.mjs
+++ b/scripts/gen_seed_avatars.mjs
@@ -8,9 +8,11 @@
  * For each monster/character we build a deterministic identicon SVG (seeded by
  * the entity name), rasterize it to PNG with @resvg/resvg-js, write it to
  * `public/uploads/seed-avatars/{kind}/{hash}.png`, and repoint the document's
- * `picture` at that path. Idempotent: existing PNGs are reused, and the path is
- * derived purely from the name so the Python seed (which sets the same path on
- * insert) and this generator always agree.
+ * `picture` at it. When the app's CDN is configured (CDN_URL + R2_* env vars)
+ * the PNG is also uploaded to R2 and `picture` gets the full CDN URL — the
+ * deployed dev environment can't serve local files. Idempotent: existing
+ * PNGs/objects are reused, and the path is derived purely from the name so the
+ * Python seed (which sets the same URL on insert) and this generator agree.
  *
  * Usage:
  *   npm run dev:gen-avatars
@@ -23,6 +25,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { MongoClient } from 'mongodb';
 import { Resvg } from '@resvg/resvg-js';
+import { S3Client, PutObjectCommand, ListObjectsV2Command } from '@aws-sdk/client-s3';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -44,6 +47,51 @@ function loadEnv() {
   }
 }
 
+// --- CDN / R2 ----------------------------------------------------------------
+// Mirrors scripts/dev_seed.py: when the app's CDN is configured (CDN_URL +
+// R2_* env vars), avatars are uploaded to R2 and documents point at full CDN
+// URLs — the deployed dev environment (Vercel) cannot serve local
+// public/uploads/ writes. Without CDN config, local files are all we need.
+
+function r2Env() {
+  const keys = [
+    'CDN_URL',
+    'R2_ACCOUNT_ID',
+    'R2_ACCESS_KEY_ID',
+    'R2_SECRET_ACCESS_KEY',
+    'R2_BUCKET',
+  ];
+  const env = Object.fromEntries(keys.map((k) => [k, process.env[k] ?? '']));
+  if (!keys.every((k) => env[k])) return null;
+  if (/prod/i.test(env.R2_BUCKET)) {
+    console.error('R2_BUCKET looks like a production bucket. Aborting.');
+    process.exit(1);
+  }
+  return env;
+}
+
+function r2ClientFor(env) {
+  return new S3Client({
+    region: 'auto',
+    endpoint: `https://${env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+    credentials: { accessKeyId: env.R2_ACCESS_KEY_ID, secretAccessKey: env.R2_SECRET_ACCESS_KEY },
+  });
+}
+
+/** Keys already present under a prefix — one LIST instead of ~350 HEADs. */
+async function listExistingKeys(s3, bucket, prefix) {
+  const keys = new Set();
+  let token;
+  do {
+    const page = await s3.send(
+      new ListObjectsV2Command({ Bucket: bucket, Prefix: prefix, ContinuationToken: token })
+    );
+    for (const obj of page.Contents ?? []) keys.add(obj.Key);
+    token = page.NextContinuationToken;
+  } while (token);
+  return keys;
+}
+
 // --- Deterministic identicon ------------------------------------------------
 
 /** Stable path (served + on disk) for an entity's avatar. */
@@ -63,6 +111,8 @@ function isReplaceablePicture(picture) {
   if (picture == null || picture === '') return true;
   if (typeof picture !== 'string') return false;
   if (picture.startsWith('/uploads/seed-avatars/')) return true;
+  // CDN-hosted seed avatar (any origin — the CDN URL may have changed).
+  if (/^https:\/\/[^/]+\/uploads\/seed-avatars\//.test(picture)) return true;
   return /(?:api\.)?dicebear\.com/i.test(picture);
 }
 
@@ -106,9 +156,10 @@ function renderPng(svg) {
 
 // --- Main -------------------------------------------------------------------
 
-async function processCollection(db, collection, kind, nameOf) {
+async function processCollection(db, collection, kind, nameOf, cdn) {
   let generated = 0;
   let reused = 0;
+  let uploaded = 0;
   let repointed = 0;
   let skipped = 0;
   const cursor = db
@@ -119,6 +170,7 @@ async function processCollection(db, collection, kind, nameOf) {
     const rel = avatarRelPath(kind, name);
     const abs = join(REPO_ROOT, 'public', rel.replace(/^\//, ''));
 
+    // Local PNG doubles as the render cache for R2 uploads.
     if (existsSync(abs)) {
       reused++;
     } else {
@@ -127,10 +179,29 @@ async function processCollection(db, collection, kind, nameOf) {
       generated++;
     }
 
-    if (doc.picture === rel) {
+    if (cdn) {
+      const key = rel.replace(/^\//, '');
+      if (!cdn.existingKeys.has(key)) {
+        await cdn.s3.send(
+          new PutObjectCommand({
+            Bucket: cdn.bucket,
+            Key: key,
+            Body: readFileSync(abs),
+            ContentType: 'image/png',
+          })
+        );
+        cdn.existingKeys.add(key);
+        uploaded++;
+      }
+    }
+
+    const publicPath = cdn ? `${cdn.base}${rel}` : rel;
+    if (doc.picture === publicPath) {
       // Already points at this seed avatar — nothing to do.
     } else if (isReplaceablePicture(doc.picture)) {
-      await db.collection(collection).updateOne({ _id: doc._id }, { $set: { picture: rel } });
+      await db
+        .collection(collection)
+        .updateOne({ _id: doc._id }, { $set: { picture: publicPath } });
       repointed++;
     } else {
       // Custom/uploaded picture — never overwrite real data.
@@ -138,7 +209,7 @@ async function processCollection(db, collection, kind, nameOf) {
     }
   }
   console.log(
-    `${collection}: ${generated} PNGs generated, ${reused} reused, ${repointed} repointed, ${skipped} custom pictures preserved`
+    `${collection}: ${generated} PNGs generated, ${reused} reused, ${uploaded} uploaded to R2, ${repointed} repointed, ${skipped} custom pictures preserved`
   );
 }
 
@@ -154,13 +225,32 @@ async function main() {
     process.exit(1);
   }
 
+  // When the CDN is configured, mirror every avatar into R2 and point the
+  // documents at CDN URLs (the deployed dev app can't see local files).
+  let cdn = null;
+  const env = r2Env();
+  if (env) {
+    const s3 = r2ClientFor(env);
+    cdn = {
+      s3,
+      bucket: env.R2_BUCKET,
+      base: env.CDN_URL.replace(/\/+$/, ''),
+      existingKeys: await listExistingKeys(s3, env.R2_BUCKET, 'uploads/seed-avatars/'),
+    };
+    console.log(`CDN configured — uploading avatars to R2 bucket '${env.R2_BUCKET}'`);
+  }
+
   const client = new MongoClient(uri);
   await client.connect();
   try {
     const db = process.env.MONGODB_DB ? client.db(process.env.MONGODB_DB) : client.db();
-    await processCollection(db, 'monsters', 'monster', (d) => d.name);
-    await processCollection(db, 'characters', 'character', (d) =>
-      `${d.firstName ?? ''} ${d.lastName ?? ''}`.trim()
+    await processCollection(db, 'monsters', 'monster', (d) => d.name, cdn);
+    await processCollection(
+      db,
+      'characters',
+      'character',
+      (d) => `${d.firstName ?? ''} ${d.lastName ?? ''}`.trim(),
+      cdn
     );
   } finally {
     await client.close();

--- a/scripts/gen_seed_avatars.mjs
+++ b/scripts/gen_seed_avatars.mjs
@@ -198,6 +198,11 @@ async function processCollection(db, collection, kind, nameOf, cdn) {
     const publicPath = cdn ? `${cdn.base}${rel}` : rel;
     if (doc.picture === publicPath) {
       // Already points at this seed avatar — nothing to do.
+    } else if (!cdn && typeof doc.picture === 'string' && doc.picture.startsWith('https://')) {
+      // Never downgrade a CDN-hosted picture to a local path just because
+      // this run lacks CDN config — the deployed dev app can't serve local
+      // files, so the repoint would break every avatar until re-run with R2.
+      skipped++;
     } else if (isReplaceablePicture(doc.picture)) {
       await db
         .collection(collection)
@@ -209,7 +214,7 @@ async function processCollection(db, collection, kind, nameOf, cdn) {
     }
   }
   console.log(
-    `${collection}: ${generated} PNGs generated, ${reused} reused, ${uploaded} uploaded to R2, ${repointed} repointed, ${skipped} custom pictures preserved`
+    `${collection}: ${generated} PNGs generated, ${reused} reused, ${uploaded} uploaded to R2, ${repointed} repointed, ${skipped} pictures preserved (custom or CDN-hosted)`
   );
 }
 

--- a/scripts/gen_seed_avatars.mjs
+++ b/scripts/gen_seed_avatars.mjs
@@ -165,33 +165,45 @@ async function processCollection(db, collection, kind, nameOf, cdn) {
   const cursor = db
     .collection(collection)
     .find({}, { projection: { name: 1, firstName: 1, lastName: 1, picture: 1 } });
+  // Uploads run with bounded concurrency: the first CDN run mirrors ~350
+  // PNGs, and one awaited round-trip each is ~10x slower than a small pool.
+  const inflight = new Set();
+  const MAX_INFLIGHT = 10;
   for await (const doc of cursor) {
     const name = nameOf(doc) || kind;
     const rel = avatarRelPath(kind, name);
     const abs = join(REPO_ROOT, 'public', rel.replace(/^\//, ''));
 
     // Local PNG doubles as the render cache for R2 uploads.
+    let png = null;
     if (existsSync(abs)) {
       reused++;
     } else {
+      png = renderPng(identiconSvg(name));
       mkdirSync(dirname(abs), { recursive: true });
-      writeFileSync(abs, renderPng(identiconSvg(name)));
+      writeFileSync(abs, png);
       generated++;
     }
 
     if (cdn) {
       const key = rel.replace(/^\//, '');
       if (!cdn.existingKeys.has(key)) {
-        await cdn.s3.send(
-          new PutObjectCommand({
-            Bucket: cdn.bucket,
-            Key: key,
-            Body: readFileSync(abs),
-            ContentType: 'image/png',
-          })
-        );
         cdn.existingKeys.add(key);
-        uploaded++;
+        const put = cdn.s3
+          .send(
+            new PutObjectCommand({
+              Bucket: cdn.bucket,
+              Key: key,
+              Body: png ?? readFileSync(abs),
+              ContentType: 'image/png',
+            })
+          )
+          .then(() => {
+            uploaded++;
+            inflight.delete(put);
+          });
+        inflight.add(put);
+        if (inflight.size >= MAX_INFLIGHT) await Promise.race(inflight);
       }
     }
 
@@ -213,6 +225,7 @@ async function processCollection(db, collection, kind, nameOf, cdn) {
       skipped++;
     }
   }
+  await Promise.all(inflight);
   console.log(
     `${collection}: ${generated} PNGs generated, ${reused} reused, ${uploaded} uploaded to R2, ${repointed} repointed, ${skipped} pictures preserved (custom or CDN-hosted)`
   );

--- a/scripts/r2_util.py
+++ b/scripts/r2_util.py
@@ -1,0 +1,94 @@
+"""Shared CDN/R2 helpers for the dev data scripts.
+
+One home for the env detection, the prod-bucket guard, and the boto3 client so
+`dev_seed.py`, `dev_clear.py`, and `repair_seed_images.py` cannot drift apart
+(e.g. a tightened guard or endpoint change applied to one script but not the
+others). Uses the same env vars as the app itself (see
+app/server/functions/uploads.ts).
+
+Two configuration levels:
+  - `r2_env()`            — the 4 R2_* vars; enough to talk to the bucket
+                            (dev_clear only needs this).
+  - `r2_env(require_cdn)` — additionally requires CDN_URL; needed by anything
+                            that WRITES objects and stores public URLs.
+"""
+
+import os
+import re
+import sys
+
+R2_ENV_KEYS = ("R2_ACCOUNT_ID", "R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY", "R2_BUCKET")
+CDN_ENV_KEYS = ("CDN_URL",) + R2_ENV_KEYS
+
+
+def r2_env(require_cdn: bool = False) -> dict[str, str] | None:
+    """The R2 (and optionally CDN) env vars, or None unless ALL are present.
+    Aborts outright on a production-looking bucket."""
+    keys = CDN_ENV_KEYS if require_cdn else R2_ENV_KEYS
+    env = {k: os.environ.get(k) or "" for k in keys}
+    if not all(env.values()):
+        return None
+    if re.search(r"prod", env["R2_BUCKET"], re.IGNORECASE):
+        sys.exit("R2_BUCKET looks like a production bucket. Aborting.")
+    return env
+
+
+_client = None
+
+
+def get_r2_client(env: dict[str, str]):
+    """Lazily-constructed shared boto3 S3 client for the R2 endpoint."""
+    global _client
+    if _client is None:
+        import boto3  # local import: only needed when R2 is configured
+
+        _client = boto3.client(
+            "s3",
+            endpoint_url=f"https://{env['R2_ACCOUNT_ID']}.r2.cloudflarestorage.com",
+            aws_access_key_id=env["R2_ACCESS_KEY_ID"],
+            aws_secret_access_key=env["R2_SECRET_ACCESS_KEY"],
+            region_name="auto",
+        )
+    return _client
+
+
+def cdn_base() -> str | None:
+    """Normalized CDN origin (no trailing slash) when fully configured."""
+    env = r2_env(require_cdn=True)
+    return env["CDN_URL"].rstrip("/") if env else None
+
+
+def public_url(rel_path: str) -> str:
+    """Where the app will serve `rel_path` from: the CDN when configured
+    (matching the validation in campaigns.ts — origin must be CDN_URL and the
+    path must start with /uploads/), else the path itself for local Vite."""
+    base = cdn_base()
+    return f"{base}{rel_path}" if base else rel_path
+
+
+def upload_to_r2(rel_path: str, body: bytes, content_type: str) -> None:
+    """Put `body` at the R2 key matching `rel_path` (leading slash stripped),
+    so `{CDN_URL}{rel_path}` serves it. Requires CDN/R2 to be configured."""
+    env = r2_env(require_cdn=True)
+    if not env:
+        sys.exit("upload_to_r2 called without full CDN/R2 configuration")
+    get_r2_client(env).put_object(
+        Bucket=env["R2_BUCKET"],
+        Key=rel_path.lstrip("/"),
+        Body=body,
+        ContentType=content_type,
+    )
+
+
+def list_r2_keys(prefix: str) -> set[str]:
+    """Existing R2 keys under `prefix` (used to skip uploads that are already
+    present and to spot dangling references). Requires R2 to be configured."""
+    env = r2_env()
+    if not env:
+        sys.exit("list_r2_keys called without R2 configuration")
+    keys: set[str] = set()
+    paginator = get_r2_client(env).get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=env["R2_BUCKET"], Prefix=prefix):
+        for obj in page.get("Contents", []):
+            keys.add(obj["Key"])
+    return keys

--- a/scripts/repair_seed_images.py
+++ b/scripts/repair_seed_images.py
@@ -27,16 +27,11 @@ from pathlib import Path
 from dotenv import load_dotenv
 from pymongo import MongoClient
 
-# Reuse the seed's SVG generator + repo anchor + CDN helpers (importing is
-# safe — dev_seed guards its insertion logic behind `if __name__ == "__main__"`).
-from dev_seed import (
-    REPO_ROOT,
-    cdn_base,
-    copy_player_portraits,
-    generate_campaign_svg,
-    list_r2_keys,
-    upload_to_r2,
-)
+# Reuse the seed's SVG generator + repo anchor (importing is safe — dev_seed
+# guards its insertion logic behind `if __name__ == "__main__"`) and the
+# shared CDN/R2 helpers.
+from dev_seed import REPO_ROOT, copy_player_portraits, generate_campaign_svg
+from r2_util import cdn_base, list_r2_keys, upload_to_r2
 
 load_dotenv()
 
@@ -95,10 +90,20 @@ def main() -> None:
     regenerated = 0
     ok = 0
     skipped = 0
+    stale_origin = 0
     for c in db.campaigns.find({}, {"name": 1, "imagePath": 1}):
         image_path = c.get("imagePath")
         name = c.get("name") or "Campaign"
         rel = served_rel_path(image_path) if image_path else None
+        if (not rel and image_path and image_path.startswith("https://")
+                and "/uploads/" in image_path):
+            # A seed image on some OTHER https origin — the CDN_URL was
+            # rotated, or this env lacks the CDN config that wrote it. This
+            # script never touches the DB, so it can't fix the doc; surface
+            # it distinctly instead of lumping it in with "not ours".
+            print(f"  WARNING stale CDN origin (re-seed to fix): {image_path}  ({name})")
+            stale_origin += 1
+            continue
         if not rel or not rel.endswith(".svg"):
             # Missing, foreign-origin, or a non-generated raster — not ours.
             skipped += 1
@@ -120,10 +125,13 @@ def main() -> None:
         print(f"  regenerated  {image_path}  ({name})")
         regenerated += 1
 
-    print(
+    summary = (
         f"\nCampaign images: {regenerated} regenerated, {ok} already present, "
         f"{skipped} skipped (no generated SVG path)."
     )
+    if stale_origin:
+        summary += f" {stale_origin} on a stale CDN origin (see warnings above)."
+    print(summary)
     client.close()
 
 

--- a/scripts/repair_seed_images.py
+++ b/scripts/repair_seed_images.py
@@ -2,12 +2,15 @@
 """
 Repair missing seed-generated images WITHOUT re-seeding.
 
-Why this exists: the dev seed writes campaign images (generated SVGs) and player
-portraits into `public/uploads/`, which is gitignored and therefore absent in a
-fresh checkout, a different working copy, or after a clean. The campaign/player
-documents still point at those URLs, so the images 404. This script reads the
-existing documents and regenerates the files at the exact paths they reference —
-it never touches the database.
+Why this exists: without the CDN configured, the dev seed writes campaign
+images (generated SVGs) and player portraits into `public/uploads/`, which is
+gitignored and therefore absent in a fresh checkout, a different working copy,
+or after a clean. With the CDN configured (CDN_URL + R2_* env vars) the seed
+uploads to R2 instead, and the bucket can likewise lose objects (e.g. a
+`dev:clear` that was not followed by a full re-seed). Either way the
+campaign/player documents still point at those URLs, so the images 404. This
+script reads the existing documents and regenerates the files at the exact
+paths they reference — local or R2 — and never touches the database.
 
 Usage:
     npm run dev:repair-images
@@ -24,9 +27,16 @@ from pathlib import Path
 from dotenv import load_dotenv
 from pymongo import MongoClient
 
-# Reuse the seed's SVG generator + repo anchor (importing is safe — dev_seed
-# guards its insertion logic behind `if __name__ == "__main__"`).
-from dev_seed import REPO_ROOT, generate_campaign_svg, copy_player_portraits
+# Reuse the seed's SVG generator + repo anchor + CDN helpers (importing is
+# safe — dev_seed guards its insertion logic behind `if __name__ == "__main__"`).
+from dev_seed import (
+    REPO_ROOT,
+    cdn_base,
+    copy_player_portraits,
+    generate_campaign_svg,
+    list_r2_keys,
+    upload_to_r2,
+)
 
 load_dotenv()
 
@@ -51,6 +61,18 @@ def public_path(image_path: str) -> Path:
     return REPO_ROOT / "public" / image_path.lstrip("/")
 
 
+def served_rel_path(image_path: str) -> str | None:
+    """Reduce an imagePath to its /uploads/... form, whether it is a local
+    relative path or a full URL on the configured CDN. None if it is neither
+    (e.g. a user upload on a different origin — not ours to recreate)."""
+    if image_path.startswith("/uploads/"):
+        return image_path
+    base = cdn_base()
+    if base and image_path.startswith(f"{base}/uploads/"):
+        return image_path[len(base):]
+    return None
+
+
 def main() -> None:
     uri = os.environ.get("MONGODB_URI")
     if not uri:
@@ -62,29 +84,39 @@ def main() -> None:
     db_name = os.environ.get("MONGODB_DB")
     db = client[db_name] if db_name else client.get_default_database()
 
-    # 1) Player portraits — re-copy the committed assets to the served path.
+    # 1) Player portraits — republish the committed assets (R2 upload when the
+    #    CDN is configured, local copy otherwise).
     copy_player_portraits()
 
-    # 2) Campaign images — regenerate any missing generated SVGs.
+    # 2) Campaign images — regenerate any missing generated SVGs at whichever
+    #    location the document references.
+    use_cdn = bool(cdn_base())
+    existing_keys = list_r2_keys("uploads/campaigns/") if use_cdn else set()
     regenerated = 0
     ok = 0
     skipped = 0
     for c in db.campaigns.find({}, {"name": 1, "imagePath": 1}):
         image_path = c.get("imagePath")
         name = c.get("name") or "Campaign"
-        if not image_path or not image_path.startswith("/uploads/"):
+        rel = served_rel_path(image_path) if image_path else None
+        if not rel or not rel.endswith(".svg"):
+            # Missing, foreign-origin, or a non-generated raster — not ours.
             skipped += 1
             continue
-        if not image_path.endswith(".svg"):
-            # Non-generated (e.g. an uploaded raster) — not ours to recreate.
-            skipped += 1
-            continue
-        dest = public_path(image_path)
-        if dest.exists():
-            ok += 1
-            continue
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        dest.write_text(generate_campaign_svg(name, palette_for(name)), encoding="utf-8")
+        cdn_hosted = rel != image_path
+        if cdn_hosted:
+            if rel.lstrip("/") in existing_keys:
+                ok += 1
+                continue
+            svg = generate_campaign_svg(name, palette_for(name))
+            upload_to_r2(rel, svg.encode("utf-8"), "image/svg+xml")
+        else:
+            dest = public_path(rel)
+            if dest.exists():
+                ok += 1
+                continue
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(generate_campaign_svg(name, palette_for(name)), encoding="utf-8")
         print(f"  regenerated  {image_path}  ({name})")
         regenerated += 1
 

--- a/scripts/seed_monster_data.py
+++ b/scripts/seed_monster_data.py
@@ -678,12 +678,17 @@ def all_monster_specs() -> list[dict]:
     return out
 
 
-def build_monster_docs(*, campaign_id, gm_id, now, with_variants: bool = False) -> list[dict]:
+def build_monster_docs(*, campaign_id, gm_id, now, with_variants: bool = False,
+                       map_picture=None) -> list[dict]:
     """Return full mongoose-shaped Monster documents ready for insertMany.
 
     When `with_variants=True`, expands each hand-authored stat block into
     multiple lightly-modified variants for volume-testing the wiki list,
     search, and tag/CR filters.
+
+    `map_picture` (optional callable) maps the served-relative avatar path to
+    its final stored URL — dev_seed passes `public_url` so pictures become CDN
+    URLs when the CDN is configured, mirroring `local_avatar_path`.
     """
     specs = all_monster_specs() if with_variants else MONSTERS
     docs = []
@@ -713,7 +718,7 @@ def build_monster_docs(*, campaign_id, gm_id, now, with_variants: bool = False) 
             "languages": spec.get("languages", []),
             "cr": spec["cr"],
             "features": spec.get("features", []),
-            "picture": _avatar(spec["name"]),
+            "picture": (map_picture or (lambda p: p))(_avatar(spec["name"])),
             "pictureCrop": None,
             "links": [
                 {"name": "D&D Beyond",

--- a/scripts/verify_session_seed.py
+++ b/scripts/verify_session_seed.py
@@ -202,6 +202,46 @@ def test_transcript_ids_are_session_scoped():
             "ids must not collide across runs with different session ids"
 
 
+def test_public_url_cdn_toggle():
+    # Seed image URLs must flip between local paths (no CDN config — localhost
+    # dev and CI) and full CDN URLs (deployed dev, where local files 404).
+    import os
+
+    r2_keys = ("CDN_URL", "R2_ACCOUNT_ID", "R2_ACCESS_KEY_ID",
+               "R2_SECRET_ACCESS_KEY", "R2_BUCKET")
+    saved = {k: os.environ.get(k) for k in r2_keys}
+    try:
+        for k in r2_keys:
+            os.environ.pop(k, None)
+        assert seed.cdn_base() is None, "no CDN without full config"
+        assert seed.public_url("/uploads/campaigns/x.svg") == "/uploads/campaigns/x.svg"
+
+        os.environ.update({
+            "CDN_URL": "https://cdn-dev.example.io/",  # trailing slash on purpose
+            "R2_ACCOUNT_ID": "acct",
+            "R2_ACCESS_KEY_ID": "key",
+            "R2_SECRET_ACCESS_KEY": "secret",
+            "R2_BUCKET": "cartyx-dev",
+        })
+        assert seed.cdn_base() == "https://cdn-dev.example.io", "trailing slash stripped"
+        assert (seed.public_url("/uploads/campaigns/x.svg")
+                == "https://cdn-dev.example.io/uploads/campaigns/x.svg")
+        avatar = seed.local_avatar_path("character", "Test Person")
+        assert avatar.startswith("https://cdn-dev.example.io/uploads/seed-avatars/character/"), avatar
+
+        # Partial config (bucket missing) must fall back to local paths rather
+        # than emitting URLs nothing will ever upload to.
+        os.environ.pop("R2_BUCKET")
+        assert seed.cdn_base() is None, "partial R2 config must disable the CDN path"
+        assert seed.public_url("/uploads/campaigns/x.svg") == "/uploads/campaigns/x.svg"
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
 def run():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     for t in tests:

--- a/scripts/verify_session_seed.py
+++ b/scripts/verify_session_seed.py
@@ -206,12 +206,10 @@ def test_public_url_cdn_toggle():
     # Seed image URLs must flip between local paths (no CDN config — localhost
     # dev and CI) and full CDN URLs (deployed dev, where local files 404).
     import os
+    from unittest import mock
 
-    r2_keys = ("CDN_URL", "R2_ACCOUNT_ID", "R2_ACCESS_KEY_ID",
-               "R2_SECRET_ACCESS_KEY", "R2_BUCKET")
-    saved = {k: os.environ.get(k) for k in r2_keys}
-    try:
-        for k in r2_keys:
+    with mock.patch.dict(os.environ):  # restores the real env on exit
+        for k in seed.CDN_ENV_KEYS:
             os.environ.pop(k, None)
         assert seed.cdn_base() is None, "no CDN without full config"
         assert seed.public_url("/uploads/campaigns/x.svg") == "/uploads/campaigns/x.svg"
@@ -234,12 +232,6 @@ def test_public_url_cdn_toggle():
         os.environ.pop("R2_BUCKET")
         assert seed.cdn_base() is None, "partial R2 config must disable the CDN path"
         assert seed.public_url("/uploads/campaigns/x.svg") == "/uploads/campaigns/x.svg"
-    finally:
-        for k, v in saved.items():
-            if v is None:
-                os.environ.pop(k, None)
-            else:
-                os.environ[k] = v
 
 
 def run():

--- a/tests/party/partykitConfig.test.ts
+++ b/tests/party/partykitConfig.test.ts
@@ -15,14 +15,22 @@ interface PartykitConfig {
 
 const config: PartykitConfig = JSON.parse(readFileSync(path.join(ROOT, 'partykit.json'), 'utf8'));
 
-/** Every party name the client connects to via usePartySocket({ party }). */
-function hookPartyNames(): string[] {
-  const hooksDir = path.join(ROOT, 'app', 'hooks');
+/**
+ * Every party name referenced anywhere in app/: client connections via
+ * usePartySocket({ party }) AND server-side HTTP broadcasts that build
+ * `/parties/<name>/…` URLs by hand (e.g. maps.ts broadcastActiveMapChanged —
+ * a stale name there 404s silently because the fetch error is swallowed).
+ */
+function referencedPartyNames(): string[] {
   const names = new Set<string>();
-  for (const file of readdirSync(hooksDir)) {
-    if (!/\.tsx?$/.test(file)) continue;
-    const src = readFileSync(path.join(hooksDir, file), 'utf8');
+  const appDir = path.join(ROOT, 'app');
+  for (const entry of readdirSync(appDir, { recursive: true, withFileTypes: true })) {
+    if (!entry.isFile() || !/\.tsx?$/.test(entry.name)) continue;
+    const src = readFileSync(path.join(entry.parentPath, entry.name), 'utf8');
     for (const m of src.matchAll(/party:\s*['"]([^'"]+)['"]/g)) {
+      names.add(m[1]);
+    }
+    for (const m of src.matchAll(/\/parties\/([a-zA-Z0-9_-]+)\//g)) {
       names.add(m[1]);
     }
   }
@@ -30,10 +38,10 @@ function hookPartyNames(): string[] {
 }
 
 describe('partykit.json', () => {
-  it('declares every party the client hooks connect to', () => {
+  it('declares every party referenced by hooks or server-side broadcast URLs', () => {
     const declared = new Set(['main', ...Object.keys(config.parties ?? {})]);
-    for (const name of hookPartyNames()) {
-      expect(declared, `party '${name}' is used by a hook but not declared`).toContain(name);
+    for (const name of referencedPartyNames()) {
+      expect(declared, `party '${name}' is referenced in app/ but not declared`).toContain(name);
     }
   });
 

--- a/tests/party/partykitConfig.test.ts
+++ b/tests/party/partykitConfig.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+// Regression guard for the dev outage where useTabletopParty/useTabletopMapParty
+// connected to parties that were never declared in partykit.json, so every
+// /parties/tabletop* WebSocket 404'd on dev, prod, AND local `partykit dev`.
+
+const ROOT = path.resolve(__dirname, '../..');
+
+interface PartykitConfig {
+  main: string;
+  parties?: Record<string, string>;
+}
+
+const config: PartykitConfig = JSON.parse(readFileSync(path.join(ROOT, 'partykit.json'), 'utf8'));
+
+/** Every party name the client connects to via usePartySocket({ party }). */
+function hookPartyNames(): string[] {
+  const hooksDir = path.join(ROOT, 'app', 'hooks');
+  const names = new Set<string>();
+  for (const file of readdirSync(hooksDir)) {
+    if (!/\.tsx?$/.test(file)) continue;
+    const src = readFileSync(path.join(hooksDir, file), 'utf8');
+    for (const m of src.matchAll(/party:\s*['"]([^'"]+)['"]/g)) {
+      names.add(m[1]);
+    }
+  }
+  return [...names];
+}
+
+describe('partykit.json', () => {
+  it('declares every party the client hooks connect to', () => {
+    const declared = new Set(['main', ...Object.keys(config.parties ?? {})]);
+    for (const name of hookPartyNames()) {
+      expect(declared, `party '${name}' is used by a hook but not declared`).toContain(name);
+    }
+  });
+
+  it('points every declared party at an existing entry file', () => {
+    const entries = [config.main, ...Object.values(config.parties ?? {})];
+    for (const entry of entries) {
+      expect(existsSync(path.join(ROOT, entry)), `${entry} does not exist`).toBe(true);
+    }
+  });
+
+  it('uses party names PartyKit can build and validate', () => {
+    // The config schema requires /^[a-z0-9_-]+$/, but the deploy codegen also
+    // interpolates the name as a JS identifier (`import <name> from ...`), so
+    // hyphens break the build. Underscore is the only safe separator.
+    for (const name of Object.keys(config.parties ?? {})) {
+      expect(name).toMatch(/^[a-z][a-z0-9_]*$/);
+    }
+  });
+});


### PR DESCRIPTION
## Why

Two long-standing dev-environment breakages, both reported as "dev is not working":

**1. Seed campaign images 404 on dev.cartyx.io.** `dev_seed.py` wrote generated campaign SVGs, player portraits, and avatar PNGs to the local `public/uploads/` (gitignored) while inserting those paths into the shared dev DB. The Vercel-deployed dev site bakes `public/` from git at build time, so those files can never exist there — every seed image 404s. `dev_clear.py` already empties the R2 bucket on reset; the seed just never filled it.

**2. Tabletop WebSockets loop forever.** `party/tabletop.ts` and `party/tabletop-map.ts` were never declared in `partykit.json`, so `/parties/tabletop*` returned 404 on dev, prod, **and** local `partykit dev` — the tabletop realtime sync has never actually connected anywhere since it shipped (45a36c0).

## What

- **partykit.json**: declare `tabletop` and `tabletop_map`. Party names must satisfy PartyKit's `/^[a-z0-9_-]+$/` config schema *and* survive deploy codegen that interpolates them as JS identifiers (hyphens break the build), so the map party is `tabletop_map` and `useTabletopMapParty` is updated to match. `collab` (y-partyserver) stays unregistered — it imports `cloudflare:workers`, which this PartyKit runtime doesn't shim, and registering it breaks the whole worker; nothing connects to it yet.
- **dev_seed.py / gen_seed_avatars.mjs**: when the app's CDN is configured (`CDN_URL` + `R2_*`, the same env the app itself uses), all seed images upload to R2 under the same `uploads/…` keys as real app uploads, and documents store full CDN URLs (passing the `campaigns.ts` imagePath validation) — i.e. seeded campaigns are stored exactly like user-created ones. Without CDN config, behavior is unchanged (local `public/uploads/` writes), so CI e2e and plain-localhost dev keep working.
- **repair_seed_images.py**: also checks/regenerates CDN-hosted campaign images.
- **Tests**: vitest test pins every hook's `party:` name to `partykit.json` (and pins the name-format constraints); `verify_session_seed.py` covers the CDN/local URL toggle.

## Verification

- `npx partykit dev`: `/parties/tabletop/*` and `/parties/tabletop_map/*` now route (were 404).
- Seeded an ephemeral `mongodb-memory-server` in **both** modes: fallback mode stores relative paths as before; CDN mode uploads and stores `https://cdn-dev.cartyx.io/uploads/…` URLs, all verified serving with 200s.
- `npm run test`: 1257/1257 pass. `tsc --noEmit` clean.

## Follow-ups (not in this PR)

- Merging `dev` into `feat/calendars-and-events` will need the same `public_url()` treatment for the new `/uploads/seed-lore/*.png` references and `gen_seed_lore_images.mjs` added there.
- After merge, the PartyKit deploy workflow triggers automatically (`party/**` / `partykit.json` paths) and re-seeding dev (`npm run dev:clear && npm run dev:seed`) will fix the existing dangling image references — or run `npm run dev:repair-images` to fix them in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)