### PR TITLE
chore: rename leftover PartyKit log labels and comments to realtime

### DIFF
--- a/app/components/mainview/InspectorSidebar.tsx
+++ b/app/components/mainview/InspectorSidebar.tsx
@@ -145,7 +145,7 @@ export function InspectorSidebar({
     setSaveError: setDiceSaveError,
   } = useDiceRolls(viewingSessionId, effectiveCampaignId, isViewingActive);
 
-  // Combined PartyKit message handler
+  // Combined realtime message handler
   const handlePartyMessage = useCallback(
     (msg: unknown) => {
       handleChatPartyMessage(msg);

--- a/app/components/mainview/tabletop/TabletopView.tsx
+++ b/app/components/mainview/tabletop/TabletopView.tsx
@@ -174,7 +174,7 @@ export function TabletopView({
     setPings((prev) => prev.filter((p) => p.id !== id));
   }, []);
 
-  // PartyKit message handler
+  // Realtime message handler
   const handleMessage = useCallback(
     (msg: TabletopMessage) => {
       switch (msg.type) {

--- a/app/hooks/useChatMessages.ts
+++ b/app/hooks/useChatMessages.ts
@@ -70,7 +70,7 @@ export function useChatMessages(sessionId: string, campaignId: string, isActiveS
           ...(m as unknown as ChatMessage),
           type: (m.type === 'CHAT' ? 'chat' : 'spell-card') as ChatMessage['type'],
         }));
-      console.debug(`[PartyKit] HISTORY received chatCount=${chatMessages.length}`);
+      console.debug(`[Realtime] HISTORY received chatCount=${chatMessages.length}`);
       setLiveMessages(chatMessages);
     } else if (msgType === 'CHAT' || msgType === 'SPELL_CARD') {
       const chatMsg = parsed as unknown as ChatMessage;
@@ -121,7 +121,7 @@ export function useChatMessages(sessionId: string, campaignId: string, isActiveS
       const wsMessage = { ...message, type: 'CHAT' as const };
       pendingSaves.current.add(message.id);
       socket.send(JSON.stringify(wsMessage));
-      console.debug(`[PartyKit] Message sent type=CHAT id=${message.id}`);
+      console.debug(`[Realtime] Message sent type=CHAT id=${message.id}`);
     },
     [sessionId, campaignId]
   );
@@ -165,7 +165,7 @@ export function useChatMessages(sessionId: string, campaignId: string, isActiveS
       };
       pendingSaves.current.add(message.id);
       socket.send(JSON.stringify(wsMessage));
-      console.debug(`[PartyKit] Message sent type=SPELL_CARD id=${message.id}`);
+      console.debug(`[Realtime] Message sent type=SPELL_CARD id=${message.id}`);
     },
     [sessionId, campaignId]
   );

--- a/app/hooks/useDiceRolls.ts
+++ b/app/hooks/useDiceRolls.ts
@@ -78,7 +78,7 @@ export function useDiceRolls(sessionId: string, campaignId: string, isActiveSess
       const diceMessages = allMessages.filter(
         (m) => m.type === 'DICE'
       ) as unknown as DiceRollMessage[];
-      console.debug(`[PartyKit] HISTORY received diceCount=${diceMessages.length}`);
+      console.debug(`[Realtime] HISTORY received diceCount=${diceMessages.length}`);
       setLiveRolls(diceMessages);
     } else if (msgType === 'DICE') {
       const diceMsg = parsed as unknown as DiceRollMessage;
@@ -125,7 +125,7 @@ export function useDiceRolls(sessionId: string, campaignId: string, isActiveSess
       const wsMessage = { ...message, type: 'DICE' as const };
       pendingSaves.current.add(message.id);
       socket.send(JSON.stringify(wsMessage));
-      console.debug(`[PartyKit] Message sent type=DICE id=${message.id}`);
+      console.debug(`[Realtime] Message sent type=DICE id=${message.id}`);
     },
     [sessionId, campaignId]
   );

--- a/app/hooks/usePartySession.ts
+++ b/app/hooks/usePartySession.ts
@@ -1,7 +1,7 @@
 import usePartySocket from 'partysocket/react';
 import { useCallback, useRef } from 'react';
 
-const PARTYKIT_HOST = import.meta.env.VITE_PUBLIC_PARTYKIT_HOST ?? 'localhost:1999';
+const REALTIME_HOST = import.meta.env.VITE_PUBLIC_PARTYKIT_HOST ?? 'localhost:1999';
 
 export function usePartySession(
   sessionId: string | null,
@@ -16,23 +16,23 @@ export function usePartySession(
       const data = JSON.parse(event.data);
       onMessageRef.current(data);
     } catch (err) {
-      console.error('[PartyKit] Failed to parse message', err);
+      console.error('[Realtime] Failed to parse message', err);
     }
   }, []);
 
   const socket = usePartySocket({
-    host: PARTYKIT_HOST,
+    host: REALTIME_HOST,
     room: sessionId ?? '__disabled__',
     party: 'main',
     query: sessionId ? async () => ({ token: await getToken() }) : () => ({ token: '' }),
     onOpen() {
-      console.info(`[PartyKit] Connected to room sessionId=${sessionId}`);
+      console.info(`[Realtime] Connected to room sessionId=${sessionId}`);
     },
     onClose(event) {
       // Suppress warnings for disabled socket (no session) and normal closures
       if (sessionId && event.code !== 1000) {
         console.warn(
-          `[PartyKit] Disconnected sessionId=${sessionId} code=${event.code} reason=${event.reason}`
+          `[Realtime] Disconnected sessionId=${sessionId} code=${event.code} reason=${event.reason}`
         );
       }
     },

--- a/app/hooks/useTabletopMapParty.ts
+++ b/app/hooks/useTabletopMapParty.ts
@@ -5,7 +5,7 @@ import type { MapTextData } from '~/types/mapText';
 import type { MapDrawingData } from '~/types/mapDrawing';
 import { parseTabletopMapMessage } from '~/types/schemas/tabletopMessage';
 
-const PARTYKIT_HOST = import.meta.env.VITE_PUBLIC_PARTYKIT_HOST ?? 'localhost:1999';
+const REALTIME_HOST = import.meta.env.VITE_PUBLIC_PARTYKIT_HOST ?? 'localhost:1999';
 
 /** Message shape sent on the `tabletop-map` party channel. */
 export type TabletopMapMessage =
@@ -89,11 +89,11 @@ export function useTabletopMapParty(
   const roomId = campaignId ? `tabletop-map-${campaignId}` : '__disabled__';
 
   const socket = usePartySocket({
-    host: PARTYKIT_HOST,
+    host: REALTIME_HOST,
     room: roomId,
-    // Party names must be valid JS identifiers (PartyKit interpolates them
-    // into generated code) AND match its /^[a-z0-9_-]+$/ config schema, so
-    // underscore is the only separator that satisfies both.
+    // Must be a PartyName registered in realtime/src/auth.ts; the underscore
+    // is kept from the PartyKit era so the wire URL (/parties/tabletop_map/…)
+    // stays unchanged.
     party: 'tabletop_map',
     query: campaignId ? async () => ({ token: await getToken() }) : () => ({ token: '' }),
     onOpen() {

--- a/app/hooks/useTabletopParty.ts
+++ b/app/hooks/useTabletopParty.ts
@@ -2,7 +2,7 @@ import usePartySocket from 'partysocket/react';
 import { useCallback, useRef } from 'react';
 import type { TabletopMessage } from '~/types/tabletop';
 
-const PARTYKIT_HOST = import.meta.env.VITE_PUBLIC_PARTYKIT_HOST ?? 'localhost:1999';
+const REALTIME_HOST = import.meta.env.VITE_PUBLIC_PARTYKIT_HOST ?? 'localhost:1999';
 
 export function useTabletopParty(
   campaignId: string | null,
@@ -24,7 +24,7 @@ export function useTabletopParty(
   const roomId = campaignId ? `tabletop-${campaignId}` : '__disabled__';
 
   const socket = usePartySocket({
-    host: PARTYKIT_HOST,
+    host: REALTIME_HOST,
     room: roomId,
     party: 'tabletop',
     query: campaignId ? async () => ({ token: await getToken() }) : () => ({ token: '' }),

--- a/app/server/functions/maps.ts
+++ b/app/server/functions/maps.ts
@@ -97,8 +97,8 @@ function createR2Client(): { client: S3Client; bucket: string } | null {
 
 /**
  * Best-effort broadcast of a `map:active-changed` event to the `tabletop-map`
- * PartyKit room so every connected client invalidates/refetches the active map
- * right away, regardless of which UI triggered the mutation. A party outage
+ * realtime room so every connected client invalidates/refetches the active map
+ * right away, regardless of which UI triggered the mutation. A realtime outage
  * must never fail the DB write, so all errors are swallowed.
  *
  * Host resolution: `REALTIME_INTERNAL_HOST` is the server-side runtime var —
@@ -129,7 +129,7 @@ export async function broadcastActiveMapChanged(
     Boolean(internalHost) || host.startsWith('localhost') || host.startsWith('127.0.0.1');
   const protocol = isLocal ? 'http' : 'https';
   // Mirrors `useTabletopMapParty`: party `tabletop_map` (underscore — the
-  // partykit.json key), room `tabletop-map-<campaignId>`.
+  // PartyName registered in realtime/src/auth.ts), room `tabletop-map-<campaignId>`.
   const url = `${protocol}://${host}/parties/tabletop_map/tabletop-map-${campaignId}`;
   try {
     const { createPartyBroadcastToken } = await import('../session');

--- a/app/types/tabletop.ts
+++ b/app/types/tabletop.ts
@@ -92,7 +92,7 @@ export interface SessionEventData {
   displayName: string;
 }
 
-// PartyKit message types for tabletop
+// Realtime message types for tabletop
 export type TabletopMessage =
   | { type: 'window:show'; screenId: string; window: WindowData; displayName: string }
   | { type: 'window:close'; screenId: string; windowId: string }

--- a/app/utils/diceRollerBridge.ts
+++ b/app/utils/diceRollerBridge.ts
@@ -11,7 +11,7 @@ export interface DiceDeliveryReport {
 }
 
 // Window events bridge the dice roller window (TabletopView subtree) to the
-// PartyKit socket owner (InspectorSidebar subtree) — same pattern useBeyond20
+// realtime socket owner (InspectorSidebar subtree) — same pattern useBeyond20
 // uses to relay extension rolls.
 const BROADCAST_EVENT = 'cartyx:dice-broadcast-request';
 const DELIVERY_EVENT = 'cartyx:dice-delivery-report';

--- a/tests/hooks/useMapDrawings.test.ts
+++ b/tests/hooks/useMapDrawings.test.ts
@@ -13,8 +13,8 @@ import type { MapDrawingData } from '~/types/mapDrawing';
 /**
  * Unit coverage for the drawing cache helpers — these are the functions the
  * realtime (party) message handler calls to apply remote changes, so they are
- * the deterministic stand-in for the multiplayer sync path (PartyKit itself is
- * not run by the test harness).
+ * the deterministic stand-in for the multiplayer sync path (the realtime
+ * service itself is not run by the test harness).
  */
 
 const CID = 'c1';


### PR DESCRIPTION
Follow-up to #501. The dice/chat/map sockets have talked to the self-hosted realtime service since Phase 3, but browser console logs still said `[PartyKit] Connected…`, local consts were named `PARTYKIT_HOST`, and comments referenced the deleted `partykit.json`. Pure rename — no behavior change:

- Console prefixes `[PartyKit]` → `[Realtime]` (usePartySession, useDiceRolls, useChatMessages)
- Local consts `PARTYKIT_HOST` → `REALTIME_HOST` (3 hooks)
- Comments now point at `realtime/src/auth.ts` for party-name registration instead of partykit.json

**Kept:** the `VITE_PUBLIC_PARTYKIT_HOST` env var name — it's baked into client image builds and referenced in chart values and compose; renaming it is a coordinated change for another day if wanted.

Verification: 1539 unit tests pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)