### PR TITLE
chore: tech-debt batch — atomic addStackItem, eslint cleanups, e2e guard, landing-page tracker

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -47,6 +47,14 @@ ENV VITE_PUBLIC_FF_CHAT=$VITE_PUBLIC_FF_CHAT \
     VITE_PUBLIC_PARTYKIT_HOST=$VITE_PUBLIC_PARTYKIT_HOST \
     VITE_PUBLIC_GLITCHTIP_DSN=$VITE_PUBLIC_GLITCHTIP_DSN \
     VITE_PUBLIC_UMAMI_WEBSITE_ID=$VITE_PUBLIC_UMAMI_WEBSITE_ID
+# public/index.html is the static landing page that shadows the React `/`
+# route in production (served straight from public/ by Nitro, not by the
+# app). Inject the Umami tracker into its <!-- UMAMI_TRACKER --> placeholder
+# only when a website ID was actually supplied at build time — local/dev
+# builds without VITE_PUBLIC_UMAMI_WEBSITE_ID stay tracker-free.
+RUN if [ -n "$VITE_PUBLIC_UMAMI_WEBSITE_ID" ]; then \
+      sed -i "s|<!-- UMAMI_TRACKER -->|<script defer src=\"https://umami.cartyx.io/script.js\" data-website-id=\"$VITE_PUBLIC_UMAMI_WEBSITE_ID\"></script>|" public/index.html; \
+    fi
 RUN npm run build
 
 FROM node:22-alpine

--- a/app/server/functions/gmscreens.ts
+++ b/app/server/functions/gmscreens.ts
@@ -1373,7 +1373,11 @@ export const deleteStack = async ({ data }: { data: z.infer<typeof deleteStackSc
 /**
  * **Duplicate rule:** A stack cannot contain two items with the same
  * `collection + documentId`.  If a duplicate is detected the call returns
- * `{ success: true, existed: true }` without modifying the stack.
+ * `{ success: true, existed: true }` without modifying the stack. Enforced
+ * atomically via a conditional `updateOne` filter — the same pattern
+ * `openWindow`/`openTabletopWindow` use — so that two concurrent calls for
+ * the same ref cannot both push an item, and two concurrent adds of
+ * *different* refs cannot both land past the per-stack item cap.
  */
 
 export { addStackItemSchema };
@@ -1402,7 +1406,9 @@ export const addStackItem = async ({ data }: { data: z.infer<typeof addStackItem
       stack.items = [];
     }
 
-    // Duplicate check
+    // Duplicate check — fast-path only. Like openWindow's `existing` check,
+    // this reads a possibly-stale snapshot; the authoritative dedupe/cap
+    // enforcement is the conditional filter in the atomic update below.
     const duplicate = stack.items.find(
       (item: { collection?: string; documentId?: unknown }) =>
         item.collection === data.collection && String(item.documentId) === data.documentId
@@ -1415,24 +1421,130 @@ export const addStackItem = async ({ data }: { data: z.infer<typeof addStackItem
       throw new Error(`A stack cannot contain more than ${GMSCREEN_LIMITS.MAX_STACK_ITEMS} items`);
     }
 
-    stack.items.push({
+    const newItem = {
       collection: data.collection,
       documentId: data.documentId,
       label: data.label,
-    });
-    screen.updatedAt = new Date();
-    await screen.save();
+    };
 
-    const created = stack.items[stack.items.length - 1];
+    // Atomic conditional push — this is the fix for the check-then-write
+    // race: two concurrent calls can both pass the `duplicate`/cap checks
+    // above (both read the array before either write lands), but this
+    // filter is re-evaluated by Mongo against the *current* document at
+    // write time. The `stacks.$elemMatch` clause requires the target stack
+    // to exist AND have no item for this ref yet (dedupe); the `$expr`
+    // clause requires that specific stack's item count to be under the cap
+    // — needed because schema validators don't run on updateOne pushes, so
+    // without it two concurrent adds of *different* refs at length cap-1
+    // would land cap+1 items in the same stack.
+    const pushResult = await GMScreen.updateOne(
+      {
+        _id: data.screenId,
+        campaignId: data.campaignId,
+        stacks: {
+          $elemMatch: {
+            _id: data.stackId,
+            items: {
+              $not: {
+                $elemMatch: { collection: data.collection, documentId: data.documentId },
+              },
+            },
+          },
+        },
+        $expr: {
+          $lt: [
+            {
+              $size: {
+                $reduce: {
+                  input: { $ifNull: ['$stacks', []] },
+                  initialValue: [],
+                  in: {
+                    $cond: [
+                      { $eq: [{ $toString: '$$this._id' }, data.stackId] },
+                      { $ifNull: ['$$this.items', []] },
+                      '$$value',
+                    ],
+                  },
+                },
+              },
+            },
+            GMSCREEN_LIMITS.MAX_STACK_ITEMS,
+          ],
+        },
+      },
+      {
+        $push: { 'stacks.$[stack].items': newItem },
+        $set: { updatedAt: new Date() },
+      },
+      {
+        arrayFilters: [{ 'stack._id': data.stackId }],
+      }
+    );
+
+    if (pushResult.modifiedCount > 0) {
+      // Re-fetch the matched stack subdoc so we can find the pushed item's
+      // Mongoose-assigned _id.
+      const refetched = (await GMScreen.findOne(
+        { _id: data.screenId, campaignId: data.campaignId, 'stacks._id': data.stackId },
+        { 'stacks.$': 1 }
+      ).lean()) as {
+        stacks?: Array<{
+          items?: Array<{ _id: unknown; collection?: string; documentId: unknown; label?: string }>;
+        }>;
+      } | null;
+      const created = refetched?.stacks?.[0]?.items?.find(
+        (item) => item.collection === data.collection && String(item.documentId) === data.documentId
+      );
+      if (!created) throw new Error('Stack item not found after creation');
+
+      serverCaptureEvent(sessionUserId, 'gmscreen_stack_item_added', {
+        campaign_id: data.campaignId,
+        screen_id: data.screenId,
+        stack_id: data.stackId,
+        item_id: String(created._id),
+      });
+
+      return { success: true, item: serializeStackItem(created), existed: false };
+    }
+
+    // The filter didn't match: either another concurrent call added an item
+    // for this ref first (dedupe loss), or a concurrent add of a *different*
+    // ref filled the last cap slot in this stack ($expr loss), or the
+    // screen/stack was deleted. Re-fetch canonical state to tell these apart:
+    // ref present → return it as existed; ref absent at cap → cap error;
+    // otherwise stack/screen not found.
+    const refreshed = await GMScreen.findOne({
+      _id: data.screenId,
+      campaignId: data.campaignId,
+    });
+    if (!refreshed) throw new Error('Screen not found');
+    if (!refreshed.stacks) refreshed.stacks = [];
+    const refreshedStack = refreshed.stacks.find(
+      (s: { _id: unknown }) => String(s._id) === data.stackId
+    );
+    if (!refreshedStack) throw new Error('Stack not found');
+    if (!refreshedStack.items) refreshedStack.items = [];
+    const race = refreshedStack.items.find(
+      (item: { collection?: string; documentId?: unknown }) =>
+        item.collection === data.collection && String(item.documentId) === data.documentId
+    );
+    if (!race) {
+      if (refreshedStack.items.length >= GMSCREEN_LIMITS.MAX_STACK_ITEMS) {
+        throw new Error(
+          `A stack cannot contain more than ${GMSCREEN_LIMITS.MAX_STACK_ITEMS} items`
+        );
+      }
+      throw new Error('Stack not found');
+    }
 
     serverCaptureEvent(sessionUserId, 'gmscreen_stack_item_added', {
       campaign_id: data.campaignId,
       screen_id: data.screenId,
       stack_id: data.stackId,
-      item_id: String(created._id),
+      item_id: String(race._id),
     });
 
-    return { success: true, item: serializeStackItem(created), existed: false };
+    return { success: true, item: serializeStackItem(race), existed: true };
   } catch (e) {
     serverCaptureException(e, sessionUserId, {
       action: 'addStackItem',

--- a/e2e/fixtures/tabletop-fixtures.ts
+++ b/e2e/fixtures/tabletop-fixtures.ts
@@ -81,3 +81,24 @@ export async function openWikiTab(page: Page): Promise<void> {
     await expect(wikiTab).toHaveAttribute('aria-selected', 'true', { timeout: 1000 });
   }).toPass({ timeout: 20_000 });
 }
+
+/**
+ * Click a Tabletop screen tab and wait for it to actually take effect.
+ *
+ * Same hydration hazard as openWikiTab: on a cold `vite dev` server a click
+ * fired before React attaches its event listeners lands on inert SSR markup
+ * and silently no-ops, leaving the wrong screen active — everything that
+ * depends on the target screen's contents (e.g. a pre-seeded floating
+ * window) then fails or times out with a confusing error far from the real
+ * cause. Retry the click until the tab is provably selected instead of a
+ * fixed sleep.
+ */
+export async function openTabletopTab(page: Page, screenId: string): Promise<void> {
+  const tab = page.getByTestId(`tabletop-tab-${screenId}`);
+  await expect(tab).toBeVisible();
+
+  await expect(async () => {
+    await tab.click();
+    await expect(tab).toHaveAttribute('aria-selected', 'true', { timeout: 1000 });
+  }).toPass({ timeout: 20_000 });
+}

--- a/e2e/locations/location-lightbox.spec.ts
+++ b/e2e/locations/location-lightbox.spec.ts
@@ -8,7 +8,7 @@
  *    pre-opened as a `collection: 'location'` floating window.
  *  - The seeded location has one image titled fixtureImageTitle.
  */
-import { test, expect } from '../fixtures/tabletop-fixtures';
+import { test, expect, openTabletopTab } from '../fixtures/tabletop-fixtures';
 import { blockPartyKit } from '../fixtures/network-mocks';
 
 test.describe('Location image gallery — lightbox (Tabletop floating window flow)', () => {
@@ -29,8 +29,11 @@ test.describe('Location image gallery — lightbox (Tabletop floating window flo
     await expect(page.getByTestId('tabletop-view')).toBeVisible();
 
     // Switch to the E2E-owned tabletop screen — the active screen on first load
-    // may be the user's pre-existing "Default" screen, not ours.
-    await page.getByTestId(`tabletop-tab-${screenId}`).click();
+    // may be the user's pre-existing "Default" screen, not ours. On a cold
+    // dev server a click fired before hydration lands on inert SSR markup
+    // and silently no-ops, so retry until the tab is provably selected
+    // (same guard as openWikiTab from the #490-era e2e fix wave).
+    await openTabletopTab(page, screenId);
 
     // The floating window for the seeded location should now be on the canvas.
     const locationWindow = page.getByRole('dialog', { name: locationName });
@@ -69,7 +72,7 @@ test.describe('Location image gallery — lightbox (Tabletop floating window flo
   }) => {
     await page.goto(tabletopUrl);
     await expect(page.getByTestId('tabletop-view')).toBeVisible();
-    await page.getByTestId(`tabletop-tab-${screenId}`).click();
+    await openTabletopTab(page, screenId);
 
     const locationWindow = page.getByRole('dialog', { name: locationName });
     await expect(locationWindow).toBeVisible();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,6 +36,11 @@ export default [
       '@typescript-eslint/no-explicit-any': 'warn',
       'react/react-in-jsx-scope': 'off',
       'no-console': ['warn', { allow: ['warn', 'error'] }],
+      // base eslint:recommended's no-undef fires on ambient DOM/TS types
+      // (e.g. RequestInit) in .ts/.tsx files. typescript-eslint's official
+      // guidance is to disable no-undef for TypeScript — tsc already catches
+      // real undefined identifiers. https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-am-using-a-rule-from-eslint-core-and-it-doesnt-work-correctly-with-typescript-code
+      'no-undef': 'off',
     },
     settings: { react: { version: 'detect' } },
   },
@@ -96,6 +101,7 @@ export default [
       'app/routeTree.gen.ts',
       'jest.config.cjs',
       'scripts/**',
+      'realtime/dist/',
     ],
   },
   ...pluginQuery.configs['flat/recommended'],

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cartyx — Enter the Realm</title>
+  <!-- UMAMI_TRACKER -->
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <style>
     *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }

--- a/tests/server/functions/gmscreens.test.ts
+++ b/tests/server/functions/gmscreens.test.ts
@@ -2413,9 +2413,53 @@ describe('addStackItem', () => {
     };
   }
 
+  /**
+   * addStackItem's create path is: (1) plain `findOne` to read current
+   * stack/items and compute the cap, (2) atomic conditional `updateOne`
+   * push scoped to the target stack via `arrayFilters`, (3) on success, a
+   * projected `findOne(...).lean()` re-fetch of the matched stack (to learn
+   * the pushed item's Mongoose-assigned `_id`). This wires up steps 2-3 for
+   * the "atomic push succeeds" case.
+   */
+  function mockSuccessfulAtomicPush(createdItem: Record<string, unknown>) {
+    vi.mocked(GMScreen.updateOne).mockResolvedValueOnce({
+      acknowledged: true,
+      matchedCount: 1,
+      modifiedCount: 1,
+      upsertedCount: 0,
+      upsertedId: null,
+    } as never);
+    vi.mocked(GMScreen.findOne).mockReturnValueOnce({
+      lean: vi.fn().mockResolvedValue({ stacks: [{ items: [createdItem] }] }),
+    } as never);
+  }
+
+  /**
+   * Simulates "lost the atomic create race": the conditional `updateOne`
+   * matches nothing (someone else added the item first, or the stack hit
+   * cap), so the code falls back to a plain re-fetch (`refreshedScreen`) and
+   * returns the winning item instead of pushing a duplicate.
+   */
+  function mockLostAtomicPushRace(refreshedScreen: Record<string, unknown>) {
+    vi.mocked(GMScreen.updateOne).mockResolvedValueOnce({
+      acknowledged: true,
+      matchedCount: 0,
+      modifiedCount: 0,
+      upsertedCount: 0,
+      upsertedId: null,
+    } as never);
+    vi.mocked(GMScreen.findOne).mockResolvedValueOnce(refreshedScreen as never);
+  }
+
   it('adds a new item to a stack', async () => {
     const screen = makeScreenWithStack([]);
-    vi.mocked(GMScreen.findOne).mockResolvedValue(screen as never);
+    vi.mocked(GMScreen.findOne).mockResolvedValueOnce(screen as never);
+    mockSuccessfulAtomicPush({
+      _id: 'si-1',
+      collection: 'note',
+      documentId: 'note-1',
+      label: 'Gandalf',
+    });
 
     const result = await _addStackItem({
       data: {
@@ -2433,7 +2477,30 @@ describe('addStackItem', () => {
     expect(result.item.collection).toBe('note');
     expect(result.item.documentId).toBe('note-1');
     expect(result.item.label).toBe('Gandalf');
-    expect(screen.save).toHaveBeenCalled();
+
+    // The dedupe AND cap guarantees live in the filter shape: assert the
+    // atomic update excludes any stack that already has an item for this
+    // ref, and gates on that specific stack's item count vs the cap.
+    const [filter, update, options] = vi.mocked(GMScreen.updateOne).mock.calls[0]!;
+    expect(filter).toMatchObject({
+      _id: 'screen-1',
+      campaignId: 'camp-1',
+      stacks: {
+        $elemMatch: {
+          _id: 'stack-1',
+          items: { $not: { $elemMatch: { collection: 'note', documentId: 'note-1' } } },
+        },
+      },
+    });
+    expect(update).toMatchObject({
+      $push: {
+        'stacks.$[stack].items': expect.objectContaining({
+          collection: 'note',
+          documentId: 'note-1',
+        }),
+      },
+    });
+    expect(options).toMatchObject({ arrayFilters: [{ 'stack._id': 'stack-1' }] });
   });
 
   it('returns existed: true for duplicate collection+documentId', async () => {
@@ -2458,6 +2525,8 @@ describe('addStackItem', () => {
     expect(result.item.id).toBe('si-1');
     expect(result.item.label).toBe('Existing');
     expect(screen.save).not.toHaveBeenCalled();
+    // The fast-path duplicate check never attempts the atomic push.
+    expect(GMScreen.updateOne).not.toHaveBeenCalled();
   });
 
   it('enforces the stack item cap', async () => {
@@ -2519,7 +2588,13 @@ describe('addStackItem', () => {
 
   it('defaults label to empty string when not provided', async () => {
     const screen = makeScreenWithStack([]);
-    vi.mocked(GMScreen.findOne).mockResolvedValue(screen as never);
+    vi.mocked(GMScreen.findOne).mockResolvedValueOnce(screen as never);
+    mockSuccessfulAtomicPush({
+      _id: 'si-1',
+      collection: 'note',
+      documentId: 'note-1',
+      label: '',
+    });
 
     const result = await _addStackItem({
       data: {
@@ -2532,6 +2607,193 @@ describe('addStackItem', () => {
     });
 
     expect(result.item.label).toBe('');
+  });
+
+  // -------------------------------------------------------------------
+  // Atomicity / dedupe-race pinning
+  // -------------------------------------------------------------------
+
+  it('does not add a duplicate on a sequential double-call for the same ref', async () => {
+    // Call 1: nothing exists yet, atomic push succeeds.
+    const screenRead1 = makeScreenWithStack([]);
+    vi.mocked(GMScreen.findOne).mockResolvedValueOnce(screenRead1 as never);
+    const createdItem = {
+      _id: 'si-1',
+      collection: 'note',
+      documentId: 'note-1',
+      label: 'Gandalf',
+    };
+    mockSuccessfulAtomicPush(createdItem);
+
+    const first = await _addStackItem({
+      data: {
+        screenId: 'screen-1',
+        campaignId: 'camp-1',
+        stackId: 'stack-1',
+        collection: 'note',
+        documentId: 'note-1',
+        label: 'Gandalf',
+      },
+    });
+    expect(first.existed).toBe(false);
+
+    // Call 2: the in-memory read now reflects the persisted item (this is
+    // what a real second request would see after the first one committed),
+    // so it takes the fast-path "duplicate" branch — same as before this fix.
+    const screenRead2 = makeScreenWithStack([createdItem]);
+    vi.mocked(GMScreen.findOne).mockResolvedValueOnce(screenRead2 as never);
+
+    const second = await _addStackItem({
+      data: {
+        screenId: 'screen-1',
+        campaignId: 'camp-1',
+        stackId: 'stack-1',
+        collection: 'note',
+        documentId: 'note-1',
+        label: 'Gandalf',
+      },
+    });
+
+    expect(second.existed).toBe(true);
+    expect(second.item.id).toBe('si-1');
+    // Only one atomic push was ever attempted across both calls.
+    expect(GMScreen.updateOne).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the create/create race: a second call that reads stale state before the first commits is rejected by the atomic filter and returns the winner instead of duplicating', async () => {
+    // Both calls read the stack as empty (simulates the TOCTOU window: two
+    // concurrent requests, neither sees the other's write yet).
+    const screenRead = makeScreenWithStack([]);
+    vi.mocked(GMScreen.findOne).mockResolvedValueOnce(screenRead as never);
+
+    const createdItem = {
+      _id: 'si-1',
+      collection: 'note',
+      documentId: 'note-1',
+      label: 'Gandalf',
+    };
+    // First call's atomic push wins.
+    mockSuccessfulAtomicPush(createdItem);
+
+    const first = await _addStackItem({
+      data: {
+        screenId: 'screen-1',
+        campaignId: 'camp-1',
+        stackId: 'stack-1',
+        collection: 'note',
+        documentId: 'note-1',
+        label: 'Gandalf',
+      },
+    });
+    expect(first.existed).toBe(false);
+
+    // Second call also read the stack as empty (same stale snapshot), so it
+    // too attempts the create path — but this time the atomic filter loses
+    // the race (matchedCount 0) because the stack now has the item the
+    // first call just pushed. It must fall back to returning the real,
+    // persisted item rather than creating a second one.
+    const screenRead2 = makeScreenWithStack([]);
+    vi.mocked(GMScreen.findOne).mockResolvedValueOnce(screenRead2 as never);
+    const refreshedScreen = makeScreenWithStack([{ ...createdItem }]);
+    mockLostAtomicPushRace(refreshedScreen);
+
+    const second = await _addStackItem({
+      data: {
+        screenId: 'screen-1',
+        campaignId: 'camp-1',
+        stackId: 'stack-1',
+        collection: 'note',
+        documentId: 'note-1',
+        label: 'Gandalf',
+      },
+    });
+
+    expect(second.existed).toBe(true);
+    expect(second.item.id).toBe('si-1');
+    // The losing call never pushed a second item: exactly one item ends up
+    // in the "canonical" (refreshed) stack.
+    expect((refreshedScreen.stacks[0] as { items: unknown[] }).items).toHaveLength(1);
+  });
+
+  it('closes the cap race: two concurrent adds of DIFFERENT refs at length cap-1 in the same stack — exactly one succeeds, the loser gets the cap error', async () => {
+    // Both calls read the stack at 49 items (one below the cap), so both
+    // pass the early app-level length check. Without the cap folded into
+    // the atomic filter, both pushes would land and the stack would end up
+    // with 51 items (the schema validator doesn't run on updateOne pushes).
+    const fortyNineItems = Array.from({ length: 49 }, (_, i) => ({
+      _id: `si-${i}`,
+      collection: 'note',
+      documentId: `note-${i}`,
+      label: `Item ${i}`,
+    }));
+    const screenA = makeScreenWithStack([...fortyNineItems]);
+    const screenB = makeScreenWithStack([...fortyNineItems]);
+    vi.mocked(GMScreen.findOne)
+      .mockResolvedValueOnce(screenA as never) // call A's initial read
+      .mockResolvedValueOnce(screenB as never); // call B's initial read
+
+    // A's atomic push wins (filter matched: dedupe clear AND size 49 < 50).
+    mockSuccessfulAtomicPush({
+      _id: 'si-a',
+      collection: 'note',
+      documentId: 'note-a',
+      label: 'A',
+    });
+    // B's push loses: the $expr size condition no longer matches (the stack
+    // now has 50 items). B re-fetches canonical state, does NOT find its own
+    // ref (different ref from A's — this is a cap loss, not a dedupe loss),
+    // sees length >= cap, and must throw the cap error.
+    vi.mocked(GMScreen.updateOne).mockResolvedValueOnce({
+      acknowledged: true,
+      matchedCount: 0,
+      modifiedCount: 0,
+      upsertedCount: 0,
+      upsertedId: null,
+    } as never);
+    const refreshedAtCap = makeScreenWithStack([
+      ...fortyNineItems,
+      { _id: 'si-a', collection: 'note', documentId: 'note-a', label: 'A' },
+    ]);
+    vi.mocked(GMScreen.findOne).mockResolvedValueOnce(refreshedAtCap as never);
+
+    const [resultA, resultB] = await Promise.allSettled([
+      _addStackItem({
+        data: {
+          screenId: 'screen-1',
+          campaignId: 'camp-1',
+          stackId: 'stack-1',
+          collection: 'note',
+          documentId: 'note-a',
+          label: 'A',
+        },
+      }),
+      _addStackItem({
+        data: {
+          screenId: 'screen-1',
+          campaignId: 'camp-1',
+          stackId: 'stack-1',
+          collection: 'note',
+          documentId: 'note-b',
+          label: 'B',
+        },
+      }),
+    ]);
+
+    expect(resultA.status).toBe('fulfilled');
+    if (resultA.status === 'fulfilled') {
+      expect(resultA.value.existed).toBe(false);
+      expect(resultA.value.item.documentId).toBe('note-a');
+    }
+    expect(resultB.status).toBe('rejected');
+    if (resultB.status === 'rejected') {
+      expect(String(resultB.reason)).toContain('A stack cannot contain more than 50 items');
+    }
+
+    // Both pushes carried the cap condition ($expr) scoped to this stack.
+    for (const call of vi.mocked(GMScreen.updateOne).mock.calls) {
+      const filter = call[0] as { $expr?: unknown };
+      expect(filter.$expr).toBeDefined();
+    }
   });
 });
 

--- a/tests/server/utils/telemetry.test.ts
+++ b/tests/server/utils/telemetry.test.ts
@@ -37,8 +37,6 @@ describe('server telemetry', () => {
     const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe('https://umami.cartyx.io/api/send');
-    // RequestInit is a TS ambient DOM type, not a runtime global; no-undef doesn't know TS type positions.
-    // eslint-disable-next-line no-undef
     const body = JSON.parse((init as RequestInit).body as string);
     expect(body).toMatchObject({
       type: 'event',
@@ -48,7 +46,6 @@ describe('server telemetry', () => {
         data: { plan: 'free', distinctId: 'user-1' },
       },
     });
-    // eslint-disable-next-line no-undef -- see above
     expect((init as RequestInit).headers).toMatchObject({
       'User-Agent': expect.stringMatching(/^Mozilla\//),
     });


### PR DESCRIPTION
## Summary

- **addStackItem TOCTOU** (`app/server/functions/gmscreens.ts`): closed the check-then-write race by mirroring `openWindow`/`openTabletopWindow`'s atomic conditional `updateOne` — dedupe enforced via `stacks: { $elemMatch: { _id, items: { $not: { $elemMatch: {...} } } } }`, cap enforced via a per-stack `$expr`/`$reduce` size check, push scoped with `arrayFilters`. Added RED→GREEN regression tests in `tests/server/functions/gmscreens.test.ts` mirroring the existing `openWindow` atomicity-pinning tests (sequential dedupe, concurrent create/create race, concurrent cap race).
- **eslint no-undef vs TS ambient types**: added `'no-undef': 'off'` scoped to the `**/*.{ts,tsx}` block in `eslint.config.mjs` (typescript-eslint's documented guidance — tsc already catches real undefined identifiers) and removed the two now-unnecessary `eslint-disable-next-line no-undef` comments in `tests/server/utils/telemetry.test.ts`.
- **eslint ignores realtime/dist**: added `realtime/dist/` to the ignores array.
- **location-lightbox.spec.ts unguarded post-goto click**: added an `openTabletopTab(page, screenId)` helper to `e2e/fixtures/tabletop-fixtures.ts`, mirroring the `openWikiTab` retry-until-selected pattern from the #490-era hydration-guard fix wave, and wired it into both tests in `e2e/locations/location-lightbox.spec.ts`.
- **Landing-page Umami tracker** (final-review F3): `public/index.html` now has a `<!-- UMAMI_TRACKER -->` placeholder in `<head>`; `Dockerfile.web` runs a guarded `sed` after `COPY public ./public` / the `ENV` block and before `npm run build`, replacing the placeholder with the Umami `<script>` tag only when `VITE_PUBLIC_UMAMI_WEBSITE_ID` is non-empty (local/dev builds without the ID stay tracker-free).

## Test plan

- [x] `npm test` — 1473 passed (includes new RED→GREEN addStackItem atomicity tests)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors, 24 warnings (same baseline as `origin/dev`, no new warnings)
- [x] Simulated the Dockerfile sed locally against a temp copy of `public/index.html` for both the empty and set `VITE_PUBLIC_UMAMI_WEBSITE_ID` cases — placeholder preserved / replaced correctly
- [ ] e2e (`location-lightbox.spec.ts`) — not run locally per instructions (env-dependent); CI will run it

🤖 Generated with [Claude Code](https://claude.com/claude-code)