### PR TITLE
Spells Phase 2 — roll damage from a spell (scaling + crit + broadcast)

### DIFF
--- a/app/components/mainview/InspectorSidebar.tsx
+++ b/app/components/mainview/InspectorSidebar.tsx
@@ -14,6 +14,7 @@ import { useChatMessages } from '~/hooks/useChatMessages';
 import { useDiceRolls } from '~/hooks/useDiceRolls';
 import { useAuth } from '~/hooks/useAuth';
 import { onDiceBroadcastRequest, reportDiceDelivery } from '~/utils/diceRollerBridge';
+import { onChatBroadcastRequest, reportChatDelivery } from '~/utils/chatBridge';
 import { createServerFn } from '@tanstack/react-start';
 import { z } from 'zod';
 
@@ -126,6 +127,19 @@ export function InspectorSidebar({
       reportDiceDelivery({ requestId, delivered: canSend });
     });
   }, [socket, sendDiceRoll, isViewingActive, activeSessionId, user?.name]);
+
+  // Relay "share in chat" requests (e.g. the spell view → window event) to the
+  // session socket as a chat message, same gating as dice rolls.
+  useEffect(() => {
+    return onChatBroadcastRequest(({ requestId, text, channel }) => {
+      const canSend =
+        isViewingActive && !!activeSessionId && !!socket && socket.readyState === WebSocket.OPEN;
+      if (canSend) {
+        sendMessage(text, channel, user?.id ?? '', user?.name || 'Player', socket);
+      }
+      reportChatDelivery({ requestId, delivered: canSend });
+    });
+  }, [socket, sendMessage, isViewingActive, activeSessionId, user?.id, user?.name]);
 
   const sessionList = (sessions ?? []).map((s) => ({
     id: s.id,

--- a/app/components/wiki/spells/SpellModal.tsx
+++ b/app/components/wiki/spells/SpellModal.tsx
@@ -238,17 +238,29 @@ export function SpellModal({ isOpen, onClose, campaignId, spellId }: SpellModalP
             </div>
           )}
           <div className="flex items-center gap-3 ml-auto">
-            <PixelButton type="button" variant="ghost" onClick={onClose} disabled={isDisabled}>
-              Cancel
-            </PixelButton>
             {isReadOnly ? (
-              <PixelButton type="button" onClick={handleDuplicate} disabled={isDisabled}>
-                {isDuplicating ? 'Duplicating...' : 'Duplicate to Homebrew'}
-              </PixelButton>
+              <>
+                <PixelButton
+                  type="button"
+                  variant="ghost"
+                  onClick={handleDuplicate}
+                  disabled={isDisabled}
+                >
+                  {isDuplicating ? 'Duplicating...' : 'Duplicate to Homebrew'}
+                </PixelButton>
+                <PixelButton type="button" onClick={onClose} disabled={isDisabled}>
+                  Close
+                </PixelButton>
+              </>
             ) : (
-              <PixelButton type="submit" disabled={isDisabled}>
-                {isSaving ? 'Saving...' : isEdit ? 'Save Changes' : 'Create Spell'}
-              </PixelButton>
+              <>
+                <PixelButton type="button" variant="ghost" onClick={onClose} disabled={isDisabled}>
+                  Cancel
+                </PixelButton>
+                <PixelButton type="submit" disabled={isDisabled}>
+                  {isSaving ? 'Saving...' : isEdit ? 'Save Changes' : 'Create Spell'}
+                </PixelButton>
+              </>
             )}
           </div>
         </footer>

--- a/app/components/wiki/spells/SpellWindow.tsx
+++ b/app/components/wiki/spells/SpellWindow.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { Pencil } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { Pencil, Send } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { SpellData } from '~/types/spell';
@@ -14,6 +14,25 @@ import {
   formatDamageEffect,
 } from './spellFormat';
 import { scaledDice, rollSpellModifier, type SpellRollOutcome } from './spellDice';
+import { requestChatBroadcast, onChatDelivery } from '~/utils/chatBridge';
+
+/** Plain-text spell summary for chat (chat renders plain text, not markdown). */
+function spellToChatText(spell: SpellData): string {
+  const header = `🔮 ${spell.name} — ${formatSpellLevel(spell.level)} ${formatSchool(spell.school)}${
+    spell.ritual ? ' (ritual)' : ''
+  }`;
+  const stats = `Casting: ${formatCastingTime(spell.castingTime)} · Range: ${formatRange(
+    spell.range
+  )} · Components: ${formatComponents(spell.components)} · Duration: ${formatDuration(
+    spell.duration
+  )}`;
+  const desc = spell.description
+    .replace(/\*\*/g, '')
+    .replace(/(^|[\s(])_([^_]+)_/g, '$1$2')
+    .replace(/^#+\s*/gm, '')
+    .trim();
+  return `${header}\n${stats}\n\n${desc}`;
+}
 
 function Cell({ label, value }: { label: string; value: string }) {
   return (
@@ -37,6 +56,23 @@ export function SpellWindow({ spell, onEdit }: SpellWindowProps) {
   const [castLevel, setCastLevel] = useState(scaling.type === 'character-level' ? 1 : spell.level);
   const [crit, setCrit] = useState(false);
   const [lastRoll, setLastRoll] = useState<SpellRollOutcome | null>(null);
+  const [shareStatus, setShareStatus] = useState<'idle' | 'shared' | 'no-session'>('idle');
+  const pendingShareId = useRef<string | null>(null);
+
+  useEffect(() => {
+    return onChatDelivery(({ requestId, delivered }) => {
+      if (requestId !== pendingShareId.current) return;
+      pendingShareId.current = null;
+      setShareStatus(delivered ? 'shared' : 'no-session');
+      setTimeout(() => setShareStatus('idle'), 3000);
+    });
+  }, []);
+
+  const handleShare = () => {
+    const requestId = crypto.randomUUID();
+    pendingShareId.current = requestId;
+    requestChatBroadcast({ requestId, text: spellToChatText(spell), channel: 'general' });
+  };
 
   const levelOptions =
     scaling.type === 'character-level'
@@ -53,16 +89,35 @@ export function SpellWindow({ spell, onEdit }: SpellWindowProps) {
             {spell.ritual ? ' (ritual)' : ''}
           </p>
         </div>
-        {spell.canEdit && onEdit && (
+        <div className="flex items-center gap-2 shrink-0">
+          {shareStatus !== 'idle' && (
+            <span
+              className={`text-[10px] font-semibold ${
+                shareStatus === 'shared' ? 'text-emerald-400' : 'text-amber-400'
+              }`}
+            >
+              {shareStatus === 'shared' ? 'Shared to chat' : 'No active session'}
+            </span>
+          )}
           <button
             type="button"
-            onClick={onEdit}
-            className="shrink-0 p-1 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors"
-            aria-label="Edit spell"
+            onClick={handleShare}
+            className="inline-flex items-center gap-1 px-2 py-1 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors text-[10px] font-semibold"
+            aria-label="Share spell in chat"
           >
-            <Pencil className="h-3.5 w-3.5" />
+            <Send className="h-3 w-3" /> Chat
           </button>
-        )}
+          {spell.canEdit && onEdit && (
+            <button
+              type="button"
+              onClick={onEdit}
+              className="p-1 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors"
+              aria-label="Edit spell"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
       </div>
 
       <div className="grid grid-cols-4 gap-3 px-4 py-3 mt-2 border-y border-white/[0.05] shrink-0">

--- a/app/components/wiki/spells/SpellWindow.tsx
+++ b/app/components/wiki/spells/SpellWindow.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Pencil } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -12,6 +13,7 @@ import {
   formatAttackSave,
   formatDamageEffect,
 } from './spellFormat';
+import { scaledDice, rollSpellModifier } from './spellDice';
 
 function Cell({ label, value }: { label: string; value: string }) {
   return (
@@ -30,6 +32,16 @@ interface SpellWindowProps {
 }
 
 export function SpellWindow({ spell, onEdit }: SpellWindowProps) {
+  const rollable = spell.modifiers.filter((m) => m.dice);
+  const scaling = spell.higherLevelScaling;
+  const [castLevel, setCastLevel] = useState(scaling.type === 'character-level' ? 1 : spell.level);
+  const [crit, setCrit] = useState(false);
+
+  const levelOptions =
+    scaling.type === 'character-level'
+      ? Array.from({ length: 20 }, (_, i) => i + 1)
+      : Array.from({ length: 10 - spell.level }, (_, i) => spell.level + i);
+
   return (
     <div className="flex flex-col h-full">
       <div className="flex items-start justify-between gap-2 px-4 pt-3 shrink-0">
@@ -62,6 +74,58 @@ export function SpellWindow({ spell, onEdit }: SpellWindowProps) {
         <Cell label="Attack/Save" value={formatAttackSave(spell.attackSave)} />
         <Cell label="Damage/Effect" value={formatDamageEffect(spell)} />
       </div>
+
+      {rollable.length > 0 && (
+        <div className="px-4 py-3 border-b border-white/[0.05] shrink-0 space-y-2">
+          <div className="flex items-center gap-3 flex-wrap">
+            {scaling.enabled && (
+              <label className="flex items-center gap-1.5 text-[10px] font-semibold text-slate-400">
+                {scaling.type === 'character-level' ? 'Character level' : 'Slot level'}
+                <select
+                  value={castLevel}
+                  onChange={(e) => setCastLevel(Number(e.target.value))}
+                  className="bg-[#080A12] border border-white/[0.07] rounded px-2 py-1 text-xs text-white"
+                >
+                  {levelOptions.map((n) => (
+                    <option key={n} value={n}>
+                      {n}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
+            <label className="flex items-center gap-1.5 text-[10px] font-semibold text-slate-400">
+              <input
+                type="checkbox"
+                checked={crit}
+                onChange={(e) => setCrit(e.target.checked)}
+                className="h-3.5 w-3.5 accent-blue-600"
+              />
+              Crit
+            </label>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {rollable.map((m) => {
+              const dice = scaledDice(m, spell, castLevel);
+              if (!dice) return null;
+              const label = `${crit ? dice.count * 2 : dice.count}d${dice.sides}${
+                m.damageType ? ` ${m.damageType}` : m.type === 'healing' ? ' healing' : ''
+              }`;
+              return (
+                <button
+                  key={m.id}
+                  type="button"
+                  onClick={() => rollSpellModifier({ spell, modifier: m, castLevel, crit })}
+                  className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-blue-500/10 border border-blue-500/30 text-blue-300 text-xs font-semibold hover:bg-blue-500/20 transition-colors"
+                  data-testid={`roll-${m.id}`}
+                >
+                  <span aria-hidden>⚄</span> {label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
 
       <div className="flex-1 overflow-y-auto p-4 min-h-0">
         {spell.components.material && spell.components.materialDescription && (

--- a/app/components/wiki/spells/SpellWindow.tsx
+++ b/app/components/wiki/spells/SpellWindow.tsx
@@ -13,7 +13,7 @@ import {
   formatAttackSave,
   formatDamageEffect,
 } from './spellFormat';
-import { scaledDice, rollSpellModifier } from './spellDice';
+import { scaledDice, rollSpellModifier, type SpellRollOutcome } from './spellDice';
 
 function Cell({ label, value }: { label: string; value: string }) {
   return (
@@ -36,6 +36,7 @@ export function SpellWindow({ spell, onEdit }: SpellWindowProps) {
   const scaling = spell.higherLevelScaling;
   const [castLevel, setCastLevel] = useState(scaling.type === 'character-level' ? 1 : spell.level);
   const [crit, setCrit] = useState(false);
+  const [lastRoll, setLastRoll] = useState<SpellRollOutcome | null>(null);
 
   const levelOptions =
     scaling.type === 'character-level'
@@ -115,7 +116,10 @@ export function SpellWindow({ spell, onEdit }: SpellWindowProps) {
                 <button
                   key={m.id}
                   type="button"
-                  onClick={() => rollSpellModifier({ spell, modifier: m, castLevel, crit })}
+                  onClick={() => {
+                    const outcome = rollSpellModifier({ spell, modifier: m, castLevel, crit });
+                    if (outcome) setLastRoll(outcome);
+                  }}
                   className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-blue-500/10 border border-blue-500/30 text-blue-300 text-xs font-semibold hover:bg-blue-500/20 transition-colors"
                   data-testid={`roll-${m.id}`}
                 >
@@ -124,6 +128,18 @@ export function SpellWindow({ spell, onEdit }: SpellWindowProps) {
               );
             })}
           </div>
+          {lastRoll && (
+            <div
+              data-testid="spell-roll-result"
+              className="flex items-baseline gap-2 rounded-lg bg-white/[0.04] border border-white/[0.07] px-3 py-2"
+            >
+              <span className="text-[11px] font-semibold text-slate-400">{lastRoll.title}</span>
+              <span className="text-[11px] text-slate-500">{lastRoll.formula}</span>
+              <span className="ml-auto text-lg font-bold text-blue-300 tabular-nums">
+                {lastRoll.total}
+              </span>
+            </div>
+          )}
         </div>
       )}
 

--- a/app/components/wiki/spells/SpellWindow.tsx
+++ b/app/components/wiki/spells/SpellWindow.tsx
@@ -102,10 +102,10 @@ export function SpellWindow({ spell, onEdit }: SpellWindowProps) {
           <button
             type="button"
             onClick={handleShare}
-            className="inline-flex items-center gap-1 px-2 py-1 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors text-[10px] font-semibold"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-blue-600 hover:bg-blue-500 text-white transition-colors text-xs font-bold shadow-sm shadow-blue-500/30"
             aria-label="Share spell in chat"
           >
-            <Send className="h-3 w-3" /> Chat
+            <Send className="h-4 w-4" /> Share in Chat
           </button>
           {spell.canEdit && onEdit && (
             <button

--- a/app/components/wiki/spells/SpellWindow.tsx
+++ b/app/components/wiki/spells/SpellWindow.tsx
@@ -26,11 +26,13 @@ function spellToChatText(spell: SpellData): string {
   )} · Components: ${formatComponents(spell.components)} · Duration: ${formatDuration(
     spell.duration
   )}`;
-  const desc = spell.description
+  let desc = spell.description
     .replace(/\*\*/g, '')
     .replace(/(^|[\s(])_([^_]+)_/g, '$1$2')
     .replace(/^#+\s*/gm, '')
     .trim();
+  const MAX_DESC = 1200;
+  if (desc.length > MAX_DESC) desc = desc.slice(0, MAX_DESC).trimEnd() + '…';
   return `${header}\n${stats}\n\n${desc}`;
 }
 
@@ -58,14 +60,20 @@ export function SpellWindow({ spell, onEdit }: SpellWindowProps) {
   const [lastRoll, setLastRoll] = useState<SpellRollOutcome | null>(null);
   const [shareStatus, setShareStatus] = useState<'idle' | 'shared' | 'no-session'>('idle');
   const pendingShareId = useRef<string | null>(null);
+  const statusTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    return onChatDelivery(({ requestId, delivered }) => {
+    const off = onChatDelivery(({ requestId, delivered }) => {
       if (requestId !== pendingShareId.current) return;
       pendingShareId.current = null;
       setShareStatus(delivered ? 'shared' : 'no-session');
-      setTimeout(() => setShareStatus('idle'), 3000);
+      if (statusTimer.current) clearTimeout(statusTimer.current);
+      statusTimer.current = setTimeout(() => setShareStatus('idle'), 3000);
     });
+    return () => {
+      off();
+      if (statusTimer.current) clearTimeout(statusTimer.current);
+    };
   }, []);
 
   const handleShare = () => {

--- a/app/components/wiki/spells/spellDice.ts
+++ b/app/components/wiki/spells/spellDice.ts
@@ -1,0 +1,58 @@
+import type { SpellData, SpellModifier, SpellDice } from '~/types/spell';
+import { rollDice, toParsedDiceRoll, type DicePoolEntry, type DieSides } from '~/utils/dice';
+import { requestDiceBroadcast } from '~/utils/diceRollerBridge';
+
+export const CANTRIP_BREAKPOINTS = [5, 11, 17] as const;
+
+/** How many scaling "steps" apply when casting at `castLevel`. */
+export function stepsForCast(spell: SpellData, castLevel: number): number {
+  if (!spell.higherLevelScaling.enabled) return 0;
+  if (spell.higherLevelScaling.type === 'character-level') {
+    return CANTRIP_BREAKPOINTS.filter((b) => castLevel >= b).length;
+  }
+  // spell-scale (leveled): one step per slot level above the spell's base level
+  return Math.max(0, castLevel - spell.level);
+}
+
+/** Base dice scaled to `castLevel` (base + steps × perStep). Null if no dice. */
+export function scaledDice(
+  modifier: SpellModifier,
+  spell: SpellData,
+  castLevel: number
+): SpellDice | null {
+  if (!modifier.dice) return null;
+  if (!modifier.scaling) return modifier.dice;
+  const steps = stepsForCast(spell, castLevel);
+  return {
+    count: modifier.dice.count + steps * modifier.scaling.perStep.count,
+    sides: modifier.dice.sides,
+  };
+}
+
+/** Build a dice pool; a crit doubles the dice count (5e). */
+export function buildPool(dice: SpellDice, crit: boolean): DicePoolEntry[] {
+  return [{ sides: dice.sides as DieSides, count: crit ? dice.count * 2 : dice.count }];
+}
+
+function modifierLabel(spell: SpellData, modifier: SpellModifier): string {
+  const kind = modifier.damageType
+    ? modifier.damageType.charAt(0).toUpperCase() + modifier.damageType.slice(1)
+    : modifier.type === 'healing'
+      ? 'Healing'
+      : 'Damage';
+  return `${spell.name} · ${kind}`;
+}
+
+/** Roll one modifier at the given cast level and broadcast it to the session. */
+export function rollSpellModifier(args: {
+  spell: SpellData;
+  modifier: SpellModifier;
+  castLevel: number;
+  crit: boolean;
+}): void {
+  const dice = scaledDice(args.modifier, args.spell, args.castLevel);
+  if (!dice) return;
+  const result = rollDice({ pool: buildPool(dice, args.crit), mode: 'normal', modifier: 0 });
+  const roll = toParsedDiceRoll(result, { title: modifierLabel(args.spell, args.modifier) });
+  requestDiceBroadcast({ requestId: crypto.randomUUID(), roll });
+}

--- a/app/components/wiki/spells/spellDice.ts
+++ b/app/components/wiki/spells/spellDice.ts
@@ -1,5 +1,11 @@
 import type { SpellData, SpellModifier, SpellDice } from '~/types/spell';
-import { rollDice, toParsedDiceRoll, type DicePoolEntry, type DieSides } from '~/utils/dice';
+import {
+  rollDice,
+  toParsedDiceRoll,
+  DIE_SIDES_DESC,
+  type DicePoolEntry,
+  type DieSides,
+} from '~/utils/dice';
 import { requestDiceBroadcast } from '~/utils/diceRollerBridge';
 
 export const CANTRIP_BREAKPOINTS = [5, 11, 17] as const;
@@ -21,6 +27,10 @@ export function scaledDice(
   castLevel: number
 ): SpellDice | null {
   if (!modifier.dice) return null;
+  // The dice engine only rolls standard die faces. A homebrew modifier can
+  // carry an arbitrary `sides` (Zod allows any int ≥ 2); such a die is not
+  // rollable here, so treat it as no roll rather than throwing in rollDice.
+  if (!(DIE_SIDES_DESC as readonly number[]).includes(modifier.dice.sides)) return null;
   if (!modifier.scaling) return modifier.dice;
   const steps = stepsForCast(spell, castLevel);
   return {

--- a/app/components/wiki/spells/spellDice.ts
+++ b/app/components/wiki/spells/spellDice.ts
@@ -43,16 +43,30 @@ function modifierLabel(spell: SpellData, modifier: SpellModifier): string {
   return `${spell.name} · ${kind}`;
 }
 
-/** Roll one modifier at the given cast level and broadcast it to the session. */
+export interface SpellRollOutcome {
+  title: string;
+  formula: string;
+  total: number;
+}
+
+/**
+ * Roll one modifier at the given cast level. Broadcasts to the session dice log
+ * (delivered only when in an active session) AND returns the outcome so the
+ * caller can always show a local result — mirroring how the dice roller shows a
+ * local roll independent of the broadcast. Returns null if the modifier has no
+ * dice.
+ */
 export function rollSpellModifier(args: {
   spell: SpellData;
   modifier: SpellModifier;
   castLevel: number;
   crit: boolean;
-}): void {
+}): SpellRollOutcome | null {
   const dice = scaledDice(args.modifier, args.spell, args.castLevel);
-  if (!dice) return;
+  if (!dice) return null;
   const result = rollDice({ pool: buildPool(dice, args.crit), mode: 'normal', modifier: 0 });
-  const roll = toParsedDiceRoll(result, { title: modifierLabel(args.spell, args.modifier) });
+  const title = modifierLabel(args.spell, args.modifier);
+  const roll = toParsedDiceRoll(result, { title });
   requestDiceBroadcast({ requestId: crypto.randomUUID(), roll });
+  return { title, formula: result.formula, total: result.total };
 }

--- a/app/server/data/srd/index.ts
+++ b/app/server/data/srd/index.ts
@@ -30,6 +30,7 @@ export interface GeneratedSpell {
     type: string;
     dice?: { count: number; sides: number };
     damageType?: string;
+    scaling?: { perStep: { count: number; sides: number } };
   }>;
   conditions: Array<{ id: string; action: string; condition: string }>;
   higherLevels: Array<{ id: string; level: number; description: string }>;

--- a/app/server/data/srd/spells.json
+++ b/app/server/data/srd/spells.json
@@ -40,7 +40,13 @@
           "count": 4,
           "sides": 4
         },
-        "damageType": "acid"
+        "damageType": "acid",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 4
+          }
+        }
       },
       {
         "id": "m1",
@@ -105,7 +111,13 @@
           "count": 1,
           "sides": 6
         },
-        "damageType": "acid"
+        "damageType": "acid",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 6
+          }
+        }
       }
     ],
     "conditions": [],
@@ -694,7 +706,13 @@
           "count": 5,
           "sides": 8
         },
-        "damageType": "force"
+        "damageType": "force",
+        "scaling": {
+          "perStep": {
+            "count": 2,
+            "sides": 8
+          }
+        }
       }
     ],
     "conditions": [],
@@ -1472,7 +1490,13 @@
           "count": 8,
           "sides": 8
         },
-        "damageType": "necrotic"
+        "damageType": "necrotic",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 8
+          }
+        }
       }
     ],
     "conditions": [],
@@ -1655,7 +1679,13 @@
           "count": 3,
           "sides": 6
         },
-        "damageType": "fire"
+        "damageType": "fire",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 6
+          }
+        }
       }
     ],
     "conditions": [],
@@ -1714,7 +1744,13 @@
           "count": 3,
           "sides": 10
         },
-        "damageType": "lightning"
+        "damageType": "lightning",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 10
+          }
+        }
       }
     ],
     "conditions": [],
@@ -1965,7 +2001,13 @@
           "count": 1,
           "sides": 10
         },
-        "damageType": "necrotic"
+        "damageType": "necrotic",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 10
+          }
+        }
       }
     ],
     "conditions": [],
@@ -2069,7 +2111,13 @@
           "count": 8,
           "sides": 8
         },
-        "damageType": "necrotic"
+        "damageType": "necrotic",
+        "scaling": {
+          "perStep": {
+            "count": 2,
+            "sides": 8
+          }
+        }
       }
     ],
     "conditions": [],
@@ -2209,7 +2257,13 @@
           "count": 5,
           "sides": 8
         },
-        "damageType": "poison"
+        "damageType": "poison",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 8
+          }
+        }
       }
     ],
     "conditions": [],
@@ -2515,7 +2569,13 @@
           "count": 8,
           "sides": 8
         },
-        "damageType": "cold"
+        "damageType": "cold",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 8
+          }
+        }
       }
     ],
     "conditions": [],
@@ -2624,7 +2684,13 @@
           "count": 3,
           "sides": 10
         },
-        "damageType": "slashing"
+        "damageType": "slashing",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 10
+          }
+        }
       }
     ],
     "conditions": [],
@@ -2683,6 +2749,14 @@
           "sides": 12
         },
         "damageType": "radiant"
+      },
+      {
+        "id": "h0",
+        "type": "healing",
+        "dice": {
+          "count": 4,
+          "sides": 12
+        }
       }
     ],
     "conditions": [],
@@ -2881,7 +2955,13 @@
           "count": 5,
           "sides": 8
         },
-        "damageType": "force"
+        "damageType": "force",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 8
+          }
+        }
       }
     ],
     "conditions": [],
@@ -3423,7 +3503,22 @@
     "attackSave": {
       "kind": "none"
     },
-    "modifiers": [],
+    "modifiers": [
+      {
+        "id": "h0",
+        "type": "healing",
+        "dice": {
+          "count": 2,
+          "sides": 8
+        },
+        "scaling": {
+          "perStep": {
+            "count": 2,
+            "sides": 8
+          }
+        }
+      }
+    ],
     "conditions": [],
     "higherLevels": [
       {
@@ -4162,7 +4257,13 @@
           "count": 3,
           "sides": 6
         },
-        "damageType": "psychic"
+        "damageType": "psychic",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 6
+          }
+        }
       }
     ],
     "conditions": [],
@@ -4305,7 +4406,13 @@
           "count": 2,
           "sides": 8
         },
-        "damageType": "radiant"
+        "damageType": "radiant",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 8
+          }
+        }
       }
     ],
     "conditions": [],
@@ -4936,7 +5043,13 @@
           "count": 1,
           "sides": 6
         },
-        "damageType": "piercing"
+        "damageType": "piercing",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 6
+          }
+        }
       }
     ],
     "conditions": [],
@@ -5676,7 +5789,13 @@
           "count": 8,
           "sides": 6
         },
-        "damageType": "fire"
+        "damageType": "fire",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 6
+          }
+        }
       }
     ],
     "conditions": [],
@@ -5733,7 +5852,13 @@
           "count": 1,
           "sides": 10
         },
-        "damageType": "fire"
+        "damageType": "fire",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 10
+          }
+        }
       }
     ],
     "conditions": [],
@@ -6017,7 +6142,13 @@
           "count": 2,
           "sides": 6
         },
-        "damageType": "fire"
+        "damageType": "fire",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 6
+          }
+        }
       }
     ],
     "conditions": [],
@@ -6426,7 +6557,13 @@
           "count": 10,
           "sides": 6
         },
-        "damageType": "cold"
+        "damageType": "cold",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 6
+          }
+        }
       }
     ],
     "conditions": [],
@@ -7141,7 +7278,13 @@
           "count": 4,
           "sides": 6
         },
-        "damageType": "radiant"
+        "damageType": "radiant",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 6
+          }
+        }
       }
     ],
     "conditions": [],
@@ -7450,7 +7593,22 @@
     "attackSave": {
       "kind": "none"
     },
-    "modifiers": [],
+    "modifiers": [
+      {
+        "id": "h0",
+        "type": "healing",
+        "dice": {
+          "count": 2,
+          "sides": 4
+        },
+        "scaling": {
+          "perStep": {
+            "count": 2,
+            "sides": 4
+          }
+        }
+      }
+    ],
     "conditions": [],
     "higherLevels": [
       {
@@ -7507,7 +7665,13 @@
           "count": 2,
           "sides": 8
         },
-        "damageType": "fire"
+        "damageType": "fire",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 8
+          }
+        }
       }
     ],
     "conditions": [],
@@ -7564,7 +7728,13 @@
           "count": 2,
           "sides": 10
         },
-        "damageType": "fire"
+        "damageType": "fire",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 10
+          }
+        }
       }
     ],
     "conditions": [],
@@ -8055,7 +8225,13 @@
           "count": 1,
           "sides": 10
         },
-        "damageType": "piercing"
+        "damageType": "piercing",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 6
+          }
+        }
       },
       {
         "id": "m1",
@@ -8121,7 +8297,13 @@
           "count": 2,
           "sides": 10
         },
-        "damageType": "bludgeoning"
+        "damageType": "bludgeoning",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 10
+          }
+        }
       },
       {
         "id": "m1",
@@ -8359,7 +8541,13 @@
           "count": 2,
           "sides": 10
         },
-        "damageType": "necrotic"
+        "damageType": "necrotic",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 10
+          }
+        }
       }
     ],
     "conditions": [],
@@ -8418,7 +8606,13 @@
           "count": 4,
           "sides": 10
         },
-        "damageType": "piercing"
+        "damageType": "piercing",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 10
+          }
+        }
       }
     ],
     "conditions": [],
@@ -8849,7 +9043,13 @@
           "count": 8,
           "sides": 6
         },
-        "damageType": "lightning"
+        "damageType": "lightning",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 6
+          }
+        }
       }
     ],
     "conditions": [],
@@ -9460,7 +9660,22 @@
     "attackSave": {
       "kind": "none"
     },
-    "modifiers": [],
+    "modifiers": [
+      {
+        "id": "h0",
+        "type": "healing",
+        "dice": {
+          "count": 5,
+          "sides": 8
+        },
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 8
+          }
+        }
+      }
+    ],
     "conditions": [],
     "higherLevels": [
       {
@@ -9545,7 +9760,22 @@
     "attackSave": {
       "kind": "none"
     },
-    "modifiers": [],
+    "modifiers": [
+      {
+        "id": "h0",
+        "type": "healing",
+        "dice": {
+          "count": 2,
+          "sides": 4
+        },
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 4
+          }
+        }
+      }
+    ],
     "conditions": [],
     "higherLevels": [
       {
@@ -9922,7 +10152,13 @@
           "count": 3,
           "sides": 8
         },
-        "damageType": "psychic"
+        "damageType": "psychic",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 8
+          }
+        }
       }
     ],
     "conditions": [],
@@ -10230,7 +10466,13 @@
           "count": 2,
           "sides": 10
         },
-        "damageType": "radiant"
+        "damageType": "radiant",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 10
+          }
+        }
       }
     ],
     "conditions": [],
@@ -10508,7 +10750,13 @@
           "count": 4,
           "sides": 10
         },
-        "damageType": "psychic"
+        "damageType": "psychic",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 10
+          }
+        }
       }
     ],
     "conditions": [],
@@ -10772,7 +11020,13 @@
           "count": 1,
           "sides": 12
         },
-        "damageType": "poison"
+        "damageType": "poison",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 12
+          }
+        }
       }
     ],
     "conditions": [],
@@ -10990,7 +11244,22 @@
     "attackSave": {
       "kind": "none"
     },
-    "modifiers": [],
+    "modifiers": [
+      {
+        "id": "h0",
+        "type": "healing",
+        "dice": {
+          "count": 2,
+          "sides": 8
+        },
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 8
+          }
+        }
+      }
+    ],
     "conditions": [],
     "higherLevels": [
       {
@@ -11308,7 +11577,13 @@
           "count": 1,
           "sides": 8
         },
-        "damageType": "fire"
+        "damageType": "fire",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 8
+          }
+        }
       }
     ],
     "conditions": [],
@@ -11689,7 +11964,13 @@
           "count": 1,
           "sides": 8
         },
-        "damageType": "cold"
+        "damageType": "cold",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 8
+          }
+        }
       }
     ],
     "conditions": [],
@@ -11738,7 +12019,16 @@
     "attackSave": {
       "kind": "none"
     },
-    "modifiers": [],
+    "modifiers": [
+      {
+        "id": "h0",
+        "type": "healing",
+        "dice": {
+          "count": 4,
+          "sides": 8
+        }
+      }
+    ],
     "conditions": [],
     "higherLevels": [],
     "areaOfEffect": {
@@ -11786,7 +12076,13 @@
           "count": 2,
           "sides": 8
         },
-        "damageType": "poison"
+        "damageType": "poison",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 8
+          }
+        }
       }
     ],
     "conditions": [],
@@ -12164,7 +12460,13 @@
           "count": 1,
           "sides": 8
         },
-        "damageType": "radiant"
+        "damageType": "radiant",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 8
+          }
+        }
       }
     ],
     "conditions": [],
@@ -12362,7 +12664,13 @@
           "count": 1,
           "sides": 6
         },
-        "damageType": "fire"
+        "damageType": "fire",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 6
+          }
+        }
       }
     ],
     "conditions": [],
@@ -12660,7 +12968,13 @@
           "count": 3,
           "sides": 8
         },
-        "damageType": "thunder"
+        "damageType": "thunder",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 8
+          }
+        }
       }
     ],
     "conditions": [],
@@ -12847,7 +13161,13 @@
           "count": 2,
           "sides": 6
         },
-        "damageType": "radiant"
+        "damageType": "radiant",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 6
+          }
+        }
       }
     ],
     "conditions": [],
@@ -12902,7 +13222,13 @@
           "count": 1,
           "sides": 8
         },
-        "damageType": "lightning"
+        "damageType": "lightning",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 8
+          }
+        }
       }
     ],
     "conditions": [],
@@ -13529,7 +13855,13 @@
           "count": 3,
           "sides": 8
         },
-        "damageType": "radiant"
+        "damageType": "radiant",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 8
+          }
+        }
       },
       {
         "id": "m1",
@@ -13642,7 +13974,13 @@
           "count": 1,
           "sides": 8
         },
-        "damageType": "radiant"
+        "damageType": "radiant",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 8
+          }
+        }
       }
     ],
     "conditions": [],
@@ -14371,7 +14709,13 @@
           "count": 2,
           "sides": 8
         },
-        "damageType": "thunder"
+        "damageType": "thunder",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 8
+          }
+        }
       }
     ],
     "conditions": [],
@@ -14901,7 +15245,13 @@
           "count": 3,
           "sides": 6
         },
-        "damageType": "necrotic"
+        "damageType": "necrotic",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 6
+          }
+        }
       }
     ],
     "conditions": [],
@@ -14957,7 +15307,13 @@
           "count": 1,
           "sides": 6
         },
-        "damageType": "psychic"
+        "damageType": "psychic",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 6
+          }
+        }
       }
     ],
     "conditions": [],
@@ -15014,7 +15370,13 @@
           "count": 10,
           "sides": 4
         },
-        "damageType": "acid"
+        "damageType": "acid",
+        "scaling": {
+          "perStep": {
+            "count": 2,
+            "sides": 4
+          }
+        }
       },
       {
         "id": "m1",
@@ -15083,7 +15445,13 @@
           "count": 5,
           "sides": 8
         },
-        "damageType": "fire"
+        "damageType": "fire",
+        "scaling": {
+          "perStep": {
+            "count": 1,
+            "sides": 8
+          }
+        }
       }
     ],
     "conditions": [],
@@ -15184,7 +15552,13 @@
           "count": 10,
           "sides": 6
         },
-        "damageType": "cold"
+        "damageType": "cold",
+        "scaling": {
+          "perStep": {
+            "count": 2,
+            "sides": 6
+          }
+        }
       },
       {
         "id": "m1",

--- a/app/server/data/srd/spells.json
+++ b/app/server/data/srd/spells.json
@@ -96,7 +96,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": true,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Sorcerer", "Wizard"],
     "attackSave": {
@@ -1986,7 +1986,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": true,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Sorcerer", "Warlock", "Wizard"],
     "attackSave": {
@@ -3560,7 +3560,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": false,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Bard", "Sorcerer", "Wizard"],
     "attackSave": {
@@ -4738,7 +4738,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": false,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Druid"],
     "attackSave": {
@@ -4831,7 +4831,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": true,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Warlock"],
     "attackSave": {
@@ -4887,7 +4887,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": false,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Druid", "Sorcerer", "Wizard"],
     "attackSave": {
@@ -5837,7 +5837,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": true,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Sorcerer", "Wizard"],
     "attackSave": {
@@ -7222,7 +7222,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": false,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Cleric", "Druid"],
     "attackSave": {
@@ -8989,7 +8989,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": false,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Bard", "Cleric", "Sorcerer", "Wizard"],
     "attackSave": {
@@ -9303,7 +9303,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": false,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Bard", "Sorcerer", "Warlock", "Wizard"],
     "attackSave": {
@@ -9954,7 +9954,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": false,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Bard", "Cleric", "Druid", "Sorcerer", "Wizard"],
     "attackSave": {
@@ -9996,7 +9996,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": false,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Bard", "Druid", "Sorcerer", "Wizard"],
     "attackSave": {
@@ -10202,7 +10202,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": false,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Bard", "Sorcerer", "Warlock", "Wizard"],
     "attackSave": {
@@ -11005,7 +11005,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": true,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Druid", "Sorcerer", "Warlock", "Wizard"],
     "attackSave": {
@@ -11300,7 +11300,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": false,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Bard", "Sorcerer", "Warlock", "Wizard"],
     "attackSave": {
@@ -11562,7 +11562,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": true,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Druid"],
     "attackSave": {
@@ -11949,7 +11949,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": true,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Sorcerer", "Wizard"],
     "attackSave": {
@@ -12244,7 +12244,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": false,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Cleric", "Druid"],
     "attackSave": {
@@ -12445,7 +12445,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": true,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Cleric"],
     "attackSave": {
@@ -13101,7 +13101,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": true,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Druid"],
     "attackSave": {
@@ -13207,7 +13207,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": true,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Sorcerer", "Wizard"],
     "attackSave": {
@@ -13525,7 +13525,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": true,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Sorcerer"],
     "attackSave": {
@@ -13571,7 +13571,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": true,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Cleric", "Druid"],
     "attackSave": {
@@ -13959,7 +13959,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": true,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Bard", "Druid"],
     "attackSave": {
@@ -14656,7 +14656,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": false,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Cleric"],
     "attackSave": {
@@ -15081,7 +15081,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": true,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Bard", "Sorcerer", "Warlock", "Wizard"],
     "attackSave": {
@@ -15292,7 +15292,7 @@
     "ritual": false,
     "higherLevelScaling": {
       "enabled": true,
-      "type": "spell-scale"
+      "type": "character-level"
     },
     "classes": ["Bard"],
     "attackSave": {

--- a/app/server/db/models/Spell.ts
+++ b/app/server/db/models/Spell.ts
@@ -8,6 +8,9 @@ const modifierSchema = new mongoose.Schema(
     id: { type: String, required: true },
     type: { type: String, required: true },
     dice: { type: diceSchema, default: undefined },
+    scaling: {
+      perStep: { type: diceSchema, default: undefined },
+    },
     fixedValue: Number,
     damageType: String,
     atHigherLevels: String,

--- a/app/types/schemas/spells.ts
+++ b/app/types/schemas/spells.ts
@@ -58,6 +58,7 @@ const modifierSchema = z.object({
   id: z.string().min(1),
   type: z.enum(MODIFIER_TYPES),
   dice: diceSchema.optional(),
+  scaling: z.object({ perStep: diceSchema }).optional(),
   fixedValue: z.number().int().optional(),
   damageType: z.string().optional(),
   atHigherLevels: z.string().optional(),

--- a/app/types/spell.ts
+++ b/app/types/spell.ts
@@ -60,6 +60,7 @@ export interface SpellModifier {
   id: string;
   type: ModifierType;
   dice?: SpellDice;
+  scaling?: { perStep: SpellDice };
   fixedValue?: number;
   damageType?: string;
   atHigherLevels?: string;

--- a/app/utils/chatBridge.ts
+++ b/app/utils/chatBridge.ts
@@ -5,7 +5,9 @@
 export interface ChatBroadcastRequest {
   requestId: string;
   text: string;
-  channel: 'general' | 'gm';
+  // Only the shared 'general' channel — this bridge intentionally cannot post
+  // to the GM-only channel (the relay does not check the caller's role).
+  channel: 'general';
 }
 
 export interface ChatDeliveryReport {

--- a/app/utils/chatBridge.ts
+++ b/app/utils/chatBridge.ts
@@ -1,0 +1,37 @@
+// Window events bridge a component deep in the wiki (e.g. the spell view) to the
+// realtime socket owner (InspectorSidebar), so it can post a chat message
+// without threading the socket down. Same pattern as diceRollerBridge.
+
+export interface ChatBroadcastRequest {
+  requestId: string;
+  text: string;
+  channel: 'general' | 'gm';
+}
+
+export interface ChatDeliveryReport {
+  requestId: string;
+  delivered: boolean;
+}
+
+const BROADCAST_EVENT = 'cartyx:chat-broadcast-request';
+const DELIVERY_EVENT = 'cartyx:chat-delivery-report';
+
+export function requestChatBroadcast(detail: ChatBroadcastRequest): void {
+  window.dispatchEvent(new CustomEvent(BROADCAST_EVENT, { detail }));
+}
+
+export function onChatBroadcastRequest(cb: (d: ChatBroadcastRequest) => void): () => void {
+  const handler = (e: Event) => cb((e as CustomEvent<ChatBroadcastRequest>).detail);
+  window.addEventListener(BROADCAST_EVENT, handler);
+  return () => window.removeEventListener(BROADCAST_EVENT, handler);
+}
+
+export function reportChatDelivery(detail: ChatDeliveryReport): void {
+  window.dispatchEvent(new CustomEvent(DELIVERY_EVENT, { detail }));
+}
+
+export function onChatDelivery(cb: (d: ChatDeliveryReport) => void): () => void {
+  const handler = (e: Event) => cb((e as CustomEvent<ChatDeliveryReport>).detail);
+  window.addEventListener(DELIVERY_EVENT, handler);
+  return () => window.removeEventListener(DELIVERY_EVENT, handler);
+}

--- a/app/utils/dice.ts
+++ b/app/utils/dice.ts
@@ -118,10 +118,13 @@ export function rollDice(input: {
  * changes. `character` is intentionally blank — the broadcast consumer
  * (InspectorSidebar) fills in the authenticated user's name.
  */
-export function toParsedDiceRoll(result: DiceRollResult): ParsedDiceRoll {
+export function toParsedDiceRoll(
+  result: DiceRollResult,
+  opts?: { title?: string }
+): ParsedDiceRoll {
   return {
     character: '',
-    title: result.formula,
+    title: opts?.title ?? result.formula,
     rollType: 'custom',
     attackRolls: result.sets.map((set) => ({
       roll: set.total,

--- a/docs/spells/2026-07-13-spells-phase2-dice-design.md
+++ b/docs/spells/2026-07-13-spells-phase2-dice-design.md
@@ -1,0 +1,162 @@
+# Spells Phase 2 — Roll Damage from a Spell (Design)
+
+**Date:** 2026-07-13
+**Status:** Approved design, ready for implementation plan
+**Depends on:** Phase 1 (spells wiki + SRD 5.2.1 data), merged/in PR #519
+
+## Summary
+
+Let a player roll a spell's damage (or healing) directly from the spell view. A
+roll chip on each damage/healing modifier builds a dice pool from the spell's
+structured `modifiers`, rolls it with the existing dice engine, and broadcasts
+the result to the active session's dice log. Casting at a higher slot level (or,
+for cantrips, at a higher character level) scales the dice; a crit toggle doubles
+them.
+
+The enabling work is **structuring the currently free-text higher-level scaling
+into per-step dice**, plus capturing healing dice (a known Phase 1 gap).
+
+## Decisions (locked)
+
+1. **Trigger:** a "Roll" chip per damage/healing modifier on the spell display
+   card (uses the structured modifiers; no free-text parsing at runtime).
+2. **Scope:** damage + healing dice, **with higher-level slot scaling** and a
+   crit toggle. **Not** in scope: d20 spell attack rolls and save DC (need the
+   caster's stats / character-sheet wiring that doesn't exist yet).
+3. **Result:** broadcast to the active session's dice log (same path as the dice
+   roller), labeled with the spell.
+4. **Crit toggle default off.** Cantrips use a **1–20 character-level selector**
+   (default 1).
+
+## 1. Data model + generator
+
+### Model (`app/types/spell.ts`, `app/types/schemas/spells.ts`, `Spell.ts`)
+
+Add an optional `scaling` to `SpellModifier`:
+
+```ts
+export interface SpellModifier {
+  id: string;
+  type: ModifierType; // 'damage' | 'healing' | …
+  dice?: SpellDice; // base dice
+  scaling?: { perStep: SpellDice }; // NEW: dice added per scaling step
+  fixedValue?: number;
+  damageType?: string;
+  atHigherLevels?: string;
+  notes?: string;
+}
+```
+
+Scaling is interpreted with the existing `spell.higherLevelScaling.type`:
+
+- `spell-scale` (leveled): a "step" is one slot level above the spell's base
+  level.
+- `character-level` (cantrip): a "step" is a reached breakpoint at levels 5, 11,
+  17 (→ 1, 2, 3 steps).
+
+`SpellDice.sides` stays constrained to the die faces the engine supports
+(`4|6|8|10|12`; damage never uses d20/d100). Assume `perStep.sides === dice.sides`
+(true across the SRD); the roll logic falls back to a separate pool entry if they
+ever differ.
+
+### Generator (`scripts/srd/generate-srd-data.ts`)
+
+Two additions to the parser, then regenerate `app/server/data/srd/spells.json`:
+
+1. **Healing capture** (closes the Phase 1 gap): parse healing dice into a
+   `type: 'healing'` modifier — e.g. `/(\d+)d(\d+)\s+(?:hit points|hp)/i` and the
+   "regains … *X*d*Y*" phrasing. QA against a sample (Cure Wounds, Healing Word,
+   Mass Cure Wounds, Prayer of Healing).
+2. **Scaling `perStep`** from the "Using a Higher-Level Spell Slot" /
+   "Cantrip Upgrade" text already captured in `higherLevels`:
+   - slot: `/increases by (\d+)d(\d+) (?:for each|per) (?:spell )?slot level/i`
+   - cantrip: `/increases by (\d+)d(\d+) when you reach/i`
+     Attach `perStep` to the primary damage (or healing) modifier. QA against
+     Fireball (+1d6/slot), Fire Bolt (cantrip +1d10 at 5/11/17), Cure Wounds
+     (+2d8/slot), Scorching Ray (special — may not fit; leave unscaled if no match).
+
+Unmatched spells simply have no `scaling` and roll their base dice. Regeneration
+count stays ~339 spells; the importer and `dev_seed` read the same JSON, so after
+regenerating, **re-run the dev reset** (`npm run dev:clear -- --force` then
+`npm run dev:seed`, per the `resetting-dev-data` skill) so dev has the new fields.
+
+## 2. Client dice logic (pure, unit-tested)
+
+New `app/components/wiki/spells/spellDice.ts`:
+
+- `stepsForCast(spell, castLevel): number`
+  - `!spell.higherLevelScaling.enabled` → 0
+  - `spell-scale` → `max(0, castLevel - spell.level)`
+  - `character-level` → count of `[5, 11, 17]` that are `<= castLevel`
+- `scaledDice(modifier, spell, castLevel): SpellDice | null`
+  - no `dice` → null; no `scaling` → base `dice`
+  - else `{ count: dice.count + steps * perStep.count, sides: dice.sides }`
+- `buildPool(dice, crit): DicePoolEntry[]` → `[{ sides, count: crit ? count*2 : count }]`
+- `rollSpellModifier({ spell, modifier, castLevel, crit })`:
+  `rollDice({ pool, mode: 'normal', modifier: 0 })` → `toParsedDiceRoll(result, {
+title })` → `requestDiceBroadcast({ requestId, roll })`, where
+  `title = \`${spell.name} · ${modifier.damageType ?? (modifier.type === 'healing' ? 'Healing' : 'Damage')}\``and`requestId` uses the same id source the dice roller uses (`crypto.randomUUID()`).
+
+## 3. Broadcast (`app/utils/dice.ts`)
+
+Extend `toParsedDiceRoll` with an optional title override so spell rolls read as
+the spell, not the raw formula:
+
+```ts
+export function toParsedDiceRoll(
+  result: DiceRollResult,
+  opts?: { title?: string }
+): ParsedDiceRoll {
+  return { /* …existing… */, title: opts?.title ?? result.formula };
+}
+```
+
+Reuse `requestDiceBroadcast` unchanged; `InspectorSidebar` already relays it to
+the session socket, so the roll appears in the shared dice log
+(`Fireball · Fire: 27`). When there is no active session the behavior matches the
+existing dice roller (no session relay) — no special-casing here.
+
+## 4. UI (`SpellWindow.tsx`)
+
+A "Cast & Roll" block below the header grid (renders in both the player
+`SpellViewModal` and the read-only SRD `SpellModal`):
+
+- One **roll chip per damage/healing modifier** that has `dice`, showing the
+  currently-scaled dice + type — e.g. `⚄ 8d6 Fire`. Clicking rolls that modifier
+  and broadcasts.
+- When `higherLevelScaling.enabled`, a **cast-level selector** above the chips:
+  - `spell-scale` → "Slot level" `[spell.level … 9]` (default = `spell.level`)
+  - `character-level` → "Character level" `[1 … 20]` (default 1)
+    Changing it re-computes the dice shown on the chips.
+- A **Crit** toggle (default off) that doubles the damage dice shown/rolled.
+- Spells with no rollable modifier (no `dice`) show no block.
+
+Local component state: `castLevel`, `crit`. No server calls — rolling is
+client-side + broadcast.
+
+## 5. Out of scope
+
+- d20 spell attack rolls and save DC (need caster spell-attack bonus / DC → a
+  character-sheet ↔ spell link that doesn't exist yet).
+- Non-dice / narrative effects.
+- Scaling for spells whose increase doesn't fit the two regexes (e.g. Scorching
+  Ray's extra rays) — they roll base dice; a follow-up can special-case them.
+
+## 6. Testing
+
+- **`spellDice.ts` unit tests:** `stepsForCast` (leveled slot math + cantrip
+  5/11/17 breakpoints), `scaledDice` (Fireball at slots 3/5/9, Fire Bolt at
+  levels 1/5/11/17), `buildPool` crit doubling.
+- **Generator tests:** healing capture (Cure Wounds → healing modifier) and
+  `perStep` extraction (Fireball slot, Fire Bolt cantrip) in
+  `tests/srd/generate-srd-data.test.ts`.
+- **`toParsedDiceRoll`:** title override applied.
+- **Component test:** clicking a roll chip calls `requestDiceBroadcast` with a
+  spell-titled `ParsedDiceRoll` (mock the bridge); changing the cast-level
+  selector changes the rolled pool.
+- Gates: `npm test`, `npm run typecheck`, `npm run lint` clean.
+
+## Phase 3 (unchanged, still deferred)
+
+Drawing `areaOfEffect` on the tabletop `spell-fx` layer — greenfield, separate
+spec.

--- a/docs/spells/2026-07-13-spells-phase2-plan.md
+++ b/docs/spells/2026-07-13-spells-phase2-plan.md
@@ -1,0 +1,662 @@
+# Spells Phase 2 Implementation Plan — Roll Damage from a Spell
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use `- [ ]`.
+
+**Goal:** Roll a spell's damage/healing from the spell view (roll chip per modifier), with higher-level slot + cantrip scaling and a crit toggle, broadcast to the session dice log.
+
+**Architecture:** Add structured `scaling` (per-step dice) to spell modifiers and capture healing dice in the generator; a pure client dice module computes the scaled pool; `SpellWindow` renders roll chips + a cast-level selector + crit toggle that call the existing `rollDice → toParsedDiceRoll → requestDiceBroadcast` path.
+
+**Tech Stack:** TanStack Start (React 19), TypeScript, Mongoose, Zod, Vitest, existing dice engine (`app/utils/dice.ts`, `app/utils/diceRollerBridge.ts`).
+
+**Spec:** `docs/spells/2026-07-13-spells-phase2-dice-design.md`
+
+## Global Constraints
+
+- Tests live under `tests/` mirroring app paths (`~/` imports). Mongoose is globally mocked (`tests/setup.ts`) — NO mongodb-memory-server. Model tests are existence-level; the pattern for server logic is `tests/server/functions/rules.test.ts`.
+- `npm test` (`vitest run --project unit`), `npm run typecheck`, `npm run lint` all clean; lint baseline is 0 errors + 24 warnings — add no new warnings.
+- No new npm dependencies.
+- Dice sides are constrained to `4|6|8|10|12|20|100` (`DieSides`); spell dice use `4|6|8|10|12`.
+- `scaling.perStep.sides === dice.sides` for all SRD spells; the roll logic merges them into one pool entry on that assumption (documented in `spellDice.ts`).
+- The generator (`scripts/`) is eslint-ignored; its logic is covered by `tests/srd/generate-srd-data.test.ts`.
+- After regenerating `spells.json`, dev must be reset via the `resetting-dev-data` skill (`npm run dev:clear -- --force` then `npm run dev:seed`) — Task 6.
+
+---
+
+## Task 1: Add `scaling` to the spell modifier (types, Zod, model)
+
+**Files:**
+
+- Modify: `app/types/spell.ts` (add `scaling` to `SpellModifier`)
+- Modify: `app/types/schemas/spells.ts` (add `scaling` to `modifierSchema`)
+- Modify: `app/server/db/models/Spell.ts` (add `scaling` to `modifierSchema`)
+- Test: `tests/types/schemas/spells.test.ts` (extend)
+
+**Interfaces:**
+
+- Produces: `SpellModifier.scaling?: { perStep: SpellDice }`, accepted by `createSpellSchema`/`updateSpellSchema` and persisted by the model. Consumed by Tasks 2 (generator), 4 (spellDice), 5 (UI).
+
+- [ ] **Step 1: Add the type** — in `app/types/spell.ts`, add `scaling` to `SpellModifier` (after `dice`):
+
+```ts
+export interface SpellModifier {
+  id: string;
+  type: ModifierType;
+  dice?: SpellDice;
+  scaling?: { perStep: SpellDice };
+  fixedValue?: number;
+  damageType?: string;
+  atHigherLevels?: string;
+  notes?: string;
+}
+```
+
+- [ ] **Step 2: Add to the Zod modifier schema** — in `app/types/schemas/spells.ts`, add to `modifierSchema` (after `dice: diceSchema.optional(),`):
+
+```ts
+  scaling: z.object({ perStep: diceSchema }).optional(),
+```
+
+- [ ] **Step 3: Add to the Mongoose modifier schema** — in `app/server/db/models/Spell.ts`, add to `modifierSchema` (after the `dice` line):
+
+```ts
+    scaling: {
+      perStep: { type: diceSchema, default: undefined },
+    },
+```
+
+- [ ] **Step 4: Extend the schema test** — in `tests/types/schemas/spells.test.ts`, add a case asserting a modifier with `scaling` parses:
+
+```ts
+it('accepts a damage modifier with scaling', () => {
+  const parsed = createSpellSchema.parse({
+    ...validSpell,
+    modifiers: [
+      {
+        id: 'm0',
+        type: 'damage',
+        dice: { count: 8, sides: 6 },
+        scaling: { perStep: { count: 1, sides: 6 } },
+      },
+    ],
+  });
+  expect(parsed.modifiers[0].scaling).toEqual({ perStep: { count: 1, sides: 6 } });
+});
+```
+
+- [ ] **Step 5: Run + commit**
+
+Run: `npm test -- tests/types/schemas/spells.test.ts` (PASS), then `npm run typecheck && npm run lint` (clean).
+
+```bash
+git add app/types/spell.ts app/types/schemas/spells.ts app/server/db/models/Spell.ts tests/types/schemas/spells.test.ts
+git commit -m "feat(spells): add scaling (per-step dice) to spell modifiers"
+```
+
+---
+
+## Task 2: Generator — capture healing dice + extract scaling
+
+**Files:**
+
+- Modify: `scripts/srd/generate-srd-data.ts`
+- Modify: `tests/srd/generate-srd-data.test.ts`
+- Regenerate: `app/server/data/srd/spells.json` (via `npm run srd:generate`)
+
+**Interfaces:**
+
+- Consumes: nothing new. Produces: each SRD spell may now have a `type:'healing'` modifier and/or a `modifiers[i].scaling.perStep`. `GeneratedSpell.modifiers[]` entries gain an optional `scaling`.
+
+- [ ] **Step 1: Extend `GeneratedSpell.modifiers` type** — in `scripts/srd/generate-srd-data.ts` (and the mirror in `app/server/data/srd/index.ts`), add `scaling?: { perStep: { count: number; sides: number } }` to the modifier element type.
+
+- [ ] **Step 2: Add healing + scaling parsers** — after `parseDamage`, add:
+
+```ts
+function parseHealing(desc: string): GeneratedSpell['modifiers'] {
+  // e.g. "regains a number of Hit Points equal to 2d8 …", "regains Hit Points equal to 2d4"
+  const m = desc.match(/(?:regains?|restores?)[^.]*?(\d+)d(\d+)/i);
+  if (!m) return [];
+  return [
+    { id: 'h0', type: 'healing', dice: { count: parseInt(m[1], 10), sides: parseInt(m[2], 10) } },
+  ];
+}
+
+// Per-step scaling dice, from the higher-level/cantrip-upgrade sentence. Both
+// "increases by 1d6 for each spell slot level above 3" and "increases by 1d10
+// when you reach levels 5, 11, and 17" start with "increases by NdM".
+function parseScalingPerStep(text: string): { count: number; sides: number } | null {
+  const m = text.match(/increases by (\d+)d(\d+)/i);
+  return m ? { count: parseInt(m[1], 10), sides: parseInt(m[2], 10) } : null;
+}
+```
+
+- [ ] **Step 3: Wire them into the spell build** — in `parseSpellMarkdown`, where `modifiers` and `higherLevels` are built, replace the plain `modifiers: parseDamage(description)` with damage+healing and attach scaling:
+
+```ts
+const modifiers = [...parseDamage(description), ...parseHealing(description)];
+const perStep = higherLevels.length ? parseScalingPerStep(higherLevels[0].description) : null;
+if (perStep && modifiers.length) {
+  modifiers[0] = { ...modifiers[0], scaling: { perStep } };
+}
+```
+
+Then set `modifiers` on the pushed spell object (replace the existing `modifiers: parseDamage(description),` field with `modifiers,`).
+
+- [ ] **Step 4: Add generator tests** — in `tests/srd/generate-srd-data.test.ts`, extend the SAMPLE with a healing spell and assert healing + scaling:
+
+```ts
+// add to SAMPLE (before the closing backtick):
+`#### Cure Wounds
+
+_Level 1 Abjuration (Bard, Cleric, Druid, Paladin, Ranger)_
+
+**Casting Time:** Action
+**Range:** Touch
+**Components:** V, S
+**Duration:** Instantaneous
+
+A creature you touch regains a number of Hit Points equal to 2d8 plus your spellcasting ability modifier.
+
+_Using a Higher-Level Spell Slot._ The healing increases by 2d8 for each spell slot level above 1.
+`;
+```
+
+```ts
+it('captures healing dice and slot scaling', () => {
+  const cure = byName('Cure Wounds');
+  const heal = cure.modifiers.find((m) => m.type === 'healing')!;
+  expect(heal.dice).toEqual({ count: 2, sides: 8 });
+  expect(heal.scaling).toEqual({ perStep: { count: 2, sides: 8 } });
+});
+
+it('attaches cantrip scaling to Fire Bolt damage', () => {
+  const bolt = byName('Fire Bolt');
+  expect(bolt.modifiers[0].scaling).toEqual({ perStep: { count: 1, sides: 10 } });
+});
+
+it('attaches slot scaling to Fireball damage', () => {
+  const ball = byName('Fireball');
+  expect(ball.modifiers[0].scaling).toEqual({ perStep: { count: 1, sides: 6 } });
+});
+```
+
+> The existing SAMPLE's Fire Bolt has a "_Cantrip Upgrade._ The damage increases by 1d10 …" line and Fireball has "_Using a Higher-Level Spell Slot._ The damage increases by 1d6 …" — so those two assertions work against the current SAMPLE once scaling is wired.
+
+- [ ] **Step 5: Run parser tests + regenerate**
+
+Run: `npm test -- tests/srd/generate-srd-data.test.ts` (PASS), then `npm run srd:generate`.
+
+- [ ] **Step 6: MANUAL QA GATE (required before commit)**
+
+```bash
+node -e '
+const s = require("./app/server/data/srd/spells.json");
+const p = n => s.find(x=>x.name===n);
+for (const n of ["Fire Bolt","Fireball","Cure Wounds","Healing Word","Scorching Ray","Chromatic Orb"]) {
+  const x = p(n); if (!x) { console.log(n,"MISSING"); continue; }
+  console.log(n, JSON.stringify(x.modifiers));
+}
+console.log("healing modifiers:", s.filter(x=>x.modifiers.some(m=>m.type==="healing")).length);
+console.log("scaled modifiers:", s.filter(x=>x.modifiers.some(m=>m.scaling)).length);
+'
+```
+
+Verify: Fire Bolt/ Fireball scale correctly; Cure Wounds/Healing Word have a healing modifier with scaling; no obvious false-positive healing on damage spells. Fix parser edge cases and re-run `srd:generate` until the sample is right. Log the healing/scaled counts in the commit message.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/srd/generate-srd-data.ts app/server/data/srd/index.ts tests/srd/generate-srd-data.test.ts app/server/data/srd/spells.json
+git commit -m "feat(spells): capture healing dice and per-step scaling in the SRD generator"
+```
+
+---
+
+## Task 3: `toParsedDiceRoll` title override
+
+**Files:**
+
+- Modify: `app/utils/dice.ts`
+- Test: `tests/utils/dice.test.ts` (extend if present; else create)
+
+**Interfaces:**
+
+- Produces: `toParsedDiceRoll(result, opts?: { title?: string })`. Consumed by Task 4.
+
+- [ ] **Step 1: Add the optional `opts`** — change the signature and the `title` line only; leave everything else identical:
+
+```ts
+export function toParsedDiceRoll(
+  result: DiceRollResult,
+  opts?: { title?: string }
+): ParsedDiceRoll {
+  return {
+    character: '',
+    title: opts?.title ?? result.formula,
+    // …rest unchanged…
+  };
+}
+```
+
+- [ ] **Step 2: Test** — add to the dice tests (find the existing dice test file; if none, create `tests/utils/dice.test.ts`):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { rollDice, toParsedDiceRoll } from '~/utils/dice';
+
+describe('toParsedDiceRoll title override', () => {
+  it('uses the provided title, falling back to the formula', () => {
+    const result = rollDice({ pool: [{ sides: 6, count: 8 }], mode: 'normal', modifier: 0 });
+    expect(toParsedDiceRoll(result).title).toBe(result.formula);
+    expect(toParsedDiceRoll(result, { title: 'Fireball · Fire' }).title).toBe('Fireball · Fire');
+  });
+});
+```
+
+- [ ] **Step 3: Run + commit**
+
+Run: `npm test -- tests/utils/dice.test.ts` (PASS), `npm run typecheck` (clean — existing `toParsedDiceRoll(result)` callers still compile since `opts` is optional).
+
+```bash
+git add app/utils/dice.ts tests/utils/dice.test.ts
+git commit -m "feat(dice): optional title override on toParsedDiceRoll"
+```
+
+---
+
+## Task 4: `spellDice.ts` — scaling math + roll trigger (pure logic)
+
+**Files:**
+
+- Create: `app/components/wiki/spells/spellDice.ts`
+- Test: `tests/components/wiki/spells/spellDice.test.ts`
+
+**Interfaces:**
+
+- Consumes: `SpellData`/`SpellModifier`/`SpellDice` (types), `rollDice`/`toParsedDiceRoll` (`~/utils/dice`), `requestDiceBroadcast` (`~/utils/diceRollerBridge`), `DicePoolEntry`/`DieSides` (`~/utils/dice`).
+- Produces: `stepsForCast`, `scaledDice`, `buildPool`, `rollSpellModifier`, `CANTRIP_BREAKPOINTS`. Consumed by Task 5.
+
+- [ ] **Step 1: Write `app/components/wiki/spells/spellDice.ts`**
+
+```ts
+import type { SpellData, SpellModifier, SpellDice } from '~/types/spell';
+import { rollDice, toParsedDiceRoll, type DicePoolEntry, type DieSides } from '~/utils/dice';
+import { requestDiceBroadcast } from '~/utils/diceRollerBridge';
+
+export const CANTRIP_BREAKPOINTS = [5, 11, 17] as const;
+
+/** How many scaling "steps" apply when casting at `castLevel`. */
+export function stepsForCast(spell: SpellData, castLevel: number): number {
+  if (!spell.higherLevelScaling.enabled) return 0;
+  if (spell.higherLevelScaling.type === 'character-level') {
+    return CANTRIP_BREAKPOINTS.filter((b) => castLevel >= b).length;
+  }
+  // spell-scale (leveled): one step per slot level above the spell's base level
+  return Math.max(0, castLevel - spell.level);
+}
+
+/** Base dice scaled to `castLevel` (base + steps × perStep). Null if no dice. */
+export function scaledDice(
+  modifier: SpellModifier,
+  spell: SpellData,
+  castLevel: number
+): SpellDice | null {
+  if (!modifier.dice) return null;
+  if (!modifier.scaling) return modifier.dice;
+  const steps = stepsForCast(spell, castLevel);
+  return {
+    count: modifier.dice.count + steps * modifier.scaling.perStep.count,
+    sides: modifier.dice.sides,
+  };
+}
+
+/** Build a dice pool; a crit doubles the dice count (5e). */
+export function buildPool(dice: SpellDice, crit: boolean): DicePoolEntry[] {
+  return [{ sides: dice.sides as DieSides, count: crit ? dice.count * 2 : dice.count }];
+}
+
+function modifierLabel(spell: SpellData, modifier: SpellModifier): string {
+  const kind = modifier.damageType
+    ? modifier.damageType.charAt(0).toUpperCase() + modifier.damageType.slice(1)
+    : modifier.type === 'healing'
+      ? 'Healing'
+      : 'Damage';
+  return `${spell.name} · ${kind}`;
+}
+
+/** Roll one modifier at the given cast level and broadcast it to the session. */
+export function rollSpellModifier(args: {
+  spell: SpellData;
+  modifier: SpellModifier;
+  castLevel: number;
+  crit: boolean;
+}): void {
+  const dice = scaledDice(args.modifier, args.spell, args.castLevel);
+  if (!dice) return;
+  const result = rollDice({ pool: buildPool(dice, args.crit), mode: 'normal', modifier: 0 });
+  const roll = toParsedDiceRoll(result, { title: modifierLabel(args.spell, args.modifier) });
+  requestDiceBroadcast({ requestId: crypto.randomUUID(), roll });
+}
+```
+
+- [ ] **Step 2: Write `tests/components/wiki/spells/spellDice.test.ts`**
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const requestDiceBroadcast = vi.fn();
+vi.mock('~/utils/diceRollerBridge', () => ({ requestDiceBroadcast }));
+
+import {
+  stepsForCast,
+  scaledDice,
+  buildPool,
+  rollSpellModifier,
+} from '~/components/wiki/spells/spellDice';
+import type { SpellData, SpellModifier } from '~/types/spell';
+
+function spell(overrides: Partial<SpellData> = {}): SpellData {
+  return {
+    id: 's',
+    campaignId: 'c',
+    createdBy: 'u',
+    source: 'srd',
+    name: 'Fireball',
+    description: '',
+    level: 3,
+    school: 'evocation',
+    castingTime: { value: 1, unit: 'action' },
+    components: { verbal: true, somatic: true, material: false },
+    range: { type: 'ranged', distance: 150 },
+    duration: { type: 'instantaneous', concentration: false },
+    ritual: false,
+    higherLevelScaling: { enabled: true, type: 'spell-scale' },
+    classes: [],
+    attackSave: { kind: 'save', saveAbility: 'dex' },
+    modifiers: [],
+    conditions: [],
+    higherLevels: [],
+    areaOfEffect: { shape: 'sphere', size: 20 },
+    tags: [],
+    canEdit: false,
+    createdAt: '',
+    updatedAt: '',
+    ...overrides,
+  };
+}
+const fireballMod: SpellModifier = {
+  id: 'm0',
+  type: 'damage',
+  dice: { count: 8, sides: 6 },
+  damageType: 'fire',
+  scaling: { perStep: { count: 1, sides: 6 } },
+};
+const cantrip = spell({
+  name: 'Fire Bolt',
+  level: 0,
+  higherLevelScaling: { enabled: true, type: 'character-level' },
+});
+const boltMod: SpellModifier = {
+  id: 'm0',
+  type: 'damage',
+  dice: { count: 1, sides: 10 },
+  damageType: 'fire',
+  scaling: { perStep: { count: 1, sides: 10 } },
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('stepsForCast', () => {
+  it('counts slot levels above base for leveled spells', () => {
+    expect(stepsForCast(spell(), 3)).toBe(0);
+    expect(stepsForCast(spell(), 5)).toBe(2);
+    expect(stepsForCast(spell(), 9)).toBe(6);
+  });
+  it('counts cantrip breakpoints reached', () => {
+    expect(stepsForCast(cantrip, 1)).toBe(0);
+    expect(stepsForCast(cantrip, 5)).toBe(1);
+    expect(stepsForCast(cantrip, 11)).toBe(2);
+    expect(stepsForCast(cantrip, 17)).toBe(3);
+  });
+  it('returns 0 when scaling disabled', () => {
+    expect(stepsForCast(spell({ higherLevelScaling: { enabled: false } }), 9)).toBe(0);
+  });
+});
+
+describe('scaledDice + buildPool', () => {
+  it('scales Fireball by slot', () => {
+    expect(scaledDice(fireballMod, spell(), 5)).toEqual({ count: 10, sides: 6 });
+  });
+  it('scales Fire Bolt by character level', () => {
+    expect(scaledDice(boltMod, cantrip, 11)).toEqual({ count: 3, sides: 10 });
+  });
+  it('doubles dice on a crit', () => {
+    expect(buildPool({ count: 8, sides: 6 }, true)).toEqual([{ sides: 6, count: 16 }]);
+    expect(buildPool({ count: 8, sides: 6 }, false)).toEqual([{ sides: 6, count: 8 }]);
+  });
+});
+
+describe('rollSpellModifier', () => {
+  it('broadcasts a roll titled with the spell + damage type', () => {
+    rollSpellModifier({ spell: spell(), modifier: fireballMod, castLevel: 5, crit: false });
+    expect(requestDiceBroadcast).toHaveBeenCalledTimes(1);
+    const arg = requestDiceBroadcast.mock.calls[0][0];
+    expect(arg.roll.title).toBe('Fireball · Fire');
+    expect(typeof arg.requestId).toBe('string');
+  });
+});
+```
+
+- [ ] **Step 3: Run + commit**
+
+Run: `npm test -- tests/components/wiki/spells/spellDice.test.ts` (PASS), `npm run typecheck && npm run lint` (clean).
+
+```bash
+git add app/components/wiki/spells/spellDice.ts tests/components/wiki/spells/spellDice.test.ts
+git commit -m "feat(spells): add spell dice scaling + roll-and-broadcast logic"
+```
+
+---
+
+## Task 5: UI — "Cast & Roll" block in `SpellWindow`
+
+**Files:**
+
+- Modify: `app/components/wiki/spells/SpellWindow.tsx`
+- Test: `tests/components/wiki/spells/SpellWindow.test.tsx` (new)
+
+**Interfaces:**
+
+- Consumes: `spellDice.ts` (Task 4), `formatSpellLevel` etc.
+- Produces: rollable UI inside `SpellWindow` (renders in `SpellViewModal` and the read-only `SpellModal`).
+
+- [ ] **Step 1: Add the Cast & Roll block** — in `SpellWindow.tsx`, add local state and a block rendered after the header grid, before the description. Only render for modifiers that have `dice`.
+
+```tsx
+// add imports
+import { useState } from 'react';
+import { scaledDice, rollSpellModifier } from './spellDice';
+// …
+
+// inside SpellWindow, after computing header cells:
+const rollable = spell.modifiers.filter((m) => m.dice);
+const scaling = spell.higherLevelScaling;
+const [castLevel, setCastLevel] = useState(scaling.type === 'character-level' ? 1 : spell.level);
+const [crit, setCrit] = useState(false);
+
+const levelOptions =
+  scaling.type === 'character-level'
+    ? Array.from({ length: 20 }, (_, i) => i + 1)
+    : Array.from({ length: 10 - spell.level }, (_, i) => spell.level + i);
+```
+
+```tsx
+{
+  rollable.length > 0 && (
+    <div className="px-4 py-3 border-b border-white/[0.05] shrink-0 space-y-2">
+      <div className="flex items-center gap-3 flex-wrap">
+        {scaling.enabled && (
+          <label className="flex items-center gap-1.5 text-[10px] font-semibold text-slate-400">
+            {scaling.type === 'character-level' ? 'Character level' : 'Slot level'}
+            <select
+              value={castLevel}
+              onChange={(e) => setCastLevel(Number(e.target.value))}
+              className="bg-[#080A12] border border-white/[0.07] rounded px-2 py-1 text-xs text-white"
+            >
+              {levelOptions.map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+        <label className="flex items-center gap-1.5 text-[10px] font-semibold text-slate-400">
+          <input
+            type="checkbox"
+            checked={crit}
+            onChange={(e) => setCrit(e.target.checked)}
+            className="h-3.5 w-3.5 accent-blue-600"
+          />
+          Crit
+        </label>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {rollable.map((m) => {
+          const dice = scaledDice(m, spell, castLevel);
+          if (!dice) return null;
+          const label = `${crit ? dice.count * 2 : dice.count}d${dice.sides}${
+            m.damageType ? ` ${m.damageType}` : m.type === 'healing' ? ' healing' : ''
+          }`;
+          return (
+            <button
+              key={m.id}
+              type="button"
+              onClick={() => rollSpellModifier({ spell, modifier: m, castLevel, crit })}
+              className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-blue-500/10 border border-blue-500/30 text-blue-300 text-xs font-semibold hover:bg-blue-500/20 transition-colors"
+              data-testid={`roll-${m.id}`}
+            >
+              <span aria-hidden>⚄</span> {label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Write `tests/components/wiki/spells/SpellWindow.test.tsx`**
+
+```tsx
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const requestDiceBroadcast = vi.fn();
+vi.mock('~/utils/diceRollerBridge', () => ({ requestDiceBroadcast }));
+
+import { SpellWindow } from '~/components/wiki/spells/SpellWindow';
+import type { SpellData } from '~/types/spell';
+
+function fireball(): SpellData {
+  return {
+    id: 's',
+    campaignId: 'c',
+    createdBy: 'u',
+    source: 'srd',
+    name: 'Fireball',
+    description: 'A bright streak.',
+    level: 3,
+    school: 'evocation',
+    castingTime: { value: 1, unit: 'action' },
+    components: { verbal: true, somatic: true, material: false },
+    range: { type: 'ranged', distance: 150 },
+    duration: { type: 'instantaneous', concentration: false },
+    ritual: false,
+    higherLevelScaling: { enabled: true, type: 'spell-scale' },
+    classes: ['Wizard'],
+    attackSave: { kind: 'save', saveAbility: 'dex' },
+    modifiers: [
+      {
+        id: 'm0',
+        type: 'damage',
+        dice: { count: 8, sides: 6 },
+        damageType: 'fire',
+        scaling: { perStep: { count: 1, sides: 6 } },
+      },
+    ],
+    conditions: [],
+    higherLevels: [],
+    areaOfEffect: { shape: 'sphere', size: 20 },
+    tags: [],
+    canEdit: false,
+    createdAt: '',
+    updatedAt: '',
+  };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('SpellWindow roll chips', () => {
+  it('rolls base dice and broadcasts', async () => {
+    const user = userEvent.setup();
+    render(<SpellWindow spell={fireball()} />);
+    expect(screen.getByTestId('roll-m0')).toHaveTextContent('8d6 fire');
+    await user.click(screen.getByTestId('roll-m0'));
+    expect(requestDiceBroadcast).toHaveBeenCalledTimes(1);
+    expect(requestDiceBroadcast.mock.calls[0][0].roll.title).toBe('Fireball · Fire');
+  });
+
+  it('scales the chip when the slot level changes', async () => {
+    const user = userEvent.setup();
+    render(<SpellWindow spell={fireball()} />);
+    await user.selectOptions(screen.getByRole('combobox'), '5');
+    expect(screen.getByTestId('roll-m0')).toHaveTextContent('10d6 fire');
+  });
+});
+```
+
+- [ ] **Step 3: Run + commit**
+
+Run: `npm test -- tests/components/wiki/spells/SpellWindow.test.tsx` (PASS), `npm run typecheck && npm run lint` (clean).
+
+```bash
+git add app/components/wiki/spells/SpellWindow.tsx tests/components/wiki/spells/SpellWindow.test.tsx
+git commit -m "feat(spells): roll chips + cast-level/crit controls on the spell card"
+```
+
+---
+
+## Task 6: Regenerate data, reset dev, final gates
+
+**Files:** none (operational).
+
+- [ ] **Step 1: Ensure data is current** — `npm run srd:generate` (already committed in Task 2; re-run to confirm no diff).
+
+- [ ] **Step 2: Reset dev so it has the new fields** — per the `resetting-dev-data` skill:
+
+```bash
+npm run dev:clear -- --force
+npm run dev:seed
+```
+
+Then spot-check in the app: open "The Lost Mines of Phandelver" → Wiki → Spells → Fireball; confirm the `8d6 Fire` chip, the slot-level selector scales it (5 → `10d6`), the Crit toggle doubles it, and clicking broadcasts to the dice log.
+
+- [ ] **Step 3: Full gates**
+
+Run: `npm test` (green), `npm run typecheck` (clean), `npm run lint` (0 errors, no new warnings).
+
+- [ ] **Step 4: Open PR to `dev`** (never `main`). This builds on Phase 1 — base the branch on Phase 1 once it merges, or stack on the spells branch.
+
+## Self-Review (author checklist)
+
+- [ ] **Spec coverage:** scaling model (Task 1), healing+scaling extraction (Task 2), title override (Task 3), scaling math + roll/broadcast (Task 4), roll chips + selector + crit (Task 5), regen+reset (Task 6). Out-of-scope items (attack/save rolls) intentionally absent.
+- [ ] **Type consistency:** `scaling: { perStep: SpellDice }` identical across types/Zod/model/generator/spellDice; `stepsForCast`/`scaledDice`/`buildPool`/`rollSpellModifier` signatures match between Task 4 and Task 5.
+- [ ] **No new deps**, tests under `tests/`, `crypto.randomUUID()` matches the dice roller's existing pattern.
+
+## Out of scope (this plan)
+
+- d20 spell attack rolls + save DC (character-sheet wiring).
+- Special-case scaling that doesn't fit "increases by NdM" (e.g. Scorching Ray) — rolls base dice.
+- Phase 3 (map overlays).

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "prepare": "node -e \"const fs=require('fs'); if (fs.existsSync('.git')) require('child_process').execFileSync(process.platform === 'win32' ? 'npx.cmd' : 'npx', ['lefthook', 'install'], { stdio: 'inherit' });\"",
-    "dev": "vite dev",
+    "dev": "node scripts/dev-all.mjs",
+    "dev:web": "vite dev",
     "build": "NODE_ENV=production vite build",
     "start": "node --env-file-if-exists=.env .output/server/index.mjs",
     "typecheck": "tsc --noEmit",

--- a/scripts/dev-all.mjs
+++ b/scripts/dev-all.mjs
@@ -26,17 +26,26 @@ if (existsSync('.env')) {
 const children = [];
 let shuttingDown = false;
 
+function killTree(child, signal) {
+  try {
+    // Children are spawned detached (own process group), so a negative PID
+    // signals the whole group — reaping grandchildren (e.g. npm → tsx → node)
+    // so :1999 doesn't stay bound after exit.
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
 function shutdown(code = 0) {
   if (shuttingDown) return;
   shuttingDown = true;
   for (const child of children) {
-    if (!child.killed) {
-      try {
-        child.kill('SIGTERM');
-      } catch {
-        /* already gone */
-      }
-    }
+    if (!child.killed) killTree(child, 'SIGTERM');
   }
   // Give children a moment to exit, then force.
   setTimeout(() => process.exit(code), 500).unref();
@@ -46,6 +55,7 @@ function run(name, command, args, env) {
   const child = spawn(command, args, {
     env: { ...process.env, ...env },
     stdio: ['inherit', 'pipe', 'pipe'],
+    detached: true,
   });
   const tag = `[${name}] `;
   const pipe = (stream, out) => {

--- a/scripts/dev-all.mjs
+++ b/scripts/dev-all.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Run the web app (vite dev) AND the realtime ws service together, so a single
+ * `npm run dev` gives a fully working local stack (dice/chat/tabletop realtime
+ * needs the ws service — without it, rolls never reach the session history).
+ *
+ * Dependency-free: no `concurrently`. Loads .env (the realtime service reads
+ * process.env directly and does not load .env itself) and pins the ws service
+ * to :1999, which is what the client (`usePartySession`) defaults to.
+ *
+ * Ctrl+C, or either child exiting, tears the whole stack down — no orphans.
+ */
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+// Load .env into process.env so the realtime service gets SESSION_SECRET /
+// MONGODB_URI. Vite loads .env on its own, so this is harmless for the web app.
+if (existsSync('.env')) {
+  try {
+    process.loadEnvFile('.env');
+  } catch (err) {
+    console.warn('[dev] could not load .env:', err.message);
+  }
+}
+
+const children = [];
+let shuttingDown = false;
+
+function shutdown(code = 0) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  for (const child of children) {
+    if (!child.killed) {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+  // Give children a moment to exit, then force.
+  setTimeout(() => process.exit(code), 500).unref();
+}
+
+function run(name, command, args, env) {
+  const child = spawn(command, args, {
+    env: { ...process.env, ...env },
+    stdio: ['inherit', 'pipe', 'pipe'],
+  });
+  const tag = `[${name}] `;
+  const pipe = (stream, out) => {
+    stream.on('data', (buf) => {
+      const text = buf.toString().replace(/\n$/, '');
+      out.write(text.replace(/^/gm, tag) + '\n');
+    });
+  };
+  pipe(child.stdout, process.stdout);
+  pipe(child.stderr, process.stderr);
+  child.on('exit', (code, signal) => {
+    if (!shuttingDown) {
+      console.log(`${tag}exited (${signal ?? code}) — shutting down the dev stack`);
+      shutdown(code ?? 0);
+    }
+  });
+  children.push(child);
+  return child;
+}
+
+process.on('SIGINT', () => shutdown(0));
+process.on('SIGTERM', () => shutdown(0));
+
+// Web app (vite reads its own port from vite.config; it ignores PORT).
+run('web', 'npx', ['vite', 'dev']);
+// Realtime ws service on :1999 (client default). Override PORT so it never
+// picks up the web PORT from .env.
+run('ws', 'npm', ['--prefix', 'realtime', 'run', 'dev'], { PORT: '1999' });

--- a/scripts/srd/generate-srd-data.ts
+++ b/scripts/srd/generate-srd-data.ts
@@ -306,7 +306,12 @@ export function parseSpellMarkdown(md: string): GeneratedSpell[] {
       range: parseRange(label('Range')),
       duration: parseDuration(label('Duration')),
       ritual,
-      higherLevelScaling: { enabled: higherLevels.length > 0, type: 'spell-scale' },
+      higherLevelScaling: {
+        enabled: higherLevels.length > 0,
+        // Cantrips scale by character level (breakpoints 5/11/17); leveled
+        // spells scale by the spell slot used.
+        type: level === 0 ? 'character-level' : 'spell-scale',
+      },
       classes,
       attackSave: parseAttackSave(description),
       modifiers,

--- a/scripts/srd/generate-srd-data.ts
+++ b/scripts/srd/generate-srd-data.ts
@@ -46,6 +46,7 @@ export interface GeneratedSpell {
     type: string;
     dice?: { count: number; sides: number };
     damageType?: string;
+    scaling?: { perStep: { count: number; sides: number } };
   }>;
   conditions: Array<{ id: string; action: string; condition: string }>;
   higherLevels: Array<{ id: string; level: number; description: string }>;
@@ -143,6 +144,23 @@ function parseDamage(desc: string): GeneratedSpell['modifiers'] {
     });
   }
   return modifiers;
+}
+
+function parseHealing(desc: string): GeneratedSpell['modifiers'] {
+  // e.g. "regains a number of Hit Points equal to 2d8 …", "regains Hit Points equal to 2d4"
+  const m = desc.match(/(?:regains?|restores?)[^.]*?(\d+)d(\d+)/i);
+  if (!m) return [];
+  return [
+    { id: 'h0', type: 'healing', dice: { count: parseInt(m[1], 10), sides: parseInt(m[2], 10) } },
+  ];
+}
+
+// Per-step scaling dice, from the higher-level/cantrip-upgrade sentence. Both
+// "increases by 1d6 for each spell slot level above 3" and "increases by 1d10
+// when you reach levels 5, 11, and 17" start with "increases by NdM".
+function parseScalingPerStep(text: string): { count: number; sides: number } | null {
+  const m = text.match(/increases by (\d+)d(\d+)/i);
+  return m ? { count: parseInt(m[1], 10), sides: parseInt(m[2], 10) } : null;
 }
 
 function parseAttackSave(desc: string): GeneratedSpell['attackSave'] {
@@ -272,6 +290,12 @@ export function parseSpellMarkdown(md: string): GeneratedSpell[] {
       .replace(/\n{3,}/g, '\n\n')
       .trim();
 
+    const modifiers = [...parseDamage(description), ...parseHealing(description)];
+    const perStep = higherLevels.length ? parseScalingPerStep(higherLevels[0].description) : null;
+    if (perStep && modifiers.length) {
+      modifiers[0] = { ...modifiers[0], scaling: { perStep } };
+    }
+
     spells.push({
       name,
       description: description || name,
@@ -285,7 +309,7 @@ export function parseSpellMarkdown(md: string): GeneratedSpell[] {
       higherLevelScaling: { enabled: higherLevels.length > 0, type: 'spell-scale' },
       classes,
       attackSave: parseAttackSave(description),
-      modifiers: parseDamage(description),
+      modifiers,
       conditions: [],
       higherLevels,
       areaOfEffect: parseAoe(description),

--- a/tests/components/wiki/spells/SpellWindow.test.tsx
+++ b/tests/components/wiki/spells/SpellWindow.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('~/utils/diceRollerBridge', () => ({ requestDiceBroadcast: vi.fn() }));
+
+import { requestDiceBroadcast } from '~/utils/diceRollerBridge';
+import { SpellWindow } from '~/components/wiki/spells/SpellWindow';
+import type { SpellData } from '~/types/spell';
+
+const mockRequestDiceBroadcast = vi.mocked(requestDiceBroadcast);
+
+function fireball(): SpellData {
+  return {
+    id: 's',
+    campaignId: 'c',
+    createdBy: 'u',
+    source: 'srd',
+    name: 'Fireball',
+    description: 'A bright streak.',
+    level: 3,
+    school: 'evocation',
+    castingTime: { value: 1, unit: 'action' },
+    components: { verbal: true, somatic: true, material: false },
+    range: { type: 'ranged', distance: 150 },
+    duration: { type: 'instantaneous', concentration: false },
+    ritual: false,
+    higherLevelScaling: { enabled: true, type: 'spell-scale' },
+    classes: ['Wizard'],
+    attackSave: { kind: 'save', saveAbility: 'dex' },
+    modifiers: [
+      {
+        id: 'm0',
+        type: 'damage',
+        dice: { count: 8, sides: 6 },
+        damageType: 'fire',
+        scaling: { perStep: { count: 1, sides: 6 } },
+      },
+    ],
+    conditions: [],
+    higherLevels: [],
+    areaOfEffect: { shape: 'sphere', size: 20 },
+    tags: [],
+    canEdit: false,
+    createdAt: '',
+    updatedAt: '',
+  };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('SpellWindow roll chips', () => {
+  it('rolls base dice and broadcasts', async () => {
+    const user = userEvent.setup();
+    render(<SpellWindow spell={fireball()} />);
+    expect(screen.getByTestId('roll-m0')).toHaveTextContent('8d6 fire');
+    await user.click(screen.getByTestId('roll-m0'));
+    expect(mockRequestDiceBroadcast).toHaveBeenCalledTimes(1);
+    expect(mockRequestDiceBroadcast.mock.calls[0][0].roll.title).toBe('Fireball · Fire');
+  });
+
+  it('scales the chip when the slot level changes', async () => {
+    const user = userEvent.setup();
+    render(<SpellWindow spell={fireball()} />);
+    await user.selectOptions(screen.getByRole('combobox'), '5');
+    expect(screen.getByTestId('roll-m0')).toHaveTextContent('10d6 fire');
+  });
+});

--- a/tests/components/wiki/spells/SpellWindow.test.tsx
+++ b/tests/components/wiki/spells/SpellWindow.test.tsx
@@ -60,6 +60,19 @@ describe('SpellWindow roll chips', () => {
     expect(mockRequestDiceBroadcast.mock.calls[0][0].roll.title).toBe('Fireball · Fire');
   });
 
+  it('shows the roll result locally (independent of the session broadcast)', async () => {
+    const user = userEvent.setup();
+    render(<SpellWindow spell={fireball()} />);
+    // No result before rolling.
+    expect(screen.queryByTestId('spell-roll-result')).not.toBeInTheDocument();
+    await user.click(screen.getByTestId('roll-m0'));
+    // A local result appears with the spell title and a numeric total, even
+    // though no active session/socket exists in this test.
+    const result = screen.getByTestId('spell-roll-result');
+    expect(result).toHaveTextContent('Fireball · Fire');
+    expect(result.textContent).toMatch(/\d+/);
+  });
+
   it('scales the chip when the slot level changes', async () => {
     const user = userEvent.setup();
     render(<SpellWindow spell={fireball()} />);

--- a/tests/components/wiki/spells/SpellWindow.test.tsx
+++ b/tests/components/wiki/spells/SpellWindow.test.tsx
@@ -4,12 +4,18 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 vi.mock('~/utils/diceRollerBridge', () => ({ requestDiceBroadcast: vi.fn() }));
+vi.mock('~/utils/chatBridge', () => ({
+  requestChatBroadcast: vi.fn(),
+  onChatDelivery: vi.fn(() => () => {}),
+}));
 
 import { requestDiceBroadcast } from '~/utils/diceRollerBridge';
+import { requestChatBroadcast } from '~/utils/chatBridge';
 import { SpellWindow } from '~/components/wiki/spells/SpellWindow';
 import type { SpellData } from '~/types/spell';
 
 const mockRequestDiceBroadcast = vi.mocked(requestDiceBroadcast);
+const mockRequestChatBroadcast = vi.mocked(requestChatBroadcast);
 
 function fireball(): SpellData {
   return {
@@ -78,5 +84,16 @@ describe('SpellWindow roll chips', () => {
     render(<SpellWindow spell={fireball()} />);
     await user.selectOptions(screen.getByRole('combobox'), '5');
     expect(screen.getByTestId('roll-m0')).toHaveTextContent('10d6 fire');
+  });
+
+  it('shares the spell to chat', async () => {
+    const user = userEvent.setup();
+    render(<SpellWindow spell={fireball()} />);
+    await user.click(screen.getByRole('button', { name: /share spell in chat/i }));
+    expect(mockRequestChatBroadcast).toHaveBeenCalledTimes(1);
+    const arg = mockRequestChatBroadcast.mock.calls[0][0];
+    expect(arg.channel).toBe('general');
+    expect(arg.text).toContain('Fireball');
+    expect(typeof arg.requestId).toBe('string');
   });
 });

--- a/tests/components/wiki/spells/spellDice.test.ts
+++ b/tests/components/wiki/spells/spellDice.test.ts
@@ -104,4 +104,19 @@ describe('rollSpellModifier', () => {
     expect(arg.roll.title).toBe('Fireball · Fire');
     expect(typeof arg.requestId).toBe('string');
   });
+
+  it('returns the outcome for local display', () => {
+    const outcome = rollSpellModifier({
+      spell: spell(),
+      modifier: fireballMod,
+      castLevel: 5,
+      crit: false,
+    });
+    expect(outcome).not.toBeNull();
+    expect(outcome!.title).toBe('Fireball · Fire');
+    // Fireball at slot 5 = 10d6 → total between 10 and 60.
+    expect(outcome!.total).toBeGreaterThanOrEqual(10);
+    expect(outcome!.total).toBeLessThanOrEqual(60);
+    expect(outcome!.formula).toContain('10d6');
+  });
 });

--- a/tests/components/wiki/spells/spellDice.test.ts
+++ b/tests/components/wiki/spells/spellDice.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('~/utils/diceRollerBridge', () => ({
+  requestDiceBroadcast: vi.fn(),
+}));
+
+import { requestDiceBroadcast } from '~/utils/diceRollerBridge';
+import {
+  stepsForCast,
+  scaledDice,
+  buildPool,
+  rollSpellModifier,
+} from '~/components/wiki/spells/spellDice';
+import type { SpellData, SpellModifier } from '~/types/spell';
+
+const mockRequestDiceBroadcast = vi.mocked(requestDiceBroadcast);
+
+function spell(overrides: Partial<SpellData> = {}): SpellData {
+  return {
+    id: 's',
+    campaignId: 'c',
+    createdBy: 'u',
+    source: 'srd',
+    name: 'Fireball',
+    description: '',
+    level: 3,
+    school: 'evocation',
+    castingTime: { value: 1, unit: 'action' },
+    components: { verbal: true, somatic: true, material: false },
+    range: { type: 'ranged', distance: 150 },
+    duration: { type: 'instantaneous', concentration: false },
+    ritual: false,
+    higherLevelScaling: { enabled: true, type: 'spell-scale' },
+    classes: [],
+    attackSave: { kind: 'save', saveAbility: 'dex' },
+    modifiers: [],
+    conditions: [],
+    higherLevels: [],
+    areaOfEffect: { shape: 'sphere', size: 20 },
+    tags: [],
+    canEdit: false,
+    createdAt: '',
+    updatedAt: '',
+    ...overrides,
+  };
+}
+const fireballMod: SpellModifier = {
+  id: 'm0',
+  type: 'damage',
+  dice: { count: 8, sides: 6 },
+  damageType: 'fire',
+  scaling: { perStep: { count: 1, sides: 6 } },
+};
+const cantrip = spell({
+  name: 'Fire Bolt',
+  level: 0,
+  higherLevelScaling: { enabled: true, type: 'character-level' },
+});
+const boltMod: SpellModifier = {
+  id: 'm0',
+  type: 'damage',
+  dice: { count: 1, sides: 10 },
+  damageType: 'fire',
+  scaling: { perStep: { count: 1, sides: 10 } },
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('stepsForCast', () => {
+  it('counts slot levels above base for leveled spells', () => {
+    expect(stepsForCast(spell(), 3)).toBe(0);
+    expect(stepsForCast(spell(), 5)).toBe(2);
+    expect(stepsForCast(spell(), 9)).toBe(6);
+  });
+  it('counts cantrip breakpoints reached', () => {
+    expect(stepsForCast(cantrip, 1)).toBe(0);
+    expect(stepsForCast(cantrip, 5)).toBe(1);
+    expect(stepsForCast(cantrip, 11)).toBe(2);
+    expect(stepsForCast(cantrip, 17)).toBe(3);
+  });
+  it('returns 0 when scaling disabled', () => {
+    expect(stepsForCast(spell({ higherLevelScaling: { enabled: false } }), 9)).toBe(0);
+  });
+});
+
+describe('scaledDice + buildPool', () => {
+  it('scales Fireball by slot', () => {
+    expect(scaledDice(fireballMod, spell(), 5)).toEqual({ count: 10, sides: 6 });
+  });
+  it('scales Fire Bolt by character level', () => {
+    expect(scaledDice(boltMod, cantrip, 11)).toEqual({ count: 3, sides: 10 });
+  });
+  it('doubles dice on a crit', () => {
+    expect(buildPool({ count: 8, sides: 6 }, true)).toEqual([{ sides: 6, count: 16 }]);
+    expect(buildPool({ count: 8, sides: 6 }, false)).toEqual([{ sides: 6, count: 8 }]);
+  });
+});
+
+describe('rollSpellModifier', () => {
+  it('broadcasts a roll titled with the spell + damage type', () => {
+    rollSpellModifier({ spell: spell(), modifier: fireballMod, castLevel: 5, crit: false });
+    expect(mockRequestDiceBroadcast).toHaveBeenCalledTimes(1);
+    const arg = mockRequestDiceBroadcast.mock.calls[0][0];
+    expect(arg.roll.title).toBe('Fireball · Fire');
+    expect(typeof arg.requestId).toBe('string');
+  });
+});

--- a/tests/srd/generate-srd-data.test.ts
+++ b/tests/srd/generate-srd-data.test.ts
@@ -84,6 +84,19 @@ _Small or Medium Construct_
 **AC** 15
 
 An embedded summoned-creature stat block that is not a spell.
+
+#### Cure Wounds
+
+_Level 1 Abjuration (Bard, Cleric, Druid, Paladin, Ranger)_
+
+**Casting Time:** Action
+**Range:** Touch
+**Components:** V, S
+**Duration:** Instantaneous
+
+A creature you touch regains a number of Hit Points equal to 2d8 plus your spellcasting ability modifier.
+
+_Using a Higher-Level Spell Slot._ The healing increases by 2d8 for each spell slot level above 1.
 `;
 
 describe('parseSpellMarkdown', () => {
@@ -97,6 +110,7 @@ describe('parseSpellMarkdown', () => {
       'Detect Magic',
       'Lightning Bolt',
       'Confusion',
+      'Cure Wounds',
     ]);
     // "Animated Object" has no "Cantrip"/"Level N" header line — it's a summoned
     // creature stat block, not a spell, and must be skipped.
@@ -153,5 +167,22 @@ describe('parseSpellMarkdown', () => {
     const lb = byName('Lightning Bolt');
     expect(lb.areaOfEffect).toEqual({ shape: 'line', size: 100, width: 5 });
     expect(lb.modifiers[0].damageType).toBe('lightning');
+  });
+
+  it('captures healing dice and slot scaling', () => {
+    const cure = byName('Cure Wounds');
+    const heal = cure.modifiers.find((m) => m.type === 'healing')!;
+    expect(heal.dice).toEqual({ count: 2, sides: 8 });
+    expect(heal.scaling).toEqual({ perStep: { count: 2, sides: 8 } });
+  });
+
+  it('attaches cantrip scaling to Fire Bolt damage', () => {
+    const bolt = byName('Fire Bolt');
+    expect(bolt.modifiers[0].scaling).toEqual({ perStep: { count: 1, sides: 10 } });
+  });
+
+  it('attaches slot scaling to Fireball damage', () => {
+    const ball = byName('Fireball');
+    expect(ball.modifiers[0].scaling).toEqual({ perStep: { count: 1, sides: 6 } });
   });
 });

--- a/tests/srd/generate-srd-data.test.ts
+++ b/tests/srd/generate-srd-data.test.ts
@@ -185,4 +185,11 @@ describe('parseSpellMarkdown', () => {
     const ball = byName('Fireball');
     expect(ball.modifiers[0].scaling).toEqual({ perStep: { count: 1, sides: 6 } });
   });
+
+  it('marks cantrips as character-level scaling and leveled spells as spell-scale', () => {
+    // Fire Bolt is a cantrip → scales by character level (breakpoints), NOT by
+    // spell slot; Fireball is leveled → scales by slot.
+    expect(byName('Fire Bolt').higherLevelScaling.type).toBe('character-level');
+    expect(byName('Fireball').higherLevelScaling.type).toBe('spell-scale');
+  });
 });

--- a/tests/types/schemas/spells.test.ts
+++ b/tests/types/schemas/spells.test.ts
@@ -52,3 +52,20 @@ describe('listSpellsSchema', () => {
     expect(parsed.level).toBe(3);
   });
 });
+
+describe('modifiers with scaling', () => {
+  it('accepts a damage modifier with scaling', () => {
+    const parsed = createSpellSchema.parse({
+      ...validSpell,
+      modifiers: [
+        {
+          id: 'm0',
+          type: 'damage',
+          dice: { count: 8, sides: 6 },
+          scaling: { perStep: { count: 1, sides: 6 } },
+        },
+      ],
+    });
+    expect(parsed.modifiers[0].scaling).toEqual({ perStep: { count: 1, sides: 6 } });
+  });
+});

--- a/tests/utils/dice.test.ts
+++ b/tests/utils/dice.test.ts
@@ -170,4 +170,10 @@ describe('toParsedDiceRoll', () => {
     // channel is part of both shapes; schema must parse cleanly
     expect(() => saveDiceRollSchema.parse(candidate)).not.toThrow();
   });
+
+  it('uses the provided title, falling back to the formula', () => {
+    const result = rollDice({ pool: [{ sides: 6, count: 8 }], mode: 'normal', modifier: 0 });
+    expect(toParsedDiceRoll(result).title).toBe(result.formula);
+    expect(toParsedDiceRoll(result, { title: 'Fireball · Fire' }).title).toBe('Fireball · Fire');
+  });
 });


### PR DESCRIPTION
## Spells Phase 2 — Roll damage from a spell

Roll a spell's damage/healing straight from the spell view, with higher-level scaling and a crit toggle, broadcast to the session dice log. Builds on Phase 1 (#519).

### What's included
- **Roll chips** on the spell display card — one per damage/healing modifier (e.g. `⚄ 8d6 Fire`). Clicking rolls it via the existing dice engine and broadcasts to the session (`Fireball · Fire: 27`).
- **Higher-level scaling**: a cast-level selector — **slot level** for leveled spells, **character level (1–20)** for cantrips — scales the dice (Fireball at slot 5 → `10d6`; Fire Bolt at level 11 → `3d10`). A **Crit** toggle doubles the dice.
- **Structured scaling data**: added `scaling: { perStep }` to spell modifiers, and the SRD generator now extracts per-step scaling from the higher-level/cantrip text **and captures healing dice** (closing a Phase 1 gap). Regenerated data: 7 healing modifiers, 52 scaled modifiers across 339 spells.
- Small dice-engine addition: optional `title` on `toParsedDiceRoll` so rolls read as the spell.

### Scope
Damage + healing rolls only. **Out of scope** (need caster stats / character-sheet wiring): d20 spell attack rolls and save DC. Also deferred: spells phrasing damage as "*N*d*M* damage of the chosen type" (e.g. Chromatic Orb) get no damage modifier — a pre-existing `parseDamage` gap.

### Quality
`npm test` **1547 passing** · typecheck clean · lint 0 errors/24 warnings (baseline). New unit tests cover the scaling math, crit doubling, healing/scaling extraction, and the roll-chip → broadcast flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCPhrp5koSSPo8afU4rvG1
