### PR TITLE
fix(windows): restore minimized windows on GM screen and tabletop

### DIFF
--- a/app/components/mainview/FloatingWindowTray.tsx
+++ b/app/components/mainview/FloatingWindowTray.tsx
@@ -1,21 +1,28 @@
 export interface FloatingWindowTrayItem {
-  id: string
-  title: string
+  id: string;
+  title: string;
 }
 
 export interface FloatingWindowTrayProps {
-  windows: FloatingWindowTrayItem[]
-  onRestore: (id: string) => void
+  windows: FloatingWindowTrayItem[];
+  onRestore: (id: string) => void;
 }
 
 export function FloatingWindowTray({ windows, onRestore }: FloatingWindowTrayProps) {
   if (windows.length === 0) {
-    return null
+    return null;
   }
 
   return (
-    <div className="absolute bottom-4 left-4 z-30 flex flex-row gap-2" role="toolbar" aria-label="Minimized windows">
-      {windows.map(window => (
+    // pointer-events-auto opts back in to clicks: FloatingWindowManager sets
+    // pointer-events-none on its wrapper so empty space passes through to
+    // content below, which would otherwise make these buttons unclickable.
+    <div
+      className="pointer-events-auto absolute bottom-4 left-4 z-30 flex flex-row gap-2"
+      role="toolbar"
+      aria-label="Minimized windows"
+    >
+      {windows.map((window) => (
         <button
           key={window.id}
           type="button"
@@ -27,5 +34,5 @@ export function FloatingWindowTray({ windows, onRestore }: FloatingWindowTrayPro
         </button>
       ))}
     </div>
-  )
+  );
 }

--- a/tests/components/mainview/FloatingWindowManager.test.tsx
+++ b/tests/components/mainview/FloatingWindowManager.test.tsx
@@ -72,6 +72,17 @@ describe('FloatingWindowManager', () => {
     expect(screen.getByRole('button', { name: 'Restore Wiki' })).toBeInTheDocument();
   });
 
+  it('tray re-enables pointer events inside the pointer-events-none wrapper', () => {
+    // The manager wrapper is pointer-events-none so clicks pass through to
+    // content below (e.g. the active map). FloatingWindow opts back in with
+    // pointer-events-auto; the tray must do the same or its restore buttons
+    // are unclickable (regression: minimized windows could not be restored).
+    render(<ControlledManager />);
+
+    const tray = screen.getByRole('toolbar', { name: 'Minimized windows' });
+    expect(tray.className).toContain('pointer-events-auto');
+  });
+
   it('closing a window calls onWindowsChange without that window', async () => {
     const user = userEvent.setup();
     const onWindowsChange = vi.fn();


### PR DESCRIPTION
## Summary
- Regression: minimized windows on the GM screen (and tabletop) could not be clicked to restore.
- Root cause: fc19300 set `pointer-events-none` on the `FloatingWindowManager` wrapper so empty space passes clicks through to the active map. Each `FloatingWindow` opts back in with `pointer-events-auto`, but `FloatingWindowTray` (the minimized-window buttons) was missed, leaving the tray unclickable.
- Fix: add `pointer-events-auto` to the tray container, mirroring `FloatingWindow`. Since the tray is shared, this repairs both GM screens and the tabletop.

## Testing
- New regression test in `FloatingWindowManager.test.tsx` asserting the tray re-enables pointer events (fails without the fix; the existing tray click tests couldn't catch this because jsdom doesn't apply Tailwind CSS).
- Verified in a real browser via Storybook `ManagerDemo` + Playwright: minimize a window → tray button appears → click restores the window (real clicks enforce pointer-events).
- `npm test`: 1467 tests / 124 files pass; lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)