### PR TITLE
fix(deploy): prod Google OAuth client ID

### DIFF
--- a/deploy/charts/cartyx/values-prod.yaml
+++ b/deploy/charts/cartyx/values-prod.yaml
@@ -9,7 +9,7 @@ web:
     # OAuth client IDs are public identifiers (they appear in every auth
     # redirect URL) — fill in and commit; the SECRETS live in the
     # kubectl-created `cartyx` Secret (see README).
-    GOOGLE_CLIENT_ID: 771084537830-mqaa7q6rpe4k87nalgqlu7bu2lt8qam2.apps.googleusercontent.com
+    GOOGLE_CLIENT_ID: 771084537830-ivq72v3vhfmundul3lcflocfur5tfpqg.apps.googleusercontent.com
     # GitHub OAuth apps allow ONE callback host each — prod needs its own
     # OAuth app (callback https://app.cartyx.io/auth/callback/github).
     GITHUB_CLIENT_ID: Ov2limoxRabMkVtRi3x


### PR DESCRIPTION
values-prod.yaml had the DEV Google client ID (copied from .env). Prod's own client (`771084537830-ivq7…`, named cartyx.io) has had the app.cartyx.io redirect registered since March — Google login on prod failed with redirect_uri_mismatch. Secrets per namespace were already correct. Cluster is hot-patched + prod HelmRelease suspended until this reaches main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)