### PR TITLE
feat: backend circuit breaker + retry hygiene

### DIFF
--- a/app/components/ConnectionBanner.tsx
+++ b/app/components/ConnectionBanner.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { subscribeBackendHealth, getBackendHealthSnapshot } from '~/utils/backend-health';
+
+// Server snapshot must be a stable reference for useSyncExternalStore.
+const SERVER_SNAPSHOT = { down: false, downSinceMs: null };
+
+/**
+ * Persistent connection-status banner driven by the backend circuit breaker.
+ * Shown under the top of the viewport while the breaker is open; flashes a
+ * brief "Reconnected" confirmation when it closes.
+ */
+export function ConnectionBanner() {
+  const health = useSyncExternalStore(
+    subscribeBackendHealth,
+    getBackendHealthSnapshot,
+    () => SERVER_SNAPSHOT
+  );
+  const [showReconnected, setShowReconnected] = useState(false);
+  const wasDown = useRef(false);
+
+  useEffect(() => {
+    const cameBackUp = wasDown.current && !health.down;
+    wasDown.current = health.down;
+    if (!cameBackUp) return;
+    setShowReconnected(true);
+    const timer = setTimeout(() => setShowReconnected(false), 2_000);
+    return () => clearTimeout(timer);
+  }, [health.down]);
+
+  if (health.down) {
+    return (
+      <div
+        role="status"
+        className="fixed inset-x-0 top-0 z-50 border-b-2 border-red-700 bg-red-900 py-1 text-center text-sm text-red-100"
+      >
+        Connection lost — reconnecting…
+      </div>
+    );
+  }
+
+  if (showReconnected) {
+    return (
+      <div
+        role="status"
+        className="fixed inset-x-0 top-0 z-50 border-b-2 border-green-700 bg-green-900 py-1 text-center text-sm text-green-100"
+      >
+        Reconnected
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/app/components/ConnectionBanner.tsx
+++ b/app/components/ConnectionBanner.tsx
@@ -31,7 +31,7 @@ export function ConnectionBanner() {
     return (
       <div
         role="status"
-        className="fixed inset-x-0 top-0 z-50 border-b-2 border-red-700 bg-red-900 py-1 text-center text-sm text-red-100"
+        className="fixed inset-x-0 top-14 z-40 border-b-2 border-red-700 bg-red-900 py-1 text-center text-sm text-red-100"
       >
         Connection lost — reconnecting…
       </div>
@@ -42,7 +42,7 @@ export function ConnectionBanner() {
     return (
       <div
         role="status"
-        className="fixed inset-x-0 top-0 z-50 border-b-2 border-green-700 bg-green-900 py-1 text-center text-sm text-green-100"
+        className="fixed inset-x-0 top-14 z-40 border-b-2 border-green-700 bg-green-900 py-1 text-center text-sm text-green-100"
       >
         Reconnected
       </div>

--- a/app/providers/QueryProvider.tsx
+++ b/app/providers/QueryProvider.tsx
@@ -1,52 +1,64 @@
-import { useState } from 'react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import type { ReactNode } from 'react'
+import { useState } from 'react';
+import { QueryClient, QueryClientProvider, QueryCache, MutationCache } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { isInfrastructureFailure } from '~/utils/error-classification';
+import { reportBackendFailure, reportBackendSuccess } from '~/utils/backend-health';
 
 function createQueryClient() {
   return new QueryClient({
+    // Feed the circuit breaker from every query/mutation outcome. On the
+    // server, backend-health is a no-op, so this is SSR-safe.
+    queryCache: new QueryCache({
+      onError: (error) => reportBackendFailure(error),
+      onSuccess: () => reportBackendSuccess(),
+    }),
+    mutationCache: new MutationCache({
+      onError: (error) => reportBackendFailure(error),
+      onSuccess: () => reportBackendSuccess(),
+    }),
     defaultOptions: {
       queries: {
         staleTime: 2 * 60 * 1000,
         gcTime: 10 * 60 * 1000,
         refetchOnWindowFocus: true,
-        retry: 1,
+        // Only infrastructure failures can heal on retry; application errors
+        // (validation, not-found, auth) never do.
+        retry: (failureCount, error) => failureCount < 1 && isInfrastructureFailure(error),
       },
     },
-  })
+  });
 }
 
 /** Get a fresh QueryClient for route loaders (SSR-safe, not shared across requests) */
-let browserQueryClient: QueryClient | null = null
+let browserQueryClient: QueryClient | null = null;
 export function getQueryClient() {
   // On the server, always create a new client (no cross-request leakage)
-  if (typeof window === 'undefined') return createQueryClient()
+  if (typeof window === 'undefined') return createQueryClient();
   // In the browser, reuse a single instance
-  if (!browserQueryClient) browserQueryClient = createQueryClient()
-  return browserQueryClient
+  if (!browserQueryClient) browserQueryClient = createQueryClient();
+  return browserQueryClient;
 }
 
 export function QueryProvider({ children }: { children: ReactNode }) {
-  const [client] = useState(() => getQueryClient())
+  const [client] = useState(() => getQueryClient());
 
   return (
     <QueryClientProvider client={client}>
       {children}
-      {import.meta.env.DEV && (
-        <ReactQueryDevtoolsLazy />
-      )}
+      {import.meta.env.DEV && <ReactQueryDevtoolsLazy />}
     </QueryClientProvider>
-  )
+  );
 }
 
 // Lazy-load devtools so they're tree-shaken from production builds
-import { lazy, Suspense } from 'react'
+import { lazy, Suspense } from 'react';
 const ReactQueryDevtoolsLazyComponent = lazy(() =>
-  import('@tanstack/react-query-devtools').then(mod => ({ default: mod.ReactQueryDevtools }))
-)
+  import('@tanstack/react-query-devtools').then((mod) => ({ default: mod.ReactQueryDevtools }))
+);
 function ReactQueryDevtoolsLazy() {
   return (
     <Suspense fallback={null}>
       <ReactQueryDevtoolsLazyComponent initialIsOpen={false} />
     </Suspense>
-  )
+  );
 }

--- a/app/routes/__root.tsx
+++ b/app/routes/__root.tsx
@@ -4,28 +4,29 @@ import {
   ScrollRestoration,
   HeadContent,
   Scripts,
-} from '@tanstack/react-router'
-import { Component, type ReactNode, type ErrorInfo } from 'react'
-import { AuthProvider } from '~/providers/AuthProvider'
-import { PostHogProvider, captureException } from '~/providers/PostHogProvider'
-import { QueryProvider } from '~/providers/QueryProvider'
-import '~/styles/globals.css'
+} from '@tanstack/react-router';
+import { Component, type ReactNode, type ErrorInfo } from 'react';
+import { ConnectionBanner } from '~/components/ConnectionBanner';
+import { AuthProvider } from '~/providers/AuthProvider';
+import { PostHogProvider, captureException } from '~/providers/PostHogProvider';
+import { QueryProvider } from '~/providers/QueryProvider';
+import '~/styles/globals.css';
 
-class ErrorBoundary extends Component<
-  { children: ReactNode },
-  { hasError: boolean }
-> {
+class ErrorBoundary extends Component<{ children: ReactNode }, { hasError: boolean }> {
   constructor(props: { children: ReactNode }) {
-    super(props)
-    this.state = { hasError: false }
+    super(props);
+    this.state = { hasError: false };
   }
 
   static getDerivedStateFromError() {
-    return { hasError: true }
+    return { hasError: true };
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
-    captureException(error, { componentStack: info.componentStack ?? undefined, source: 'ErrorBoundary' })
+    captureException(error, {
+      componentStack: info.componentStack ?? undefined,
+      source: 'ErrorBoundary',
+    });
   }
 
   render() {
@@ -34,7 +35,9 @@ class ErrorBoundary extends Component<
         <div className="min-h-screen bg-[#0D1117] flex items-center justify-center text-white">
           <div className="text-center p-8 border border-[#30363d] rounded-lg max-w-md">
             <h1 className="text-2xl font-bold mb-4">Something went wrong</h1>
-            <p className="text-gray-400 mb-6">An unexpected error occurred. Please try refreshing the page.</p>
+            <p className="text-gray-400 mb-6">
+              An unexpected error occurred. Please try refreshing the page.
+            </p>
             <button
               onClick={() => this.setState({ hasError: false })}
               className="px-6 py-2 bg-indigo-600 hover:bg-indigo-700 rounded text-white font-medium transition-colors"
@@ -43,9 +46,9 @@ class ErrorBoundary extends Component<
             </button>
           </div>
         </div>
-      )
+      );
     }
-    return this.props.children
+    return this.props.children;
   }
 }
 
@@ -55,14 +58,15 @@ export const Route = createRootRoute({
       { charSet: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
       { title: 'Cartyx — D&D Campaign Management' },
-      { name: 'description', content: 'Manage your D&D campaigns, invite players, and forge legendary adventures.' },
+      {
+        name: 'description',
+        content: 'Manage your D&D campaigns, invite players, and forge legendary adventures.',
+      },
     ],
-    links: [
-      { rel: 'icon', href: '/favicon.ico' },
-    ],
+    links: [{ rel: 'icon', href: '/favicon.ico' }],
   }),
   component: RootComponent,
-})
+});
 
 function RootComponent() {
   return (
@@ -75,6 +79,7 @@ function RootComponent() {
           <AuthProvider>
             <PostHogProvider>
               <ErrorBoundary>
+                <ConnectionBanner />
                 <ScrollRestoration />
                 <Outlet />
               </ErrorBoundary>
@@ -84,5 +89,5 @@ function RootComponent() {
         <Scripts />
       </body>
     </html>
-  )
+  );
 }

--- a/app/server/db/connection.ts
+++ b/app/server/db/connection.ts
@@ -40,6 +40,9 @@ export async function connectDB(): Promise<void> {
   } catch (e) {
     connectPromise = null;
     serverCaptureException(e, undefined, { action: 'connectDB' });
+    // Still useful server-side (logging, any in-process caller), but this
+    // does NOT survive server-fn serialization — the client-side circuit
+    // breaker classifier matches on the error message instead.
     if (e instanceof Error && !Object.prototype.hasOwnProperty.call(e, 'status')) {
       Object.assign(e, { status: 503 });
     }

--- a/app/server/db/connection.ts
+++ b/app/server/db/connection.ts
@@ -1,21 +1,21 @@
-import mongoose from 'mongoose'
-import { bootstrapDB, isBootstrapped } from './bootstrap'
-import { getBootstrapPolicy } from './policy'
-import { serverCaptureException } from '../utils/posthog'
+import mongoose from 'mongoose';
+import { bootstrapDB, isBootstrapped } from './bootstrap';
+import { getBootstrapPolicy } from './policy';
+import { serverCaptureException } from '../utils/posthog';
 
-let connectPromise: Promise<typeof mongoose> | null = null
+let connectPromise: Promise<typeof mongoose> | null = null;
 
 export async function connectDB(): Promise<void> {
-  const uri = process.env.MONGODB_URI
-  if (!uri) return
+  const uri = process.env.MONGODB_URI;
+  if (!uri) return;
 
-  const policy = getBootstrapPolicy()
+  const policy = getBootstrapPolicy();
 
   try {
     if (connectPromise) {
       // A connection attempt is already in flight — wait for it regardless
       // of readyState, so concurrent callers always share one attempt.
-      await connectPromise
+      await connectPromise;
     } else if (mongoose.connection.readyState === 0) {
       // Disconnected — start a new connection and track the promise so
       // concurrent callers can await it.
@@ -26,29 +26,32 @@ export async function connectDB(): Promise<void> {
       // In development autoIndex stays on for convenience.
       connectPromise = mongoose.connect(uri, {
         autoIndex: policy.autoIndex,
-      })
-      await connectPromise
-      connectPromise = null
+      });
+      await connectPromise;
+      connectPromise = null;
     }
     // readyState 1 (connected) with no in-flight promise — nothing to do
 
     // Always attempt bootstrap — it's idempotent and must succeed even if
     // a previous connect succeeded but bootstrap failed partway through.
     if (!isBootstrapped()) {
-      await bootstrapDB(policy)
+      await bootstrapDB(policy);
     }
   } catch (e) {
-    connectPromise = null
-    serverCaptureException(e, undefined, { action: 'connectDB' })
-    throw e
+    connectPromise = null;
+    serverCaptureException(e, undefined, { action: 'connectDB' });
+    if (e instanceof Error && !Object.prototype.hasOwnProperty.call(e, 'status')) {
+      Object.assign(e, { status: 503 });
+    }
+    throw e;
   }
 }
 
 export function isDBConnected(): boolean {
-  return mongoose.connection.readyState === 1
+  return mongoose.connection.readyState === 1;
 }
 
 /** @internal Reset module state — test-only. */
 export function __resetConnectPromiseForTests(): void {
-  connectPromise = null
+  connectPromise = null;
 }

--- a/app/server/functions/health.ts
+++ b/app/server/functions/health.ts
@@ -8,6 +8,9 @@ import { connectDB, isDBConnected } from '../db/connection';
  */
 export async function healthCheck(): Promise<{ ok: true }> {
   await connectDB();
+  // status: 503 is harmless and useful for in-process/server-side callers,
+  // but it does not survive server-fn serialization to the client — the
+  // client-side classifier matches on the "database not connected" message.
   if (!isDBConnected()) throw Object.assign(new Error('Database not connected'), { status: 503 });
   const db = mongoose.connection.db;
   if (!db) throw Object.assign(new Error('Database not connected'), { status: 503 });

--- a/app/server/functions/health.ts
+++ b/app/server/functions/health.ts
@@ -8,9 +8,9 @@ import { connectDB, isDBConnected } from '../db/connection';
  */
 export async function healthCheck(): Promise<{ ok: true }> {
   await connectDB();
-  if (!isDBConnected()) throw new Error('Database not connected');
+  if (!isDBConnected()) throw Object.assign(new Error('Database not connected'), { status: 503 });
   const db = mongoose.connection.db;
-  if (!db) throw new Error('Database not connected');
+  if (!db) throw Object.assign(new Error('Database not connected'), { status: 503 });
   await db.admin().command({ ping: 1 });
   return { ok: true };
 }

--- a/app/server/functions/health.ts
+++ b/app/server/functions/health.ts
@@ -1,0 +1,16 @@
+import mongoose from 'mongoose';
+import { connectDB, isDBConnected } from '../db/connection';
+
+/**
+ * Circuit-breaker recovery probe. Must reflect real backend health: a probe
+ * that skipped the DB would close the breaker while every DB-dependent
+ * endpoint still fails, causing open/close flapping.
+ */
+export async function healthCheck(): Promise<{ ok: true }> {
+  await connectDB();
+  if (!isDBConnected()) throw new Error('Database not connected');
+  const db = mongoose.connection.db;
+  if (!db) throw new Error('Database not connected');
+  await db.admin().command({ ping: 1 });
+  return { ok: true };
+}

--- a/app/server/functions/rpc.ts
+++ b/app/server/functions/rpc.ts
@@ -30,3 +30,8 @@ export const getCampaign = createServerFn({ method: 'GET' })
     const { getCampaign } = await import('~/server/functions/campaigns');
     return getCampaign({ data });
   });
+
+export const healthCheck = createServerFn({ method: 'GET' }).handler(async () => {
+  const { healthCheck } = await import('~/server/functions/health');
+  return healthCheck();
+});

--- a/app/utils/backend-health.ts
+++ b/app/utils/backend-health.ts
@@ -1,0 +1,151 @@
+/**
+ * Browser-only integration between the circuit breaker and the app.
+ *
+ * When the breaker opens we flip TanStack Query's onlineManager to offline —
+ * that pauses every query refetch and mutation centrally (paused mutations
+ * auto-resume on recovery). Recovery is driven by probing the healthCheck
+ * server fn on the breaker's backoff schedule. Direct callers that bypass
+ * TanStack Query (withRetry, uploadToR2) consult isBackendDown()/whenBackendUp().
+ *
+ * On the server every facade function is a no-op that reports "up".
+ */
+import { onlineManager } from '@tanstack/react-query';
+import { createCircuitBreaker, type CircuitBreaker } from '~/utils/circuit-breaker';
+import { isInfrastructureFailure } from '~/utils/error-classification';
+import { captureEvent } from '~/utils/posthog-client';
+// ~/server/functions/rpc is the sanctioned client-safe RPC facade (createServerFn
+// strips the server body from the client bundle; see rpc.ts header comment), not a
+// raw ~/server/* module.
+// eslint-disable-next-line no-restricted-imports
+import { healthCheck } from '~/server/functions/rpc';
+
+export interface BackendHealthSnapshot {
+  down: boolean;
+  downSinceMs: number | null;
+}
+
+export interface BackendHealthDeps {
+  probe: () => Promise<unknown>;
+  setOnline: (online: boolean) => void;
+  capture: (event: string, properties?: Record<string, unknown>) => void;
+  now: () => number;
+}
+
+export interface BackendHealth {
+  reportFailure(error: unknown): void;
+  reportSuccess(): void;
+  isDown(): boolean;
+  whenUp(): Promise<void>;
+  subscribe(listener: () => void): () => void;
+  getSnapshot(): BackendHealthSnapshot;
+}
+
+const UP_SNAPSHOT: BackendHealthSnapshot = { down: false, downSinceMs: null };
+
+export function createBackendHealth(
+  deps: BackendHealthDeps,
+  breaker: CircuitBreaker = createCircuitBreaker()
+): BackendHealth {
+  const listeners = new Set<() => void>();
+  let upWaiters: Array<() => void> = [];
+  let snapshot: BackendHealthSnapshot = UP_SNAPSHOT;
+
+  function notify() {
+    for (const listener of listeners) listener();
+  }
+
+  function scheduleProbe() {
+    setTimeout(() => void runProbe(), breaker.probeDelayMs());
+  }
+
+  async function runProbe() {
+    breaker.beginProbe();
+    let ok = false;
+    try {
+      await deps.probe();
+      ok = true;
+    } catch {
+      ok = false;
+    }
+    if (breaker.resolveProbe(ok) === 'closed') {
+      deps.capture('backend_circuit_closed', {
+        downtime_ms: snapshot.downSinceMs === null ? 0 : deps.now() - snapshot.downSinceMs,
+        probe_attempts: breaker.probeAttempts(),
+      });
+      snapshot = { down: false, downSinceMs: null };
+      deps.setOnline(true);
+      const waiters = upWaiters;
+      upWaiters = [];
+      for (const resolve of waiters) resolve();
+      notify();
+    } else {
+      scheduleProbe();
+    }
+  }
+
+  return {
+    reportFailure(error) {
+      if (!isInfrastructureFailure(error)) return;
+      if (breaker.recordFailure(deps.now()) !== 'opened') return;
+      snapshot = { down: true, downSinceMs: deps.now() };
+      deps.setOnline(false);
+      deps.capture('backend_circuit_opened', {
+        consecutive_failures: breaker.consecutiveFailures(),
+        trigger_error_name: error instanceof Error ? error.name : 'unknown',
+      });
+      scheduleProbe();
+      notify();
+    },
+    reportSuccess() {
+      breaker.recordSuccess();
+    },
+    isDown() {
+      return snapshot.down;
+    },
+    whenUp() {
+      if (!snapshot.down) return Promise.resolve();
+      return new Promise<void>((resolve) => upWaiters.push(resolve));
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    getSnapshot() {
+      return snapshot;
+    },
+  };
+}
+
+const NOOP_HEALTH: BackendHealth = {
+  reportFailure() {},
+  reportSuccess() {},
+  isDown: () => false,
+  whenUp: () => Promise.resolve(),
+  subscribe: () => () => {},
+  getSnapshot: () => UP_SNAPSHOT,
+};
+
+let singleton: BackendHealth | null = null;
+
+function getBackendHealth(): BackendHealth {
+  if (typeof window === 'undefined') return NOOP_HEALTH;
+  if (!singleton) {
+    singleton = createBackendHealth({
+      probe: () => healthCheck(),
+      setOnline: (online) => onlineManager.setOnline(online),
+      capture: captureEvent,
+      now: () => Date.now(),
+    });
+  }
+  return singleton;
+}
+
+export const reportBackendFailure = (error: unknown): void =>
+  getBackendHealth().reportFailure(error);
+export const reportBackendSuccess = (): void => getBackendHealth().reportSuccess();
+export const isBackendDown = (): boolean => getBackendHealth().isDown();
+export const whenBackendUp = (): Promise<void> => getBackendHealth().whenUp();
+export const subscribeBackendHealth = (listener: () => void): (() => void) =>
+  getBackendHealth().subscribe(listener);
+export const getBackendHealthSnapshot = (): BackendHealthSnapshot =>
+  getBackendHealth().getSnapshot();

--- a/app/utils/backend-health.ts
+++ b/app/utils/backend-health.ts
@@ -107,16 +107,27 @@ export function createBackendHealth(
       breaker.beginProbe();
       const ok = await raceProbeWithTimeout();
       if (breaker.resolveProbe(ok) === 'closed') {
-        deps.capture('backend_circuit_closed', {
-          downtime_ms: snapshot.downSinceMs === null ? 0 : deps.now() - snapshot.downSinceMs,
-          probe_attempts: breaker.probeAttempts(),
-        });
+        // Compute downtime before mutating the snapshot below, then run all
+        // state/side effects before telemetry: a throwing `capture` must not
+        // strand the breaker resolved-closed while our own snapshot/
+        // onlineManager/waiters still think it's down.
+        const downtimeMs = snapshot.downSinceMs === null ? 0 : deps.now() - snapshot.downSinceMs;
+        const probeAttempts = breaker.probeAttempts();
         snapshot = { down: false, downSinceMs: null };
         deps.setOnline(true);
         const waiters = upWaiters;
         upWaiters = [];
         for (const resolve of waiters) resolve();
         notify();
+        try {
+          deps.capture('backend_circuit_closed', {
+            downtime_ms: downtimeMs,
+            probe_attempts: probeAttempts,
+          });
+        } catch {
+          // Telemetry failures must not affect breaker state; the breaker is
+          // already resolved-closed and its side effects already ran above.
+        }
       } else {
         scheduleProbe();
       }
@@ -185,7 +196,7 @@ function getBackendHealth(): BackendHealth {
   if (typeof window === 'undefined') return NOOP_HEALTH;
   if (!singleton) {
     singleton = createBackendHealth({
-      probe: () => healthCheck(),
+      probe: () => healthCheck({ signal: AbortSignal.timeout(10_000) }),
       setOnline: (online) => onlineManager.setOnline(online),
       capture: captureEvent,
       now: () => Date.now(),

--- a/app/utils/backend-health.ts
+++ b/app/utils/backend-health.ts
@@ -36,6 +36,13 @@ export interface BackendHealthDeps {
    * mutations against a backend we already know is down.
    */
   subscribeOnline?: (listener: (online: boolean) => void) => void;
+  /**
+   * Upper bound on how long a recovery probe is allowed to hang before it's
+   * treated as failed. A probe stuck on a dead connection (no timeout of its
+   * own) would otherwise stall the breaker's entire backoff schedule.
+   * Defaults to 10s.
+   */
+  probeTimeoutMs?: number;
 }
 
 export interface BackendHealth {
@@ -56,6 +63,7 @@ export function createBackendHealth(
   const listeners = new Set<() => void>();
   let upWaiters: Array<() => void> = [];
   let snapshot: BackendHealthSnapshot = UP_SNAPSHOT;
+  const probeTimeoutMs = deps.probeTimeoutMs ?? 10_000;
 
   function notify() {
     for (const listener of listeners) listener();
@@ -65,16 +73,39 @@ export function createBackendHealth(
     setTimeout(() => void runProbe(), breaker.probeDelayMs());
   }
 
+  // Races the probe against a deadline. If the deadline wins, the probe is
+  // treated as failed; a stale probe that later settles is ignored (guarded
+  // by `settled`) so it can't resolve twice or flip breaker state after the
+  // fact.
+  function raceProbeWithTimeout(): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      let settled = false;
+      const deadline = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        resolve(false);
+      }, probeTimeoutMs);
+      deps.probe().then(
+        () => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(deadline);
+          resolve(true);
+        },
+        () => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(deadline);
+          resolve(false);
+        }
+      );
+    });
+  }
+
   async function runProbe() {
     try {
       breaker.beginProbe();
-      let ok = false;
-      try {
-        await deps.probe();
-        ok = true;
-      } catch {
-        ok = false;
-      }
+      const ok = await raceProbeWithTimeout();
       if (breaker.resolveProbe(ok) === 'closed') {
         deps.capture('backend_circuit_closed', {
           downtime_ms: snapshot.downSinceMs === null ? 0 : deps.now() - snapshot.downSinceMs,
@@ -93,7 +124,10 @@ export function createBackendHealth(
       // A throwing side effect (capture/setOnline/breaker call) must not
       // become an unhandled rejection that strands the breaker open with no
       // probe scheduled — fall back to rescheduling on the existing backoff.
-      scheduleProbe();
+      // Only do so if the breaker is still open: if it already closed, a
+      // side effect throwing after the fact must not spin up a perpetual
+      // no-op probe timer.
+      if (breaker.state() === 'open') scheduleProbe();
     }
   }
 

--- a/app/utils/backend-health.ts
+++ b/app/utils/backend-health.ts
@@ -29,6 +29,13 @@ export interface BackendHealthDeps {
   setOnline: (online: boolean) => void;
   capture: (event: string, properties?: Record<string, unknown>) => void;
   now: () => number;
+  /**
+   * Optional hook into the browser's online/offline signal (e.g. TanStack
+   * Query's onlineManager). A laptop wake / Wi-Fi switch fires `online` even
+   * while the breaker is open, which would otherwise un-pause queries and
+   * mutations against a backend we already know is down.
+   */
+  subscribeOnline?: (listener: (online: boolean) => void) => void;
 }
 
 export interface BackendHealth {
@@ -59,28 +66,41 @@ export function createBackendHealth(
   }
 
   async function runProbe() {
-    breaker.beginProbe();
-    let ok = false;
     try {
-      await deps.probe();
-      ok = true;
+      breaker.beginProbe();
+      let ok = false;
+      try {
+        await deps.probe();
+        ok = true;
+      } catch {
+        ok = false;
+      }
+      if (breaker.resolveProbe(ok) === 'closed') {
+        deps.capture('backend_circuit_closed', {
+          downtime_ms: snapshot.downSinceMs === null ? 0 : deps.now() - snapshot.downSinceMs,
+          probe_attempts: breaker.probeAttempts(),
+        });
+        snapshot = { down: false, downSinceMs: null };
+        deps.setOnline(true);
+        const waiters = upWaiters;
+        upWaiters = [];
+        for (const resolve of waiters) resolve();
+        notify();
+      } else {
+        scheduleProbe();
+      }
     } catch {
-      ok = false;
-    }
-    if (breaker.resolveProbe(ok) === 'closed') {
-      deps.capture('backend_circuit_closed', {
-        downtime_ms: snapshot.downSinceMs === null ? 0 : deps.now() - snapshot.downSinceMs,
-        probe_attempts: breaker.probeAttempts(),
-      });
-      snapshot = { down: false, downSinceMs: null };
-      deps.setOnline(true);
-      const waiters = upWaiters;
-      upWaiters = [];
-      for (const resolve of waiters) resolve();
-      notify();
-    } else {
+      // A throwing side effect (capture/setOnline/breaker call) must not
+      // become an unhandled rejection that strands the breaker open with no
+      // probe scheduled — fall back to rescheduling on the existing backoff.
       scheduleProbe();
     }
+  }
+
+  if (deps.subscribeOnline) {
+    deps.subscribeOnline((online) => {
+      if (online && snapshot.down) deps.setOnline(false);
+    });
   }
 
   return {
@@ -135,6 +155,9 @@ function getBackendHealth(): BackendHealth {
       setOnline: (online) => onlineManager.setOnline(online),
       capture: captureEvent,
       now: () => Date.now(),
+      subscribeOnline: (listener) => {
+        onlineManager.subscribe(() => listener(onlineManager.isOnline()));
+      },
     });
   }
   return singleton;

--- a/app/utils/circuit-breaker.ts
+++ b/app/utils/circuit-breaker.ts
@@ -1,0 +1,85 @@
+/**
+ * Pure circuit-breaker state machine: closed → open → half-open → closed.
+ *
+ * Time is passed in and no timers are owned here — the caller (see
+ * ~/utils/backend-health) schedules probes using `probeDelayMs()`. This keeps
+ * the transition logic deterministic and unit-testable, in the same style as
+ * ~/utils/exception-throttle.
+ */
+export type CircuitState = 'closed' | 'open' | 'half-open';
+
+export interface CircuitBreakerOptions {
+  failureThreshold?: number;
+  initialProbeDelayMs?: number;
+  probeBackoffFactor?: number;
+  maxProbeDelayMs?: number;
+}
+
+export interface CircuitBreaker {
+  state(): CircuitState;
+  recordFailure(nowMs: number): 'opened' | null;
+  recordSuccess(): void;
+  probeDelayMs(): number;
+  beginProbe(): void;
+  resolveProbe(ok: boolean): CircuitState;
+  consecutiveFailures(): number;
+  probeAttempts(): number;
+  openedAtMs(): number | null;
+}
+
+export function createCircuitBreaker(options: CircuitBreakerOptions = {}): CircuitBreaker {
+  const {
+    failureThreshold = 5,
+    initialProbeDelayMs = 5_000,
+    probeBackoffFactor = 2,
+    maxProbeDelayMs = 60_000,
+  } = options;
+
+  let state: CircuitState = 'closed';
+  let consecutiveFailures = 0;
+  let probeAttempts = 0;
+  let probeDelay = initialProbeDelayMs;
+  let openedAt: number | null = null;
+
+  return {
+    state: () => state,
+    consecutiveFailures: () => consecutiveFailures,
+    probeAttempts: () => probeAttempts,
+    probeDelayMs: () => probeDelay,
+    openedAtMs: () => openedAt,
+
+    recordFailure(nowMs) {
+      if (state !== 'closed') return null;
+      consecutiveFailures++;
+      if (consecutiveFailures < failureThreshold) return null;
+      state = 'open';
+      openedAt = nowMs;
+      probeAttempts = 0;
+      probeDelay = initialProbeDelayMs;
+      return 'opened';
+    },
+
+    recordSuccess() {
+      if (state === 'closed') consecutiveFailures = 0;
+    },
+
+    beginProbe() {
+      if (state !== 'open') throw new Error(`beginProbe called in state '${state}'`);
+      state = 'half-open';
+      probeAttempts++;
+    },
+
+    resolveProbe(ok) {
+      if (state !== 'half-open') throw new Error(`resolveProbe called in state '${state}'`);
+      if (ok) {
+        state = 'closed';
+        consecutiveFailures = 0;
+        openedAt = null;
+        return 'closed';
+      }
+      state = 'open';
+      probeDelay = Math.min(probeDelay * probeBackoffFactor, maxProbeDelayMs);
+      return 'open';
+    },
+  };
+}

--- a/app/utils/error-classification.ts
+++ b/app/utils/error-classification.ts
@@ -1,0 +1,28 @@
+/**
+ * Classifies failures for the backend circuit breaker and retry policy.
+ *
+ * Only *infrastructure* failures (the network or the server process is
+ * unhealthy) count toward tripping the breaker and are worth retrying.
+ * Application errors thrown by server-fn code (validation, not-found, auth)
+ * cannot heal on retry and must never trip the breaker.
+ */
+
+/** Thrown by guarded callers when the circuit breaker is open. */
+export class BackendUnavailableError extends Error {
+  constructor() {
+    super('Backend temporarily unavailable — reconnecting');
+    this.name = 'BackendUnavailableError';
+  }
+}
+
+const NETWORK_ERROR_PATTERN = /failed to fetch|load failed|networkerror/i;
+
+export function isInfrastructureFailure(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (error instanceof BackendUnavailableError) return false;
+  if (error instanceof TypeError && NETWORK_ERROR_PATTERN.test(error.message)) return true;
+  if (error.name === 'TimeoutError') return true;
+  const status = (error as { status?: unknown }).status;
+  if (typeof status === 'number' && status >= 500) return true;
+  return false;
+}

--- a/app/utils/error-classification.ts
+++ b/app/utils/error-classification.ts
@@ -17,6 +17,21 @@ export class BackendUnavailableError extends Error {
 
 const NETWORK_ERROR_PATTERN = /failed to fetch|load failed|networkerror/i;
 
+/**
+ * Message patterns for infrastructure failures that can arrive as plain
+ * `Error`s — i.e. without a `status` we can check — because they crossed a
+ * boundary that discards it:
+ *  - the TanStack start-client-core server-fn fetcher deserializes a 500 into
+ *    a plain rethrown Error, and a non-serialized proxy/platform response
+ *    (nginx/ALB/Cloudflare) arrives as `new Error(await response.text())`;
+ *  - a deploy in progress can make the client reference a server-fn manifest
+ *    entry that no longer exists on the new deployment;
+ *  - the Mongo driver can throw mid-query on a disconnect without the
+ *    server-fn layer having a chance to tag `status` on it.
+ */
+const TRANSPORT_ERROR_PATTERN =
+  /502 bad gateway|503 service unavailable|504 gateway time-?out|gateway timeout|server function info not found|server selection timed out|ECONNREFUSED|ECONNRESET|ETIMEDOUT|EAI_AGAIN|getaddrinfo|socket hang up|topology .*(closed|destroyed)/i;
+
 export function isInfrastructureFailure(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   if (error instanceof BackendUnavailableError) return false;
@@ -24,5 +39,6 @@ export function isInfrastructureFailure(error: unknown): boolean {
   if (error.name === 'TimeoutError') return true;
   const status = (error as { status?: unknown }).status;
   if (typeof status === 'number' && status >= 500) return true;
+  if (TRANSPORT_ERROR_PATTERN.test(error.message)) return true;
   return false;
 }

--- a/app/utils/error-classification.ts
+++ b/app/utils/error-classification.ts
@@ -39,9 +39,17 @@ const NETWORK_ERROR_PATTERN = /failed to fetch|load failed|networkerror/i;
  *    server-fn layer having a chance to tag `status` on it;
  *  - our own DB-layer guards (health.ts, oauth.ts upsertUser) throw
  *    "database not connected" messages when the connection is down.
+ *  - a mid-session Mongo disconnect surfaces as mongoose command-buffering
+ *    timeouts, driver `MongoNetworkError`/`PoolClearedError` drops, or
+ *    "MongoClient must be connected" guard messages;
+ *  - Vercel's platform-level failures (as opposed to our own handler code)
+ *    arrive as `FUNCTION_INVOCATION_FAILED`/`FUNCTION_INVOCATION_TIMEOUT`
+ *    error bodies. The generic "A server error has occurred" text Vercel
+ *    pairs with those codes is deliberately NOT matched on its own — it's
+ *    too generic and would false-positive on unrelated app copy.
  */
 const TRANSPORT_ERROR_PATTERN =
-  /502 bad gateway|503 service unavailable|504 gateway time-?out|gateway timeout|server function info not found|server selection timed out|ECONNREFUSED|ECONNRESET|ETIMEDOUT|EAI_AGAIN|getaddrinfo|socket hang up|topology .*(closed|destroyed)|database not connected/i;
+  /502 bad gateway|503 service unavailable|504 gateway time-?out|gateway timeout|server function info not found|server selection timed out|ECONNREFUSED|ECONNRESET|ETIMEDOUT|EAI_AGAIN|getaddrinfo|socket hang up|topology .*(closed|destroyed)|database not connected|buffering timed out|connection \d+ to .* closed|pool .*(was )?cleared|client must be connected|FUNCTION_INVOCATION_FAILED|FUNCTION_INVOCATION_TIMEOUT/i;
 
 export function isInfrastructureFailure(error: unknown): boolean {
   if (!(error instanceof Error)) return false;

--- a/app/utils/error-classification.ts
+++ b/app/utils/error-classification.ts
@@ -5,6 +5,15 @@
  * unhealthy) count toward tripping the breaker and are worth retrying.
  * Application errors thrown by server-fn code (validation, not-found, auth)
  * cannot heal on retry and must never trip the breaker.
+ *
+ * Server-fn errors cross the wire as plain `Error`s: TanStack Start's
+ * serialization (seroval) does NOT preserve own props on `Error` instances,
+ * so a handler throwing `Object.assign(new Error(...), { status: 503 })`
+ * arrives client-side with only `name`/`message` — `status` is gone.
+ * Classification of server-thrown failures therefore relies entirely on
+ * message patterns below; the `status >= 500` branch only ever fires for
+ * errors constructed client-side (e.g. from a fetch Response), never for
+ * ones that came back through a server function.
  */
 
 /** Thrown by guarded callers when the circuit breaker is open. */
@@ -27,10 +36,12 @@ const NETWORK_ERROR_PATTERN = /failed to fetch|load failed|networkerror/i;
  *  - a deploy in progress can make the client reference a server-fn manifest
  *    entry that no longer exists on the new deployment;
  *  - the Mongo driver can throw mid-query on a disconnect without the
- *    server-fn layer having a chance to tag `status` on it.
+ *    server-fn layer having a chance to tag `status` on it;
+ *  - our own DB-layer guards (health.ts, oauth.ts upsertUser) throw
+ *    "database not connected" messages when the connection is down.
  */
 const TRANSPORT_ERROR_PATTERN =
-  /502 bad gateway|503 service unavailable|504 gateway time-?out|gateway timeout|server function info not found|server selection timed out|ECONNREFUSED|ECONNRESET|ETIMEDOUT|EAI_AGAIN|getaddrinfo|socket hang up|topology .*(closed|destroyed)/i;
+  /502 bad gateway|503 service unavailable|504 gateway time-?out|gateway timeout|server function info not found|server selection timed out|ECONNREFUSED|ECONNRESET|ETIMEDOUT|EAI_AGAIN|getaddrinfo|socket hang up|topology .*(closed|destroyed)|database not connected/i;
 
 export function isInfrastructureFailure(error: unknown): boolean {
   if (!(error instanceof Error)) return false;

--- a/app/utils/retryMutation.ts
+++ b/app/utils/retryMutation.ts
@@ -6,6 +6,13 @@ const INITIAL_RETRY_DELAY_MS = 1_000;
 const MAX_RETRY_DELAY_MS = 30_000;
 const JITTER_RATIO = 0.2;
 const MAX_RETRIES = 12;
+/**
+ * Upper bound on how long withRetry will wait for the circuit breaker to
+ * recover before giving up. Without this, a prolonged outage would await
+ * whenBackendUp() forever, silently stranding the save (and the user) with
+ * no feedback that their message was never persisted.
+ */
+const BREAKER_WAIT_MAX_MS = 120_000;
 
 export interface RetryContext {
   sessionId: string;
@@ -26,14 +33,14 @@ function retryDelayMs(attempt: number): number {
 function exhaust(
   context: RetryContext,
   err: unknown,
-  onExhausted: OnRetriesExhausted | undefined
+  onExhausted: OnRetriesExhausted | undefined,
+  attemptsMade: number
 ): null {
-  console.error(
-    `[Save] Failed after ${MAX_RETRIES} retries`,
-    context.messageType,
-    context.messageId,
-    err
-  );
+  const label =
+    attemptsMade === 0
+      ? `Failed before any attempt (breaker wait exceeded ${BREAKER_WAIT_MAX_MS}ms)`
+      : `Failed after ${attemptsMade} attempt${attemptsMade === 1 ? '' : 's'}`;
+  console.error(`[Save] ${label}`, context.messageType, context.messageId, err);
 
   captureEvent('party.mongo_save_failed', {
     sessionId: context.sessionId,
@@ -48,15 +55,52 @@ function exhaust(
   return null;
 }
 
+/**
+ * Races whenBackendUp() against BREAKER_WAIT_MAX_MS. If the deadline wins,
+ * resolves 'timeout'; a whenBackendUp() that settles later is ignored
+ * (guarded by `settled`) so a stale wait can't resume a loop that already
+ * exhausted.
+ */
+function raceBreakerWait(): Promise<'up' | 'timeout'> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const deadline = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      resolve('timeout');
+    }, BREAKER_WAIT_MAX_MS);
+    whenBackendUp().then(() => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(deadline);
+      resolve('up');
+    });
+  });
+}
+
 export async function withRetry<T>(
   fn: () => Promise<T>,
   context: RetryContext,
   onExhausted?: OnRetriesExhausted
 ): Promise<T | null> {
+  let attemptsMade = 0;
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     // While the circuit breaker is open, sending the request is pointless —
     // wait for recovery instead of burning an attempt against a dead backend.
-    if (isBackendDown()) await whenBackendUp();
+    // Cap the wait so a prolonged outage can't strand the save (and the
+    // user) forever with no feedback.
+    if (isBackendDown()) {
+      const outcome = await raceBreakerWait();
+      if (outcome === 'timeout') {
+        return exhaust(
+          context,
+          new Error(`Backend still unavailable after ${BREAKER_WAIT_MAX_MS}ms; giving up`),
+          onExhausted,
+          attemptsMade
+        );
+      }
+    }
+    attemptsMade++;
     try {
       return await fn();
     } catch (err) {
@@ -66,11 +110,11 @@ export async function withRetry<T>(
       // retry — burning the backoff schedule on them only delays the
       // inevitable failure. Go straight to the exhaustion path.
       if (!isInfrastructureFailure(err)) {
-        return exhaust(context, err, onExhausted);
+        return exhaust(context, err, onExhausted, attemptsMade);
       }
 
       if (attempt === MAX_RETRIES) {
-        return exhaust(context, err, onExhausted);
+        return exhaust(context, err, onExhausted, attemptsMade);
       }
 
       const delay = retryDelayMs(attempt);

--- a/app/utils/retryMutation.ts
+++ b/app/utils/retryMutation.ts
@@ -1,5 +1,6 @@
 import { captureEvent } from '~/utils/posthog-client';
-import { isBackendDown, whenBackendUp } from '~/utils/backend-health';
+import { isBackendDown, reportBackendFailure, whenBackendUp } from '~/utils/backend-health';
+import { isInfrastructureFailure } from '~/utils/error-classification';
 
 const INITIAL_RETRY_DELAY_MS = 1_000;
 const MAX_RETRY_DELAY_MS = 30_000;
@@ -22,6 +23,31 @@ function retryDelayMs(attempt: number): number {
   return Math.round(base * jitterFactor);
 }
 
+function exhaust(
+  context: RetryContext,
+  err: unknown,
+  onExhausted: OnRetriesExhausted | undefined
+): null {
+  console.error(
+    `[Save] Failed after ${MAX_RETRIES} retries`,
+    context.messageType,
+    context.messageId,
+    err
+  );
+
+  captureEvent('party.mongo_save_failed', {
+    sessionId: context.sessionId,
+    campaignId: context.campaignId,
+    messageType: context.messageType,
+    messageId: context.messageId,
+    errorMessage: err instanceof Error ? err.message : String(err),
+    errorName: err instanceof Error ? err.name : undefined,
+  });
+
+  onExhausted?.(context, err);
+  return null;
+}
+
 export async function withRetry<T>(
   fn: () => Promise<T>,
   context: RetryContext,
@@ -34,25 +60,17 @@ export async function withRetry<T>(
     try {
       return await fn();
     } catch (err) {
+      reportBackendFailure(err);
+
+      // Application errors (validation, not-found, auth, ...) cannot heal on
+      // retry — burning the backoff schedule on them only delays the
+      // inevitable failure. Go straight to the exhaustion path.
+      if (!isInfrastructureFailure(err)) {
+        return exhaust(context, err, onExhausted);
+      }
+
       if (attempt === MAX_RETRIES) {
-        console.error(
-          `[Save] Failed after ${MAX_RETRIES} retries`,
-          context.messageType,
-          context.messageId,
-          err
-        );
-
-        captureEvent('party.mongo_save_failed', {
-          sessionId: context.sessionId,
-          campaignId: context.campaignId,
-          messageType: context.messageType,
-          messageId: context.messageId,
-          errorMessage: err instanceof Error ? err.message : String(err),
-          errorName: err instanceof Error ? err.name : undefined,
-        });
-
-        onExhausted?.(context, err);
-        return null;
+        return exhaust(context, err, onExhausted);
       }
 
       const delay = retryDelayMs(attempt);

--- a/app/utils/retryMutation.ts
+++ b/app/utils/retryMutation.ts
@@ -1,6 +1,9 @@
 import { captureEvent } from '~/utils/posthog-client';
+import { isBackendDown, whenBackendUp } from '~/utils/backend-health';
 
-const RETRY_DELAY_MS = 5_000;
+const INITIAL_RETRY_DELAY_MS = 1_000;
+const MAX_RETRY_DELAY_MS = 30_000;
+const JITTER_RATIO = 0.2;
 const MAX_RETRIES = 12;
 
 export interface RetryContext {
@@ -12,12 +15,22 @@ export interface RetryContext {
 
 export type OnRetriesExhausted = (context: RetryContext, error: unknown) => void;
 
+/** Exponential backoff with ±20% jitter so retries from many clients desynchronize. */
+function retryDelayMs(attempt: number): number {
+  const base = Math.min(INITIAL_RETRY_DELAY_MS * 2 ** attempt, MAX_RETRY_DELAY_MS);
+  const jitterFactor = 1 + (Math.random() * 2 - 1) * JITTER_RATIO;
+  return Math.round(base * jitterFactor);
+}
+
 export async function withRetry<T>(
   fn: () => Promise<T>,
   context: RetryContext,
   onExhausted?: OnRetriesExhausted
 ): Promise<T | null> {
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    // While the circuit breaker is open, sending the request is pointless —
+    // wait for recovery instead of burning an attempt against a dead backend.
+    if (isBackendDown()) await whenBackendUp();
     try {
       return await fn();
     } catch (err) {
@@ -42,13 +55,14 @@ export async function withRetry<T>(
         return null;
       }
 
+      const delay = retryDelayMs(attempt);
       console.warn(
-        `[Save] Attempt ${attempt + 1} failed, retrying in ${RETRY_DELAY_MS}ms`,
+        `[Save] Attempt ${attempt + 1} failed, retrying in ${delay}ms`,
         context.messageType,
         context.messageId
       );
 
-      await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+      await new Promise((r) => setTimeout(r, delay));
     }
   }
   return null;

--- a/app/utils/uploadToR2.ts
+++ b/app/utils/uploadToR2.ts
@@ -1,36 +1,39 @@
-import { createServerFn } from '@tanstack/react-start'
-import { captureException } from '~/providers/PostHogProvider'
-import { getUploadUrlSchema } from '~/types/schemas/uploads'
+import { createServerFn } from '@tanstack/react-start';
+import { captureException } from '~/providers/PostHogProvider';
+import { getUploadUrlSchema } from '~/types/schemas/uploads';
+import { isBackendDown } from '~/utils/backend-health';
+import { BackendUnavailableError } from '~/utils/error-classification';
 
 const getUploadUrlFn = createServerFn({ method: 'POST' })
   .inputValidator(getUploadUrlSchema)
   .handler(async ({ data }) => {
-    const { getUploadUrl } = await import('~/server/functions/uploads')
-    return getUploadUrl({ data })
-  })
+    const { getUploadUrl } = await import('~/server/functions/uploads');
+    return getUploadUrl({ data });
+  });
 
 export async function uploadToR2(
   file: File,
-  subdir = 'uploads/campaigns',
+  subdir = 'uploads/campaigns'
 ): Promise<{ imageKey: string; publicUrl: string }> {
+  if (isBackendDown()) throw new BackendUnavailableError();
   try {
     const { uploadUrl, imageKey, publicUrl } = await getUploadUrlFn({
       data: { contentType: file.type, subdir },
-    })
+    });
 
     const response = await fetch(uploadUrl, {
       method: 'PUT',
       headers: { 'Content-Type': file.type },
       body: file,
-    })
+    });
 
     if (!response.ok) {
-      throw new Error(`R2 upload failed: ${response.status}`)
+      throw new Error(`R2 upload failed: ${response.status}`);
     }
 
-    return { imageKey, publicUrl }
+    return { imageKey, publicUrl };
   } catch (e) {
-    captureException(e, { action: 'uploadToR2', fileName: file.name, fileSize: file.size })
-    throw e
+    captureException(e, { action: 'uploadToR2', fileName: file.name, fileSize: file.size });
+    throw e;
   }
 }

--- a/app/utils/uploadToR2.ts
+++ b/app/utils/uploadToR2.ts
@@ -1,7 +1,7 @@
 import { createServerFn } from '@tanstack/react-start';
 import { captureException } from '~/providers/PostHogProvider';
 import { getUploadUrlSchema } from '~/types/schemas/uploads';
-import { isBackendDown } from '~/utils/backend-health';
+import { isBackendDown, reportBackendFailure } from '~/utils/backend-health';
 import { BackendUnavailableError } from '~/utils/error-classification';
 
 const getUploadUrlFn = createServerFn({ method: 'POST' })
@@ -33,6 +33,7 @@ export async function uploadToR2(
 
     return { imageKey, publicUrl };
   } catch (e) {
+    reportBackendFailure(e);
     captureException(e, { action: 'uploadToR2', fileName: file.name, fileSize: file.size });
     throw e;
   }

--- a/tests/components/ConnectionBanner.test.tsx
+++ b/tests/components/ConnectionBanner.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { BackendHealthSnapshot } from '~/utils/backend-health';
+
+const { store } = vi.hoisted(() => {
+  const listeners = new Set<() => void>();
+  let snapshot: BackendHealthSnapshot = { down: false, downSinceMs: null };
+  return {
+    store: {
+      listeners,
+      subscribe(listener: () => void) {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+      getSnapshot: () => snapshot,
+      set(next: BackendHealthSnapshot) {
+        snapshot = next;
+        for (const listener of listeners) listener();
+      },
+    },
+  };
+});
+
+vi.mock('~/utils/backend-health', () => ({
+  subscribeBackendHealth: store.subscribe,
+  getBackendHealthSnapshot: store.getSnapshot,
+}));
+
+import { ConnectionBanner } from '~/components/ConnectionBanner';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  store.set({ down: false, downSinceMs: null });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('ConnectionBanner', () => {
+  it('renders nothing while healthy', () => {
+    const { container } = render(<ConnectionBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the outage banner while the breaker is open', () => {
+    render(<ConnectionBanner />);
+    act(() => store.set({ down: true, downSinceMs: 0 }));
+    expect(screen.getByRole('status')).toHaveTextContent('Connection lost — reconnecting…');
+  });
+
+  it('flashes "Reconnected" for 2s after recovery, then clears', () => {
+    render(<ConnectionBanner />);
+    act(() => store.set({ down: true, downSinceMs: 0 }));
+    act(() => store.set({ down: false, downSinceMs: null }));
+    expect(screen.getByRole('status')).toHaveTextContent('Reconnected');
+    act(() => vi.advanceTimersByTime(2_000));
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+});

--- a/tests/providers/QueryProvider.test.tsx
+++ b/tests/providers/QueryProvider.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockReportFailure, mockReportSuccess } = vi.hoisted(() => ({
+  mockReportFailure: vi.fn(),
+  mockReportSuccess: vi.fn(),
+}));
+
+vi.mock('~/utils/backend-health', () => ({
+  reportBackendFailure: mockReportFailure,
+  reportBackendSuccess: mockReportSuccess,
+}));
+
+import { getQueryClient } from '~/providers/QueryProvider';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('QueryProvider defaults', () => {
+  it('retries infrastructure failures exactly once', () => {
+    const retry = getQueryClient().getDefaultOptions().queries?.retry;
+    expect(typeof retry).toBe('function');
+    const retryFn = retry as (count: number, error: Error) => boolean;
+    const infra = new TypeError('Failed to fetch');
+    expect(retryFn(0, infra)).toBe(true);
+    expect(retryFn(1, infra)).toBe(false);
+  });
+
+  it('never retries application errors', () => {
+    const retryFn = getQueryClient().getDefaultOptions().queries?.retry as (
+      count: number,
+      error: Error
+    ) => boolean;
+    expect(retryFn(0, new Error('Screen not found'))).toBe(false);
+    expect(retryFn(0, Object.assign(new Error('unauthorized'), { status: 401 }))).toBe(false);
+  });
+
+  it('query and mutation cache callbacks feed the breaker', () => {
+    const client = getQueryClient();
+    const err = new TypeError('Failed to fetch');
+    // The cache config callbacks are invoked by TanStack internals; call them
+    // directly here to verify the wiring without spinning up real fetches.
+    client.getQueryCache().config.onError?.(err, {} as never);
+    client.getMutationCache().config.onError?.(err, undefined, undefined, {} as never);
+    expect(mockReportFailure).toHaveBeenCalledTimes(2);
+    client.getQueryCache().config.onSuccess?.({}, {} as never);
+    client.getMutationCache().config.onSuccess?.({}, undefined, undefined, {} as never);
+    expect(mockReportSuccess).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/providers/QueryProvider.test.tsx
+++ b/tests/providers/QueryProvider.test.tsx
@@ -41,10 +41,12 @@ describe('QueryProvider defaults', () => {
     // The cache config callbacks are invoked by TanStack internals; call them
     // directly here to verify the wiring without spinning up real fetches.
     client.getQueryCache().config.onError?.(err, {} as never);
-    client.getMutationCache().config.onError?.(err, undefined, undefined, {} as never);
+    client.getMutationCache().config.onError?.(err, undefined, undefined, {} as never, {} as never);
     expect(mockReportFailure).toHaveBeenCalledTimes(2);
     client.getQueryCache().config.onSuccess?.({}, {} as never);
-    client.getMutationCache().config.onSuccess?.({}, undefined, undefined, {} as never);
+    client
+      .getMutationCache()
+      .config.onSuccess?.({}, undefined, undefined, {} as never, {} as never);
     expect(mockReportSuccess).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/server/db/connection.test.ts
+++ b/tests/server/db/connection.test.ts
@@ -1,15 +1,15 @@
-import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
 
 const mongooseMock = vi.hoisted(() => ({
   connect: vi.fn().mockResolvedValue(undefined),
   connection: { readyState: 0 },
   models: {},
-}))
+}));
 
 const bootstrapMock = vi.hoisted(() => ({
   bootstrapDB: vi.fn().mockResolvedValue(undefined),
   isBootstrapped: vi.fn().mockReturnValue(false),
-}))
+}));
 
 const policyMock = vi.hoisted(() => ({
   getBootstrapPolicy: vi.fn().mockReturnValue({
@@ -20,27 +20,27 @@ const policyMock = vi.hoisted(() => ({
     autoIndex: true,
     timeoutMs: 30_000,
   }),
-}))
+}));
 
-vi.mock('mongoose', () => ({ default: mongooseMock }))
-vi.mock('~/server/db/bootstrap', () => bootstrapMock)
-vi.mock('~/server/db/policy', () => policyMock)
+vi.mock('mongoose', () => ({ default: mongooseMock }));
+vi.mock('~/server/db/bootstrap', () => bootstrapMock);
+vi.mock('~/server/db/policy', () => policyMock);
 vi.mock('~/server/utils/posthog', () => ({
   serverCaptureException: vi.fn(),
-}))
+}));
 
-import { connectDB, isDBConnected, __resetConnectPromiseForTests } from '~/server/db/connection'
+import { connectDB, isDBConnected, __resetConnectPromiseForTests } from '~/server/db/connection';
 
-const originalMongoUri = process.env.MONGODB_URI
+const originalMongoUri = process.env.MONGODB_URI;
 
 describe('connectDB', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-    __resetConnectPromiseForTests()
-    mongooseMock.connect.mockResolvedValue(undefined)
-    mongooseMock.connection.readyState = 0
-    bootstrapMock.isBootstrapped.mockReturnValue(false)
-    bootstrapMock.bootstrapDB.mockResolvedValue(undefined)
+    vi.clearAllMocks();
+    __resetConnectPromiseForTests();
+    mongooseMock.connect.mockResolvedValue(undefined);
+    mongooseMock.connection.readyState = 0;
+    bootstrapMock.isBootstrapped.mockReturnValue(false);
+    bootstrapMock.bootstrapDB.mockResolvedValue(undefined);
     policyMock.getBootstrapPolicy.mockReturnValue({
       environment: 'development',
       syncIndexes: true,
@@ -48,26 +48,26 @@ describe('connectDB', () => {
       failOnCriticalDrift: false,
       autoIndex: true,
       timeoutMs: 30_000,
-    })
-    process.env.MONGODB_URI = 'mongodb://localhost/test'
-  })
+    });
+    process.env.MONGODB_URI = 'mongodb://localhost/test';
+  });
 
   afterAll(() => {
     if (originalMongoUri === undefined) {
-      delete process.env.MONGODB_URI
+      delete process.env.MONGODB_URI;
     } else {
-      process.env.MONGODB_URI = originalMongoUri
+      process.env.MONGODB_URI = originalMongoUri;
     }
-  })
+  });
 
   it('connects and bootstraps on first call', async () => {
-    await connectDB()
+    await connectDB();
 
     expect(mongooseMock.connect).toHaveBeenCalledWith('mongodb://localhost/test', {
       autoIndex: true,
-    })
-    expect(bootstrapMock.bootstrapDB).toHaveBeenCalledTimes(1)
-  })
+    });
+    expect(bootstrapMock.bootstrapDB).toHaveBeenCalledTimes(1);
+  });
 
   it('uses autoIndex from the resolved policy', async () => {
     policyMock.getBootstrapPolicy.mockReturnValue({
@@ -77,14 +77,14 @@ describe('connectDB', () => {
       failOnCriticalDrift: true,
       autoIndex: false,
       timeoutMs: 10_000,
-    })
+    });
 
-    await connectDB()
+    await connectDB();
 
     expect(mongooseMock.connect).toHaveBeenCalledWith('mongodb://localhost/test', {
       autoIndex: false,
-    })
-  })
+    });
+  });
 
   it('passes the resolved policy to bootstrapDB', async () => {
     const policy = {
@@ -94,103 +94,116 @@ describe('connectDB', () => {
       failOnCriticalDrift: false,
       autoIndex: false,
       timeoutMs: 15_000,
-    }
-    policyMock.getBootstrapPolicy.mockReturnValue(policy)
+    };
+    policyMock.getBootstrapPolicy.mockReturnValue(policy);
 
-    await connectDB()
+    await connectDB();
 
-    expect(bootstrapMock.bootstrapDB).toHaveBeenCalledWith(policy)
-  })
+    expect(bootstrapMock.bootstrapDB).toHaveBeenCalledWith(policy);
+  });
 
   it('skips connect but retries bootstrap when already connected and bootstrap failed', async () => {
-    mongooseMock.connection.readyState = 1
-    bootstrapMock.isBootstrapped.mockReturnValue(false)
+    mongooseMock.connection.readyState = 1;
+    bootstrapMock.isBootstrapped.mockReturnValue(false);
 
-    await connectDB()
+    await connectDB();
 
-    expect(mongooseMock.connect).not.toHaveBeenCalled()
-    expect(bootstrapMock.bootstrapDB).toHaveBeenCalledTimes(1)
-  })
+    expect(mongooseMock.connect).not.toHaveBeenCalled();
+    expect(bootstrapMock.bootstrapDB).toHaveBeenCalledTimes(1);
+  });
 
   it('skips both connect and bootstrap when already connected and bootstrapped', async () => {
-    mongooseMock.connection.readyState = 1
-    bootstrapMock.isBootstrapped.mockReturnValue(true)
+    mongooseMock.connection.readyState = 1;
+    bootstrapMock.isBootstrapped.mockReturnValue(true);
 
-    await connectDB()
+    await connectDB();
 
-    expect(mongooseMock.connect).not.toHaveBeenCalled()
-    expect(bootstrapMock.bootstrapDB).not.toHaveBeenCalled()
-  })
+    expect(mongooseMock.connect).not.toHaveBeenCalled();
+    expect(bootstrapMock.bootstrapDB).not.toHaveBeenCalled();
+  });
 
   it('returns early when MONGODB_URI is not set', async () => {
-    delete process.env.MONGODB_URI
+    delete process.env.MONGODB_URI;
 
-    await connectDB()
+    await connectDB();
 
-    expect(mongooseMock.connect).not.toHaveBeenCalled()
-    expect(bootstrapMock.bootstrapDB).not.toHaveBeenCalled()
-  })
+    expect(mongooseMock.connect).not.toHaveBeenCalled();
+    expect(bootstrapMock.bootstrapDB).not.toHaveBeenCalled();
+  });
 
   it('waits for in-flight connection when readyState is 2 (connecting)', async () => {
-    let resolveConnect!: () => void
+    let resolveConnect!: () => void;
     mongooseMock.connect.mockImplementation(
       () =>
         new Promise<void>((resolve) => {
-          mongooseMock.connection.readyState = 2
+          mongooseMock.connection.readyState = 2;
           resolveConnect = () => {
-            mongooseMock.connection.readyState = 1
-            resolve()
-          }
-        }),
-    )
+            mongooseMock.connection.readyState = 1;
+            resolve();
+          };
+        })
+    );
 
-    const first = connectDB()
-    const second = connectDB()
+    const first = connectDB();
+    const second = connectDB();
 
-    resolveConnect()
-    await Promise.all([first, second])
+    resolveConnect();
+    await Promise.all([first, second]);
 
-    expect(mongooseMock.connect).toHaveBeenCalledTimes(1)
-    expect(bootstrapMock.bootstrapDB).toHaveBeenCalled()
-  })
+    expect(mongooseMock.connect).toHaveBeenCalledTimes(1);
+    expect(bootstrapMock.bootstrapDB).toHaveBeenCalled();
+  });
 
   it('shares one connect attempt when two callers race before readyState flips', async () => {
-    let resolveConnect!: () => void
+    let resolveConnect!: () => void;
     mongooseMock.connect.mockImplementation(
       () =>
         new Promise<void>((resolve) => {
           resolveConnect = () => {
-            mongooseMock.connection.readyState = 1
-            resolve()
-          }
-        }),
-    )
+            mongooseMock.connection.readyState = 1;
+            resolve();
+          };
+        })
+    );
 
-    const first = connectDB()
-    const second = connectDB()
+    const first = connectDB();
+    const second = connectDB();
 
-    resolveConnect()
-    await Promise.all([first, second])
+    resolveConnect();
+    await Promise.all([first, second]);
 
-    expect(mongooseMock.connect).toHaveBeenCalledTimes(1)
-    expect(bootstrapMock.bootstrapDB).toHaveBeenCalled()
-  })
+    expect(mongooseMock.connect).toHaveBeenCalledTimes(1);
+    expect(bootstrapMock.bootstrapDB).toHaveBeenCalled();
+  });
 
   it('rethrows errors from bootstrap', async () => {
-    bootstrapMock.bootstrapDB.mockRejectedValueOnce(new Error('bootstrap failed'))
+    bootstrapMock.bootstrapDB.mockRejectedValueOnce(new Error('bootstrap failed'));
 
-    await expect(connectDB()).rejects.toThrow('bootstrap failed')
-  })
-})
+    await expect(connectDB()).rejects.toThrow('bootstrap failed');
+  });
+
+  it('tags a rethrown connect error with status 503 when it has no own status', async () => {
+    mongooseMock.connect.mockRejectedValueOnce(new Error('connect ECONNREFUSED'));
+
+    await expect(connectDB()).rejects.toMatchObject({ status: 503 });
+  });
+
+  it('does not overwrite an existing status on the rethrown error', async () => {
+    const err = Object.assign(new Error('boom'), { status: 401 });
+    mongooseMock.connect.mockRejectedValueOnce(err);
+
+    await expect(connectDB()).rejects.toMatchObject({ status: 401 });
+  });
+});
 
 describe('isDBConnected', () => {
   it('returns true when readyState is 1', () => {
-    mongooseMock.connection.readyState = 1
-    expect(isDBConnected()).toBe(true)
-  })
+    mongooseMock.connection.readyState = 1;
+    expect(isDBConnected()).toBe(true);
+  });
 
   it('returns false when readyState is 0', () => {
-    mongooseMock.connection.readyState = 0
-    expect(isDBConnected()).toBe(false)
-  })
-})
+    mongooseMock.connection.readyState = 0;
+    expect(isDBConnected()).toBe(false);
+  });
+});

--- a/tests/server/functions/health.test.ts
+++ b/tests/server/functions/health.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockCommand, mockConnectDB, mockIsDBConnected } = vi.hoisted(() => ({
+  mockCommand: vi.fn(),
+  mockConnectDB: vi.fn(),
+  mockIsDBConnected: vi.fn(),
+}));
+
+vi.mock('mongoose', () => ({
+  default: {
+    connection: {
+      get db() {
+        return { admin: () => ({ command: mockCommand }) };
+      },
+    },
+  },
+}));
+
+vi.mock('~/server/db/connection', () => ({
+  connectDB: mockConnectDB,
+  isDBConnected: mockIsDBConnected,
+}));
+
+import { healthCheck } from '~/server/functions/health';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsDBConnected.mockReturnValue(true);
+  mockCommand.mockResolvedValue({ ok: 1 });
+});
+
+describe('healthCheck', () => {
+  it('connects, pings Mongo, and reports ok', async () => {
+    await expect(healthCheck()).resolves.toEqual({ ok: true });
+    expect(mockConnectDB).toHaveBeenCalled();
+    expect(mockCommand).toHaveBeenCalledWith({ ping: 1 });
+  });
+
+  it('throws when the DB is not connected', async () => {
+    mockIsDBConnected.mockReturnValue(false);
+    await expect(healthCheck()).rejects.toThrow('Database not connected');
+    expect(mockCommand).not.toHaveBeenCalled();
+  });
+
+  it('propagates ping failures', async () => {
+    mockCommand.mockRejectedValue(new Error('no reachable servers'));
+    await expect(healthCheck()).rejects.toThrow('no reachable servers');
+  });
+});

--- a/tests/server/functions/health.test.ts
+++ b/tests/server/functions/health.test.ts
@@ -1,16 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockCommand, mockConnectDB, mockIsDBConnected } = vi.hoisted(() => ({
+const { mockCommand, mockConnectDB, mockIsDBConnected, mongooseState } = vi.hoisted(() => ({
   mockCommand: vi.fn(),
   mockConnectDB: vi.fn(),
   mockIsDBConnected: vi.fn(),
+  mongooseState: { db: undefined as unknown },
 }));
 
 vi.mock('mongoose', () => ({
   default: {
     connection: {
       get db() {
-        return { admin: () => ({ command: mockCommand }) };
+        return mongooseState.db;
       },
     },
   },
@@ -27,6 +28,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockIsDBConnected.mockReturnValue(true);
   mockCommand.mockResolvedValue({ ok: 1 });
+  mongooseState.db = { admin: () => ({ command: mockCommand }) };
 });
 
 describe('healthCheck', () => {
@@ -40,6 +42,22 @@ describe('healthCheck', () => {
     mockIsDBConnected.mockReturnValue(false);
     await expect(healthCheck()).rejects.toThrow('Database not connected');
     expect(mockCommand).not.toHaveBeenCalled();
+  });
+
+  it('tags the "not connected" error with status 503 when isDBConnected is false', async () => {
+    mockIsDBConnected.mockReturnValue(false);
+    await expect(healthCheck()).rejects.toMatchObject({
+      status: 503,
+      message: 'Database not connected',
+    });
+  });
+
+  it('tags the "not connected" error with status 503 when mongoose.connection.db is undefined', async () => {
+    mongooseState.db = undefined;
+    await expect(healthCheck()).rejects.toMatchObject({
+      status: 503,
+      message: 'Database not connected',
+    });
   });
 
   it('propagates ping failures', async () => {

--- a/tests/utils/backend-health.test.ts
+++ b/tests/utils/backend-health.test.ts
@@ -1,0 +1,128 @@
+// tests/utils/backend-health.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// backend-health imports the healthCheck RPC wrapper at module level for the
+// production singleton; stub it so this test never evaluates rpc.ts.
+vi.mock('~/server/functions/rpc', () => ({ healthCheck: vi.fn() }));
+
+import { createBackendHealth, type BackendHealthDeps } from '~/utils/backend-health';
+
+function makeDeps(overrides: Partial<BackendHealthDeps> = {}) {
+  return {
+    probe: vi.fn().mockResolvedValue({ ok: true }),
+    setOnline: vi.fn(),
+    capture: vi.fn(),
+    now: () => Date.now(),
+    ...overrides,
+  };
+}
+
+function networkError() {
+  return new TypeError('Failed to fetch');
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('createBackendHealth', () => {
+  it('opens after 5 consecutive infrastructure failures: goes offline, notifies, captures one event', () => {
+    const deps = makeDeps();
+    const health = createBackendHealth(deps);
+    const listener = vi.fn();
+    health.subscribe(listener);
+
+    for (let i = 0; i < 5; i++) health.reportFailure(networkError());
+
+    expect(health.isDown()).toBe(true);
+    expect(deps.setOnline).toHaveBeenCalledExactlyOnceWith(false);
+    expect(deps.capture).toHaveBeenCalledExactlyOnceWith('backend_circuit_opened', {
+      consecutive_failures: 5,
+      trigger_error_name: 'TypeError',
+    });
+    expect(listener).toHaveBeenCalled();
+  });
+
+  it('ignores application errors entirely', () => {
+    const deps = makeDeps();
+    const health = createBackendHealth(deps);
+    for (let i = 0; i < 10; i++) health.reportFailure(new Error('not found'));
+    expect(health.isDown()).toBe(false);
+    expect(deps.setOnline).not.toHaveBeenCalled();
+  });
+
+  it('a success between failures prevents tripping', () => {
+    const deps = makeDeps();
+    const health = createBackendHealth(deps);
+    for (let i = 0; i < 4; i++) health.reportFailure(networkError());
+    health.reportSuccess();
+    for (let i = 0; i < 4; i++) health.reportFailure(networkError());
+    expect(health.isDown()).toBe(false);
+  });
+
+  it('recovers via probe: goes back online and captures downtime', async () => {
+    const deps = makeDeps();
+    const health = createBackendHealth(deps);
+    for (let i = 0; i < 5; i++) health.reportFailure(networkError());
+    (deps.capture as ReturnType<typeof vi.fn>).mockClear();
+
+    await vi.advanceTimersByTimeAsync(5_000); // first probe fires and succeeds
+
+    expect(health.isDown()).toBe(false);
+    expect(deps.setOnline).toHaveBeenLastCalledWith(true);
+    expect(deps.capture).toHaveBeenCalledExactlyOnceWith('backend_circuit_closed', {
+      downtime_ms: 5_000,
+      probe_attempts: 1,
+    });
+  });
+
+  it('failed probes back off (5s, 10s, 20s...) and stay down', async () => {
+    const probe = vi.fn().mockRejectedValue(networkError());
+    const deps = makeDeps({ probe });
+    const health = createBackendHealth(deps);
+    for (let i = 0; i < 5; i++) health.reportFailure(networkError());
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(probe).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(probe).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(probe).toHaveBeenCalledTimes(3);
+    expect(health.isDown()).toBe(true);
+
+    probe.mockResolvedValue({ ok: true });
+    await vi.advanceTimersByTimeAsync(40_000);
+    expect(health.isDown()).toBe(false);
+  });
+
+  it('whenUp resolves immediately when up and on recovery when down', async () => {
+    const deps = makeDeps();
+    const health = createBackendHealth(deps);
+    await expect(health.whenUp()).resolves.toBeUndefined();
+
+    for (let i = 0; i < 5; i++) health.reportFailure(networkError());
+    const resolved = vi.fn();
+    void health.whenUp().then(resolved);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(5_000); // probe succeeds
+    expect(resolved).toHaveBeenCalled();
+  });
+
+  it('getSnapshot returns a stable reference between transitions', () => {
+    const health = createBackendHealth(makeDeps());
+    const a = health.getSnapshot();
+    expect(health.getSnapshot()).toBe(a);
+    for (let i = 0; i < 5; i++) health.reportFailure(networkError());
+    const b = health.getSnapshot();
+    expect(b).not.toBe(a);
+    expect(b).toEqual({ down: true, downSinceMs: 0 });
+    expect(health.getSnapshot()).toBe(b);
+  });
+});

--- a/tests/utils/backend-health.test.ts
+++ b/tests/utils/backend-health.test.ts
@@ -125,4 +125,41 @@ describe('createBackendHealth', () => {
     expect(b).toEqual({ down: true, downSinceMs: 0 });
     expect(health.getSnapshot()).toBe(b);
   });
+
+  describe('browser online events while the breaker is open', () => {
+    it('re-asserts offline when the browser fires online while the breaker is open', () => {
+      let onlineListener: ((online: boolean) => void) | undefined;
+      const deps = makeDeps({
+        subscribeOnline: (listener) => {
+          onlineListener = listener;
+        },
+      });
+      const health = createBackendHealth(deps);
+
+      for (let i = 0; i < 5; i++) health.reportFailure(networkError());
+      expect(deps.setOnline).toHaveBeenLastCalledWith(false);
+      (deps.setOnline as ReturnType<typeof vi.fn>).mockClear();
+
+      // Simulate a laptop wake / Wi-Fi switch firing the browser's online event.
+      onlineListener?.(true);
+
+      expect(deps.setOnline).toHaveBeenCalledWith(false);
+      expect(health.isDown()).toBe(true);
+    });
+
+    it('does not force offline from the online subscription when the breaker is closed', () => {
+      let onlineListener: ((online: boolean) => void) | undefined;
+      const deps = makeDeps({
+        subscribeOnline: (listener) => {
+          onlineListener = listener;
+        },
+      });
+      const health = createBackendHealth(deps);
+
+      onlineListener?.(true);
+
+      expect(deps.setOnline).not.toHaveBeenCalled();
+      expect(health.isDown()).toBe(false);
+    });
+  });
 });

--- a/tests/utils/backend-health.test.ts
+++ b/tests/utils/backend-health.test.ts
@@ -126,6 +126,83 @@ describe('createBackendHealth', () => {
     expect(health.getSnapshot()).toBe(b);
   });
 
+  describe('probe timeout', () => {
+    it('treats a probe that never settles as failed after probeTimeoutMs, then backs off and stays open', async () => {
+      const releaseProbes: Array<() => void> = [];
+      const probe = vi.fn(
+        () =>
+          new Promise((resolve) => {
+            releaseProbes.push(() => resolve({ ok: true }));
+          })
+      );
+      const deps = makeDeps({ probe, probeTimeoutMs: 10_000 });
+      const health = createBackendHealth(deps);
+      for (let i = 0; i < 5; i++) health.reportFailure(networkError());
+
+      await vi.advanceTimersByTimeAsync(5_000); // first probe fires (hangs)
+      expect(probe).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(10_000); // probe timeout elapses -> treated as failed
+      expect(health.isDown()).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(10_000); // next probe scheduled per backoff (10s)
+      expect(probe).toHaveBeenCalledTimes(2);
+      expect(health.isDown()).toBe(true);
+
+      // The stale first probe resolving after its timeout must not close the
+      // breaker, even though a second probe is now legitimately in flight.
+      releaseProbes[0]?.();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(health.isDown()).toBe(true);
+    });
+
+    it('behaves normally when the probe settles well within the timeout (2s)', async () => {
+      const probe = vi.fn(
+        () => new Promise((resolve) => setTimeout(() => resolve({ ok: true }), 2_000))
+      );
+      const deps = makeDeps({ probe, probeTimeoutMs: 10_000 });
+      const health = createBackendHealth(deps);
+      for (let i = 0; i < 5; i++) health.reportFailure(networkError());
+
+      await vi.advanceTimersByTimeAsync(5_000); // probe begins
+      await vi.advanceTimersByTimeAsync(2_000); // probe resolves well before the timeout
+      expect(health.isDown()).toBe(false);
+    });
+
+    it('defaults probeTimeoutMs to 10s when not provided', async () => {
+      const probe = vi.fn(() => new Promise(() => {})); // never settles
+      const deps = makeDeps({ probe });
+      const health = createBackendHealth(deps);
+      for (let i = 0; i < 5; i++) health.reportFailure(networkError());
+
+      await vi.advanceTimersByTimeAsync(5_000); // probe begins
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(probe).toHaveBeenCalledTimes(1); // still within default timeout, no reschedule yet
+      await vi.advanceTimersByTimeAsync(1);
+      // timeout elapsed -> probe treated as failed -> resolveProbe(false) -> stays open,
+      // backoff reschedules (10s) without throwing.
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(probe).toHaveBeenCalledTimes(2);
+      expect(health.isDown()).toBe(true);
+    });
+
+    it('does not reschedule when a side effect throws after the breaker already closed (freebie)', async () => {
+      const probe = vi.fn().mockResolvedValue({ ok: true });
+      const capture = vi.fn((event: string) => {
+        if (event === 'backend_circuit_closed') throw new Error('capture boom');
+      });
+      const deps = makeDeps({ probe, capture });
+      const health = createBackendHealth(deps);
+      for (let i = 0; i < 5; i++) health.reportFailure(networkError());
+
+      await vi.advanceTimersByTimeAsync(5_000); // probe fires, succeeds, capture throws
+      expect(probe).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(60_000); // no perpetual reschedule
+      expect(probe).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('browser online events while the breaker is open', () => {
     it('re-asserts offline when the browser fires online while the breaker is open', () => {
       let onlineListener: ((online: boolean) => void) | undefined;

--- a/tests/utils/circuit-breaker.test.ts
+++ b/tests/utils/circuit-breaker.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { createCircuitBreaker } from '~/utils/circuit-breaker';
+
+describe('createCircuitBreaker', () => {
+  it('starts closed and stays closed below the threshold', () => {
+    const cb = createCircuitBreaker({ failureThreshold: 5 });
+    for (let i = 0; i < 4; i++) expect(cb.recordFailure(i)).toBeNull();
+    expect(cb.state()).toBe('closed');
+    expect(cb.consecutiveFailures()).toBe(4);
+  });
+
+  it('opens on the Nth consecutive failure and reports it', () => {
+    const cb = createCircuitBreaker({ failureThreshold: 5 });
+    for (let i = 0; i < 4; i++) cb.recordFailure(i);
+    expect(cb.recordFailure(100)).toBe('opened');
+    expect(cb.state()).toBe('open');
+    expect(cb.openedAtMs()).toBe(100);
+  });
+
+  it('a success resets the consecutive count', () => {
+    const cb = createCircuitBreaker({ failureThreshold: 3 });
+    cb.recordFailure(0);
+    cb.recordFailure(1);
+    cb.recordSuccess();
+    cb.recordFailure(2);
+    cb.recordFailure(3);
+    expect(cb.state()).toBe('closed');
+    expect(cb.recordFailure(4)).toBe('opened');
+  });
+
+  it('failures while open or half-open are no-ops', () => {
+    const cb = createCircuitBreaker({ failureThreshold: 1 });
+    cb.recordFailure(0);
+    expect(cb.recordFailure(1)).toBeNull();
+    cb.beginProbe();
+    expect(cb.recordFailure(2)).toBeNull();
+    expect(cb.state()).toBe('half-open');
+  });
+
+  it('probe backoff doubles per failed probe and is capped', () => {
+    const cb = createCircuitBreaker({
+      failureThreshold: 1,
+      initialProbeDelayMs: 5_000,
+      probeBackoffFactor: 2,
+      maxProbeDelayMs: 60_000,
+    });
+    cb.recordFailure(0);
+    expect(cb.probeDelayMs()).toBe(5_000);
+    for (const expected of [10_000, 20_000, 40_000, 60_000, 60_000]) {
+      cb.beginProbe();
+      expect(cb.resolveProbe(false)).toBe('open');
+      expect(cb.probeDelayMs()).toBe(expected);
+    }
+    expect(cb.probeAttempts()).toBe(5);
+  });
+
+  it('a successful probe closes the breaker and resets failure state', () => {
+    const cb = createCircuitBreaker({ failureThreshold: 2 });
+    cb.recordFailure(0);
+    cb.recordFailure(1);
+    cb.beginProbe();
+    expect(cb.resolveProbe(true)).toBe('closed');
+    expect(cb.state()).toBe('closed');
+    expect(cb.consecutiveFailures()).toBe(0);
+    expect(cb.openedAtMs()).toBeNull();
+    // probeAttempts retained for telemetry until the next open
+    expect(cb.probeAttempts()).toBe(1);
+  });
+
+  it('re-opening after a recovery starts a fresh probe schedule', () => {
+    const cb = createCircuitBreaker({ failureThreshold: 1, initialProbeDelayMs: 5_000 });
+    cb.recordFailure(0);
+    cb.beginProbe();
+    cb.resolveProbe(false); // backoff now 10s
+    cb.beginProbe();
+    cb.resolveProbe(true); // closed
+    cb.recordFailure(100); // re-opened
+    expect(cb.probeDelayMs()).toBe(5_000);
+    expect(cb.probeAttempts()).toBe(0);
+  });
+
+  it('guards invalid transitions', () => {
+    const cb = createCircuitBreaker();
+    expect(() => cb.beginProbe()).toThrow();
+    expect(() => cb.resolveProbe(true)).toThrow();
+  });
+});

--- a/tests/utils/error-classification.test.ts
+++ b/tests/utils/error-classification.test.ts
@@ -70,6 +70,11 @@ describe('isInfrastructureFailure', () => {
     expect(isInfrastructureFailure(new Error('Topology is destroyed'))).toBe(true);
   });
 
+  it('classifies DB-disconnected messages that cross the wire untagged (status is dropped by seroval)', () => {
+    expect(isInfrastructureFailure(new Error('Database not connected'))).toBe(true);
+    expect(isInfrastructureFailure(new Error('upsertUser: database not connected'))).toBe(true);
+  });
+
   it('still does NOT classify ordinary app errors after the pattern extension', () => {
     expect(isInfrastructureFailure(new Error('Screen 42 not found in this campaign'))).toBe(false);
     expect(isInfrastructureFailure(new Error('unauthorized'))).toBe(false);

--- a/tests/utils/error-classification.test.ts
+++ b/tests/utils/error-classification.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { isInfrastructureFailure, BackendUnavailableError } from '~/utils/error-classification';
+
+describe('isInfrastructureFailure', () => {
+  it('classifies fetch network errors as infrastructure', () => {
+    expect(isInfrastructureFailure(new TypeError('Failed to fetch'))).toBe(true); // Chrome
+    expect(isInfrastructureFailure(new TypeError('Load failed'))).toBe(true); // Safari
+    expect(
+      isInfrastructureFailure(new TypeError('NetworkError when attempting to fetch resource.'))
+    ).toBe(true); // Firefox
+  });
+
+  it('classifies errors carrying a 5xx status as infrastructure', () => {
+    const err = Object.assign(new Error('Internal Server Error'), { status: 500 });
+    expect(isInfrastructureFailure(err)).toBe(true);
+    expect(isInfrastructureFailure(Object.assign(new Error('bad gateway'), { status: 502 }))).toBe(
+      true
+    );
+  });
+
+  it('classifies timeouts as infrastructure', () => {
+    const err = new Error('signal timed out');
+    err.name = 'TimeoutError';
+    expect(isInfrastructureFailure(err)).toBe(true);
+  });
+
+  it('does NOT classify application errors, 4xx, aborts, or non-errors', () => {
+    expect(isInfrastructureFailure(new Error('Screen not found in this campaign'))).toBe(false);
+    expect(isInfrastructureFailure(Object.assign(new Error('unauthorized'), { status: 401 }))).toBe(
+      false
+    );
+    const abort = new Error('aborted');
+    abort.name = 'AbortError';
+    expect(isInfrastructureFailure(abort)).toBe(false);
+    expect(isInfrastructureFailure('string error')).toBe(false);
+    expect(isInfrastructureFailure(null)).toBe(false);
+  });
+
+  it('does NOT classify BackendUnavailableError (never feeds the breaker its own output)', () => {
+    expect(isInfrastructureFailure(new BackendUnavailableError())).toBe(false);
+  });
+});
+
+describe('BackendUnavailableError', () => {
+  it('has a stable name and message', () => {
+    const err = new BackendUnavailableError();
+    expect(err.name).toBe('BackendUnavailableError');
+    expect(err.message).toBe('Backend temporarily unavailable — reconnecting');
+    expect(err).toBeInstanceOf(Error);
+  });
+});

--- a/tests/utils/error-classification.test.ts
+++ b/tests/utils/error-classification.test.ts
@@ -84,6 +84,40 @@ describe('isInfrastructureFailure', () => {
       )
     ).toBe(false);
   });
+
+  it('classifies a mid-session Mongo disconnect as infrastructure', () => {
+    expect(
+      isInfrastructureFailure(
+        new Error('Operation `campaigns.findOne()` buffering timed out after 10000ms')
+      )
+    ).toBe(true);
+    expect(
+      isInfrastructureFailure(new Error('MongoNetworkError: connection 4 to host:27017 closed'))
+    ).toBe(true);
+    expect(
+      isInfrastructureFailure(
+        new Error(
+          'PoolClearedError: connection pool for host:27017 was cleared because another operation failed with a network error'
+        )
+      )
+    ).toBe(true);
+    expect(isInfrastructureFailure(new Error('MongoClient must be connected'))).toBe(true);
+  });
+
+  it('classifies Vercel platform failure bodies as infrastructure', () => {
+    expect(isInfrastructureFailure(new Error('FUNCTION_INVOCATION_FAILED'))).toBe(true);
+    expect(isInfrastructureFailure(new Error('FUNCTION_INVOCATION_TIMEOUT'))).toBe(true);
+    expect(
+      isInfrastructureFailure(
+        new Error('A server error has occurred\n\nFUNCTION_INVOCATION_FAILED')
+      )
+    ).toBe(true);
+  });
+
+  it('does NOT classify the generic Vercel error text on its own, or unrelated "closed" copy', () => {
+    expect(isInfrastructureFailure(new Error('A server error has occurred'))).toBe(false);
+    expect(isInfrastructureFailure(new Error('The user closed the dialog'))).toBe(false);
+  });
 });
 
 describe('BackendUnavailableError', () => {

--- a/tests/utils/error-classification.test.ts
+++ b/tests/utils/error-classification.test.ts
@@ -39,6 +39,46 @@ describe('isInfrastructureFailure', () => {
   it('does NOT classify BackendUnavailableError (never feeds the breaker its own output)', () => {
     expect(isInfrastructureFailure(new BackendUnavailableError())).toBe(false);
   });
+
+  it('classifies proxy/platform error bodies rethrown by the server-fn fetcher', () => {
+    expect(isInfrastructureFailure(new Error('502 Bad Gateway'))).toBe(true);
+    expect(isInfrastructureFailure(new Error('503 Service Unavailable'))).toBe(true);
+    expect(isInfrastructureFailure(new Error('504 Gateway Timeout'))).toBe(true);
+    expect(isInfrastructureFailure(new Error('504 Gateway Time-out'))).toBe(true);
+    expect(isInfrastructureFailure(new Error('upstream connect error: gateway timeout'))).toBe(
+      true
+    );
+  });
+
+  it('classifies deploy-rollover manifest misses', () => {
+    expect(isInfrastructureFailure(new Error('Server function info not found.'))).toBe(true);
+  });
+
+  it('classifies Mongo/driver infra messages that cross the wire untagged', () => {
+    expect(isInfrastructureFailure(new Error('Server selection timed out after 30000 ms'))).toBe(
+      true
+    );
+    expect(isInfrastructureFailure(new Error('connect ECONNREFUSED 127.0.0.1:27017'))).toBe(true);
+    expect(isInfrastructureFailure(new Error('read ECONNRESET'))).toBe(true);
+    expect(isInfrastructureFailure(new Error('connect ETIMEDOUT'))).toBe(true);
+    expect(isInfrastructureFailure(new Error('queryA EAI_AGAIN cluster0.mongodb.net'))).toBe(true);
+    expect(isInfrastructureFailure(new Error('getaddrinfo ENOTFOUND cluster0.mongodb.net'))).toBe(
+      true
+    );
+    expect(isInfrastructureFailure(new Error('socket hang up'))).toBe(true);
+    expect(isInfrastructureFailure(new Error('topology was closed'))).toBe(true);
+    expect(isInfrastructureFailure(new Error('Topology is destroyed'))).toBe(true);
+  });
+
+  it('still does NOT classify ordinary app errors after the pattern extension', () => {
+    expect(isInfrastructureFailure(new Error('Screen 42 not found in this campaign'))).toBe(false);
+    expect(isInfrastructureFailure(new Error('unauthorized'))).toBe(false);
+    expect(
+      isInfrastructureFailure(
+        new Error('Invalid input: expected string, received number at "name"')
+      )
+    ).toBe(false);
+  });
 });
 
 describe('BackendUnavailableError', () => {

--- a/tests/utils/retryMutation.test.ts
+++ b/tests/utils/retryMutation.test.ts
@@ -5,14 +5,16 @@ vi.mock('~/utils/posthog-client', () => ({
   captureEvent: vi.fn(),
 }));
 
-const { mockIsBackendDown, mockWhenBackendUp } = vi.hoisted(() => ({
+const { mockIsBackendDown, mockWhenBackendUp, mockReportBackendFailure } = vi.hoisted(() => ({
   mockIsBackendDown: vi.fn(() => false),
   mockWhenBackendUp: vi.fn(() => Promise.resolve()),
+  mockReportBackendFailure: vi.fn(),
 }));
 
 vi.mock('~/utils/backend-health', () => ({
   isBackendDown: mockIsBackendDown,
   whenBackendUp: mockWhenBackendUp,
+  reportBackendFailure: mockReportBackendFailure,
 }));
 
 import { withRetry } from '~/utils/retryMutation';
@@ -46,7 +48,10 @@ describe('withRetry', () => {
   });
 
   it('retries on failure and succeeds', async () => {
-    const fn = vi.fn().mockRejectedValueOnce(new Error('fail')).mockResolvedValue('ok');
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValue('ok');
 
     const promise = withRetry(fn, ctx);
     await vi.advanceTimersByTimeAsync(1_000);
@@ -54,10 +59,11 @@ describe('withRetry', () => {
 
     expect(result).toBe('ok');
     expect(fn).toHaveBeenCalledTimes(2);
+    expect(mockReportBackendFailure).toHaveBeenCalledWith(expect.any(TypeError));
   });
 
   it('returns null and calls onExhausted after max retries', async () => {
-    const fn = vi.fn().mockRejectedValue(new Error('fail'));
+    const fn = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
     const onExhausted = vi.fn();
 
     const promise = withRetry(fn, ctx, onExhausted);
@@ -72,6 +78,34 @@ describe('withRetry', () => {
     expect(result).toBeNull();
     expect(fn).toHaveBeenCalledTimes(13);
     expect(onExhausted).toHaveBeenCalledWith(ctx, expect.any(Error));
+    expect(mockReportBackendFailure).toHaveBeenCalledWith(expect.any(TypeError));
+  });
+});
+
+describe('withRetry error classification', () => {
+  it('does not retry application errors — fails fast to the exhaustion path', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('validation failed'));
+    const onExhausted = vi.fn();
+
+    const result = await withRetry(fn, ctx, onExhausted);
+
+    expect(result).toBeNull();
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(onExhausted).toHaveBeenCalledWith(ctx, expect.any(Error));
+    expect(mockReportBackendFailure).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('still retries infrastructure errors with backoff', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValue('ok');
+
+    const promise = withRetry(fn, ctx);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(promise).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -79,9 +113,9 @@ describe('withRetry backoff', () => {
   it('uses exponential backoff between attempts (1s, 2s, 4s with jitter pinned to 1.0)', async () => {
     const fn = vi
       .fn()
-      .mockRejectedValueOnce(new Error('fail'))
-      .mockRejectedValueOnce(new Error('fail'))
-      .mockRejectedValueOnce(new Error('fail'))
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
       .mockResolvedValue('ok');
     const promise = withRetry(fn, ctx);
 
@@ -97,7 +131,7 @@ describe('withRetry backoff', () => {
   });
 
   it('caps the backoff at 30s', async () => {
-    const fn = vi.fn().mockRejectedValue(new Error('fail'));
+    const fn = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
     void withRetry(fn, ctx);
     // Attempts 1..12 fail; delays: 1,2,4,8,16,30,30,30,30,30,30,30 (s)
     await vi.advanceTimersByTimeAsync(0);
@@ -109,7 +143,10 @@ describe('withRetry backoff', () => {
 
   it('applies jitter within ±20% of the base delay', async () => {
     (Math.random as ReturnType<typeof vi.fn>).mockReturnValue(0); // jitter factor = 0.8
-    const fn = vi.fn().mockRejectedValueOnce(new Error('fail')).mockResolvedValue('ok');
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValue('ok');
     const promise = withRetry(fn, ctx);
     await vi.advanceTimersByTimeAsync(0);
     await vi.advanceTimersByTimeAsync(799);

--- a/tests/utils/retryMutation.test.ts
+++ b/tests/utils/retryMutation.test.ts
@@ -5,12 +5,25 @@ vi.mock('~/utils/posthog-client', () => ({
   captureEvent: vi.fn(),
 }));
 
+const { mockIsBackendDown, mockWhenBackendUp } = vi.hoisted(() => ({
+  mockIsBackendDown: vi.fn(() => false),
+  mockWhenBackendUp: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('~/utils/backend-health', () => ({
+  isBackendDown: mockIsBackendDown,
+  whenBackendUp: mockWhenBackendUp,
+}));
+
 import { withRetry } from '~/utils/retryMutation';
 import type { RetryContext } from '~/utils/retryMutation';
 
 beforeEach(() => {
   vi.clearAllMocks();
   vi.useFakeTimers();
+  mockIsBackendDown.mockReturnValue(false);
+  mockWhenBackendUp.mockReturnValue(Promise.resolve());
+  vi.spyOn(Math, 'random').mockReturnValue(0.5); // jitter factor = 1.0 exactly
 });
 
 afterEach(() => {
@@ -36,7 +49,7 @@ describe('withRetry', () => {
     const fn = vi.fn().mockRejectedValueOnce(new Error('fail')).mockResolvedValue('ok');
 
     const promise = withRetry(fn, ctx);
-    await vi.advanceTimersByTimeAsync(5000);
+    await vi.advanceTimersByTimeAsync(1_000);
     const result = await promise;
 
     expect(result).toBe('ok');
@@ -49,8 +62,9 @@ describe('withRetry', () => {
 
     const promise = withRetry(fn, ctx, onExhausted);
 
-    for (let i = 0; i < 12; i++) {
-      await vi.advanceTimersByTimeAsync(5000);
+    // Delays: 1,2,4,8,16,30,30,30,30,30,30,30 (s) — 12 retries after the initial attempt
+    for (const delaySec of [1, 2, 4, 8, 16, 30, 30, 30, 30, 30, 30, 30]) {
+      await vi.advanceTimersByTimeAsync(delaySec * 1_000);
     }
 
     const result = await promise;
@@ -58,5 +72,67 @@ describe('withRetry', () => {
     expect(result).toBeNull();
     expect(fn).toHaveBeenCalledTimes(13);
     expect(onExhausted).toHaveBeenCalledWith(ctx, expect.any(Error));
+  });
+});
+
+describe('withRetry backoff', () => {
+  it('uses exponential backoff between attempts (1s, 2s, 4s with jitter pinned to 1.0)', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValue('ok');
+    const promise = withRetry(fn, ctx);
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fn).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(fn).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(fn).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(fn).toHaveBeenCalledTimes(4);
+    await expect(promise).resolves.toBe('ok');
+  });
+
+  it('caps the backoff at 30s', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('fail'));
+    void withRetry(fn, ctx);
+    // Attempts 1..12 fail; delays: 1,2,4,8,16,30,30,30,30,30,30,30 (s)
+    await vi.advanceTimersByTimeAsync(0);
+    for (const delaySec of [1, 2, 4, 8, 16, 30, 30, 30, 30, 30, 30, 30]) {
+      await vi.advanceTimersByTimeAsync(delaySec * 1_000);
+    }
+    expect(fn).toHaveBeenCalledTimes(13); // initial + 12 retries
+  });
+
+  it('applies jitter within ±20% of the base delay', async () => {
+    (Math.random as ReturnType<typeof vi.fn>).mockReturnValue(0); // jitter factor = 0.8
+    const fn = vi.fn().mockRejectedValueOnce(new Error('fail')).mockResolvedValue('ok');
+    const promise = withRetry(fn, ctx);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(799);
+    expect(fn).toHaveBeenCalledTimes(1); // 800ms not yet elapsed
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fn).toHaveBeenCalledTimes(2);
+    await expect(promise).resolves.toBe('ok');
+  });
+
+  it('waits for the backend to come back before attempting while the breaker is open', async () => {
+    mockIsBackendDown.mockReturnValue(true);
+    let releaseBackend!: () => void;
+    mockWhenBackendUp.mockReturnValue(new Promise<void>((r) => (releaseBackend = r)));
+    const fn = vi.fn().mockResolvedValue('ok');
+
+    const promise = withRetry(fn, ctx);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fn).not.toHaveBeenCalled();
+
+    mockIsBackendDown.mockReturnValue(false);
+    releaseBackend();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fn).toHaveBeenCalledTimes(1);
+    await expect(promise).resolves.toBe('ok');
   });
 });

--- a/tests/utils/retryMutation.test.ts
+++ b/tests/utils/retryMutation.test.ts
@@ -19,6 +19,7 @@ vi.mock('~/utils/backend-health', () => ({
 
 import { withRetry } from '~/utils/retryMutation';
 import type { RetryContext } from '~/utils/retryMutation';
+import { captureEvent as captureEventMock } from '~/utils/posthog-client';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -171,5 +172,81 @@ describe('withRetry backoff', () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(fn).toHaveBeenCalledTimes(1);
     await expect(promise).resolves.toBe('ok');
+  });
+});
+
+describe('withRetry breaker-wait deadline', () => {
+  it('exhausts after ~120s if the breaker never recovers, without ever calling fn', async () => {
+    mockIsBackendDown.mockReturnValue(true);
+    mockWhenBackendUp.mockReturnValue(new Promise<void>(() => {})); // never resolves
+    const fn = vi.fn();
+    const onExhausted = vi.fn();
+
+    const promise = withRetry(fn, ctx, onExhausted);
+    await vi.advanceTimersByTimeAsync(120_000);
+    const result = await promise;
+
+    expect(result).toBeNull();
+    expect(fn).not.toHaveBeenCalled();
+    expect(onExhausted).toHaveBeenCalledWith(ctx, expect.any(Error));
+    expect(captureEventMock).toHaveBeenCalledWith(
+      'party.mongo_save_failed',
+      expect.objectContaining({
+        sessionId: ctx.sessionId,
+        campaignId: ctx.campaignId,
+        messageType: ctx.messageType,
+        messageId: ctx.messageId,
+      })
+    );
+  });
+
+  it('proceeds and succeeds if the breaker recovers before the deadline (30s)', async () => {
+    mockIsBackendDown.mockReturnValue(true);
+    let releaseBackend!: () => void;
+    mockWhenBackendUp.mockReturnValue(new Promise<void>((r) => (releaseBackend = r)));
+    const fn = vi.fn().mockResolvedValue('ok');
+
+    const promise = withRetry(fn, ctx);
+    await vi.advanceTimersByTimeAsync(30_000);
+    mockIsBackendDown.mockReturnValue(false);
+    releaseBackend();
+    await vi.advanceTimersByTimeAsync(0);
+
+    await expect(promise).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the healthy path unchanged', async () => {
+    mockIsBackendDown.mockReturnValue(false);
+    const fn = vi.fn().mockResolvedValue('ok');
+
+    const result = await withRetry(fn, ctx);
+
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(mockWhenBackendUp).not.toHaveBeenCalled();
+  });
+
+  it('ignores a stale whenBackendUp resolution that arrives after the deadline already exhausted', async () => {
+    mockIsBackendDown.mockReturnValue(true);
+    let releaseBackend!: () => void;
+    mockWhenBackendUp.mockReturnValue(new Promise<void>((r) => (releaseBackend = r)));
+    const fn = vi.fn().mockResolvedValue('ok');
+    const onExhausted = vi.fn();
+
+    const promise = withRetry(fn, ctx, onExhausted);
+    await vi.advanceTimersByTimeAsync(120_000); // deadline hits, exhausts
+
+    const result = await promise;
+    expect(result).toBeNull();
+    expect(fn).not.toHaveBeenCalled();
+    expect(onExhausted).toHaveBeenCalledTimes(1);
+
+    // Backend "recovers" after the fact — must not resume/resurrect the loop.
+    mockIsBackendDown.mockReturnValue(false);
+    releaseBackend();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fn).not.toHaveBeenCalled();
+    expect(onExhausted).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/utils/uploadToR2.test.ts
+++ b/tests/utils/uploadToR2.test.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockIsBackendDown, mockCaptureException, mockGetUploadUrl } = vi.hoisted(() => ({
-  mockIsBackendDown: vi.fn(() => false),
-  mockCaptureException: vi.fn(),
-  mockGetUploadUrl: vi.fn(),
-}));
+const { mockIsBackendDown, mockCaptureException, mockGetUploadUrl, mockReportBackendFailure } =
+  vi.hoisted(() => ({
+    mockIsBackendDown: vi.fn(() => false),
+    mockCaptureException: vi.fn(),
+    mockGetUploadUrl: vi.fn(),
+    mockReportBackendFailure: vi.fn(),
+  }));
 
-vi.mock('~/utils/backend-health', () => ({ isBackendDown: mockIsBackendDown }));
+vi.mock('~/utils/backend-health', () => ({
+  isBackendDown: mockIsBackendDown,
+  reportBackendFailure: mockReportBackendFailure,
+}));
 vi.mock('~/providers/PostHogProvider', () => ({ captureException: mockCaptureException }));
 vi.mock('@tanstack/react-start', () => ({
   createServerFn: () => ({
@@ -46,5 +51,19 @@ describe('uploadToR2 breaker guard', () => {
       publicUrl: 'https://cdn.example/k',
     });
     fetchSpy.mockRestore();
+  });
+
+  it('reports the failure to the circuit breaker before capturing the exception', async () => {
+    const error = new TypeError('Failed to fetch');
+    mockGetUploadUrl.mockRejectedValue(error);
+
+    await expect(uploadToR2(file)).rejects.toBe(error);
+
+    expect(mockReportBackendFailure).toHaveBeenCalledWith(error);
+    expect(mockCaptureException).toHaveBeenCalledWith(error, {
+      action: 'uploadToR2',
+      fileName: file.name,
+      fileSize: file.size,
+    });
   });
 });

--- a/tests/utils/uploadToR2.test.ts
+++ b/tests/utils/uploadToR2.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockIsBackendDown, mockCaptureException, mockGetUploadUrl } = vi.hoisted(() => ({
+  mockIsBackendDown: vi.fn(() => false),
+  mockCaptureException: vi.fn(),
+  mockGetUploadUrl: vi.fn(),
+}));
+
+vi.mock('~/utils/backend-health', () => ({ isBackendDown: mockIsBackendDown }));
+vi.mock('~/providers/PostHogProvider', () => ({ captureException: mockCaptureException }));
+vi.mock('@tanstack/react-start', () => ({
+  createServerFn: () => ({
+    inputValidator: () => ({ handler: () => mockGetUploadUrl }),
+  }),
+}));
+
+import { uploadToR2 } from '~/utils/uploadToR2';
+import { BackendUnavailableError } from '~/utils/error-classification';
+
+const file = new File(['content'], 'map.png', { type: 'image/png' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsBackendDown.mockReturnValue(false);
+});
+
+describe('uploadToR2 breaker guard', () => {
+  it('fails fast with BackendUnavailableError while the breaker is open, without calling the server or PostHog', async () => {
+    mockIsBackendDown.mockReturnValue(true);
+    await expect(uploadToR2(file)).rejects.toBeInstanceOf(BackendUnavailableError);
+    expect(mockGetUploadUrl).not.toHaveBeenCalled();
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('proceeds normally when the backend is healthy', async () => {
+    mockGetUploadUrl.mockResolvedValue({
+      uploadUrl: 'https://r2.example/put',
+      imageKey: 'k',
+      publicUrl: 'https://cdn.example/k',
+    });
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    await expect(uploadToR2(file)).resolves.toEqual({
+      imageKey: 'k',
+      publicUrl: 'https://cdn.example/k',
+    });
+    fetchSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Circuit breaker trips after 5 consecutive infrastructure failures and pauses ALL client traffic via TanStack `onlineManager`; browser `online` events are re-asserted offline while the breaker is open so a laptop wake can't un-pause traffic against a dead backend
- Recovery via a Mongo-ping `healthCheck` server fn probed on a 5s → 60s exponential backoff
- Error-aware retry: infrastructure failures retry once; application errors / 4xx never retry (queries AND the chat/dice `withRetry` loop)
- `withRetry`: exponential backoff + ±20% jitter (was fixed 5s × 12), waits out an open breaker, and feeds failures to the breaker; `uploadToR2` fails fast with `BackendUnavailableError` and feeds the breaker
- Persistent "Connection lost — reconnecting…" banner under the Topbar + 2s "Reconnected" flash on recovery
- Telemetry: exactly two events (`backend_circuit_opened` / `backend_circuit_closed`) — incident visibility with no event storm

## Verification
- 1423 unit tests pass (122 files); `tsc --noEmit` clean; prettier + eslint clean on all changed files
- Live smoke test against the dev server: breaker trips at exactly 5 failures, probe fires on backoff schedule, real `healthCheck` (Mongo ping) closes it
- Final whole-branch review + adversarial re-review passed; known minor follow-ups: double-feed when `uploadToR2` runs inside a mutation (earlier trip, no false positives), one-request burst can slip through per browser `online` event before the re-assert, `runProbe` catch could check breaker state before rescheduling, "after 12 retries" log copy on fail-fast path

🤖 Generated with [Claude Code](https://claude.com/claude-code)