### PR TITLE
chore: promote dev → main (Phase 5 review fixes: server-event UA, login decoupling)

### DIFF
--- a/app/routes/auth/callback/$provider.tsx
+++ b/app/routes/auth/callback/$provider.tsx
@@ -51,7 +51,8 @@ const handleCallback = createServerFn({ method: 'GET' })
 
         const user = await upsertUser(profile);
         await setSession(user);
-        await serverCaptureEvent(user.id, 'user_logged_in', { provider });
+        // Fire-and-forget: telemetry must never block or fail login.
+        void serverCaptureEvent(user.id, 'user_logged_in', { provider });
         return { redirectTo: '/campaigns' };
       } catch (e) {
         const errMessage = e instanceof Error ? e.message : String(e);

--- a/app/server/utils/telemetry.ts
+++ b/app/server/utils/telemetry.ts
@@ -7,6 +7,10 @@ import * as Sentry from '@sentry/node';
  * intentionally preserved so this replacement telemetry stack drops in
  * without touching callers.
  */
+// Umami discards bot-looking UAs (isbot); a browser UA is required for server events to be recorded.
+const UMAMI_UA =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
 let initialized = false;
 function ensureInit(): boolean {
   const dsn = process.env.GLITCHTIP_DSN;
@@ -41,7 +45,7 @@ export async function serverCaptureEvent(
   try {
     await fetch(`${host}/api/send`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'User-Agent': 'cartyx-server/1.0' },
+      headers: { 'Content-Type': 'application/json', 'User-Agent': UMAMI_UA },
       body: JSON.stringify({
         type: 'event',
         payload: {
@@ -52,6 +56,7 @@ export async function serverCaptureEvent(
           data: { ...properties, distinctId },
         },
       }),
+      signal: AbortSignal.timeout(2000),
     });
   } catch {
     // fire-and-forget: telemetry must never fail the caller

--- a/app/utils/telemetry-client.ts
+++ b/app/utils/telemetry-client.ts
@@ -11,8 +11,9 @@ import * as Sentry from '@sentry/browser';
  * considered instead, but `npm run build` never passes `--mode`, so both the
  * dev.cartyx.io and app.cartyx.io images resolve MODE to 'production' —
  * using it would mislabel dev-environment errors as prod in GlitchTip, which
- * is worse than omitting. Wiring a real per-environment value is Task 12's
- * job (a new VITE_PUBLIC_APP_ENV build arg), not this task's.
+ * is worse than omitting. This is intentionally not being wired up: each
+ * environment already has its own GlitchTip DSN, so an `environment` tag
+ * would be redundant.
  */
 const dsn = import.meta.env.VITE_PUBLIC_GLITCHTIP_DSN as string | undefined;
 
@@ -40,6 +41,7 @@ export function captureException(
 type Umami = { track: (event: string, data?: Record<string, unknown>) => void };
 
 export function captureEvent(event: string, properties?: Record<string, unknown>): void {
+  if (typeof window === 'undefined') return;
   const umami = (window as Window & { umami?: Umami }).umami;
   umami?.track(event, properties);
 }

--- a/deploy/charts/cartyx/tests/render-tests.sh
+++ b/deploy/charts/cartyx/tests/render-tests.sh
@@ -167,19 +167,26 @@ if helm template cartyx "$CHART_DIR" $local_args -f "$CHART_DIR/values-local.yam
 if helm template cartyx "$CHART_DIR" $local_args -f "$CHART_DIR/values-local.yaml" 2>&1 |
   grep -qE "kind: (Ingress|Certificate|Middleware)"; then bad "values-local disables ingress stack"; else ok; fi
 
-# --- Task 12: telemetry env (GLITCHTIP_DSN / UMAMI_WEBSITE_ID) ---
+# --- Task 12: telemetry env (GLITCHTIP_DSN / UMAMI_WEBSITE_ID / UMAMI_HOST) ---
 assert_not_contains "empty GLITCHTIP_DSN is omitted" "name: GLITCHTIP_DSN"
 assert_not_contains "empty UMAMI_WEBSITE_ID is omitted" "name: UMAMI_WEBSITE_ID"
+assert_not_contains "empty UMAMI_HOST is omitted" "name: UMAMI_HOST"
 assert_contains "non-empty GLITCHTIP_DSN renders" "name: GLITCHTIP_DSN" \
   --set web.env.GLITCHTIP_DSN=https://key@glitchtip.test/1
 assert_contains "non-empty UMAMI_WEBSITE_ID renders" "name: UMAMI_WEBSITE_ID" \
   --set web.env.UMAMI_WEBSITE_ID=test-website-id
+assert_contains "non-empty UMAMI_HOST renders" "name: UMAMI_HOST" \
+  --set web.env.UMAMI_HOST=http://umami.platform.svc:3000
 prod_out=$(render_env values-prod.yaml)
 dev_out=$(render_env values-dev.yaml)
 echo "$prod_out" | grep -q "value: \"https://1fd010e17ff4468fa6e3b07c94fcd31b@glitchtip.cartyx.io/1\"" \
   && ok || bad "values-prod GLITCHTIP_DSN resolves"
 echo "$dev_out" | grep -q "value: \"4cde88ee-3ef0-4104-adb0-6247d4ecbb30\"" \
   && ok || bad "values-dev UMAMI_WEBSITE_ID resolves"
+echo "$prod_out" | grep -q "value: \"http://umami.platform.svc:3000\"" \
+  && ok || bad "values-prod UMAMI_HOST resolves"
+echo "$dev_out" | grep -q "value: \"http://umami.platform.svc:3000\"" \
+  && ok || bad "values-dev UMAMI_HOST resolves"
 
 # ---- summary ----
 echo "render-tests: $PASS passed, $FAIL failed"

--- a/deploy/charts/cartyx/values-dev.yaml
+++ b/deploy/charts/cartyx/values-dev.yaml
@@ -16,6 +16,8 @@ web:
     CDN_URL: https://cdn-dev.cartyx.io
     GLITCHTIP_DSN: https://0cb27f44eaa9497fbff9a1e7ce803915@glitchtip.cartyx.io/2
     UMAMI_WEBSITE_ID: 4cde88ee-3ef0-4104-adb0-6247d4ecbb30
+    # In-cluster path — avoids the pod -> Cloudflare -> tunnel hairpin for server events.
+    UMAMI_HOST: http://umami.platform.svc:3000
   resources:
     limits:
       memory: 384Mi

--- a/deploy/charts/cartyx/values-prod.yaml
+++ b/deploy/charts/cartyx/values-prod.yaml
@@ -18,6 +18,8 @@ web:
     CDN_URL: https://cdn.cartyx.io
     GLITCHTIP_DSN: https://1fd010e17ff4468fa6e3b07c94fcd31b@glitchtip.cartyx.io/1
     UMAMI_WEBSITE_ID: 7ef99b87-59b5-46c5-922f-d4e66ccb51d6
+    # In-cluster path — avoids the pod -> Cloudflare -> tunnel hairpin for server events.
+    UMAMI_HOST: http://umami.platform.svc:3000
 
 ingress:
   webHost: app.cartyx.io

--- a/deploy/charts/cartyx/values.yaml
+++ b/deploy/charts/cartyx/values.yaml
@@ -42,6 +42,7 @@ web:
     # telemetry disabled (see app/server/utils/telemetry.ts).
     GLITCHTIP_DSN: ''
     UMAMI_WEBSITE_ID: ''
+    UMAMI_HOST: ''
 
 realtime:
   image:

--- a/docs/specs/2026-07-07-selfhost-migration-roadmap.md
+++ b/docs/specs/2026-07-07-selfhost-migration-roadmap.md
@@ -87,6 +87,8 @@ Design: `2026-07-09-app-helm-chart-design.md`; plan: `2026-07-09-app-helm-chart-
 
 ### Phase 5 — Observability platform (replaces PostHog)
 
+**Status: shipped 2026-07-11.** Platform (Grafana/GlitchTip/Umami/VictoriaLogs/VictoriaMetrics/Alloy/shared Postgres) deployed via `cartyx-infrastructure`'s `platform/` (per-component HelmReleases, NOT the umbrella chart this section originally sketched — see `docs/specs/2026-07-11-observability-platform-design.md`). App telemetry swapped in PR #505, promoted #506. Deferred: Discord webhook live-test; VictoriaMetrics replaced Prometheus.
+
 - `deploy/charts/platform/`: umbrella with dependencies — Grafana, Prometheus (kube-prometheus-stack or plain prometheus chart), VictoriaLogs (`victoria-logs-single`), Alloy, GlitchTip (official chart), Umami, shared Postgres (single StatefulSet, two databases)
 - Code swaps in `app/`:
   - `captureException` → `@sentry/browser` / `@sentry/node` with GlitchTip DSN (wrappers in `app/utils/posthog-client.ts` + `app/server/utils/posthog.ts` keep their call sites; rename files in the process)

--- a/tests/server/utils/telemetry.test.ts
+++ b/tests/server/utils/telemetry.test.ts
@@ -49,7 +49,20 @@ describe('server telemetry', () => {
       },
     });
     // eslint-disable-next-line no-undef -- see above
-    expect((init as RequestInit).headers).toMatchObject({ 'User-Agent': expect.any(String) });
+    expect((init as RequestInit).headers).toMatchObject({
+      'User-Agent': expect.stringMatching(/^Mozilla\//),
+    });
+  });
+
+  it('serverCaptureEvent survives an aborting fetch without throwing', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(Object.assign(new Error('aborted'), { name: 'AbortError' }))
+    );
+    const { serverCaptureEvent } = await import('~/server/utils/telemetry');
+    await expect(
+      serverCaptureEvent('user-1', 'campaign.created', { plan: 'free' })
+    ).resolves.toBeUndefined();
   });
 
   it('is a no-op without env vars', async () => {


### PR DESCRIPTION
Promotes PR #510 + #509 docs. Server Umami events verified organically on dev (db.bootstrap.* recorded post-rollout). Fixes: browser UA so Umami's bot filter stops discarding server events; login callback de-awaited + 2s abort timeout; in-cluster UMAMI_HOST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)