### PR TITLE
fix(tabletop): persist active screen on tab create so map activation works

### DIFF
--- a/app/components/mainview/tabletop/TabletopView.tsx
+++ b/app/components/mainview/tabletop/TabletopView.tsx
@@ -166,6 +166,9 @@ export function TabletopView({
       .then((result) => {
         if (result?.success) {
           setActiveScreenId(result.screen.id);
+          // Persist the selection so the Maps panel (which reads the saved
+          // player-state, not this local state) targets the new tab.
+          updateState.mutate({ activeScreenId: result.screen.id });
           mutations.invalidateList();
         }
       })
@@ -173,7 +176,7 @@ export function TabletopView({
         // Reset guard so user can retry
         autoCreatedRef.current = false;
       });
-  }, [isLoading, isGM, screens.length, mutations]);
+  }, [isLoading, isGM, screens.length, mutations, updateState]);
 
   // Fetch detail for active screen
   const { screen: activeScreen } = useTabletopScreenDetail(campaignId, activeScreenId);
@@ -250,6 +253,9 @@ export function TabletopView({
     if (result.success) {
       await mutations.invalidateList();
       setActiveScreenId(result.screen.id);
+      // Persist the selection so the Maps panel (which reads the saved
+      // player-state, not this local state) targets the new tab.
+      updateState.mutate({ activeScreenId: result.screen.id });
       send({ type: 'tab:create', screen: result.screen });
     }
     setDialog({ type: 'none' });

--- a/tests/components/mainview/TabletopView.test.tsx
+++ b/tests/components/mainview/TabletopView.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { TabletopScreenData, TabletopScreenDetailData } from '~/types/tabletop';
@@ -41,6 +41,11 @@ const noopMutation = {
   error: null as Error | null,
 };
 
+// Dedicated mocks so createScreen and updateState can be asserted independently
+// (the shared noopMutation reuses the same vi.fn across mutations).
+const mockCreateScreenAsync = vi.fn().mockResolvedValue({});
+const mockUpdateStateMutate = vi.fn();
+
 let listResult: { screens: TabletopScreenData[]; isLoading: boolean; error: string | null } = {
   screens: mockScreens,
   isLoading: false,
@@ -57,7 +62,7 @@ vi.mock('~/hooks/useTabletopScreens', () => ({
   useTabletopScreenList: () => listResult,
   useTabletopScreenDetail: () => detailResult,
   useTabletopMutations: () => ({
-    createScreen: { ...noopMutation },
+    createScreen: { ...noopMutation, mutateAsync: mockCreateScreenAsync },
     renameScreen: { ...noopMutation },
     deleteScreen: { ...noopMutation },
     updateSettings: { ...noopMutation },
@@ -72,7 +77,7 @@ vi.mock('~/hooks/useTabletopPlayerState', () => ({
   useTabletopPlayerState: () => ({
     playerState: null,
     isLoading: false,
-    updateState: { ...noopMutation },
+    updateState: { ...noopMutation, mutate: mockUpdateStateMutate },
   }),
 }));
 
@@ -119,6 +124,37 @@ describe('TabletopView', () => {
     vi.clearAllMocks();
     listResult = { screens: mockScreens, isLoading: false, error: null };
     detailResult = { screen: mockDetail, isLoading: false, error: null };
+    mockCreateScreenAsync.mockResolvedValue({});
+  });
+
+  it('persists the newly auto-created default tab as the active screen', async () => {
+    // Fresh GM with no tabs: the auto-create effect creates a "Default" tab.
+    // The new tab must be persisted to player-state (activeScreenId), not just
+    // held in local state — otherwise the Maps panel targets the wrong/no tab
+    // and activating a map appears to do nothing until the tab is clicked.
+    listResult = { screens: [], isLoading: false, error: null };
+    detailResult = { screen: null, isLoading: false, error: null };
+    mockCreateScreenAsync.mockResolvedValue({
+      success: true,
+      screen: { ...mockScreens[0]!, id: 'ts-new' },
+    });
+
+    render(
+      <TabletopView
+        campaignId="c1"
+        isGM={true}
+        currentUserId={null}
+        getToken={mockGetToken}
+        sessionId={null}
+        openToolWindows={[]}
+        onCloseToolWindow={vi.fn()}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    await waitFor(() =>
+      expect(mockUpdateStateMutate).toHaveBeenCalledWith({ activeScreenId: 'ts-new' })
+    );
   });
 
   it('renders the tabletop view with correct test id', () => {


### PR DESCRIPTION
## Fix: creating a tab then activating a map required extra clicks

**Symptom:** After creating a new tab and uploading a map, clicking "Set Active" appeared to do nothing — it took ~3 clicks (and clicking the tab in the tab bar) before the map showed up.

**Root cause:** There were two records of "which tab is current":
- `TabletopView.activeScreenId` (local React state) — drives what's *rendered*.
- `playerState.activeScreenId` (persisted) — what the **Maps panel** reads to decide which tab to attach the map to.

Clicking a tab (`handleScreenChange`) updated **both**, but the two **tab-creation** paths (`handleCreateScreen` and the auto-create effect) updated only the local one. So right after creating a tab, `playerState` still pointed at the old/no tab, and "Set Active" wrote `activeMapId` onto the wrong tab — while the view (keyed on the new tab) stayed blank. Clicking the tab finally persisted the selection and re-synced them.

**Fix:** Both create paths now persist the new tab's id to player-state (`updateState.mutate({ activeScreenId })`), exactly like clicking a tab does — so the Maps panel targets the tab that's actually being viewed. Adds a regression test asserting the auto-create path persists the new screen.

Scope: 1 component + 1 test. `npm test` green (1492), typecheck clean, lint at baseline (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCPhrp5koSSPo8afU4rvG1
