### PR TITLE
Spells Phase 3: draw spell AoE templates on the tabletop map

### DIFF
--- a/app/components/Toast.tsx
+++ b/app/components/Toast.tsx
@@ -1,48 +1,65 @@
-import { useState, useCallback, useEffect, useRef } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+export type ToastVariant = 'info' | 'error';
 
 interface ToastState {
-  message: string
-  visible: boolean
+  message: string;
+  variant: ToastVariant;
+  visible: boolean;
 }
 
-let _showToast: ((msg: string) => void) | null = null
+let _showToast: ((msg: string, variant: ToastVariant) => void) | null = null;
 
-export function showToast(message: string) {
-  _showToast?.(message)
+/** Show a transient toast. `variant` defaults to 'info'; use 'error' for failures. */
+export function showToast(message: string, variant: ToastVariant = 'info') {
+  _showToast?.(message, variant);
 }
 
 export function Toast() {
-  const [state, setState] = useState<ToastState>({ message: '', visible: false })
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [state, setState] = useState<ToastState>({
+    message: '',
+    variant: 'info',
+    visible: false,
+  });
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const show = useCallback((message: string) => {
+  const show = useCallback((message: string, variant: ToastVariant) => {
     // Clear any existing timeout
-    if (timerRef.current) clearTimeout(timerRef.current)
-    setState({ message, visible: true })
-    timerRef.current = setTimeout(() => {
-      setState(s => ({ ...s, visible: false }))
-      timerRef.current = null
-    }, 2400)
-  }, [])
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setState({ message, variant, visible: true });
+    // Errors linger a little longer so they're not missed.
+    timerRef.current = setTimeout(
+      () => {
+        setState((s) => ({ ...s, visible: false }));
+        timerRef.current = null;
+      },
+      variant === 'error' ? 4000 : 2400
+    );
+  }, []);
 
   // Register/cleanup global handler
   useEffect(() => {
-    _showToast = show
+    _showToast = show;
     return () => {
-      _showToast = null
-      if (timerRef.current) clearTimeout(timerRef.current)
-    }
-  }, [show])
+      _showToast = null;
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [show]);
+
+  const palette =
+    state.variant === 'error'
+      ? 'bg-slate-800 border-red-500/40 text-red-300'
+      : 'bg-slate-800 border-blue-500/30 text-blue-300';
 
   return (
     <div
-      role="status"
-      aria-live="polite"
+      role={state.variant === 'error' ? 'alert' : 'status'}
+      aria-live={state.variant === 'error' ? 'assertive' : 'polite'}
       className={`fixed bottom-7 left-1/2 z-50 -translate-x-1/2 transition-transform duration-300 ease-spring
-        bg-slate-800 border border-blue-500/30 rounded-xl px-5 py-3 text-sm text-blue-300 font-medium whitespace-nowrap
+        rounded-xl border px-5 py-3 text-sm font-medium whitespace-nowrap ${palette}
         ${state.visible ? 'translate-y-0' : 'translate-y-20 pointer-events-none'}`}
     >
       {state.message}
     </div>
-  )
+  );
 }

--- a/app/components/mainview/ToolBar.tsx
+++ b/app/components/mainview/ToolBar.tsx
@@ -5,6 +5,7 @@ import {
   Pencil,
   Type,
   Ruler,
+  Cone,
   Dices,
   Stamp,
   Layers,
@@ -13,7 +14,7 @@ import {
 import type { ToolWindowId } from './tabletop/toolWindowState';
 
 export type ToolType =
-  'pointer' | 'hand' | 'drawing' | 'text' | 'ruler' | 'dice' | 'stamp' | 'layer';
+  'pointer' | 'hand' | 'drawing' | 'text' | 'ruler' | 'aoe' | 'dice' | 'stamp' | 'layer';
 
 export interface ToolBarProps {
   activeTool: ToolType;
@@ -33,6 +34,7 @@ const tools: { id: ToolType; icon: React.ElementType; label: string; gmOnly?: bo
   { id: 'drawing', icon: Pencil, label: 'Drawing', gmOnly: true },
   { id: 'text', icon: Type, label: 'Text' },
   { id: 'ruler', icon: Ruler, label: 'Ruler' },
+  { id: 'aoe', icon: Cone, label: 'Spell AoE' },
   { id: 'dice', icon: Dices, label: 'Dice' },
   { id: 'stamp', icon: Stamp, label: 'Stamp' },
   // The Layers panel is GM-only (only rendered for the GM in ActiveMapStage), so

--- a/app/components/mainview/tabletop/ActiveMapStage.tsx
+++ b/app/components/mainview/tabletop/ActiveMapStage.tsx
@@ -17,6 +17,7 @@ import {
   Pencil,
   Ruler as RulerIcon,
   Layers as LayersIcon,
+  Circle as CircleIcon,
   Trash2,
 } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
@@ -42,10 +43,21 @@ import {
   applyDrawingRemoveFromCache,
   applyDrawingsClearToCache,
 } from '~/hooks/useMapDrawings';
+import {
+  useMapAoE,
+  useMapAoEMutations,
+  applyAoeAddToCache,
+  applyAoeRemoveFromCache,
+  applyAoeClearToCache,
+} from '~/hooks/useMapAoE';
 import { MapToken } from './MapToken';
 import { LayersPanel } from './LayersPanel';
 import { RulerSettingsPanel } from './RulerSettingsPanel';
 import { useRulerTool } from './useRulerTool';
+import { useAoeTool } from './useAoeTool';
+import { MapAoELayer } from './MapAoELayer';
+import { AoeSettingsPanel } from './AoeSettingsPanel';
+import type { AoeInput } from './aoeGeometry';
 import { RulerOverlay } from './RulerOverlay';
 import { ToolWindow } from './ToolWindow';
 import { TOOL_WINDOW_META, type ToolWindowId } from './toolWindowState';
@@ -69,6 +81,7 @@ import {
   movedGeometry,
 } from './ActiveMapStage.geometry';
 import type { MapLayerId } from '~/types/mapLayer';
+import type { AoeShape, MapAoEData } from '~/types/mapAoe';
 import type { TabletopMapMessage } from '~/hooks/useTabletopMapParty';
 
 interface ActiveMapStageProps {
@@ -85,6 +98,8 @@ interface ActiveMapStageProps {
   windowManager: ToolWindowManager;
   /** Whether the measurement (ruler) tool is active. */
   rulerActive?: boolean;
+  /** Whether the Spell AoE tool is active (click to place a template). */
+  aoeActive?: boolean;
   /** Whether the text tool is active (click to write, click text to select). */
   textActive?: boolean;
   /** Whether the drawing tool is active (draw shapes / erase on the map). */
@@ -125,6 +140,7 @@ export function ActiveMapStage({
   openToolWindows,
   windowManager,
   rulerActive = false,
+  aoeActive = false,
   textActive = false,
   drawingActive = false,
   pointerActive = false,
@@ -204,6 +220,17 @@ export function ActiveMapStage({
     width: number;
     height: number;
   } | null>(null);
+
+  // Spell AoE templates — shared, persisted, multiplayer. Any member can place a
+  // template; deletion is gated to the author or a GM (server-enforced). The tool
+  // settings (shape/size/width/color) are the local "brush" for this client.
+  const { data: aoes = [] } = useMapAoE(campaignId, map.id);
+  const aoeMutations = useMapAoEMutations(campaignId, map.id);
+  const [aoeShape, setAoeShape] = useState<AoeShape>('sphere');
+  const [aoeSizeFt, setAoeSizeFt] = useState(20);
+  const [aoeWidthFt, setAoeWidthFt] = useState(5);
+  const [aoeColor, setAoeColor] = useState('#3b82f6');
+  const [selectedAoeId, setSelectedAoeId] = useState<string | null>(null);
 
   // Layers — GM-local working layer + per-layer visibility (GM's own view;
   // players never gain this panel so it stays empty for them).
@@ -310,6 +337,18 @@ export function ActiveMapStage({
   // drawing mutation is GM-only. So only a GM may modify any drawing. Kept as a
   // per-drawing predicate to match the MapDrawingLayer `canModify` prop shape.
   const canModifyDrawing = useCallback((_d: MapDrawingData) => isGM, [isGM]);
+
+  // A player may delete only their own AoE template; a GM may delete anyone's.
+  // The server enforces this; the client mirrors it for affordances.
+  const canModifyAoe = useCallback(
+    (a: MapAoEData) => isGM || (currentUserId != null && a.createdBy === currentUserId),
+    [isGM, currentUserId]
+  );
+
+  // Clear the AoE selection when the tool is deselected.
+  useEffect(() => {
+    if (!aoeActive) setSelectedAoeId(null);
+  }, [aoeActive]);
 
   // Clear the drawing preview + selection when the drawing tool is deselected.
   useEffect(() => {
@@ -539,6 +578,83 @@ export function ActiveMapStage({
     imageHeight: map.imageHeight,
   });
 
+  // Spell AoE tool — a ruler-style placement state machine. Committing a
+  // template persists it (optimistically added to the cache) and broadcasts to
+  // peers. Like the ruler, it short-circuits the stage pointer handlers below.
+  const commitAoe = useCallback(
+    (committed: AoeInput & { color: string }) => {
+      aoeMutations.create.mutate(committed, {
+        onSuccess: (res) => {
+          applyAoeAddToCache(qc, campaignId, map.id, res.aoe);
+          onBroadcast({ type: 'aoe:added', mapId: map.id, aoe: res.aoe });
+        },
+      });
+    },
+    [aoeMutations.create, qc, campaignId, map.id, onBroadcast]
+  );
+
+  const aoe = useAoeTool({
+    aoeActive,
+    shape: aoeShape,
+    sizeFt: aoeSizeFt,
+    widthFt: aoeWidthFt,
+    color: aoeColor,
+    domToImage,
+    pixelsPerSquare: map.scale.pixelsPerSquare,
+    feetPerSquare: map.scale.feetPerSquare,
+    imageWidth: map.imageWidth,
+    imageHeight: map.imageHeight,
+    onCommit: commitAoe,
+  });
+
+  const removeAoe = useCallback(
+    (aoeId: string) => {
+      applyAoeRemoveFromCache(qc, campaignId, map.id, aoeId);
+      aoeMutations.remove.mutate(aoeId, {
+        onSuccess: () => onBroadcast({ type: 'aoe:removed', mapId: map.id, aoeId }),
+      });
+      setSelectedAoeId((cur) => (cur === aoeId ? null : cur));
+    },
+    [qc, campaignId, map.id, aoeMutations.remove, onBroadcast]
+  );
+
+  const clearAllAoe = useCallback(() => {
+    if (!isGM) return;
+    applyAoeClearToCache(qc, campaignId, map.id);
+    setSelectedAoeId(null);
+    aoeMutations.clear.mutate(undefined, {
+      onSuccess: () => onBroadcast({ type: 'aoe:cleared', mapId: map.id }),
+    });
+  }, [isGM, qc, campaignId, map.id, aoeMutations.clear, onBroadcast]);
+
+  // Keyboard: Delete/Backspace removes the selected AoE (permission-gated); Esc
+  // clears the selection. Not GM-gated — players can delete their own template.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const tgt = e.target as HTMLElement | null;
+      if (tgt) {
+        const tag = tgt.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || tgt.isContentEditable)
+          return;
+      }
+      if (e.key === 'Escape') {
+        if (selectedAoeId) {
+          e.preventDefault();
+          setSelectedAoeId(null);
+        }
+        return;
+      }
+      if (e.key !== 'Delete' && e.key !== 'Backspace') return;
+      if (!selectedAoeId) return;
+      const a = aoes.find((x) => x.id === selectedAoeId);
+      if (!a || !canModifyAoe(a)) return;
+      e.preventDefault();
+      removeAoe(a.id);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [selectedAoeId, aoes, canModifyAoe, removeAoe]);
+
   // -------------------------------------------------------------------------
   // Pointer drag — either pans the viewport (drag on background) or moves a
   // token (drag started on a token). The MapToken component reports drag
@@ -635,6 +751,12 @@ export function ActiveMapStage({
     const panOverride = middlePan || spaceHeld;
 
     if (!panOverride) {
+      // Spell AoE tool: a click places/aims a template. Fully owns the pointer
+      // while active (no pan/select), like the ruler.
+      if (aoeActive) {
+        aoe.onPointerDown(e);
+        return;
+      }
       // Ruler tool: a background click drops/relocates the measurement anchor
       // (clicks on tokens are handled by MapToken). No pan/select while measuring.
       if (rulerActive) {
@@ -972,6 +1094,12 @@ export function ActiveMapStage({
       ruler.onPointerMove(e);
       return;
     }
+    // Spell AoE tool: aim a directional template's second point as the cursor
+    // moves (unless a pan override is in progress).
+    if (aoeActive && d.mode !== 'pan') {
+      aoe.onPointerMove(e);
+      return;
+    }
     if (d.mode === 'idle') return;
     if (d.mode === 'pan') {
       setViewport({
@@ -1280,7 +1408,7 @@ export function ActiveMapStage({
       ? 'cursor-grabbing'
       : handActive || spaceHeld
         ? 'cursor-grab'
-        : rulerActive || drawingActive
+        : rulerActive || drawingActive || aoeActive
           ? 'cursor-crosshair'
           : textActive
             ? 'cursor-text'
@@ -1305,6 +1433,13 @@ export function ActiveMapStage({
       onPointerUp={onPointerUp}
       onPointerCancel={onPointerUp}
       onDoubleClick={(e) => {
+        // Spell AoE tool: a double-click cancels an in-progress directional
+        // placement (mirrors the ruler's reset).
+        if (aoeActive) {
+          e.preventDefault();
+          aoe.reset();
+          return;
+        }
         // Ruler tool: a double-click resets the measurement — the tool stops
         // drawing until the next click (also clears a multi-point polyline).
         if (!rulerActive) return;
@@ -1356,6 +1491,20 @@ export function ActiveMapStage({
           data-testid="map-grid-overlay"
         />
       )}
+
+      {/* Spell AoE templates (shared) — one SVG overlay above the map/grid but
+          BENEATH drawings/tokens, so the tint reads as a floor effect. */}
+      <MapAoELayer
+        visible={!spellFxHidden}
+        aoes={aoes}
+        preview={aoe.preview}
+        effectiveScale={effectiveScale}
+        imageOffsetX={imageOffsetX}
+        imageOffsetY={imageOffsetY}
+        selectedId={selectedAoeId}
+        onSelect={setSelectedAoeId}
+        canModify={canModifyAoe}
+      />
 
       {/* Drawing layer (shared) — one SVG overlay above the map/grid, plus the
           selected drawing's bounding box + corner resize handle. */}
@@ -1538,6 +1687,27 @@ export function ActiveMapStage({
             onChangeColor={applyTextColor}
             fontSize={textFontSize}
             onChangeFontSize={applyTextFontSize}
+          />
+        </ToolWindow>
+      )}
+
+      {openToolWindows.includes('aoe') && (
+        <ToolWindow
+          title={TOOL_WINDOW_META.aoe.title}
+          icon={CircleIcon}
+          {...windowManager.getWindowProps('aoe')}
+        >
+          <AoeSettingsPanel
+            shape={aoeShape}
+            onShape={setAoeShape}
+            sizeFt={aoeSizeFt}
+            onSizeFt={setAoeSizeFt}
+            widthFt={aoeWidthFt}
+            onWidthFt={setAoeWidthFt}
+            color={aoeColor}
+            onColor={setAoeColor}
+            onClearAll={clearAllAoe}
+            canClearAll={isGM}
           />
         </ToolWindow>
       )}

--- a/app/components/mainview/tabletop/ActiveMapStage.tsx
+++ b/app/components/mainview/tabletop/ActiveMapStage.tsx
@@ -629,7 +629,10 @@ export function ActiveMapStage({
 
   // Keyboard: Delete/Backspace removes the selected AoE (permission-gated); Esc
   // clears the selection. Not GM-gated — players can delete their own template.
+  // Only while the AoE tool is armed, so Backspace in another tool can't delete
+  // a template (selection is likewise only possible while armed).
   useEffect(() => {
+    if (!aoeActive) return;
     const onKey = (e: KeyboardEvent) => {
       const tgt = e.target as HTMLElement | null;
       if (tgt) {
@@ -653,7 +656,7 @@ export function ActiveMapStage({
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [selectedAoeId, aoes, canModifyAoe, removeAoe]);
+  }, [aoeActive, selectedAoeId, aoes, canModifyAoe, removeAoe]);
 
   // -------------------------------------------------------------------------
   // Pointer drag — either pans the viewport (drag on background) or moves a
@@ -1503,6 +1506,7 @@ export function ActiveMapStage({
         imageOffsetY={imageOffsetY}
         selectedId={selectedAoeId}
         onSelect={setSelectedAoeId}
+        interactive={aoeActive}
         canModify={canModifyAoe}
       />
 

--- a/app/components/mainview/tabletop/ActiveMapStage.tsx
+++ b/app/components/mainview/tabletop/ActiveMapStage.tsx
@@ -232,6 +232,7 @@ export function ActiveMapStage({
   const [aoeSizeFt, setAoeSizeFt] = useState(20);
   const [aoeWidthFt, setAoeWidthFt] = useState(5);
   const [aoeColor, setAoeColor] = useState('#3b82f6');
+  const [aoeLabel, setAoeLabel] = useState('');
   const [selectedAoeId, setSelectedAoeId] = useState<string | null>(null);
   // Per-viewer show/hide for spell AoE visuals — everyone gets this toggle
   // (local only, not broadcast); hides the AoE layer for this client alone.
@@ -590,14 +591,18 @@ export function ActiveMapStage({
   // peers. Like the ruler, it short-circuits the stage pointer handlers below.
   const commitAoe = useCallback(
     (committed: AoeInput & { color: string }) => {
-      aoeMutations.create.mutate(committed, {
-        onSuccess: (res) => {
-          applyAoeAddToCache(qc, campaignId, map.id, res.aoe);
-          onBroadcast({ type: 'aoe:added', mapId: map.id, aoe: res.aoe });
-        },
-      });
+      const label = aoeLabel.trim();
+      aoeMutations.create.mutate(
+        { ...committed, label: label || undefined },
+        {
+          onSuccess: (res) => {
+            applyAoeAddToCache(qc, campaignId, map.id, res.aoe);
+            onBroadcast({ type: 'aoe:added', mapId: map.id, aoe: res.aoe });
+          },
+        }
+      );
     },
-    [aoeMutations.create, qc, campaignId, map.id, onBroadcast]
+    [aoeMutations.create, qc, campaignId, map.id, onBroadcast, aoeLabel]
   );
 
   const aoe = useAoeTool({
@@ -1786,6 +1791,8 @@ export function ActiveMapStage({
             onWidthFt={setAoeWidthFt}
             color={aoeColor}
             onColor={setAoeColor}
+            label={aoeLabel}
+            onLabel={setAoeLabel}
             onClearAll={clearAllAoe}
             canClearAll={isGM}
           />

--- a/app/components/mainview/tabletop/ActiveMapStage.tsx
+++ b/app/components/mainview/tabletop/ActiveMapStage.tsx
@@ -1139,8 +1139,9 @@ export function ActiveMapStage({
       return;
     }
     // Spell AoE tool: aim a directional template's second point as the cursor
-    // moves (unless a pan override is in progress).
-    if (aoeActive && d.mode !== 'pan') {
+    // moves — but not while dragging an existing template (mode 'aoe') or a pan
+    // override, so an in-progress move falls through to the drag branch below.
+    if (aoeActive && d.mode !== 'pan' && d.mode !== 'aoe') {
       aoe.onPointerMove(e);
       return;
     }

--- a/app/components/mainview/tabletop/ActiveMapStage.tsx
+++ b/app/components/mainview/tabletop/ActiveMapStage.tsx
@@ -1348,6 +1348,19 @@ export function ActiveMapStage({
                 y: ny,
                 final: true,
               }),
+            onError: () => {
+              // Persist failed: revert peers (and the local cache) to the
+              // pre-drag position so no one is left with a ghost.
+              applyTextMoveToCache(qc, campaignId, map.id, d.textId, d.startX, d.startY);
+              onBroadcast({
+                type: 'text:moved',
+                mapId: map.id,
+                textId: d.textId,
+                x: d.startX,
+                y: d.startY,
+                final: true,
+              });
+            },
           }
         );
       }
@@ -1370,6 +1383,20 @@ export function ActiveMapStage({
                 originY: ny,
                 final: true,
               }),
+            onError: () => {
+              // Persist failed: peers got interim positions during the drag —
+              // revert them (and the local cache) to the pre-drag origin rather
+              // than leaving a ghost. The hook's onError also toasts + refetches.
+              applyAoeMoveToCache(qc, campaignId, map.id, d.aoeId, d.startOriginX, d.startOriginY);
+              onBroadcast({
+                type: 'aoe:moved',
+                mapId: map.id,
+                aoeId: d.aoeId,
+                originX: d.startOriginX,
+                originY: d.startOriginY,
+                final: true,
+              });
+            },
           }
         );
       }

--- a/app/components/mainview/tabletop/ActiveMapStage.tsx
+++ b/app/components/mainview/tabletop/ActiveMapStage.tsx
@@ -18,6 +18,7 @@ import {
   Ruler as RulerIcon,
   Layers as LayersIcon,
   Circle as CircleIcon,
+  Sparkles,
   Trash2,
 } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
@@ -49,6 +50,7 @@ import {
   applyAoeAddToCache,
   applyAoeRemoveFromCache,
   applyAoeClearToCache,
+  applyAoeMoveToCache,
 } from '~/hooks/useMapAoE';
 import { MapToken } from './MapToken';
 import { LayersPanel } from './LayersPanel';
@@ -231,6 +233,9 @@ export function ActiveMapStage({
   const [aoeWidthFt, setAoeWidthFt] = useState(5);
   const [aoeColor, setAoeColor] = useState('#3b82f6');
   const [selectedAoeId, setSelectedAoeId] = useState<string | null>(null);
+  // Per-viewer show/hide for spell AoE visuals — everyone gets this toggle
+  // (local only, not broadcast); hides the AoE layer for this client alone.
+  const [showSpellEffects, setShowSpellEffects] = useState(true);
 
   // Layers — GM-local working layer + per-layer visibility (GM's own view;
   // players never gain this panel so it stays empty for them).
@@ -345,10 +350,12 @@ export function ActiveMapStage({
     [isGM, currentUserId]
   );
 
-  // Clear the AoE selection when the tool is deselected.
+  // AoE templates are selectable/movable under the pointer tool (like map text)
+  // and under the AoE tool. Clear the selection when leaving both, so a stray
+  // Delete/Backspace in an unrelated tool (ruler, hand) can't remove a template.
   useEffect(() => {
-    if (!aoeActive) setSelectedAoeId(null);
-  }, [aoeActive]);
+    if (!aoeActive && !pointerActive) setSelectedAoeId(null);
+  }, [aoeActive, pointerActive]);
 
   // Clear the drawing preview + selection when the drawing tool is deselected.
   useEffect(() => {
@@ -629,10 +636,9 @@ export function ActiveMapStage({
 
   // Keyboard: Delete/Backspace removes the selected AoE (permission-gated); Esc
   // clears the selection. Not GM-gated — players can delete their own template.
-  // Only while the AoE tool is armed, so Backspace in another tool can't delete
-  // a template (selection is likewise only possible while armed).
+  // A template can only be selected under the pointer/AoE tools, and the
+  // selection auto-clears when leaving both, so this can't fire from another tool.
   useEffect(() => {
-    if (!aoeActive) return;
     const onKey = (e: KeyboardEvent) => {
       const tgt = e.target as HTMLElement | null;
       if (tgt) {
@@ -656,7 +662,7 @@ export function ActiveMapStage({
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [aoeActive, selectedAoeId, aoes, canModifyAoe, removeAoe]);
+  }, [selectedAoeId, aoes, canModifyAoe, removeAoe]);
 
   // -------------------------------------------------------------------------
   // Pointer drag — either pans the viewport (drag on background) or moves a
@@ -687,6 +693,16 @@ export function ActiveMapStage({
         startClientY: number;
         startX: number;
         startY: number;
+        lastBroadcastAt: number;
+        moved: boolean;
+      }
+    | {
+        mode: 'aoe';
+        aoeId: string;
+        startClientX: number;
+        startClientY: number;
+        startOriginX: number;
+        startOriginY: number;
         lastBroadcastAt: number;
         moved: boolean;
       }
@@ -741,7 +757,7 @@ export function ActiveMapStage({
       };
   const dragRef = useRef<DragState>({ mode: 'idle' });
   const [dragMode, setDragMode] = useState<
-    'idle' | 'pan' | 'token' | 'text' | 'draw' | 'erase' | 'resize' | 'move'
+    'idle' | 'pan' | 'token' | 'text' | 'aoe' | 'draw' | 'erase' | 'resize' | 'move'
   >('idle');
 
   const onPanPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
@@ -919,6 +935,31 @@ export function ActiveMapStage({
       setDragMode('text');
     },
     [cancelTextDraft, clearSelection]
+  );
+
+  // Pointer-down on an existing AoE template (pointer/AoE tool, own/GM only):
+  // select it, and a drag past a small threshold relocates it — mirrors text.
+  const beginAoeDrag = useCallback(
+    (a: MapAoEData, e: ReactPointerEvent<SVGElement>) => {
+      if (e.button !== 0) return;
+      if (!canModifyAoe(a)) return;
+      e.stopPropagation();
+      clearSelection();
+      setSelectedAoeId(a.id);
+      (e.target as Element).setPointerCapture?.(e.pointerId);
+      dragRef.current = {
+        mode: 'aoe',
+        aoeId: a.id,
+        startClientX: e.clientX,
+        startClientY: e.clientY,
+        startOriginX: a.originX,
+        startOriginY: a.originY,
+        lastBroadcastAt: 0,
+        moved: false,
+      };
+      setDragMode('aoe');
+    },
+    [canModifyAoe, clearSelection]
   );
 
   // Begin resizing the selected drawing from its corner handle (own/GM only).
@@ -1142,6 +1183,18 @@ export function ActiveMapStage({
         d.lastBroadcastAt = now;
         onBroadcast({ type: 'text:moved', mapId: map.id, textId: d.textId, x: nx, y: ny });
       }
+    } else if (d.mode === 'aoe') {
+      const dxImage = (e.clientX - d.startClientX) / effectiveScale;
+      const dyImage = (e.clientY - d.startClientY) / effectiveScale;
+      const nx = clamp(d.startOriginX + dxImage, 0, map.imageWidth);
+      const ny = clamp(d.startOriginY + dyImage, 0, map.imageHeight);
+      if (Math.abs(dxImage) > 1 || Math.abs(dyImage) > 1) d.moved = true;
+      applyAoeMoveToCache(qc, campaignId, map.id, d.aoeId, nx, ny);
+      const now = Date.now();
+      if (now - d.lastBroadcastAt >= MOVE_BROADCAST_INTERVAL_MS) {
+        d.lastBroadcastAt = now;
+        onBroadcast({ type: 'aoe:moved', mapId: map.id, aoeId: d.aoeId, originX: nx, originY: ny });
+      }
     } else if (d.mode === 'draw' && d.kind === 'pencil') {
       const img = domToImage(e.clientX, e.clientY);
       if (!img) return;
@@ -1287,6 +1340,28 @@ export function ActiveMapStage({
                 textId: d.textId,
                 x: nx,
                 y: ny,
+                final: true,
+              }),
+          }
+        );
+      }
+    } else if (d.mode === 'aoe') {
+      if (d.moved) {
+        const dxImage = (e.clientX - d.startClientX) / effectiveScale;
+        const dyImage = (e.clientY - d.startClientY) / effectiveScale;
+        const nx = clamp(d.startOriginX + dxImage, 0, map.imageWidth);
+        const ny = clamp(d.startOriginY + dyImage, 0, map.imageHeight);
+        applyAoeMoveToCache(qc, campaignId, map.id, d.aoeId, nx, ny);
+        aoeMutations.move.mutate(
+          { aoeId: d.aoeId, originX: nx, originY: ny },
+          {
+            onSuccess: () =>
+              onBroadcast({
+                type: 'aoe:moved',
+                mapId: map.id,
+                aoeId: d.aoeId,
+                originX: nx,
+                originY: ny,
                 final: true,
               }),
           }
@@ -1498,15 +1573,15 @@ export function ActiveMapStage({
       {/* Spell AoE templates (shared) — one SVG overlay above the map/grid but
           BENEATH drawings/tokens, so the tint reads as a floor effect. */}
       <MapAoELayer
-        visible={!spellFxHidden}
+        visible={!spellFxHidden && showSpellEffects}
         aoes={aoes}
         preview={aoe.preview}
         effectiveScale={effectiveScale}
         imageOffsetX={imageOffsetX}
         imageOffsetY={imageOffsetY}
         selectedId={selectedAoeId}
-        onSelect={setSelectedAoeId}
-        interactive={aoeActive}
+        onBeginDrag={beginAoeDrag}
+        interactive={aoeActive || pointerActive}
         canModify={canModifyAoe}
       />
 
@@ -1765,6 +1840,22 @@ export function ActiveMapStage({
           data-testid="map-text-toggle"
         >
           <Type className="h-3.5 w-3.5" />
+        </button>
+        {/* Spell AoE visuals — per-viewer show/hide, available to everyone. */}
+        <button
+          type="button"
+          aria-label={showSpellEffects ? 'Hide spell effects' : 'Show spell effects'}
+          aria-pressed={showSpellEffects}
+          title={showSpellEffects ? 'Hide spell effects' : 'Show spell effects'}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={() => setShowSpellEffects((v) => !v)}
+          className={[
+            'flex h-7 w-7 items-center justify-center rounded transition-colors',
+            showSpellEffects ? 'bg-white/15 text-[#60A5FA]' : 'text-slate-200 hover:bg-white/10',
+          ].join(' ')}
+          data-testid="map-spell-effects-toggle"
+        >
+          <Sparkles className="h-3.5 w-3.5" />
         </button>
         {/* Drawings are GM-only — players never see the drawing controls. */}
         {isGM && (

--- a/app/components/mainview/tabletop/AoeSettingsPanel.tsx
+++ b/app/components/mainview/tabletop/AoeSettingsPanel.tsx
@@ -1,0 +1,165 @@
+import { Circle, Cone, Box, Minus, Cylinder } from 'lucide-react';
+import { ColorPicker } from '~/components/shared/ColorPicker';
+import type { AoeShape } from '~/types/mapAoe';
+
+/** Minimum size/width, in feet — a zero-size template is meaningless. */
+export const MIN_AOE_FT = 5;
+
+const SHAPES: { id: AoeShape; icon: typeof Circle; label: string }[] = [
+  { id: 'sphere', icon: Circle, label: 'Sphere' },
+  { id: 'cone', icon: Cone, label: 'Cone' },
+  { id: 'cube', icon: Box, label: 'Cube' },
+  { id: 'line', icon: Minus, label: 'Line' },
+  { id: 'cylinder', icon: Cylinder, label: 'Cylinder' },
+];
+
+interface AoeSettingsPanelProps {
+  shape: AoeShape;
+  onShape: (s: AoeShape) => void;
+  sizeFt: number;
+  onSizeFt: (n: number) => void;
+  widthFt: number;
+  onWidthFt: (n: number) => void;
+  color: string;
+  onColor: (c: string) => void;
+  onClearAll: () => void;
+  /** GM only — the button is hidden entirely when false. */
+  canClearAll: boolean;
+}
+
+/**
+ * Settings content for the Spell AoE tool — pick a shape, size (and width for
+ * lines), and color, then click the map to place the template. Hosted inside
+ * a shared {@link ToolWindow}. The tool is armed simply by being the active
+ * map tool (no separate "place on map" toggle — same pattern as
+ * drawing/text/ruler).
+ */
+export function AoeSettingsPanel({
+  shape,
+  onShape,
+  sizeFt,
+  onSizeFt,
+  widthFt,
+  onWidthFt,
+  color,
+  onColor,
+  onClearAll,
+  canClearAll,
+}: AoeSettingsPanelProps) {
+  return (
+    <div
+      className="w-60"
+      data-testid="aoe-settings-panel"
+      role="group"
+      aria-label="Spell AoE settings"
+    >
+      <div className="px-3 py-3">
+        {/* Shape picker */}
+        <span
+          id="aoe-shape-label"
+          className="mb-2 block font-sans text-[10px] font-semibold tracking-wide text-slate-500"
+        >
+          Shape
+        </span>
+        <div className="mb-3 flex gap-1.5" role="group" aria-labelledby="aoe-shape-label">
+          {SHAPES.map(({ id, icon: Icon, label }) => {
+            const active = id === shape;
+            return (
+              <button
+                key={id}
+                type="button"
+                onClick={() => onShape(id)}
+                aria-pressed={active}
+                aria-label={label}
+                title={label}
+                data-testid={`aoe-shape-${id}`}
+                className={[
+                  'flex h-9 flex-1 items-center justify-center rounded transition-colors',
+                  active
+                    ? 'bg-white/15 text-[#60A5FA]'
+                    : 'bg-white/[0.04] text-slate-300 hover:bg-white/10',
+                ].join(' ')}
+              >
+                <Icon className="h-4 w-4" />
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Size */}
+        <span
+          id="aoe-size-label"
+          className="mb-2 block font-sans text-[10px] font-semibold tracking-wide text-slate-500"
+        >
+          Size (ft)
+        </span>
+        <div className="mb-3 flex items-center gap-2">
+          <input
+            type="number"
+            min={MIN_AOE_FT}
+            step={5}
+            value={sizeFt}
+            onChange={(e) => {
+              const n = Math.round(Number(e.target.value));
+              if (!Number.isFinite(n)) return;
+              onSizeFt(Math.max(MIN_AOE_FT, n));
+            }}
+            aria-labelledby="aoe-size-label"
+            data-testid="aoe-size-input"
+            className="w-20 rounded-lg border border-white/[0.1] bg-white/[0.04] px-2 py-1.5 font-mono text-xs text-slate-300 focus:border-blue-500/40 focus:outline-none"
+          />
+          <span className="font-sans text-[10px] text-slate-500">ft</span>
+        </div>
+
+        {/* Width (line only) */}
+        {shape === 'line' && (
+          <>
+            <span
+              id="aoe-width-label"
+              className="mb-2 block font-sans text-[10px] font-semibold tracking-wide text-slate-500"
+            >
+              Width (ft)
+            </span>
+            <div className="mb-3 flex items-center gap-2">
+              <input
+                type="number"
+                min={MIN_AOE_FT}
+                step={5}
+                value={widthFt}
+                onChange={(e) => {
+                  const n = Math.round(Number(e.target.value));
+                  if (!Number.isFinite(n)) return;
+                  onWidthFt(Math.max(MIN_AOE_FT, n));
+                }}
+                aria-labelledby="aoe-width-label"
+                data-testid="aoe-width-input"
+                className="w-20 rounded-lg border border-white/[0.1] bg-white/[0.04] px-2 py-1.5 font-mono text-xs text-slate-300 focus:border-blue-500/40 focus:outline-none"
+              />
+              <span className="font-sans text-[10px] text-slate-500">ft</span>
+            </div>
+          </>
+        )}
+
+        {/* Color */}
+        <ColorPicker label="Color" value={color} onChange={onColor} />
+
+        {/* Clear all (GM only) */}
+        {canClearAll && (
+          <button
+            type="button"
+            onClick={onClearAll}
+            data-testid="aoe-clear-all"
+            className="mt-3 w-full rounded px-2.5 py-1.5 font-sans text-xs text-red-300 transition-colors bg-white/[0.04] hover:bg-red-500/10 hover:text-red-200"
+          >
+            Clear all AoE
+          </button>
+        )}
+      </div>
+
+      <p className="border-t border-white/[0.07] px-3 py-2 font-sans text-[10px] leading-snug text-slate-500">
+        Click the map to place a template. Cone and Line aim on a second click; other shapes place
+        immediately.
+      </p>
+    </div>
+  );
+}

--- a/app/components/mainview/tabletop/AoeSettingsPanel.tsx
+++ b/app/components/mainview/tabletop/AoeSettingsPanel.tsx
@@ -22,6 +22,9 @@ interface AoeSettingsPanelProps {
   onWidthFt: (n: number) => void;
   color: string;
   onColor: (c: string) => void;
+  /** Optional label drawn on the template (e.g. the spell name). */
+  label: string;
+  onLabel: (s: string) => void;
   onClearAll: () => void;
   /** GM only — the button is hidden entirely when false. */
   canClearAll: boolean;
@@ -43,6 +46,8 @@ export function AoeSettingsPanel({
   onWidthFt,
   color,
   onColor,
+  label,
+  onLabel,
   onClearAll,
   canClearAll,
 }: AoeSettingsPanelProps) {
@@ -142,6 +147,24 @@ export function AoeSettingsPanel({
 
         {/* Color */}
         <ColorPicker label="Color" value={color} onChange={onColor} />
+
+        {/* Optional label (e.g. spell name) — drawn on the template. */}
+        <span
+          id="aoe-label-label"
+          className="mb-2 mt-3 block font-sans text-[10px] font-semibold tracking-wide text-slate-500"
+        >
+          Label (optional)
+        </span>
+        <input
+          type="text"
+          value={label}
+          maxLength={60}
+          placeholder="e.g. Fireball"
+          onChange={(e) => onLabel(e.target.value)}
+          aria-labelledby="aoe-label-label"
+          data-testid="aoe-label-input"
+          className="w-full rounded-lg border border-white/[0.1] bg-white/[0.04] px-2 py-1.5 font-sans text-xs text-slate-300 placeholder:text-slate-600 focus:border-blue-500/40 focus:outline-none"
+        />
 
         {/* Clear all (GM only) */}
         {canClearAll && (

--- a/app/components/mainview/tabletop/MapAoELayer.tsx
+++ b/app/components/mainview/tabletop/MapAoELayer.tsx
@@ -92,21 +92,86 @@ export function MapAoELayer({
     return <polygon key={opts.id ?? 'preview'} {...common} points={points} />;
   };
 
+  // Small, semi-transparent labels centered on the template's origin: the
+  // optional user label (e.g. spell name) plus the placer's name below it. A
+  // thin dark outline keeps them legible on any map; the fill stays translucent
+  // so tokens/terrain underneath remain visible. Non-interactive.
+  const renderLabel = (a: MapAoEData) => {
+    const userLabel = a.label?.trim();
+    const name = a.createdByName?.trim();
+    if (!userLabel && !name) return null;
+    const x = toDomX(a.originX);
+    const y = toDomY(a.originY);
+    const outline = { paintOrder: 'stroke' as const, pointerEvents: 'none' as const };
+    return (
+      <g key={`label-${a.id}`} aria-hidden="true">
+        {userLabel && (
+          <text
+            x={x}
+            y={name ? y - 4 : y}
+            textAnchor="middle"
+            dominantBaseline="middle"
+            fontSize={12}
+            fontWeight={600}
+            fill="#ffffff"
+            fillOpacity={0.85}
+            stroke="rgba(0,0,0,0.55)"
+            strokeWidth={2.5}
+            style={outline}
+          >
+            {userLabel}
+          </text>
+        )}
+        {name && (
+          <text
+            x={x}
+            y={userLabel ? y + 11 : y}
+            textAnchor="middle"
+            dominantBaseline="middle"
+            fontSize={9.5}
+            fill="#ffffff"
+            fillOpacity={0.7}
+            stroke="rgba(0,0,0,0.5)"
+            strokeWidth={2}
+            style={outline}
+          >
+            {name}
+          </text>
+        )}
+      </g>
+    );
+  };
+
+  const labels = aoes.map(renderLabel).filter(Boolean);
+
   return (
-    <svg
-      className="pointer-events-none absolute inset-0 z-10 h-full w-full"
-      data-testid="map-aoe-layer"
-      role="group"
-      aria-label="Spell area-of-effect templates"
-    >
-      {aoes.map((a) =>
-        renderShape(a, a.color, {
-          id: a.id,
-          interactive: interactive && !!canModify && canModify(a),
-          aoe: a,
-        })
+    <>
+      <svg
+        className="pointer-events-none absolute inset-0 z-10 h-full w-full"
+        data-testid="map-aoe-layer"
+        role="group"
+        aria-label="Spell area-of-effect templates"
+      >
+        {aoes.map((a) =>
+          renderShape(a, a.color, {
+            id: a.id,
+            interactive: interactive && !!canModify && canModify(a),
+            aoe: a,
+          })
+        )}
+        {preview && renderShape(preview, preview.color, { interactive: false })}
+      </svg>
+      {/* Labels sit above tokens (z-40) but semi-transparent, so the caster's
+          name / spell name reads while tokens and terrain stay visible. */}
+      {labels.length > 0 && (
+        <svg
+          className="pointer-events-none absolute inset-0 z-40 h-full w-full"
+          data-testid="map-aoe-label-layer"
+          aria-hidden="true"
+        >
+          {labels}
+        </svg>
       )}
-      {preview && renderShape(preview, preview.color, { interactive: false })}
-    </svg>
+    </>
   );
 }

--- a/app/components/mainview/tabletop/MapAoELayer.tsx
+++ b/app/components/mainview/tabletop/MapAoELayer.tsx
@@ -1,0 +1,92 @@
+import type { MapAoEData } from '~/types/mapAoe';
+import { aoeShapeGeometry, type AoeInput } from './aoeGeometry';
+
+interface MapAoELayerProps {
+  visible: boolean;
+  aoes: MapAoEData[];
+  preview: (AoeInput & { color: string }) | null;
+  effectiveScale: number;
+  imageOffsetX: number;
+  imageOffsetY: number;
+  onSelect?: (id: string) => void;
+  selectedId?: string | null;
+  /** A template can be selected/deleted only by its author or the GM. */
+  canModify?: (a: MapAoEData) => boolean;
+}
+
+export function MapAoELayer({
+  visible,
+  aoes,
+  preview,
+  effectiveScale,
+  imageOffsetX,
+  imageOffsetY,
+  onSelect,
+  _selectedId,
+  canModify,
+}: MapAoELayerProps) {
+  if (!visible) return null;
+  const toDomX = (x: number) => imageOffsetX + x * effectiveScale;
+  const toDomY = (y: number) => imageOffsetY + y * effectiveScale;
+
+  const renderShape = (
+    input: AoeInput,
+    color: string,
+    opts: { id?: string; interactive: boolean }
+  ) => {
+    const g = aoeShapeGeometry(input);
+    const selectable = opts.interactive && !!opts.id;
+    const common = {
+      'data-testid': opts.id ? 'map-aoe' : undefined,
+      'data-aoe-id': opts.id,
+      'data-aoe-shape': input.shape,
+      fill: color,
+      fillOpacity: 0.3,
+      stroke: color,
+      strokeOpacity: 0.9,
+      strokeWidth: Math.max(1, 2 * effectiveScale),
+      style: { pointerEvents: (selectable ? 'all' : 'none') as 'all' | 'none', cursor: 'pointer' },
+      onPointerDown: selectable && opts.id ? () => onSelect?.(opts.id!) : undefined,
+      'aria-hidden': true as const,
+    };
+    if (g.kind === 'circle') {
+      return (
+        <circle
+          key={opts.id ?? 'preview'}
+          {...common}
+          cx={toDomX(g.cx)}
+          cy={toDomY(g.cy)}
+          r={g.r * effectiveScale}
+        />
+      );
+    }
+    if (g.kind === 'rect') {
+      return (
+        <rect
+          key={opts.id ?? 'preview'}
+          {...common}
+          x={toDomX(g.x)}
+          y={toDomY(g.y)}
+          width={g.w * effectiveScale}
+          height={g.h * effectiveScale}
+        />
+      );
+    }
+    const points = g.points.map((p) => `${toDomX(p.x)},${toDomY(p.y)}`).join(' ');
+    return <polygon key={opts.id ?? 'preview'} {...common} points={points} />;
+  };
+
+  return (
+    <svg
+      className="pointer-events-none absolute inset-0 z-10 h-full w-full"
+      data-testid="map-aoe-layer"
+      role="group"
+      aria-label="Spell area-of-effect templates"
+    >
+      {aoes.map((a) =>
+        renderShape(a, a.color, { id: a.id, interactive: !!canModify && canModify(a) })
+      )}
+      {preview && renderShape(preview, preview.color, { interactive: false })}
+    </svg>
+  );
+}

--- a/app/components/mainview/tabletop/MapAoELayer.tsx
+++ b/app/components/mainview/tabletop/MapAoELayer.tsx
@@ -1,3 +1,4 @@
+import type { PointerEvent as ReactPointerEvent } from 'react';
 import type { MapAoEData } from '~/types/mapAoe';
 import { aoeShapeGeometry, type AoeInput } from './aoeGeometry';
 
@@ -47,7 +48,16 @@ export function MapAoELayer({
       strokeOpacity: 0.9,
       strokeWidth: Math.max(1, 2 * effectiveScale),
       style: { pointerEvents: (selectable ? 'all' : 'none') as 'all' | 'none', cursor: 'pointer' },
-      onPointerDown: selectable && opts.id ? () => onSelect?.(opts.id!) : undefined,
+      // Stop propagation so selecting an existing template does not also reach
+      // the stage's placement handler (which would commit a duplicate AoE) —
+      // mirrors beginDrawingMove / beginTextDrag in ActiveMapStage.
+      onPointerDown:
+        selectable && opts.id
+          ? (e: ReactPointerEvent<SVGElement>) => {
+              e.stopPropagation();
+              onSelect?.(opts.id!);
+            }
+          : undefined,
       'aria-hidden': true as const,
     };
     if (g.kind === 'circle') {

--- a/app/components/mainview/tabletop/MapAoELayer.tsx
+++ b/app/components/mainview/tabletop/MapAoELayer.tsx
@@ -11,6 +11,12 @@ interface MapAoELayerProps {
   imageOffsetY: number;
   onSelect?: (id: string) => void;
   selectedId?: string | null;
+  /**
+   * Whether templates are selectable right now. Only true while the AoE tool is
+   * armed — otherwise the shapes stay `pointer-events-none` so they never
+   * swallow pans/measurements or get selected+deleted from an unrelated tool.
+   */
+  interactive?: boolean;
   /** A template can be selected/deleted only by its author or the GM. */
   canModify?: (a: MapAoEData) => boolean;
 }
@@ -25,6 +31,7 @@ export function MapAoELayer({
   onSelect,
   // selectedId is accepted for API symmetry but unused this phase (no selected-highlight yet).
   selectedId: _selectedId,
+  interactive = false,
   canModify,
 }: MapAoELayerProps) {
   if (!visible) return null;
@@ -95,7 +102,10 @@ export function MapAoELayer({
       aria-label="Spell area-of-effect templates"
     >
       {aoes.map((a) =>
-        renderShape(a, a.color, { id: a.id, interactive: !!canModify && canModify(a) })
+        renderShape(a, a.color, {
+          id: a.id,
+          interactive: interactive && !!canModify && canModify(a),
+        })
       )}
       {preview && renderShape(preview, preview.color, { interactive: false })}
     </svg>

--- a/app/components/mainview/tabletop/MapAoELayer.tsx
+++ b/app/components/mainview/tabletop/MapAoELayer.tsx
@@ -22,7 +22,8 @@ export function MapAoELayer({
   imageOffsetX,
   imageOffsetY,
   onSelect,
-  _selectedId,
+  // selectedId is accepted for API symmetry but unused this phase (no selected-highlight yet).
+  selectedId: _selectedId,
   canModify,
 }: MapAoELayerProps) {
   if (!visible) return null;

--- a/app/components/mainview/tabletop/MapAoELayer.tsx
+++ b/app/components/mainview/tabletop/MapAoELayer.tsx
@@ -100,8 +100,24 @@ export function MapAoELayer({
     const userLabel = a.label?.trim();
     const name = a.createdByName?.trim();
     if (!userLabel && !name) return null;
-    const x = toDomX(a.originX);
-    const y = toDomY(a.originY);
+    // Anchor at the shape's CENTROID, not the origin: for cone/line the origin
+    // is the apex — right where the caster's token usually is — so a label there
+    // would hide the token. The centroid sits in the middle of the effect.
+    const g = aoeShapeGeometry(a);
+    let cx: number;
+    let cy: number;
+    if (g.kind === 'circle') {
+      cx = g.cx;
+      cy = g.cy;
+    } else if (g.kind === 'rect') {
+      cx = g.x + g.w / 2;
+      cy = g.y + g.h / 2;
+    } else {
+      cx = g.points.reduce((s, p) => s + p.x, 0) / g.points.length;
+      cy = g.points.reduce((s, p) => s + p.y, 0) / g.points.length;
+    }
+    const x = toDomX(cx);
+    const y = toDomY(cy);
     const outline = { paintOrder: 'stroke' as const, pointerEvents: 'none' as const };
     return (
       <g key={`label-${a.id}`} aria-hidden="true">

--- a/app/components/mainview/tabletop/MapAoELayer.tsx
+++ b/app/components/mainview/tabletop/MapAoELayer.tsx
@@ -9,15 +9,16 @@ interface MapAoELayerProps {
   effectiveScale: number;
   imageOffsetX: number;
   imageOffsetY: number;
-  onSelect?: (id: string) => void;
+  /** Pointer-down on a selectable template — begins a select/drag (like map text). */
+  onBeginDrag?: (a: MapAoEData, e: ReactPointerEvent<SVGElement>) => void;
   selectedId?: string | null;
   /**
-   * Whether templates are selectable right now. Only true while the AoE tool is
-   * armed — otherwise the shapes stay `pointer-events-none` so they never
-   * swallow pans/measurements or get selected+deleted from an unrelated tool.
+   * Whether templates are selectable/draggable right now. True while the AoE
+   * tool OR the pointer tool is active (parity with map text) — otherwise the
+   * shapes stay `pointer-events-none` so they never swallow pans/measurements.
    */
   interactive?: boolean;
-  /** A template can be selected/deleted only by its author or the GM. */
+  /** A template can be selected/moved/deleted only by its author or the GM. */
   canModify?: (a: MapAoEData) => boolean;
 }
 
@@ -28,7 +29,7 @@ export function MapAoELayer({
   effectiveScale,
   imageOffsetX,
   imageOffsetY,
-  onSelect,
+  onBeginDrag,
   // selectedId is accepted for API symmetry but unused this phase (no selected-highlight yet).
   selectedId: _selectedId,
   interactive = false,
@@ -41,10 +42,10 @@ export function MapAoELayer({
   const renderShape = (
     input: AoeInput,
     color: string,
-    opts: { id?: string; interactive: boolean }
+    opts: { id?: string; interactive: boolean; aoe?: MapAoEData }
   ) => {
     const g = aoeShapeGeometry(input);
-    const selectable = opts.interactive && !!opts.id;
+    const selectable = opts.interactive && !!opts.id && !!opts.aoe;
     const common = {
       'data-testid': opts.id ? 'map-aoe' : undefined,
       'data-aoe-id': opts.id,
@@ -55,15 +56,12 @@ export function MapAoELayer({
       strokeOpacity: 0.9,
       strokeWidth: Math.max(1, 2 * effectiveScale),
       style: { pointerEvents: (selectable ? 'all' : 'none') as 'all' | 'none', cursor: 'pointer' },
-      // Stop propagation so selecting an existing template does not also reach
-      // the stage's placement handler (which would commit a duplicate AoE) —
-      // mirrors beginDrawingMove / beginTextDrag in ActiveMapStage.
+      // onBeginDrag stops propagation itself so selecting/dragging an existing
+      // template doesn't also reach the stage's placement handler — mirrors
+      // beginTextDrag in ActiveMapStage.
       onPointerDown:
-        selectable && opts.id
-          ? (e: ReactPointerEvent<SVGElement>) => {
-              e.stopPropagation();
-              onSelect?.(opts.id!);
-            }
+        selectable && opts.aoe
+          ? (e: ReactPointerEvent<SVGElement>) => onBeginDrag?.(opts.aoe!, e)
           : undefined,
       'aria-hidden': true as const,
     };
@@ -105,6 +103,7 @@ export function MapAoELayer({
         renderShape(a, a.color, {
           id: a.id,
           interactive: interactive && !!canModify && canModify(a),
+          aoe: a,
         })
       )}
       {preview && renderShape(preview, preview.color, { interactive: false })}

--- a/app/components/mainview/tabletop/MapAoELayer.tsx
+++ b/app/components/mainview/tabletop/MapAoELayer.tsx
@@ -1,4 +1,4 @@
-import type { PointerEvent as ReactPointerEvent } from 'react';
+import { memo, type PointerEvent as ReactPointerEvent } from 'react';
 import type { MapAoEData } from '~/types/mapAoe';
 import { aoeShapeGeometry, type AoeInput } from './aoeGeometry';
 
@@ -22,7 +22,7 @@ interface MapAoELayerProps {
   canModify?: (a: MapAoEData) => boolean;
 }
 
-export function MapAoELayer({
+function MapAoELayerImpl({
   visible,
   aoes,
   preview,
@@ -191,3 +191,10 @@ export function MapAoELayer({
     </>
   );
 }
+
+/**
+ * Memoised: the stage re-renders on many unrelated state changes (token drags,
+ * hover, etc.); with stable props (query data + useCallback handlers) this skips
+ * the AoE re-render + geometry work unless the templates/preview/transform move.
+ */
+export const MapAoELayer = memo(MapAoELayerImpl);

--- a/app/components/mainview/tabletop/TabletopView.tsx
+++ b/app/components/mainview/tabletop/TabletopView.tsx
@@ -611,6 +611,7 @@ export function TabletopView({
             currentUserId={currentUserId}
             onBroadcast={sendMapMessage}
             rulerActive={activeTool === 'ruler'}
+            aoeActive={activeTool === 'aoe'}
             textActive={activeTool === 'text'}
             drawingActive={activeTool === 'drawing'}
             pointerActive={activeTool === 'pointer'}

--- a/app/components/mainview/tabletop/aoeGeometry.ts
+++ b/app/components/mainview/tabletop/aoeGeometry.ts
@@ -1,0 +1,49 @@
+import type { AoeShape } from '~/types/mapAoe';
+
+export function feetToPixels(
+  feet: number,
+  scale: { pixelsPerSquare: number; feetPerSquare: number }
+): number {
+  const perSquare = scale.feetPerSquare || 5;
+  return (feet / perSquare) * (scale.pixelsPerSquare || 1);
+}
+
+export interface AoeInput {
+  shape: AoeShape;
+  originX: number;
+  originY: number;
+  sizePx: number;
+  widthPx?: number;
+  rotation: number;
+}
+
+export type AoeShapeGeometry =
+  | { kind: 'circle'; cx: number; cy: number; r: number }
+  | { kind: 'rect'; x: number; y: number; w: number; h: number }
+  | { kind: 'polygon'; points: Array<{ x: number; y: number }> };
+
+/** Map-local geometry for an AoE template. Line/cone are rotated by `rotation`. */
+export function aoeShapeGeometry(aoe: AoeInput): AoeShapeGeometry {
+  const { shape, originX: ox, originY: oy, sizePx: L, rotation } = aoe;
+  const cos = Math.cos(rotation);
+  const sin = Math.sin(rotation);
+  // local (aim-aligned, apex/origin at 0,0) → map-local
+  const at = (lx: number, ly: number) => ({
+    x: ox + (lx * cos - ly * sin),
+    y: oy + (lx * sin + ly * cos),
+  });
+
+  if (shape === 'sphere' || shape === 'cylinder') {
+    return { kind: 'circle', cx: ox, cy: oy, r: L };
+  }
+  if (shape === 'cube') {
+    // Axis-aligned square centered on the origin.
+    return { kind: 'rect', x: ox - L / 2, y: oy - L / 2, w: L, h: L };
+  }
+  if (shape === 'line') {
+    const W = aoe.widthPx ?? Math.max(1, L / 20);
+    return { kind: 'polygon', points: [at(0, -W / 2), at(L, -W / 2), at(L, W / 2), at(0, W / 2)] };
+  }
+  // cone — 5e: width == length at the far edge (isosceles triangle, apex at origin)
+  return { kind: 'polygon', points: [at(0, 0), at(L, L / 2), at(L, -L / 2)] };
+}

--- a/app/components/mainview/tabletop/toolWindowState.ts
+++ b/app/components/mainview/tabletop/toolWindowState.ts
@@ -1,15 +1,16 @@
 import type { ToolType } from '~/components/mainview/ToolBar';
 
-/** Toolbar tools that open a window. drawing/text/ruler are also map modes. */
-export type ToolWindowId = 'drawing' | 'text' | 'ruler' | 'dice' | 'layer';
+/** Toolbar tools that open a window. drawing/text/ruler/aoe are also map modes. */
+export type ToolWindowId = 'drawing' | 'text' | 'ruler' | 'aoe' | 'dice' | 'layer';
 
-const MODAL_TOOLS: ReadonlySet<ToolType> = new Set(['drawing', 'text', 'ruler']);
+const MODAL_TOOLS: ReadonlySet<ToolType> = new Set(['drawing', 'text', 'ruler', 'aoe']);
 const WINDOW_ONLY_TOOLS: ReadonlySet<ToolType> = new Set(['dice', 'layer']);
 
 export const TOOL_WINDOW_META: Record<ToolWindowId, { title: string }> = {
   drawing: { title: 'Draw' },
   text: { title: 'Text' },
   ruler: { title: 'Measurement' },
+  aoe: { title: 'Spell AoE' },
   dice: { title: 'Dice Roller' },
   layer: { title: 'Layers' },
 };

--- a/app/components/mainview/tabletop/useAoeTool.ts
+++ b/app/components/mainview/tabletop/useAoeTool.ts
@@ -1,0 +1,111 @@
+import { useCallback, useEffect, useState, type PointerEvent as ReactPointerEvent } from 'react';
+import { clamp } from './ActiveMapStage.geometry';
+import { feetToPixels, type AoeInput } from './aoeGeometry';
+import type { AoeShape } from '~/types/mapAoe';
+
+interface Options {
+  aoeActive: boolean;
+  shape: AoeShape;
+  sizeFt: number;
+  widthFt: number;
+  color: string;
+  domToImage: (clientX: number, clientY: number) => { x: number; y: number } | null;
+  pixelsPerSquare: number;
+  feetPerSquare: number;
+  imageWidth: number;
+  imageHeight: number;
+  onCommit: (aoe: AoeInput & { color: string }) => void;
+}
+
+const RADIAL: AoeShape[] = ['sphere', 'cube', 'cylinder'];
+
+/**
+ * The AoE placement tool — a ruler-style state machine for dropping a spell
+ * area-of-effect template on the map. Radial shapes (sphere/cube/cylinder)
+ * commit on the first click at the clicked origin. Directional shapes
+ * (cone/line) set their origin on the first click, aim live as the cursor
+ * moves, and commit on the second click with the rotation implied by the
+ * origin→cursor vector. Extracted alongside useRulerTool; the tool
+ * short-circuits the stage's pointer handlers while active.
+ */
+export function useAoeTool(o: Options) {
+  const [origin, setOrigin] = useState<{ x: number; y: number } | null>(null);
+  const [cursor, setCursor] = useState<{ x: number; y: number } | null>(null);
+
+  const reset = useCallback(() => {
+    setOrigin(null);
+    setCursor(null);
+  }, []);
+
+  useEffect(() => {
+    if (!o.aoeActive) reset();
+  }, [o.aoeActive, reset]);
+
+  // Esc cancels an in-progress directional placement.
+  useEffect(() => {
+    if (!o.aoeActive) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' || !origin) return;
+      const el = e.target as HTMLElement | null;
+      if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable))
+        return;
+      e.preventDefault();
+      reset();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [o.aoeActive, origin, reset]);
+
+  const sizePx = feetToPixels(o.sizeFt, o);
+  const widthPx = o.shape === 'line' ? feetToPixels(o.widthFt, o) : undefined;
+
+  const build = useCallback(
+    (ox: number, oy: number, rotation: number): AoeInput & { color: string } => ({
+      shape: o.shape,
+      originX: ox,
+      originY: oy,
+      sizePx,
+      widthPx,
+      rotation,
+      color: o.color,
+    }),
+    [o.shape, o.color, sizePx, widthPx]
+  );
+
+  const onPointerDown = useCallback(
+    (e: ReactPointerEvent<HTMLDivElement>) => {
+      const img = o.domToImage(e.clientX, e.clientY);
+      if (!img) return;
+      const p = { x: clamp(img.x, 0, o.imageWidth), y: clamp(img.y, 0, o.imageHeight) };
+      if (RADIAL.includes(o.shape)) {
+        o.onCommit(build(p.x, p.y, 0));
+        reset();
+        return;
+      }
+      if (!origin) {
+        setOrigin(p);
+        setCursor(p);
+      } else {
+        const rotation = Math.atan2(p.y - origin.y, p.x - origin.x);
+        o.onCommit(build(origin.x, origin.y, rotation));
+        reset();
+      }
+    },
+    [o, origin, build, reset]
+  );
+
+  const onPointerMove = useCallback(
+    (e: ReactPointerEvent<HTMLDivElement>) => {
+      if (!origin) return;
+      const img = o.domToImage(e.clientX, e.clientY);
+      if (img) setCursor(img);
+    },
+    [o, origin]
+  );
+
+  const preview: (AoeInput & { color: string }) | null = origin
+    ? build(origin.x, origin.y, cursor ? Math.atan2(cursor.y - origin.y, cursor.x - origin.x) : 0)
+    : null;
+
+  return { preview, onPointerDown, onPointerMove, reset };
+}

--- a/app/components/mainview/tabletop/useAoeTool.ts
+++ b/app/components/mainview/tabletop/useAoeTool.ts
@@ -41,6 +41,13 @@ export function useAoeTool(o: Options) {
     if (!o.aoeActive) reset();
   }, [o.aoeActive, reset]);
 
+  // Switching shape mid-placement abandons the in-progress origin — otherwise a
+  // directional placement started as one shape could commit at that stale origin
+  // with a different shape's size (mismatched template).
+  useEffect(() => {
+    reset();
+  }, [o.shape, reset]);
+
   // Esc cancels an in-progress directional placement.
   useEffect(() => {
     if (!o.aoeActive) return;

--- a/app/hooks/useMapAoE.ts
+++ b/app/hooks/useMapAoE.ts
@@ -8,6 +8,7 @@ import {
   createMapAoESchema,
   removeMapAoESchema,
   clearMapAoESchema,
+  updateMapAoESchema,
 } from '~/types/schemas/mapAoe';
 
 // ---------------------------------------------------------------------------
@@ -40,6 +41,13 @@ const clearMapAoEFn = createServerFn({ method: 'POST' })
   .handler(async ({ data }) => {
     const { clearMapAoE } = await import('~/server/functions/mapAoE');
     return clearMapAoE({ data });
+  });
+
+const moveMapAoEFn = createServerFn({ method: 'POST' })
+  .inputValidator(updateMapAoESchema)
+  .handler(async ({ data }) => {
+    const { moveMapAoE } = await import('~/server/functions/mapAoE');
+    return moveMapAoE({ data });
   });
 
 // ---------------------------------------------------------------------------
@@ -94,7 +102,23 @@ export function useMapAoEMutations(campaignId: string, mapId: string) {
     onError: (e) => captureException(e, { action: 'useMapAoEMutations.clear' }),
   });
 
-  return { create, remove, clear };
+  const move = useMutation({
+    mutationFn: async (input: { aoeId: string; originX: number; originY: number }) => {
+      return await moveMapAoEFn({
+        data: {
+          campaignId,
+          mapId,
+          id: input.aoeId,
+          originX: input.originX,
+          originY: input.originY,
+        },
+      });
+    },
+    onSuccess: invalidate,
+    onError: (e) => captureException(e, { action: 'useMapAoEMutations.move' }),
+  });
+
+  return { create, remove, clear, move };
 }
 
 // ---------------------------------------------------------------------------
@@ -132,4 +156,18 @@ export function applyAoeClearToCache(
   mapId: string
 ) {
   qc.setQueryData<MapAoEData[]>(queryKeys.mapAoe.list(campaignId, mapId), () => []);
+}
+
+export function applyAoeMoveToCache(
+  qc: ReturnType<typeof useQueryClient>,
+  campaignId: string,
+  mapId: string,
+  aoeId: string,
+  originX: number,
+  originY: number
+) {
+  qc.setQueryData<MapAoEData[]>(queryKeys.mapAoe.list(campaignId, mapId), (prev) => {
+    if (!prev) return prev;
+    return prev.map((a) => (a.id === aoeId ? { ...a, originX, originY } : a));
+  });
 }

--- a/app/hooks/useMapAoE.ts
+++ b/app/hooks/useMapAoE.ts
@@ -69,6 +69,13 @@ export function useMapAoEMutations(campaignId: string, mapId: string) {
   const qc = useQueryClient();
   const invalidate = () =>
     qc.invalidateQueries({ queryKey: queryKeys.mapAoe.list(campaignId, mapId) });
+  // On failure, reconcile the optimistic cache with server truth (a removed /
+  // moved / cleared template reappears / reverts) instead of leaving a lie —
+  // mirrors useMapDrawings.
+  const onError = (action: string) => (e: unknown) => {
+    captureException(e, { action });
+    invalidate();
+  };
 
   const create = useMutation({
     mutationFn: async (input: {
@@ -84,7 +91,7 @@ export function useMapAoEMutations(campaignId: string, mapId: string) {
       return await createMapAoEFn({ data: { campaignId, mapId, ...input } });
     },
     onSuccess: invalidate,
-    onError: (e) => captureException(e, { action: 'useMapAoEMutations.create' }),
+    onError: onError('useMapAoEMutations.create'),
   });
 
   const remove = useMutation({
@@ -92,7 +99,7 @@ export function useMapAoEMutations(campaignId: string, mapId: string) {
       return await removeMapAoEFn({ data: { campaignId, mapId, id: aoeId } });
     },
     onSuccess: invalidate,
-    onError: (e) => captureException(e, { action: 'useMapAoEMutations.remove' }),
+    onError: onError('useMapAoEMutations.remove'),
   });
 
   const clear = useMutation({
@@ -100,7 +107,7 @@ export function useMapAoEMutations(campaignId: string, mapId: string) {
       return await clearMapAoEFn({ data: { campaignId, mapId } });
     },
     onSuccess: invalidate,
-    onError: (e) => captureException(e, { action: 'useMapAoEMutations.clear' }),
+    onError: onError('useMapAoEMutations.clear'),
   });
 
   const move = useMutation({
@@ -116,7 +123,7 @@ export function useMapAoEMutations(campaignId: string, mapId: string) {
       });
     },
     onSuccess: invalidate,
-    onError: (e) => captureException(e, { action: 'useMapAoEMutations.move' }),
+    onError: onError('useMapAoEMutations.move'),
   });
 
   return { create, remove, clear, move };

--- a/app/hooks/useMapAoE.ts
+++ b/app/hooks/useMapAoE.ts
@@ -1,6 +1,7 @@
 import { createServerFn } from '@tanstack/react-start';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { captureException } from '~/providers/TelemetryProvider';
+import { showToast } from '~/components/Toast';
 import { queryKeys } from '~/utils/queryKeys';
 import type { MapAoEData, AoeShape } from '~/types/mapAoe';
 import {
@@ -69,11 +70,12 @@ export function useMapAoEMutations(campaignId: string, mapId: string) {
   const qc = useQueryClient();
   const invalidate = () =>
     qc.invalidateQueries({ queryKey: queryKeys.mapAoe.list(campaignId, mapId) });
-  // On failure, reconcile the optimistic cache with server truth (a removed /
-  // moved / cleared template reappears / reverts) instead of leaving a lie —
-  // mirrors useMapDrawings.
-  const onError = (action: string) => (e: unknown) => {
+  // On failure: tell the user, log it, and reconcile the optimistic cache with
+  // server truth (a removed / moved / cleared template reappears / reverts)
+  // instead of leaving a lie — mirrors useMapDrawings.
+  const onError = (action: string, userMessage: string) => (e: unknown) => {
     captureException(e, { action });
+    showToast(userMessage, 'error');
     invalidate();
   };
 
@@ -91,7 +93,10 @@ export function useMapAoEMutations(campaignId: string, mapId: string) {
       return await createMapAoEFn({ data: { campaignId, mapId, ...input } });
     },
     onSuccess: invalidate,
-    onError: onError('useMapAoEMutations.create'),
+    onError: onError(
+      'useMapAoEMutations.create',
+      'Couldn’t place the spell effect. Please try again.'
+    ),
   });
 
   const remove = useMutation({
@@ -99,7 +104,10 @@ export function useMapAoEMutations(campaignId: string, mapId: string) {
       return await removeMapAoEFn({ data: { campaignId, mapId, id: aoeId } });
     },
     onSuccess: invalidate,
-    onError: onError('useMapAoEMutations.remove'),
+    onError: onError(
+      'useMapAoEMutations.remove',
+      'Couldn’t delete the spell effect. Please try again.'
+    ),
   });
 
   const clear = useMutation({
@@ -107,7 +115,10 @@ export function useMapAoEMutations(campaignId: string, mapId: string) {
       return await clearMapAoEFn({ data: { campaignId, mapId } });
     },
     onSuccess: invalidate,
-    onError: onError('useMapAoEMutations.clear'),
+    onError: onError(
+      'useMapAoEMutations.clear',
+      'Couldn’t clear the spell effects. Please try again.'
+    ),
   });
 
   const move = useMutation({
@@ -123,7 +134,10 @@ export function useMapAoEMutations(campaignId: string, mapId: string) {
       });
     },
     onSuccess: invalidate,
-    onError: onError('useMapAoEMutations.move'),
+    onError: onError(
+      'useMapAoEMutations.move',
+      'Couldn’t move the spell effect. Please try again.'
+    ),
   });
 
   return { create, remove, clear, move };

--- a/app/hooks/useMapAoE.ts
+++ b/app/hooks/useMapAoE.ts
@@ -1,0 +1,135 @@
+import { createServerFn } from '@tanstack/react-start';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { captureException } from '~/providers/TelemetryProvider';
+import { queryKeys } from '~/utils/queryKeys';
+import type { MapAoEData, AoeShape } from '~/types/mapAoe';
+import {
+  listMapAoESchema,
+  createMapAoESchema,
+  removeMapAoESchema,
+  clearMapAoESchema,
+} from '~/types/schemas/mapAoe';
+
+// ---------------------------------------------------------------------------
+// Server function wrappers — dynamic imports keep Mongoose server-only.
+// ---------------------------------------------------------------------------
+
+const listMapAoEFn = createServerFn({ method: 'GET' })
+  .inputValidator(listMapAoESchema)
+  .handler(async ({ data }) => {
+    const { listMapAoE } = await import('~/server/functions/mapAoE');
+    return listMapAoE({ data });
+  });
+
+const createMapAoEFn = createServerFn({ method: 'POST' })
+  .inputValidator(createMapAoESchema)
+  .handler(async ({ data }) => {
+    const { createMapAoE } = await import('~/server/functions/mapAoE');
+    return createMapAoE({ data });
+  });
+
+const removeMapAoEFn = createServerFn({ method: 'POST' })
+  .inputValidator(removeMapAoESchema)
+  .handler(async ({ data }) => {
+    const { removeMapAoE } = await import('~/server/functions/mapAoE');
+    return removeMapAoE({ data });
+  });
+
+const clearMapAoEFn = createServerFn({ method: 'POST' })
+  .inputValidator(clearMapAoESchema)
+  .handler(async ({ data }) => {
+    const { clearMapAoE } = await import('~/server/functions/mapAoE');
+    return clearMapAoE({ data });
+  });
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+export function useMapAoE(campaignId: string | null | undefined, mapId: string | null | undefined) {
+  return useQuery({
+    queryKey: queryKeys.mapAoe.list(campaignId ?? '', mapId ?? ''),
+    enabled: Boolean(campaignId && mapId),
+    queryFn: async (): Promise<MapAoEData[]> => {
+      const res = await listMapAoEFn({ data: { campaignId: campaignId!, mapId: mapId! } });
+      return res.aoes;
+    },
+  });
+}
+
+export function useMapAoEMutations(campaignId: string, mapId: string) {
+  const qc = useQueryClient();
+  const invalidate = () =>
+    qc.invalidateQueries({ queryKey: queryKeys.mapAoe.list(campaignId, mapId) });
+
+  const create = useMutation({
+    mutationFn: async (input: {
+      shape: AoeShape;
+      originX: number;
+      originY: number;
+      sizePx: number;
+      widthPx?: number;
+      rotation: number;
+      color: string;
+    }) => {
+      return await createMapAoEFn({ data: { campaignId, mapId, ...input } });
+    },
+    onSuccess: invalidate,
+    onError: (e) => captureException(e, { action: 'useMapAoEMutations.create' }),
+  });
+
+  const remove = useMutation({
+    mutationFn: async (aoeId: string) => {
+      return await removeMapAoEFn({ data: { campaignId, mapId, id: aoeId } });
+    },
+    onSuccess: invalidate,
+    onError: (e) => captureException(e, { action: 'useMapAoEMutations.remove' }),
+  });
+
+  const clear = useMutation({
+    mutationFn: async () => {
+      return await clearMapAoEFn({ data: { campaignId, mapId } });
+    },
+    onSuccess: invalidate,
+    onError: (e) => captureException(e, { action: 'useMapAoEMutations.clear' }),
+  });
+
+  return { create, remove, clear };
+}
+
+// ---------------------------------------------------------------------------
+// Cache helpers — used for optimistic + realtime (party) updates.
+// ---------------------------------------------------------------------------
+
+export function applyAoeAddToCache(
+  qc: ReturnType<typeof useQueryClient>,
+  campaignId: string,
+  mapId: string,
+  aoe: MapAoEData
+) {
+  qc.setQueryData<MapAoEData[]>(queryKeys.mapAoe.list(campaignId, mapId), (prev) => {
+    if (!prev) return [aoe];
+    if (prev.some((a) => a.id === aoe.id)) return prev;
+    return [...prev, aoe];
+  });
+}
+
+export function applyAoeRemoveFromCache(
+  qc: ReturnType<typeof useQueryClient>,
+  campaignId: string,
+  mapId: string,
+  aoeId: string
+) {
+  qc.setQueryData<MapAoEData[]>(queryKeys.mapAoe.list(campaignId, mapId), (prev) => {
+    if (!prev) return prev;
+    return prev.filter((a) => a.id !== aoeId);
+  });
+}
+
+export function applyAoeClearToCache(
+  qc: ReturnType<typeof useQueryClient>,
+  campaignId: string,
+  mapId: string
+) {
+  qc.setQueryData<MapAoEData[]>(queryKeys.mapAoe.list(campaignId, mapId), () => []);
+}

--- a/app/hooks/useMapAoE.ts
+++ b/app/hooks/useMapAoE.ts
@@ -79,6 +79,7 @@ export function useMapAoEMutations(campaignId: string, mapId: string) {
       widthPx?: number;
       rotation: number;
       color: string;
+      label?: string;
     }) => {
       return await createMapAoEFn({ data: { campaignId, mapId, ...input } });
     },

--- a/app/hooks/useMapDrawings.ts
+++ b/app/hooks/useMapDrawings.ts
@@ -1,6 +1,7 @@
 import { createServerFn } from '@tanstack/react-start';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { captureException } from '~/providers/TelemetryProvider';
+import { showToast } from '~/components/Toast';
 import { queryKeys } from '~/utils/queryKeys';
 import type { MapDrawingData, MapDrawingKind } from '~/types/mapDrawing';
 import {
@@ -100,8 +101,9 @@ export function useMapDrawingMutations(campaignId: string, mapId: string) {
   // mid-drag and race the optimistic geometry writes.
   const invalidate = () =>
     qc.invalidateQueries({ queryKey: queryKeys.mapDrawings.list(campaignId, mapId) });
-  const onError = (action: string) => (e: unknown) => {
+  const onError = (action: string, userMessage: string) => (e: unknown) => {
     captureException(e, { action });
+    showToast(userMessage, 'error');
     invalidate();
   };
 
@@ -109,28 +111,40 @@ export function useMapDrawingMutations(campaignId: string, mapId: string) {
     mutationFn: async (input: CreateDrawingInput) => {
       return await createMapDrawingFn({ data: { campaignId, mapId, ...input } });
     },
-    onError: onError('useMapDrawingMutations.create'),
+    onError: onError(
+      'useMapDrawingMutations.create',
+      'Couldn’t save the drawing. Please try again.'
+    ),
   });
 
   const update = useMutation({
     mutationFn: async (input: UpdateDrawingInput) => {
       return await updateMapDrawingFn({ data: { campaignId, mapId, ...input } });
     },
-    onError: onError('useMapDrawingMutations.update'),
+    onError: onError(
+      'useMapDrawingMutations.update',
+      'Couldn’t update the drawing. Please try again.'
+    ),
   });
 
   const remove = useMutation({
     mutationFn: async (drawingId: string) => {
       return await deleteMapDrawingFn({ data: { campaignId, mapId, drawingId } });
     },
-    onError: onError('useMapDrawingMutations.remove'),
+    onError: onError(
+      'useMapDrawingMutations.remove',
+      'Couldn’t delete the drawing. Please try again.'
+    ),
   });
 
   const clear = useMutation({
     mutationFn: async () => {
       return await clearMapDrawingsFn({ data: { campaignId, mapId } });
     },
-    onError: onError('useMapDrawingMutations.clear'),
+    onError: onError(
+      'useMapDrawingMutations.clear',
+      'Couldn’t clear the drawings. Please try again.'
+    ),
   });
 
   return { create, update, remove, clear };

--- a/app/hooks/useMapTexts.ts
+++ b/app/hooks/useMapTexts.ts
@@ -1,6 +1,7 @@
 import { createServerFn } from '@tanstack/react-start';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { captureException } from '~/providers/TelemetryProvider';
+import { showToast } from '~/components/Toast';
 import { queryKeys } from '~/utils/queryKeys';
 import type { MapTextData } from '~/types/mapText';
 import {
@@ -64,6 +65,13 @@ export function useMapTextMutations(campaignId: string, mapId: string) {
   const qc = useQueryClient();
   const invalidate = () =>
     qc.invalidateQueries({ queryKey: queryKeys.mapTexts.list(campaignId, mapId) });
+  // On failure: tell the user, log it, and reconcile the optimistic cache with
+  // server truth instead of leaving a lie.
+  const onError = (action: string, userMessage: string) => (e: unknown) => {
+    captureException(e, { action });
+    showToast(userMessage, 'error');
+    invalidate();
+  };
 
   const create = useMutation({
     mutationFn: async (input: {
@@ -76,7 +84,7 @@ export function useMapTextMutations(campaignId: string, mapId: string) {
       return await createMapTextFn({ data: { campaignId, mapId, ...input } });
     },
     onSuccess: invalidate,
-    onError: (e) => captureException(e, { action: 'useMapTextMutations.create' }),
+    onError: onError('useMapTextMutations.create', 'Couldn’t add the text. Please try again.'),
   });
 
   const update = useMutation({
@@ -91,7 +99,7 @@ export function useMapTextMutations(campaignId: string, mapId: string) {
       return await updateMapTextFn({ data: { campaignId, mapId, ...input } });
     },
     onSuccess: invalidate,
-    onError: (e) => captureException(e, { action: 'useMapTextMutations.update' }),
+    onError: onError('useMapTextMutations.update', 'Couldn’t update the text. Please try again.'),
   });
 
   const remove = useMutation({
@@ -99,7 +107,7 @@ export function useMapTextMutations(campaignId: string, mapId: string) {
       return await deleteMapTextFn({ data: { campaignId, mapId, textId } });
     },
     onSuccess: invalidate,
-    onError: (e) => captureException(e, { action: 'useMapTextMutations.remove' }),
+    onError: onError('useMapTextMutations.remove', 'Couldn’t delete the text. Please try again.'),
   });
 
   return { create, update, remove };

--- a/app/hooks/useMapTokens.ts
+++ b/app/hooks/useMapTokens.ts
@@ -1,6 +1,7 @@
 import { createServerFn } from '@tanstack/react-start';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { captureException } from '~/providers/TelemetryProvider';
+import { showToast } from '~/components/Toast';
 import { queryKeys } from '~/utils/queryKeys';
 import type { MapTokenData } from '~/types/mapToken';
 import type { TokenSource } from '~/types/schemas/mapTokens';
@@ -75,6 +76,13 @@ export function useMapTokenMutations(campaignId: string, mapId: string) {
   const qc = useQueryClient();
   const invalidate = () =>
     qc.invalidateQueries({ queryKey: queryKeys.mapTokens.list(campaignId, mapId) });
+  // On failure: tell the user, log it, and reconcile the optimistic cache with
+  // server truth instead of leaving a lie.
+  const onError = (action: string, userMessage: string) => (e: unknown) => {
+    captureException(e, { action });
+    showToast(userMessage, 'error');
+    invalidate();
+  };
 
   const create = useMutation({
     mutationFn: async (input: {
@@ -86,7 +94,7 @@ export function useMapTokenMutations(campaignId: string, mapId: string) {
       return await createMapTokenFn({ data: { campaignId, mapId, ...input } });
     },
     onSuccess: invalidate,
-    onError: (e) => captureException(e, { action: 'useMapTokenMutations.create' }),
+    onError: onError('useMapTokenMutations.create', 'Couldn’t add the token. Please try again.'),
   });
 
   const createBatch = useMutation({
@@ -96,7 +104,10 @@ export function useMapTokenMutations(campaignId: string, mapId: string) {
       });
     },
     onSuccess: invalidate,
-    onError: (e) => captureException(e, { action: 'useMapTokenMutations.createBatch' }),
+    onError: onError(
+      'useMapTokenMutations.createBatch',
+      'Couldn’t add the tokens. Please try again.'
+    ),
   });
 
   const move = useMutation({
@@ -104,7 +115,7 @@ export function useMapTokenMutations(campaignId: string, mapId: string) {
       return await moveMapTokenFn({ data: { campaignId, mapId, ...input } });
     },
     onSuccess: invalidate,
-    onError: (e) => captureException(e, { action: 'useMapTokenMutations.move' }),
+    onError: onError('useMapTokenMutations.move', 'Couldn’t move the token. Please try again.'),
   });
 
   const update = useMutation({
@@ -114,7 +125,7 @@ export function useMapTokenMutations(campaignId: string, mapId: string) {
       return await updateMapTokenFn({ data: { campaignId, mapId, ...input } });
     },
     onSuccess: invalidate,
-    onError: (e) => captureException(e, { action: 'useMapTokenMutations.update' }),
+    onError: onError('useMapTokenMutations.update', 'Couldn’t update the token. Please try again.'),
   });
 
   const remove = useMutation({
@@ -122,7 +133,7 @@ export function useMapTokenMutations(campaignId: string, mapId: string) {
       return await deleteMapTokenFn({ data: { campaignId, mapId, tokenId } });
     },
     onSuccess: invalidate,
-    onError: (e) => captureException(e, { action: 'useMapTokenMutations.remove' }),
+    onError: onError('useMapTokenMutations.remove', 'Couldn’t remove the token. Please try again.'),
   });
 
   return { create, createBatch, move, update, remove };

--- a/app/hooks/useMaps.ts
+++ b/app/hooks/useMaps.ts
@@ -1,6 +1,7 @@
 import { createServerFn } from '@tanstack/react-start';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { captureException } from '~/providers/TelemetryProvider';
+import { showToast } from '~/components/Toast';
 import { queryKeys } from '~/utils/queryKeys';
 import type { MapData, MapListItem } from '~/types/map';
 import {
@@ -121,6 +122,11 @@ export function useMapsMutations(campaignId: string) {
     qc.invalidateQueries({ queryKey: queryKeys.maps.list(campaignId) });
     qc.invalidateQueries({ queryKey: queryKeys.maps.activeAll(campaignId) });
   };
+  // On failure: tell the user and log it.
+  const onError = (action: string, userMessage: string) => (e: unknown) => {
+    captureException(e, { action });
+    showToast(userMessage, 'error');
+  };
 
   const createMap = useMutation({
     mutationFn: async (input: Omit<Parameters<typeof createMapFn>[0]['data'], 'campaignId'>) => {
@@ -128,7 +134,7 @@ export function useMapsMutations(campaignId: string) {
       return res.map;
     },
     onSuccess: invalidateLists,
-    onError: (e) => captureException(e, { action: 'useMapsMutations.createMap' }),
+    onError: onError('useMapsMutations.createMap', 'Couldn’t create the map. Please try again.'),
   });
 
   const updateMapScale = useMutation({
@@ -142,7 +148,10 @@ export function useMapsMutations(campaignId: string) {
       qc.invalidateQueries({ queryKey: queryKeys.maps.detail(campaignId, m.id) });
       invalidateLists();
     },
-    onError: (e) => captureException(e, { action: 'useMapsMutations.updateMapScale' }),
+    onError: onError(
+      'useMapsMutations.updateMapScale',
+      'Couldn’t update the map scale. Please try again.'
+    ),
   });
 
   const updateMap = useMutation({
@@ -154,7 +163,7 @@ export function useMapsMutations(campaignId: string) {
       qc.invalidateQueries({ queryKey: queryKeys.maps.detail(campaignId, m.id) });
       invalidateLists();
     },
-    onError: (e) => captureException(e, { action: 'useMapsMutations.updateMap' }),
+    onError: onError('useMapsMutations.updateMap', 'Couldn’t update the map. Please try again.'),
   });
 
   const deleteMap = useMutation({
@@ -162,7 +171,7 @@ export function useMapsMutations(campaignId: string) {
       return await deleteMapFn({ data: { id: mapId, campaignId } });
     },
     onSuccess: invalidateLists,
-    onError: (e) => captureException(e, { action: 'useMapsMutations.deleteMap' }),
+    onError: onError('useMapsMutations.deleteMap', 'Couldn’t delete the map. Please try again.'),
   });
 
   const setActiveMap = useMutation({
@@ -172,7 +181,10 @@ export function useMapsMutations(campaignId: string) {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: queryKeys.maps.activeAll(campaignId) });
     },
-    onError: (e) => captureException(e, { action: 'useMapsMutations.setActiveMap' }),
+    onError: onError(
+      'useMapsMutations.setActiveMap',
+      'Couldn’t switch the active map. Please try again.'
+    ),
   });
 
   return { createMap, updateMapScale, updateMap, deleteMap, setActiveMap };

--- a/app/hooks/useTabletopMapParty.ts
+++ b/app/hooks/useTabletopMapParty.ts
@@ -3,6 +3,7 @@ import usePartySocket from 'partysocket/react';
 import type { MapTokenData } from '~/types/mapToken';
 import type { MapTextData } from '~/types/mapText';
 import type { MapDrawingData } from '~/types/mapDrawing';
+import type { MapAoEData } from '~/types/mapAoe';
 import { parseTabletopMapMessage } from '~/types/schemas/tabletopMessage';
 
 const REALTIME_HOST = import.meta.env.VITE_PUBLIC_PARTYKIT_HOST ?? 'localhost:1999';
@@ -54,7 +55,12 @@ export type TabletopMapMessage =
       height: number;
     }
   | { type: 'drawing:removed'; mapId: string; drawingId: string }
-  | { type: 'drawing:cleared'; mapId: string };
+  | { type: 'drawing:cleared'; mapId: string }
+  // AoE templates are shared (visible to all viewers), unlike drawings which
+  // are GM-only — see useTabletopMapSync's inbound reducer.
+  | { type: 'aoe:added'; mapId: string; aoe: MapAoEData }
+  | { type: 'aoe:removed'; mapId: string; aoeId: string }
+  | { type: 'aoe:cleared'; mapId: string };
 
 /**
  * useTabletopMapParty — subscribes to the campaign's map party channel

--- a/app/hooks/useTabletopMapParty.ts
+++ b/app/hooks/useTabletopMapParty.ts
@@ -59,6 +59,15 @@ export type TabletopMapMessage =
   // AoE templates are shared (visible to all viewers), unlike drawings which
   // are GM-only — see useTabletopMapSync's inbound reducer.
   | { type: 'aoe:added'; mapId: string; aoe: MapAoEData }
+  | {
+      type: 'aoe:moved';
+      mapId: string;
+      aoeId: string;
+      originX: number;
+      originY: number;
+      /** True for the final, persisted broadcast after drag-end; false during drag. */
+      final?: boolean;
+    }
   | { type: 'aoe:removed'; mapId: string; aoeId: string }
   | { type: 'aoe:cleared'; mapId: string };
 

--- a/app/hooks/useTabletopMapSync.ts
+++ b/app/hooks/useTabletopMapSync.ts
@@ -20,6 +20,7 @@ import {
   applyDrawingRemoveFromCache,
   applyDrawingsClearToCache,
 } from './useMapDrawings';
+import { applyAoeAddToCache, applyAoeRemoveFromCache, applyAoeClearToCache } from './useMapAoE';
 
 /**
  * Subscribes to the campaign's tabletop-map party and applies inbound
@@ -84,6 +85,14 @@ export function useTabletopMapSync(
       applyDrawingRemoveFromCache(queryClient, campaignId, msg.mapId, msg.drawingId);
     } else if (msg.type === 'drawing:cleared') {
       applyDrawingsClearToCache(queryClient, campaignId, msg.mapId);
+    } else if (msg.type === 'aoe:added') {
+      // AoE templates are shared (like map text), not GM-gated like drawings —
+      // this branch runs for all viewers, including non-GM.
+      applyAoeAddToCache(queryClient, campaignId, msg.mapId, msg.aoe);
+    } else if (msg.type === 'aoe:removed') {
+      applyAoeRemoveFromCache(queryClient, campaignId, msg.mapId, msg.aoeId);
+    } else if (msg.type === 'aoe:cleared') {
+      applyAoeClearToCache(queryClient, campaignId, msg.mapId);
     }
   });
 

--- a/app/hooks/useTabletopMapSync.ts
+++ b/app/hooks/useTabletopMapSync.ts
@@ -20,7 +20,12 @@ import {
   applyDrawingRemoveFromCache,
   applyDrawingsClearToCache,
 } from './useMapDrawings';
-import { applyAoeAddToCache, applyAoeRemoveFromCache, applyAoeClearToCache } from './useMapAoE';
+import {
+  applyAoeAddToCache,
+  applyAoeRemoveFromCache,
+  applyAoeClearToCache,
+  applyAoeMoveToCache,
+} from './useMapAoE';
 
 /**
  * Subscribes to the campaign's tabletop-map party and applies inbound
@@ -89,6 +94,8 @@ export function useTabletopMapSync(
       // AoE templates are shared (like map text), not GM-gated like drawings —
       // this branch runs for all viewers, including non-GM.
       applyAoeAddToCache(queryClient, campaignId, msg.mapId, msg.aoe);
+    } else if (msg.type === 'aoe:moved') {
+      applyAoeMoveToCache(queryClient, campaignId, msg.mapId, msg.aoeId, msg.originX, msg.originY);
     } else if (msg.type === 'aoe:removed') {
       applyAoeRemoveFromCache(queryClient, campaignId, msg.mapId, msg.aoeId);
     } else if (msg.type === 'aoe:cleared') {

--- a/app/hooks/useTabletopScreens.ts
+++ b/app/hooks/useTabletopScreens.ts
@@ -2,6 +2,7 @@ import { createServerFn } from '@tanstack/react-start';
 import type { TabletopScreenData, TabletopScreenDetailData } from '~/types/tabletop';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { captureException } from '~/providers/TelemetryProvider';
+import { showToast } from '~/components/Toast';
 import { queryKeys } from '~/utils/queryKeys';
 import {
   listTabletopScreensSchema,
@@ -137,6 +138,7 @@ export function useTabletopMutations(campaignId: string) {
     // List invalidation is deferred to the caller so it can set selection first
     onError: (e) => {
       captureException(e, { action: 'createTabletopScreen' });
+      showToast('Couldn’t create the tab. Please try again.', 'error');
     },
   });
 
@@ -148,6 +150,7 @@ export function useTabletopMutations(campaignId: string) {
     },
     onError: (e) => {
       captureException(e, { action: 'renameTabletopScreen' });
+      showToast('Couldn’t rename the tab. Please try again.', 'error');
     },
   });
 
@@ -156,6 +159,7 @@ export function useTabletopMutations(campaignId: string) {
     // List invalidation is deferred to the caller so it can set selection first
     onError: (e) => {
       captureException(e, { action: 'deleteTabletopScreen' });
+      showToast('Couldn’t delete the tab. Please try again.', 'error');
     },
   });
 
@@ -178,6 +182,7 @@ export function useTabletopMutations(campaignId: string) {
     },
     onError: (e) => {
       captureException(e, { action: 'updateTabletopScreenSettings' });
+      showToast('Couldn’t save the tabletop settings. Please try again.', 'error');
     },
   });
 

--- a/app/routes/campaigns/$campaignId/play.tsx
+++ b/app/routes/campaigns/$campaignId/play.tsx
@@ -7,6 +7,7 @@ import { getMe } from '~/server/functions/rpc';
 import { useCampaign } from '~/hooks/useCampaigns';
 import { useActivePlayerContext } from '~/providers/ActivePlayerProvider';
 import { CampaignHeader } from '~/components/mainview/CampaignHeader';
+import { Toast } from '~/components/Toast';
 import { DashboardView } from '~/components/mainview/DashboardView';
 import { MainView } from '~/components/mainview/MainView';
 import { TabletopView } from '~/components/mainview/TabletopView';
@@ -219,6 +220,7 @@ function PlayPageContent() {
           )}
         </MainView>
       </div>
+      <Toast />
     </div>
   );
 }

--- a/app/server/db/governance.ts
+++ b/app/server/db/governance.ts
@@ -99,6 +99,11 @@ export const INDEX_GOVERNANCE: Record<string, GovernanceEntry[]> = {
       severity: 'critical',
     },
   ],
+  // Shared map-object collections — the compound index serves the per-map
+  // list query (`find({ mapId, campaignId })`). Performance, not correctness.
+  MapText: [{ key: { mapId: 1, campaignId: 1 }, severity: 'optional' }],
+  MapDrawing: [{ key: { mapId: 1, campaignId: 1 }, severity: 'optional' }],
+  MapAoE: [{ key: { campaignId: 1, mapId: 1 }, severity: 'optional' }],
   Monster: [
     { key: { campaignId: 1, updatedAt: -1 }, severity: 'optional' },
     { key: { campaignId: 1, name: 1 }, severity: 'optional' },

--- a/app/server/db/inspect.ts
+++ b/app/server/db/inspect.ts
@@ -10,6 +10,9 @@ import { Race } from './models/Race';
 import { User } from './models/User';
 import { Map as MapModel } from './models/Map';
 import { MapToken } from './models/MapToken';
+import { MapText } from './models/MapText';
+import { MapDrawing } from './models/MapDrawing';
+import { MapAoE } from './models/MapAoE';
 import { Monster } from './models/Monster';
 
 /** All Mongoose models the app declares. Order does not matter. */
@@ -25,6 +28,9 @@ export const ALL_MODELS: mongoose.Model<any>[] = [
   Race,
   MapModel,
   MapToken,
+  MapText,
+  MapDrawing,
+  MapAoE,
   Monster,
 ];
 

--- a/app/server/db/models/MapAoE.ts
+++ b/app/server/db/models/MapAoE.ts
@@ -29,6 +29,8 @@ const mapAoESchema = new mongoose.Schema(
     rotation: { type: Number, required: true },
     // 6-digit hex color.
     color: { type: String, required: true },
+    // Optional user label, e.g. the spell name.
+    label: { type: String },
     // The author. Used to gate deletion: a player may delete only their own
     // AoE; a GM may delete anyone's.
     createdBy: {
@@ -36,6 +38,9 @@ const mapAoESchema = new mongoose.Schema(
       ref: 'User',
       required: true,
     },
+    // Placer's display name, denormalised at create time so viewers can
+    // render it without a per-viewer user lookup.
+    createdByName: { type: String, default: '' },
     createdAt: { type: Date, default: Date.now },
     updatedAt: { type: Date, default: Date.now },
   },

--- a/app/server/db/models/MapAoE.ts
+++ b/app/server/db/models/MapAoE.ts
@@ -1,0 +1,51 @@
+import mongoose from 'mongoose';
+
+// Spell area-of-effect template on a map. Any member can create an AoE;
+// deletion is gated to the author (createdBy) or any GM.
+const mapAoESchema = new mongoose.Schema(
+  {
+    mapId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Map',
+      required: true,
+    },
+    // Denormalised for cheap auth checks (avoids a Map lookup per write).
+    campaignId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Campaign',
+      required: true,
+    },
+    // Shape of the area-of-effect.
+    shape: { type: String, required: true },
+    // Origin in map-local pixel coordinates (the image's native pixel space).
+    // Center for sphere/cube/cylinder, apex for cone/line.
+    originX: { type: Number, required: true },
+    originY: { type: Number, required: true },
+    // Radius / length / edge, in map-local pixels.
+    sizePx: { type: Number, required: true },
+    // Line width / cylinder height, in map-local pixels (optional).
+    widthPx: { type: Number },
+    // Aim in radians (cone/line); 0 for radial shapes.
+    rotation: { type: Number, required: true },
+    // 6-digit hex color.
+    color: { type: String, required: true },
+    // The author. Used to gate deletion: a player may delete only their own
+    // AoE; a GM may delete anyone's.
+    createdBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+    },
+    createdAt: { type: Date, default: Date.now },
+    updatedAt: { type: Date, default: Date.now },
+  },
+  { collection: 'mapAoE' }
+);
+
+// istanbul ignore next
+if (typeof (mapAoESchema as { index?: unknown }).index === 'function') {
+  // Queries always filter by (campaignId, mapId), so index the compound shape.
+  mapAoESchema.index({ campaignId: 1, mapId: 1 });
+}
+
+export const MapAoE = mongoose.models.MapAoE || mongoose.model('MapAoE', mapAoESchema);

--- a/app/server/functions/mapAoE.ts
+++ b/app/server/functions/mapAoE.ts
@@ -1,8 +1,29 @@
 import { z } from 'zod';
 import { requireCampaignMember } from '../utils/requireCampaignMember';
 import { MapAoE } from '../db/models/MapAoE';
+import { Map as MapModel } from '../db/models/Map';
 import { User } from '../db/models/User';
 import { serverCaptureException, serverCaptureEvent } from '../utils/telemetry';
+
+/**
+ * Max AoE templates per map. Any member can create, only a GM can clear-all, so
+ * cap growth to protect Mongo and every client's SVG render from a runaway
+ * client. Well above any realistic encounter's needs.
+ */
+const MAX_AOE_PER_MAP = 200;
+
+/** Load a map's image bounds (for clamping an origin server-side). */
+async function mapBounds(campaignId: string, mapId: string): Promise<{ w: number; h: number }> {
+  const map = await MapModel.findOne({ _id: mapId, campaignId }, 'imageWidth imageHeight').lean();
+  if (!map) throw new Error('Map not found');
+  const m = map as { imageWidth?: number; imageHeight?: number };
+  return {
+    w: m.imageWidth ?? Number.POSITIVE_INFINITY,
+    h: m.imageHeight ?? Number.POSITIVE_INFINITY,
+  };
+}
+
+const clampTo = (v: number, max: number) => Math.max(0, Math.min(max, v));
 import type { MapAoEData, AoeShape } from '~/types/mapAoe';
 import {
   createMapAoESchema,
@@ -88,6 +109,19 @@ export const createMapAoE = async ({ data }: { data: z.infer<typeof createMapAoE
     const member = await requireCampaignMember(data.campaignId);
     sessionUserId = member.sessionUserId;
 
+    // Enforce a per-map cap (any member can create; only a GM clears all).
+    const count = await MapAoE.countDocuments({
+      campaignId: data.campaignId,
+      mapId: data.mapId,
+    });
+    if (count >= MAX_AOE_PER_MAP) {
+      throw new Error(`This map already has the maximum of ${MAX_AOE_PER_MAP} AoE templates`);
+    }
+
+    // Clamp the origin into the map's image bounds (the client clamps too, but
+    // the server is the source of truth for a direct RPC).
+    const { w, h } = await mapBounds(data.campaignId, data.mapId);
+
     const u = await User.findById(member.userId).select('firstName lastName email').lean();
     const uDoc = u as { firstName?: string; lastName?: string; email?: string } | null;
     const createdByName =
@@ -97,8 +131,8 @@ export const createMapAoE = async ({ data }: { data: z.infer<typeof createMapAoE
       mapId: data.mapId,
       campaignId: data.campaignId,
       shape: data.shape,
-      originX: data.originX,
-      originY: data.originY,
+      originX: clampTo(data.originX, w),
+      originY: clampTo(data.originY, h),
       sizePx: data.sizePx,
       widthPx: data.widthPx,
       rotation: data.rotation,
@@ -178,8 +212,10 @@ export const moveMapAoE = async ({ data }: { data: z.infer<typeof updateMapAoESc
     const canMove = String(doc.createdBy) === member.userId || member.isGM;
     if (!canMove) throw new Error('Forbidden');
 
-    doc.originX = data.originX;
-    doc.originY = data.originY;
+    // Clamp into the map's image bounds (server is source of truth).
+    const { w, h } = await mapBounds(data.campaignId, data.mapId);
+    doc.originX = clampTo(data.originX, w);
+    doc.originY = clampTo(data.originY, h);
     await doc.save();
 
     return { aoe: serializeAoE(doc.toObject() as AoEDoc) };

--- a/app/server/functions/mapAoE.ts
+++ b/app/server/functions/mapAoE.ts
@@ -103,7 +103,9 @@ export const createMapAoE = async ({ data }: { data: z.infer<typeof createMapAoE
       widthPx: data.widthPx,
       rotation: data.rotation,
       color: data.color,
-      label: data.label,
+      // Never persist a blank/whitespace-only label (UI already omits it; this
+      // guards direct server-fn callers).
+      label: data.label?.trim() || undefined,
       createdBy: member.userId,
       createdByName,
     });

--- a/app/server/functions/mapAoE.ts
+++ b/app/server/functions/mapAoE.ts
@@ -1,0 +1,165 @@
+import { z } from 'zod';
+import { requireCampaignMember } from '../utils/requireCampaignMember';
+import { MapAoE } from '../db/models/MapAoE';
+import { serverCaptureException, serverCaptureEvent } from '../utils/telemetry';
+import type { MapAoEData, AoeShape } from '~/types/mapAoe';
+import {
+  createMapAoESchema,
+  listMapAoESchema,
+  removeMapAoESchema,
+  clearMapAoESchema,
+} from '~/types/schemas/mapAoe';
+
+// ---------------------------------------------------------------------------
+// Serialiser
+// ---------------------------------------------------------------------------
+
+type AoEDoc = {
+  _id: unknown;
+  mapId: unknown;
+  campaignId: unknown;
+  shape?: string;
+  originX?: number;
+  originY?: number;
+  sizePx?: number;
+  widthPx?: number;
+  rotation?: number;
+  color?: string;
+  createdBy?: unknown;
+  createdAt?: Date;
+  updatedAt?: Date;
+};
+
+function serializeAoE(a: AoEDoc): MapAoEData {
+  return {
+    id: String(a._id),
+    mapId: String(a.mapId),
+    campaignId: String(a.campaignId),
+    shape: (a.shape ?? 'sphere') as AoeShape,
+    originX: a.originX ?? 0,
+    originY: a.originY ?? 0,
+    sizePx: a.sizePx ?? 0,
+    widthPx: typeof a.widthPx === 'number' ? a.widthPx : undefined,
+    rotation: a.rotation ?? 0,
+    color: a.color ?? '#fbbf24',
+    createdBy: a.createdBy ? String(a.createdBy) : '',
+    createdAt: a.createdAt instanceof Date ? a.createdAt.toISOString() : '',
+    updatedAt: a.updatedAt instanceof Date ? a.updatedAt.toISOString() : '',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Server functions
+// ---------------------------------------------------------------------------
+
+/** List every AoE on a map. All members see all AoEs (it's shared, not GM-gated). */
+export const listMapAoE = async ({ data }: { data: z.infer<typeof listMapAoESchema> }) => {
+  let sessionUserId: string | undefined;
+  try {
+    const member = await requireCampaignMember(data.campaignId);
+    sessionUserId = member.sessionUserId;
+
+    const docs = await MapAoE.find({ mapId: data.mapId, campaignId: data.campaignId })
+      .sort({ createdAt: 1 })
+      .lean();
+    return { aoes: docs.map((d) => serializeAoE(d as AoEDoc)) };
+  } catch (e) {
+    serverCaptureException(e, sessionUserId, {
+      action: 'listMapAoE',
+      campaignId: data.campaignId,
+      mapId: data.mapId,
+    });
+    throw e;
+  }
+};
+
+/** Create an AoE template on a map. Any member (player or GM) may create one. */
+export const createMapAoE = async ({ data }: { data: z.infer<typeof createMapAoESchema> }) => {
+  let sessionUserId: string | undefined;
+  try {
+    const member = await requireCampaignMember(data.campaignId);
+    sessionUserId = member.sessionUserId;
+
+    const doc = await MapAoE.create({
+      mapId: data.mapId,
+      campaignId: data.campaignId,
+      shape: data.shape,
+      originX: data.originX,
+      originY: data.originY,
+      sizePx: data.sizePx,
+      widthPx: data.widthPx,
+      rotation: data.rotation,
+      color: data.color,
+      createdBy: member.userId,
+    });
+
+    serverCaptureEvent(sessionUserId, 'map_aoe_created', {
+      campaign_id: data.campaignId,
+      map_id: data.mapId,
+    });
+    return { aoe: serializeAoE(doc.toObject() as AoEDoc) };
+  } catch (e) {
+    serverCaptureException(e, sessionUserId, {
+      action: 'createMapAoE',
+      campaignId: data.campaignId,
+      mapId: data.mapId,
+    });
+    throw e;
+  }
+};
+
+/**
+ * Remove an AoE. A player may remove only their own AoE; a GM may remove
+ * anyone's. This permission check is the authoritative one.
+ */
+export const removeMapAoE = async ({ data }: { data: z.infer<typeof removeMapAoESchema> }) => {
+  let sessionUserId: string | undefined;
+  try {
+    const member = await requireCampaignMember(data.campaignId);
+    sessionUserId = member.sessionUserId;
+
+    const doc = await MapAoE.findOne({
+      _id: data.id,
+      mapId: data.mapId,
+      campaignId: data.campaignId,
+    });
+    if (!doc) throw new Error('AoE not found');
+
+    const canRemove = String(doc.createdBy) === member.userId || member.isGM;
+    if (!canRemove) throw new Error('Forbidden');
+
+    await doc.deleteOne();
+    return { success: true };
+  } catch (e) {
+    serverCaptureException(e, sessionUserId, {
+      action: 'removeMapAoE',
+      campaignId: data.campaignId,
+      mapId: data.mapId,
+      id: data.id,
+    });
+    throw e;
+  }
+};
+
+/** Clear every AoE on a map. GM-only. */
+export const clearMapAoE = async ({ data }: { data: z.infer<typeof clearMapAoESchema> }) => {
+  let sessionUserId: string | undefined;
+  try {
+    const member = await requireCampaignMember(data.campaignId);
+    sessionUserId = member.sessionUserId;
+
+    if (!member.isGM) throw new Error('Forbidden');
+
+    await MapAoE.deleteMany({ campaignId: data.campaignId, mapId: data.mapId });
+    return { success: true };
+  } catch (e) {
+    serverCaptureException(e, sessionUserId, {
+      action: 'clearMapAoE',
+      campaignId: data.campaignId,
+      mapId: data.mapId,
+    });
+    throw e;
+  }
+};
+
+export { createMapAoESchema, listMapAoESchema, removeMapAoESchema, clearMapAoESchema };

--- a/app/server/functions/mapAoE.ts
+++ b/app/server/functions/mapAoE.ts
@@ -61,6 +61,8 @@ export const listMapAoE = async ({ data }: { data: z.infer<typeof listMapAoESche
 
     const docs = await MapAoE.find({ mapId: data.mapId, campaignId: data.campaignId })
       .sort({ createdAt: 1 })
+      // Bound the result set.
+      .limit(2000)
       .lean();
     return { aoes: docs.map((d) => serializeAoE(d as AoEDoc)) };
   } catch (e) {

--- a/app/server/functions/mapAoE.ts
+++ b/app/server/functions/mapAoE.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { requireCampaignMember } from '../utils/requireCampaignMember';
 import { MapAoE } from '../db/models/MapAoE';
+import { User } from '../db/models/User';
 import { serverCaptureException, serverCaptureEvent } from '../utils/telemetry';
 import type { MapAoEData, AoeShape } from '~/types/mapAoe';
 import {
@@ -26,7 +27,9 @@ type AoEDoc = {
   widthPx?: number;
   rotation?: number;
   color?: string;
+  label?: string;
   createdBy?: unknown;
+  createdByName?: string;
   createdAt?: Date;
   updatedAt?: Date;
 };
@@ -43,7 +46,9 @@ function serializeAoE(a: AoEDoc): MapAoEData {
     widthPx: typeof a.widthPx === 'number' ? a.widthPx : undefined,
     rotation: a.rotation ?? 0,
     color: a.color ?? '#fbbf24',
+    label: a.label ?? undefined,
     createdBy: a.createdBy ? String(a.createdBy) : '',
+    createdByName: a.createdByName ?? '',
     createdAt: a.createdAt instanceof Date ? a.createdAt.toISOString() : '',
     updatedAt: a.updatedAt instanceof Date ? a.updatedAt.toISOString() : '',
   };
@@ -83,6 +88,11 @@ export const createMapAoE = async ({ data }: { data: z.infer<typeof createMapAoE
     const member = await requireCampaignMember(data.campaignId);
     sessionUserId = member.sessionUserId;
 
+    const u = await User.findById(member.userId).select('firstName lastName email').lean();
+    const uDoc = u as { firstName?: string; lastName?: string; email?: string } | null;
+    const createdByName =
+      [uDoc?.firstName, uDoc?.lastName].filter(Boolean).join(' ') || uDoc?.email || 'Unknown';
+
     const doc = await MapAoE.create({
       mapId: data.mapId,
       campaignId: data.campaignId,
@@ -93,7 +103,9 @@ export const createMapAoE = async ({ data }: { data: z.infer<typeof createMapAoE
       widthPx: data.widthPx,
       rotation: data.rotation,
       color: data.color,
+      label: data.label,
       createdBy: member.userId,
+      createdByName,
     });
 
     serverCaptureEvent(sessionUserId, 'map_aoe_created', {

--- a/app/server/functions/mapAoE.ts
+++ b/app/server/functions/mapAoE.ts
@@ -8,6 +8,7 @@ import {
   listMapAoESchema,
   removeMapAoESchema,
   clearMapAoESchema,
+  updateMapAoESchema,
 } from '~/types/schemas/mapAoe';
 
 // ---------------------------------------------------------------------------
@@ -143,6 +144,42 @@ export const removeMapAoE = async ({ data }: { data: z.infer<typeof removeMapAoE
   }
 };
 
+/**
+ * Move an AoE's origin. A player may move only their own AoE; a GM may move
+ * anyone's. This permission check is the authoritative one.
+ */
+export const moveMapAoE = async ({ data }: { data: z.infer<typeof updateMapAoESchema> }) => {
+  let sessionUserId: string | undefined;
+  try {
+    const member = await requireCampaignMember(data.campaignId);
+    sessionUserId = member.sessionUserId;
+
+    const doc = await MapAoE.findOne({
+      _id: data.id,
+      mapId: data.mapId,
+      campaignId: data.campaignId,
+    });
+    if (!doc) throw new Error('AoE not found');
+
+    const canMove = String(doc.createdBy) === member.userId || member.isGM;
+    if (!canMove) throw new Error('Forbidden');
+
+    doc.originX = data.originX;
+    doc.originY = data.originY;
+    await doc.save();
+
+    return { aoe: serializeAoE(doc.toObject() as AoEDoc) };
+  } catch (e) {
+    serverCaptureException(e, sessionUserId, {
+      action: 'moveMapAoE',
+      campaignId: data.campaignId,
+      mapId: data.mapId,
+      id: data.id,
+    });
+    throw e;
+  }
+};
+
 /** Clear every AoE on a map. GM-only. */
 export const clearMapAoE = async ({ data }: { data: z.infer<typeof clearMapAoESchema> }) => {
   let sessionUserId: string | undefined;
@@ -164,4 +201,10 @@ export const clearMapAoE = async ({ data }: { data: z.infer<typeof clearMapAoESc
   }
 };
 
-export { createMapAoESchema, listMapAoESchema, removeMapAoESchema, clearMapAoESchema };
+export {
+  createMapAoESchema,
+  listMapAoESchema,
+  removeMapAoESchema,
+  clearMapAoESchema,
+  updateMapAoESchema,
+};

--- a/app/types/mapAoe.ts
+++ b/app/types/mapAoe.ts
@@ -1,0 +1,24 @@
+export type AoeShape = 'sphere' | 'cone' | 'cube' | 'line' | 'cylinder';
+
+/** A spell area-of-effect template on a map (multiplayer, persisted). */
+export interface MapAoEData {
+  id: string;
+  mapId: string;
+  campaignId: string;
+  shape: AoeShape;
+  /** Origin in map-local pixels — center (sphere/cube/cylinder) or apex (cone/line). */
+  originX: number;
+  originY: number;
+  /** Radius / length / edge, in map-local pixels. */
+  sizePx: number;
+  /** Line width / cylinder height, in map-local pixels (optional). */
+  widthPx?: number;
+  /** Aim in radians (cone/line); 0 for radial shapes. */
+  rotation: number;
+  /** 6-digit hex. */
+  color: string;
+  /** Author user id — a player may delete only their own; a GM may delete any. */
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/app/types/mapAoe.ts
+++ b/app/types/mapAoe.ts
@@ -5,6 +5,8 @@ export interface MapAoEData {
   id: string;
   mapId: string;
   campaignId: string;
+  /** Optional user label, e.g. the spell name. */
+  label?: string;
   shape: AoeShape;
   /** Origin in map-local pixels — center (sphere/cube/cylinder) or apex (cone/line). */
   originX: number;
@@ -19,6 +21,8 @@ export interface MapAoEData {
   color: string;
   /** Author user id — a player may delete only their own; a GM may delete any. */
   createdBy: string;
+  /** Placer's display name, denormalized at create time so viewers don't need a user lookup. */
+  createdByName: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/app/types/schemas/mapAoe.ts
+++ b/app/types/schemas/mapAoe.ts
@@ -15,6 +15,7 @@ export const createMapAoESchema = z.object({
   widthPx: z.number().finite().positive().max(MAX_AOE_PX).optional(),
   rotation: z.number().finite(),
   color: z.string().regex(/^#[0-9a-fA-F]{6}$/),
+  label: z.string().trim().max(60).optional(),
 });
 
 export const listMapAoESchema = z.object({

--- a/app/types/schemas/mapAoe.ts
+++ b/app/types/schemas/mapAoe.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+export const AOE_SHAPES = ['sphere', 'cone', 'cube', 'line', 'cylinder'] as const;
+
+export const createMapAoESchema = z.object({
+  campaignId: z.string().trim().min(1),
+  mapId: z.string().trim().min(1),
+  shape: z.enum(AOE_SHAPES),
+  originX: z.number(),
+  originY: z.number(),
+  sizePx: z.number().positive(),
+  widthPx: z.number().positive().optional(),
+  rotation: z.number(),
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/),
+});
+
+export const listMapAoESchema = z.object({
+  campaignId: z.string().trim().min(1),
+  mapId: z.string().trim().min(1),
+});
+export const removeMapAoESchema = z.object({
+  campaignId: z.string().trim().min(1),
+  mapId: z.string().trim().min(1),
+  id: z.string().trim().min(1),
+});
+export const clearMapAoESchema = z.object({
+  campaignId: z.string().trim().min(1),
+  mapId: z.string().trim().min(1),
+});

--- a/app/types/schemas/mapAoe.ts
+++ b/app/types/schemas/mapAoe.ts
@@ -2,15 +2,18 @@ import { z } from 'zod';
 
 export const AOE_SHAPES = ['sphere', 'cone', 'cube', 'line', 'cylinder'] as const;
 
+/** Sane ceiling so a malicious/buggy client can't persist a map-swallowing template. */
+export const MAX_AOE_PX = 20000;
+
 export const createMapAoESchema = z.object({
   campaignId: z.string().trim().min(1),
   mapId: z.string().trim().min(1),
   shape: z.enum(AOE_SHAPES),
-  originX: z.number(),
-  originY: z.number(),
-  sizePx: z.number().positive(),
-  widthPx: z.number().positive().optional(),
-  rotation: z.number(),
+  originX: z.number().finite(),
+  originY: z.number().finite(),
+  sizePx: z.number().finite().positive().max(MAX_AOE_PX),
+  widthPx: z.number().finite().positive().max(MAX_AOE_PX).optional(),
+  rotation: z.number().finite(),
   color: z.string().regex(/^#[0-9a-fA-F]{6}$/),
 });
 
@@ -26,4 +29,11 @@ export const removeMapAoESchema = z.object({
 export const clearMapAoESchema = z.object({
   campaignId: z.string().trim().min(1),
   mapId: z.string().trim().min(1),
+});
+export const updateMapAoESchema = z.object({
+  campaignId: z.string().trim().min(1),
+  mapId: z.string().trim().min(1),
+  id: z.string().trim().min(1),
+  originX: z.number().finite(),
+  originY: z.number().finite(),
 });

--- a/app/types/schemas/tabletopMessage.ts
+++ b/app/types/schemas/tabletopMessage.ts
@@ -68,6 +68,22 @@ const drawingData = z.object({
   updatedAt: isoDate,
 });
 
+const aoeData = z.object({
+  id,
+  mapId: id,
+  campaignId: id,
+  shape: z.enum(['sphere', 'cone', 'cube', 'line', 'cylinder']),
+  originX: num,
+  originY: num,
+  sizePx: num,
+  widthPx: num.optional(),
+  rotation: num,
+  color: z.string(),
+  createdBy: z.string(),
+  createdAt: isoDate,
+  updatedAt: isoDate,
+});
+
 const messageSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('map:active-changed'),
@@ -109,6 +125,9 @@ const messageSchema = z.discriminatedUnion('type', [
   }),
   z.object({ type: z.literal('drawing:removed'), mapId: id, drawingId: id }),
   z.object({ type: z.literal('drawing:cleared'), mapId: id }),
+  z.object({ type: z.literal('aoe:added'), mapId: id, aoe: aoeData }),
+  z.object({ type: z.literal('aoe:removed'), mapId: id, aoeId: id }),
+  z.object({ type: z.literal('aoe:cleared'), mapId: id }),
 ]);
 
 /** Parse + validate a raw inbound frame. Returns null for malformed messages. */

--- a/app/types/schemas/tabletopMessage.ts
+++ b/app/types/schemas/tabletopMessage.ts
@@ -68,6 +68,10 @@ const drawingData = z.object({
   updatedAt: isoDate,
 });
 
+// Bound so a forged broadcast can't inject a giant transient template — mirrors
+// MAX_AOE_PX in ~/types/schemas/mapAoe.
+const MAX_AOE_PX = 20000;
+
 const aoeData = z.object({
   id,
   mapId: id,
@@ -75,8 +79,8 @@ const aoeData = z.object({
   shape: z.enum(['sphere', 'cone', 'cube', 'line', 'cylinder']),
   originX: num,
   originY: num,
-  sizePx: num,
-  widthPx: num.optional(),
+  sizePx: num.max(MAX_AOE_PX),
+  widthPx: num.max(MAX_AOE_PX).optional(),
   rotation: num,
   color: z.string(),
   createdBy: z.string(),
@@ -126,6 +130,14 @@ const messageSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('drawing:removed'), mapId: id, drawingId: id }),
   z.object({ type: z.literal('drawing:cleared'), mapId: id }),
   z.object({ type: z.literal('aoe:added'), mapId: id, aoe: aoeData }),
+  z.object({
+    type: z.literal('aoe:moved'),
+    mapId: id,
+    aoeId: id,
+    originX: z.number().finite(),
+    originY: z.number().finite(),
+    final: z.boolean().optional(),
+  }),
   z.object({ type: z.literal('aoe:removed'), mapId: id, aoeId: id }),
   z.object({ type: z.literal('aoe:cleared'), mapId: id }),
 ]);

--- a/app/types/schemas/tabletopMessage.ts
+++ b/app/types/schemas/tabletopMessage.ts
@@ -83,7 +83,10 @@ const aoeData = z.object({
   widthPx: num.max(MAX_AOE_PX).optional(),
   rotation: num,
   color: z.string(),
+  label: z.string().optional(),
   createdBy: z.string(),
+  // `.default('')` tolerates older senders that predate this field.
+  createdByName: z.string().default(''),
   createdAt: isoDate,
   updatedAt: isoDate,
 });

--- a/app/types/schemas/tabletopMessage.ts
+++ b/app/types/schemas/tabletopMessage.ts
@@ -83,7 +83,7 @@ const aoeData = z.object({
   widthPx: num.max(MAX_AOE_PX).optional(),
   rotation: num,
   color: z.string(),
-  label: z.string().optional(),
+  label: z.string().max(60).optional(),
   createdBy: z.string(),
   // `.default('')` tolerates older senders that predate this field.
   createdByName: z.string().default(''),

--- a/app/types/schemas/tabletopMessage.ts
+++ b/app/types/schemas/tabletopMessage.ts
@@ -79,14 +79,17 @@ const aoeData = z.object({
   shape: z.enum(['sphere', 'cone', 'cube', 'line', 'cylinder']),
   originX: num,
   originY: num,
-  sizePx: num.max(MAX_AOE_PX),
-  widthPx: num.max(MAX_AOE_PX).optional(),
+  // Match the create schema so a forged peer frame can't inject a degenerate
+  // template (negative/zero radius, non-hex color) even transiently.
+  sizePx: num.positive().max(MAX_AOE_PX),
+  widthPx: num.positive().max(MAX_AOE_PX).optional(),
   rotation: num,
-  color: z.string(),
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/),
   label: z.string().max(60).optional(),
   createdBy: z.string(),
-  // `.default('')` tolerates older senders that predate this field.
-  createdByName: z.string().default(''),
+  // `.default('')` tolerates older senders that predate this field; a generous
+  // cap blocks a giant-text abuse without rejecting legitimate long names.
+  createdByName: z.string().max(200).default(''),
   createdAt: isoDate,
   updatedAt: isoDate,
 });

--- a/app/utils/queryKeys.ts
+++ b/app/utils/queryKeys.ts
@@ -176,6 +176,10 @@ export const queryKeys = {
     list: (campaignId: string, mapId: string) =>
       ['mapDrawings', 'list', campaignId, mapId] as const,
   },
+  mapAoe: {
+    all: ['mapAoe'] as const,
+    list: (campaignId: string, mapId: string) => ['mapAoe', 'list', campaignId, mapId] as const,
+  },
   lore: {
     all: ['lore'] as const,
     list: (campaignId: string, filters?: string) =>

--- a/docs/spells/2026-07-13-spells-phase3-aoe-design.md
+++ b/docs/spells/2026-07-13-spells-phase3-aoe-design.md
@@ -159,9 +159,25 @@ just above the grid, below `MapDrawingLayer`/tokens).
   `aoe:cleared`) — **GM-only** (shown only to the GM; server rejects non-GM).
 - Templates persist on the map until removed (they don't auto-expire).
 
-## 7. Out of scope (this phase)
+## 7. Delivered beyond the original design (follow-up requests)
 
-- Drag-to-resize / drag-to-move existing templates (place + delete only).
+The following were added during implementation, on top of the original
+"place + delete only" scope, and are part of the shipped feature:
+
+- **Drag-to-move** existing templates with the pointer tool (owner/GM), exactly
+  like map text: optimistic + throttled `aoe:moved` broadcast, `moveMapAoE`
+  persist with a `final` broadcast on release.
+- **Placer name + optional label** drawn in the effect: the caster's name is
+  denormalized onto the doc at create time (`createdByName`, server-set); an
+  optional user `label` (e.g. the spell name) can be entered in the panel. Both
+  render as small, semi-transparent, outlined text anchored at the shape's
+  **centroid** (so a cone/line label doesn't hide the caster's token at the apex).
+- **Per-viewer visibility toggle** — an always-available "Show spell effects"
+  control (not GM-gated) that hides/shows AoE for that viewer only.
+
+## Out of scope (this phase)
+
+- Drag-to-**resize** existing templates (move is supported; resize is not).
 - Grid snapping of the origin.
 - Auto-fill from a specific spell's `areaOfEffect`/`range` ("Show on map from a
   spell" — a later enhancement; the data is already stored on spells).

--- a/docs/spells/2026-07-13-spells-phase3-aoe-design.md
+++ b/docs/spells/2026-07-13-spells-phase3-aoe-design.md
@@ -1,0 +1,188 @@
+# Spells Phase 3 — Spell AoE Overlays on the Map (Design)
+
+**Date:** 2026-07-13
+**Status:** Approved design, ready for implementation plan
+**Depends on:** Phase 1 (spells) + the existing tabletop (map drawings/text/tokens, realtime map sync). Merged in `dev`.
+
+## Summary
+
+Add a **"Spell AoE" tabletop tool**: pick a shape (sphere / cone / cube / line /
+cylinder) and a size in feet, then place a **semi-transparent** area-of-effect
+template on the active map so the table can see where an effect (e.g. Fireball)
+lands. Templates are **shared** — persisted and broadcast in real time to every
+connected player (like map text), **placeable by anyone**, each in the placer's
+**chosen color**. The tool is generic (you enter the shape/size); it is not tied
+to a specific spell's stored data in this phase.
+
+It reuses the established tabletop machinery: the **ruler tool's** placement
+interaction, the **drawing layer's** SVG rendering + coordinate math, the
+**map-text** realtime persistence/broadcast model (shared, not GM-gated), the
+`spell-fx` layer's visibility gate, and the shared **`ColorPicker`**.
+
+## Decisions (locked)
+
+1. **Invocation:** a generic map toolbar "Spell AoE" tool (shape + size picker),
+   not spell-linked (a future "Show on map from a spell" can pre-fill it).
+2. **Visibility:** shared — persisted + broadcast to all; **player-visible and
+   player-placeable** (anyone, not just the GM).
+3. **Semi-transparent** so tokens/terrain underneath stay visible.
+4. **Color:** each placer picks a color (full `ColorPicker`, like map text), and
+   each template stores its own color.
+5. **Size:** entered in **feet**; drawn via the grid scaling engine
+   (`feet → px = (feet / feetPerSquare) * pixelsPerSquare`).
+
+## 1. Data model + persistence
+
+New document type, mirroring `MapText`/`MapDrawing` (`app/types/mapAoe.ts`):
+
+```ts
+export type AoeShape = 'sphere' | 'cone' | 'cube' | 'line' | 'cylinder';
+
+export interface MapAoEData {
+  id: string;
+  mapId: string;
+  campaignId: string;
+  createdBy: string;
+  shape: AoeShape;
+  originX: number; // map-local pixels — center (sphere/cube/cylinder) or apex (cone/line)
+  originY: number;
+  sizePx: number; // radius / length / edge, in MAP-LOCAL PIXELS
+  widthPx?: number; // line width; (cylinder height is informational, top-down)
+  rotation: number; // radians; aim for cone/line (0 for radial shapes)
+  color: string; // 6-digit hex
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+Geometry is stored in **map-local pixels** (converted from feet at placement
+time using the map's `scale.pixelsPerSquare`/`feetPerSquare`). This matches how
+drawings store geometry, so it survives pan/zoom and different clients.
+
+- **Model:** `app/server/db/models/MapAoE.ts` (clone `MapText`/`MapDrawing`
+  model: campaignId/mapId/createdBy + fields + indexes on `{campaignId, mapId}`).
+- **Zod:** `app/types/schemas/mapAoe.ts` (create/list/remove/clear).
+- **Server functions:** `app/server/functions/mapAoE.ts` — `createMapAoE`,
+  `listMapAoE`, `removeMapAoE`, `clearMapAoE`. Auth via `requireCampaignMember`;
+  **any member may create/remove** (mirror map-text auth, NOT the GM-only drawing
+  auth), and `listMapAoE` **returns AoE to all members** (players included).
+- **Hook:** `app/hooks/useMapAoE.ts` — `useMapAoE(campaignId, mapId)` query +
+  `useMapAoEMutations` (create/remove/clear) + `applyAoeAddToCache` /
+  `applyAoeRemoveFromCache` / `applyAoeClearToCache` cache helpers (used for both
+  optimistic local writes and inbound realtime writes) — cloned from
+  `useMapDrawings.ts`.
+- **queryKeys:** add a `mapAoe` block.
+
+## 2. Realtime broadcast (shared, text-model)
+
+- Add `aoe:added | aoe:removed | aoe:cleared` variants to the
+  `TabletopMapMessage` union in `app/hooks/useTabletopMapParty.ts` (room/party
+  unchanged: `tabletop-map-${campaignId}`).
+- Each mutation's `onSuccess` applies the authoritative doc to the local cache
+  then `onBroadcast({ type: 'aoe:added', mapId, aoe })` (same pattern as
+  `drawing:added` in `ActiveMapStage.tsx`).
+- Inbound: add an `aoe:*` branch to the reducer in
+  `app/hooks/useTabletopMapSync.ts` that dispatches to the `applyAoe*ToCache`
+  helpers. **Follow the text path, not the drawing path** — do NOT add `aoe:` to
+  the GM-only drop-gate; AoE is shared to players.
+
+## 3. Placement interaction (`useAoeTool`, ruler-style)
+
+New `app/components/mainview/tabletop/useAoeTool.ts`, modeled on `useRulerTool`:
+
+- Armed while the Spell AoE tool's "Place on map" is active (an `aoeActive`
+  boolean prop, like `rulerActive`); it **short-circuits the stage pointer
+  handlers** the same way the ruler does.
+- **First click** → sets the **origin** (`domToImage`, clamped to image bounds):
+  center for sphere/cube/cylinder, apex for cone/line.
+  - **Radial shapes (sphere/cube/cylinder):** the first click **commits**
+    immediately at the tool's entered size.
+  - **Directional shapes (cone/line):** after the origin click, the template
+    **rotates to follow the cursor** (`onPointerMove` sets `rotation =
+atan2(cursor−origin)`); a **second click commits**.
+- **Esc / double-click** cancels the in-progress placement (reuse the ruler's
+  Esc handler + `onDoubleClick` reset wiring).
+- On commit → `create.mutate(...)` → cache + broadcast (§2).
+- State: `{ origin: ImagePoint | null, cursor: ImagePoint | null }`; exposes an
+  in-progress **preview** shape.
+
+## 4. Rendering (`MapAoELayer`, SVG on `spell-fx`)
+
+New `app/components/mainview/tabletop/MapAoELayer.tsx`, modeled on
+`MapDrawingLayer`: one `pointer-events-none` `<svg className="absolute inset-0
+… ">` overlay. Each template positioned with the shared transform
+`imageOffsetX + x*effectiveScale`; sizes scaled by `effectiveScale`.
+Semi-transparent: `fill={color}` + `fillOpacity={0.3}`, `stroke={color}` +
+`strokeOpacity={0.9}` (tokens underneath remain visible).
+
+Shape geometry (in an aim-aligned local frame, then rotated by `rotation` and
+translated to origin):
+
+- **sphere / cylinder** → `<circle>` r = `sizePx` (radius). (Cylinder is drawn
+  as its top-down circle; `widthPx`/height is metadata.)
+- **cube** → `<rect>` edge = `sizePx`, centered on origin (axis-aligned).
+- **line** → rectangle length `sizePx` × width `widthPx`, from origin along the
+  aim: corners `(0,±W/2)`,`(L,±W/2)` → rotate → `<polygon>`.
+- **cone** → 5e cone (width == length at the far edge): apex at origin, base
+  corners `(L, +L/2)` and `(L, −L/2)` → rotate → `<polygon>` (isosceles triangle).
+
+Rendered in the stage's compositing after the map/grid and gated by
+`!hiddenLayers.has('spell-fx')`. An in-progress placement renders as a
+non-interactive **preview** (reuse the drawing `preview` pattern). Stacking:
+below tokens/text so tokens stay readable on top of the tint (place the AoE SVG
+just above the grid, below `MapDrawingLayer`/tokens).
+
+## 5. Tool UI
+
+- **`AoeSettingsPanel.tsx`** (clone `TextSettingsPanel`/`DrawingSettingsPanel`):
+  five **shape** buttons, a **Size (ft)** number field, a **Width (ft)** field
+  shown for `line` (and cylinder height, optional), the shared **`ColorPicker`**,
+  and a **"Place on map"** arm button + a **"Clear all AoE"** action.
+- Register a new **`ToolWindowId` `'aoe'`** in `toolWindowState.ts` and a toolbar
+  entry (an SVG/lucide icon) alongside Draw/Text/Ruler.
+- **Player-accessible:** the tool must be available to players, not GM-only
+  (unlike the draw tool). Verify the toolbar/ToolWindow gating and expose it to
+  all session participants. When placing, feet → `sizePx` is computed once from
+  the current map's `scale`.
+
+## 6. Clearing / removing
+
+- Clicking an existing template selects it; **Delete** removes it (broadcast
+  `aoe:removed`). Reuse the drawing selection-lite pattern (a hit target per
+  template), but **no resize handles** in this phase.
+- **"Clear all AoE"** in the tool removes every template on the map (broadcast
+  `aoe:cleared`) — mirrors drawings' clear.
+- Templates persist on the map until removed (they don't auto-expire).
+
+## 7. Out of scope (this phase)
+
+- Drag-to-resize / drag-to-move existing templates (place + delete only).
+- Grid snapping of the origin.
+- Auto-fill from a specific spell's `areaOfEffect`/`range` ("Show on map from a
+  spell" — a later enhancement; the data is already stored on spells).
+- Range enforcement (how far the origin may be from a caster token).
+- Non-square grids (uses `scale.gridType === 'square'`; if no grid scale, fall
+  back to a sane default and note it).
+
+## 8. Testing
+
+- **Geometry unit tests** (`aoeGeometry.ts`): feet→px; cone triangle corners;
+  rotated line rectangle; radial circle radius — deterministic, no DOM.
+- **Placement hook** (`useAoeTool`): origin→(aim)→commit state machine for radial
+  vs directional shapes; Esc/double-click cancel; commit calls create with the
+  right geometry.
+- **`useMapAoE`**: create/remove/clear apply to cache + fire the right broadcast
+  (mocked socket), following the `useMapDrawings` test pattern.
+- **Realtime sync**: an inbound `aoe:added` message applies to the cache for a
+  non-GM receiver (shared, unlike drawings).
+- **Component**: `AoeSettingsPanel` arms placement + changes shape/size/color;
+  `MapAoELayer` renders each shape with the expected SVG element.
+- Gates: `npm test`, `npm run typecheck`, `npm run lint` clean.
+
+## Notes
+
+- After any data-shape work that touches the SRD generator, no regeneration is
+  needed here (Phase 3 adds a new collection, not spell data).
+- To exercise the shared broadcast locally, run `npm run dev` (now starts the web
+  app + realtime ws service together) and reset dev data per the
+  `resetting-dev-data` skill if needed.

--- a/docs/spells/2026-07-13-spells-phase3-aoe-design.md
+++ b/docs/spells/2026-07-13-spells-phase3-aoe-design.md
@@ -63,9 +63,12 @@ drawings store geometry, so it survives pan/zoom and different clients.
   model: campaignId/mapId/createdBy + fields + indexes on `{campaignId, mapId}`).
 - **Zod:** `app/types/schemas/mapAoe.ts` (create/list/remove/clear).
 - **Server functions:** `app/server/functions/mapAoE.ts` — `createMapAoE`,
-  `listMapAoE`, `removeMapAoE`, `clearMapAoE`. Auth via `requireCampaignMember`;
-  **any member may create/remove** (mirror map-text auth, NOT the GM-only drawing
-  auth), and `listMapAoE` **returns AoE to all members** (players included).
+  `listMapAoE`, `removeMapAoE`, `clearMapAoE`. Auth via `requireCampaignMember`:
+  **any member may create**; `listMapAoE` **returns AoE to all members**
+  (players included); **`removeMapAoE` requires the caller to be the template's
+  `createdBy` OR the GM** (a player deletes only their own); **`clearMapAoE` is
+  GM-only** (wipes everyone's). The server is the source of truth for these
+  checks — the UI gating below is only affordance.
 - **Hook:** `app/hooks/useMapAoE.ts` — `useMapAoE(campaignId, mapId)` query +
   `useMapAoEMutations` (create/remove/clear) + `applyAoeAddToCache` /
   `applyAoeRemoveFromCache` / `applyAoeClearToCache` cache helpers (used for both
@@ -149,9 +152,11 @@ just above the grid, below `MapDrawingLayer`/tokens).
 
 - Clicking an existing template selects it; **Delete** removes it (broadcast
   `aoe:removed`). Reuse the drawing selection-lite pattern (a hit target per
-  template), but **no resize handles** in this phase.
-- **"Clear all AoE"** in the tool removes every template on the map (broadcast
-  `aoe:cleared`) — mirrors drawings' clear.
+  template), but **no resize handles** in this phase. A player may delete **only
+  templates they placed** (`createdBy === user`); the **GM may delete any**. The
+  delete affordance is shown accordingly, and the server enforces it.
+- **"Clear all AoE"** removes every template on the map (broadcast
+  `aoe:cleared`) — **GM-only** (shown only to the GM; server rejects non-GM).
 - Templates persist on the map until removed (they don't auto-expire).
 
 ## 7. Out of scope (this phase)

--- a/docs/spells/2026-07-13-spells-phase3-plan.md
+++ b/docs/spells/2026-07-13-spells-phase3-plan.md
@@ -1,0 +1,730 @@
+# Spells Phase 3 Implementation Plan — Spell AoE Overlays on the Map
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use `- [ ]`.
+
+**Goal:** A generic "Spell AoE" tabletop tool — pick a shape + size (ft), place a semi-transparent template on the active map; shared/broadcast to all players, each in the placer's color; players delete their own, GM clears all.
+
+**Architecture:** A new persisted `MapAoE` map-object (cloned from the shared map-**text** model: created by any member, visible to all, per-object `createdBy`), broadcast over the existing tabletop-map party. A pure geometry module converts feet→pixels and each shape→SVG geometry; `MapAoELayer` renders it; `useAoeTool` drives ruler-style placement; an `AoeSettingsPanel` tool window arms it. Wired into `ActiveMapStage` like the ruler + drawing layers.
+
+**Tech Stack:** TanStack Start (React 19), TypeScript, Mongoose, Zod, Vitest, the tabletop realtime stack (`useTabletopMapParty`/`useTabletopMapSync`).
+
+**Spec:** `docs/spells/2026-07-13-spells-phase3-aoe-design.md`
+
+## Global Constraints
+
+- Tests under `tests/` mirroring app paths (`~/` imports). Mongoose globally mocked (`tests/setup.ts`) — no in-memory DB; server-fn tests follow `tests/server/functions/rules.test.ts` (mock session/connection/models; real `requireCampaignMember`).
+- `npm test`, `npm run typecheck`, `npm run lint` clean; lint baseline 0 errors + 24 warnings, no new warnings. No new npm dependencies.
+- **AoE follows the shared map-TEXT model, not GM-only drawings:** created by any member, returned to all members, and (crucially) NOT added to the GM-only inbound drop-gate in `useTabletopMapSync.ts:42-50`.
+- Geometry stored in **map-local pixels**; rendered via the shared transform `imageOffsetX + x*effectiveScale` (see `MapDrawingLayer.tsx`).
+- Auth: create = any member; remove = `createdBy` OR GM; clear = GM-only. Server enforces; UI only gates affordance.
+
+## Template files to clone (named per task)
+
+- Data model: `app/types/mapText.ts`, `app/server/db/models/MapText.ts`, `app/types/schemas/mapText*.ts`
+- Server fns: `app/server/functions/mapTexts.ts`
+- Hook + cache helpers: `app/hooks/useMapTexts.ts`
+- Realtime: `app/hooks/useTabletopMapParty.ts` (message union + `parseTabletopMapMessage`), `app/hooks/useTabletopMapSync.ts`
+- Render: `app/components/mainview/tabletop/MapDrawingLayer.tsx`, `MapTextLayer.tsx`
+- Placement: `app/components/mainview/tabletop/useRulerTool.ts`
+- Tool UI: `app/components/mainview/tabletop/DrawingSettingsPanel.tsx`, `TextSettingsPanel.tsx`, `toolWindowState.ts`, `~/components/shared/ColorPicker`
+- Stage wiring: `app/components/mainview/tabletop/ActiveMapStage.tsx` (ruler + drawing integration points)
+
+---
+
+## Task 1: Data model — type, Zod, Mongoose
+
+**Files:**
+
+- Create: `app/types/mapAoe.ts`
+- Create: `app/types/schemas/mapAoe.ts`
+- Create: `app/server/db/models/MapAoE.ts`
+- Test: `tests/server/db/mapaoe-model.test.ts`
+
+**Interfaces:**
+
+- Produces: `MapAoEData`, `AoeShape`; `createMapAoESchema`/`listMapAoESchema`/`removeMapAoESchema`/`clearMapAoESchema`; the `MapAoE` model.
+
+- [ ] **Step 1: `app/types/mapAoe.ts`**
+
+```ts
+export type AoeShape = 'sphere' | 'cone' | 'cube' | 'line' | 'cylinder';
+
+/** A spell area-of-effect template on a map (multiplayer, persisted). */
+export interface MapAoEData {
+  id: string;
+  mapId: string;
+  campaignId: string;
+  shape: AoeShape;
+  /** Origin in map-local pixels — center (sphere/cube/cylinder) or apex (cone/line). */
+  originX: number;
+  originY: number;
+  /** Radius / length / edge, in map-local pixels. */
+  sizePx: number;
+  /** Line width / cylinder height, in map-local pixels (optional). */
+  widthPx?: number;
+  /** Aim in radians (cone/line); 0 for radial shapes. */
+  rotation: number;
+  /** 6-digit hex. */
+  color: string;
+  /** Author user id — a player may delete only their own; a GM may delete any. */
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+- [ ] **Step 2: `app/types/schemas/mapAoe.ts`**
+
+```ts
+import { z } from 'zod';
+
+export const AOE_SHAPES = ['sphere', 'cone', 'cube', 'line', 'cylinder'] as const;
+
+export const createMapAoESchema = z.object({
+  campaignId: z.string().trim().min(1),
+  mapId: z.string().trim().min(1),
+  shape: z.enum(AOE_SHAPES),
+  originX: z.number(),
+  originY: z.number(),
+  sizePx: z.number().positive(),
+  widthPx: z.number().positive().optional(),
+  rotation: z.number(),
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/),
+});
+
+export const listMapAoESchema = z.object({
+  campaignId: z.string().trim().min(1),
+  mapId: z.string().trim().min(1),
+});
+export const removeMapAoESchema = z.object({
+  campaignId: z.string().trim().min(1),
+  mapId: z.string().trim().min(1),
+  id: z.string().trim().min(1),
+});
+export const clearMapAoESchema = z.object({
+  campaignId: z.string().trim().min(1),
+  mapId: z.string().trim().min(1),
+});
+```
+
+- [ ] **Step 3: `app/server/db/models/MapAoE.ts`** — clone `app/server/db/models/MapText.ts`; replace text-specific fields (`text`, `fontSize`, `x`, `y`) with `shape`, `originX`, `originY`, `sizePx`, `widthPx`, `rotation`, `color`. Keep `mapId`/`campaignId`/`createdBy`/timestamps and the `{ campaignId: 1, mapId: 1 }` index and the `mongoose.models.MapAoE || mongoose.model(...)` guard.
+
+- [ ] **Step 4: `tests/server/db/mapaoe-model.test.ts`** — existence-level (Mongoose is mocked), like `tests/server/db/spell-model.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { MapAoE } from '~/server/db/models/MapAoE';
+describe('MapAoE model', () => {
+  it('is exported and defined', () => {
+    expect(MapAoE).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 5:** `npm test -- tests/server/db/mapaoe-model.test.ts` (PASS), `npm run typecheck && npm run lint` clean. Commit:
+
+```bash
+git add app/types/mapAoe.ts app/types/schemas/mapAoe.ts app/server/db/models/MapAoE.ts tests/server/db/mapaoe-model.test.ts
+git commit -m "feat(aoe): add MapAoE model, types, and schemas"
+```
+
+---
+
+## Task 2: Geometry module (pure, tested)
+
+**Files:**
+
+- Create: `app/components/mainview/tabletop/aoeGeometry.ts`
+- Test: `tests/components/mainview/tabletop/aoeGeometry.test.ts`
+
+**Interfaces:**
+
+- Produces: `feetToPixels(feet, { pixelsPerSquare, feetPerSquare })`, and `aoeShapeGeometry(aoe)` returning a discriminated union of map-local `{ kind:'circle', cx,cy,r } | { kind:'rect', x,y,w,h } | { kind:'polygon', points:{x,y}[] }`. Consumed by Task 6 (layer) and Task 7 (preview).
+
+- [ ] **Step 1: `app/components/mainview/tabletop/aoeGeometry.ts`**
+
+```ts
+import type { AoeShape } from '~/types/mapAoe';
+
+export function feetToPixels(
+  feet: number,
+  scale: { pixelsPerSquare: number; feetPerSquare: number }
+): number {
+  const perSquare = scale.feetPerSquare || 5;
+  return (feet / perSquare) * (scale.pixelsPerSquare || 1);
+}
+
+export interface AoeInput {
+  shape: AoeShape;
+  originX: number;
+  originY: number;
+  sizePx: number;
+  widthPx?: number;
+  rotation: number;
+}
+
+export type AoeShapeGeometry =
+  | { kind: 'circle'; cx: number; cy: number; r: number }
+  | { kind: 'rect'; x: number; y: number; w: number; h: number }
+  | { kind: 'polygon'; points: Array<{ x: number; y: number }> };
+
+/** Map-local geometry for an AoE template. Line/cone are rotated by `rotation`. */
+export function aoeShapeGeometry(aoe: AoeInput): AoeShapeGeometry {
+  const { shape, originX: ox, originY: oy, sizePx: L, rotation } = aoe;
+  const cos = Math.cos(rotation);
+  const sin = Math.sin(rotation);
+  // local (aim-aligned, apex/origin at 0,0) → map-local
+  const at = (lx: number, ly: number) => ({
+    x: ox + (lx * cos - ly * sin),
+    y: oy + (lx * sin + ly * cos),
+  });
+
+  if (shape === 'sphere' || shape === 'cylinder') {
+    return { kind: 'circle', cx: ox, cy: oy, r: L };
+  }
+  if (shape === 'cube') {
+    // Axis-aligned square centered on the origin.
+    return { kind: 'rect', x: ox - L / 2, y: oy - L / 2, w: L, h: L };
+  }
+  if (shape === 'line') {
+    const W = aoe.widthPx ?? Math.max(1, L / 20);
+    return { kind: 'polygon', points: [at(0, -W / 2), at(L, -W / 2), at(L, W / 2), at(0, W / 2)] };
+  }
+  // cone — 5e: width == length at the far edge (isosceles triangle, apex at origin)
+  return { kind: 'polygon', points: [at(0, 0), at(L, L / 2), at(L, -L / 2)] };
+}
+```
+
+- [ ] **Step 2: `tests/components/mainview/tabletop/aoeGeometry.test.ts`**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { feetToPixels, aoeShapeGeometry } from '~/components/mainview/tabletop/aoeGeometry';
+
+describe('feetToPixels', () => {
+  it('converts feet using the grid scale', () => {
+    // 20 ft on a 5-ft, 50px grid = 4 squares = 200 px
+    expect(feetToPixels(20, { pixelsPerSquare: 50, feetPerSquare: 5 })).toBe(200);
+  });
+});
+
+describe('aoeShapeGeometry', () => {
+  const base = { originX: 100, originY: 100, sizePx: 40, rotation: 0 };
+  it('sphere/cylinder → circle at origin', () => {
+    expect(aoeShapeGeometry({ ...base, shape: 'sphere' })).toEqual({
+      kind: 'circle',
+      cx: 100,
+      cy: 100,
+      r: 40,
+    });
+    expect(aoeShapeGeometry({ ...base, shape: 'cylinder' }).kind).toBe('circle');
+  });
+  it('cube → centered square', () => {
+    expect(aoeShapeGeometry({ ...base, shape: 'cube' })).toEqual({
+      kind: 'rect',
+      x: 80,
+      y: 80,
+      w: 40,
+      h: 40,
+    });
+  });
+  it('line at rotation 0 → rectangle extending +x', () => {
+    const g = aoeShapeGeometry({ ...base, shape: 'line', widthPx: 10 });
+    expect(g.kind).toBe('polygon');
+    if (g.kind === 'polygon') {
+      expect(g.points[0]).toEqual({ x: 100, y: 95 }); // (0,-5)
+      expect(g.points[1]).toEqual({ x: 140, y: 95 }); // (40,-5)
+      expect(g.points[2]).toEqual({ x: 140, y: 105 }); // (40,5)
+    }
+  });
+  it('cone at rotation 0 → apex at origin, base at x=origin+L', () => {
+    const g = aoeShapeGeometry({ ...base, shape: 'cone' });
+    if (g.kind === 'polygon') {
+      expect(g.points[0]).toEqual({ x: 100, y: 100 }); // apex
+      expect(g.points[1]).toEqual({ x: 140, y: 120 }); // (L, L/2)
+      expect(g.points[2]).toEqual({ x: 140, y: 80 }); // (L, -L/2)
+    }
+  });
+  it('rotates line/cone by rotation', () => {
+    const g = aoeShapeGeometry({ ...base, shape: 'cone', rotation: Math.PI / 2 });
+    if (g.kind === 'polygon') {
+      // apex unchanged; far edge now points +y
+      expect(g.points[0]).toEqual({ x: 100, y: 100 });
+      expect(g.points[1].y).toBeCloseTo(140);
+    }
+  });
+});
+```
+
+- [ ] **Step 3:** `npm test -- tests/components/mainview/tabletop/aoeGeometry.test.ts` (PASS), typecheck/lint clean. Commit `feat(aoe): add AoE geometry (feet→px + shape → svg geometry)`.
+
+---
+
+## Task 3: Server functions (auth: create/list/remove/clear)
+
+**Files:**
+
+- Create: `app/server/functions/mapAoE.ts`
+- Test: `tests/server/functions/mapAoE.test.ts`
+
+**Interfaces:**
+
+- Produces: `createMapAoE`, `listMapAoE`, `removeMapAoE`, `clearMapAoE` (`async ({ data }) => …`).
+
+- [ ] **Step 1: Clone `app/server/functions/mapTexts.ts` → `mapAoE.ts`**, adapting:
+  - `createMapAoE` — `requireCampaignMember` (any member); build a `MapAoE` doc from `createMapAoESchema` fields + `createdBy: member.userId`; `MapAoE.create(...)`; serialize + return.
+  - `listMapAoE` — `requireCampaignMember`; `MapAoE.find({ campaignId, mapId }).sort({ createdAt: 1 }).lean()`; **return to all members** (no GM filter).
+  - `removeMapAoE` — `requireCampaignMember`; fetch the doc; **allow if `String(doc.createdBy) === member.userId || member.isGM`, else throw `'Forbidden'`**; `doc.deleteOne()`.
+  - `clearMapAoE` — `requireCampaignMember`; **`if (!member.isGM) throw new Error('Forbidden')`**; `MapAoE.deleteMany({ campaignId, mapId })`.
+  - Re-export the schemas; wrap each in try/catch with `serverCaptureException` like the other map functions.
+
+- [ ] **Step 2: `tests/server/functions/mapAoE.test.ts`** — mock pattern from `tests/server/functions/rules.test.ts` (mock `~/server/session`, `~/server/db/connection`, `~/server/db/models/User`, `~/server/db/models/Campaign`, `~/server/db/models/MapAoE`, telemetry). Cover:
+  - `createMapAoE` sets `createdBy` to the member and returns the doc; a non-member is rejected (via `requireCampaignMember`).
+  - `listMapAoE` returns docs to a **player** (non-GM) — not GM-gated.
+  - `removeMapAoE`: player removes own (mock `MapAoE.findOne` → `{ createdBy: 'dbuser-1', deleteOne }`) → succeeds; player removing another's (`createdBy: 'other'`, isGM false) → throws `'Forbidden'`; GM removes any → succeeds.
+  - `clearMapAoE`: GM → `deleteMany` called; non-GM → throws `'Forbidden'`.
+
+  Use `mockGMCampaign`/`mockPlayerCampaign` from the rules pattern to flip GM.
+
+- [ ] **Step 3:** run the test (PASS), typecheck/lint clean. Commit `feat(aoe): add map AoE server functions with per-owner/GM auth`.
+
+---
+
+## Task 4: Hook + cache helpers + query keys
+
+**Files:**
+
+- Modify: `app/utils/queryKeys.ts` (add `mapAoe` block after `mapDrawings`/`mapTexts`)
+- Create: `app/hooks/useMapAoE.ts`
+
+**Interfaces:**
+
+- Produces: `useMapAoE(campaignId, mapId)`; `useMapAoEMutations` (`create`/`remove`/`clear`); `applyAoeAddToCache`, `applyAoeRemoveFromCache`, `applyAoeClearToCache`.
+
+- [ ] **Step 1:** Add to `app/utils/queryKeys.ts`:
+
+```ts
+  mapAoe: {
+    all: ['mapAoe'] as const,
+    list: (campaignId: string, mapId: string) => ['mapAoe', 'list', campaignId, mapId] as const,
+  },
+```
+
+- [ ] **Step 2: Clone `app/hooks/useMapTexts.ts` → `useMapAoE.ts`**, adapting names (`text`→`aoe`, `MapTextData`→`MapAoEData`), the server-fn imports (`~/server/functions/mapAoE`), the query key (`queryKeys.mapAoe.list`), and the mutation set to **create/remove/clear** (drop update/move — AoE isn't edited/moved this phase). Keep the `apply*ToCache` helpers: `applyAoeAddToCache` (append), `applyAoeRemoveFromCache` (filter by id), `applyAoeClearToCache` (empty the list). Each `createServerFn` wrapper dynamically imports `~/server/functions/mapAoE`.
+
+- [ ] **Step 3:** typecheck/lint clean (thin RPC wiring; no dedicated unit test, like `useMapTexts`/`useRaces`). Commit `feat(aoe): add useMapAoE hook + cache helpers + query keys`.
+
+---
+
+## Task 5: Realtime — message union + inbound sync
+
+**Files:**
+
+- Modify: `app/hooks/useTabletopMapParty.ts` (union + `parseTabletopMapMessage`)
+- Modify: `app/hooks/useTabletopMapSync.ts` (inbound branch, shared)
+
+**Interfaces:**
+
+- Produces: `aoe:added | aoe:removed | aoe:cleared` messages; inbound reducer applies them to the cache for all viewers.
+
+- [ ] **Step 1:** In `app/hooks/useTabletopMapParty.ts` add to the `TabletopMapMessage` union (next to `drawing:*`) and to `parseTabletopMapMessage` validation:
+
+```ts
+  | { type: 'aoe:added'; mapId: string; aoe: MapAoEData }
+  | { type: 'aoe:removed'; mapId: string; aoeId: string }
+  | { type: 'aoe:cleared'; mapId: string }
+```
+
+Import `MapAoEData` and validate the new variants the same way `drawing:*` are validated (shape check on `msg.aoe`, `msg.aoeId`, `msg.mapId`).
+
+- [ ] **Step 2:** In `app/hooks/useTabletopMapSync.ts`: import the `applyAoe*ToCache` helpers from `./useMapAoE`, and add branches to the reducer **after** the `drawing:*` branches — **outside** the `if (!isGM)` drop-gate (AoE is shared):
+
+```ts
+    } else if (msg.type === 'aoe:added') {
+      applyAoeAddToCache(queryClient, campaignId, msg.mapId, msg.aoe);
+    } else if (msg.type === 'aoe:removed') {
+      applyAoeRemoveFromCache(queryClient, campaignId, msg.mapId, msg.aoeId);
+    } else if (msg.type === 'aoe:cleared') {
+      applyAoeClearToCache(queryClient, campaignId, msg.mapId);
+    }
+```
+
+- [ ] **Step 3: Test** the shared-visibility invariant in `tests/hooks/useTabletopMapSync.test.tsx` (if a sync test exists) or a focused new test: an inbound `aoe:added` message applies to the cache **even for a non-GM** receiver (contrast with `drawing:added`, which is dropped for non-GM). If no sync test harness exists, assert `parseTabletopMapMessage` accepts a valid `aoe:added` and rejects a malformed one in a new `tests/hooks/useTabletopMapParty.test.ts` (check the repo for an existing party test to extend).
+
+- [ ] **Step 4:** typecheck/lint clean, `npm test` green. Commit `feat(aoe): broadcast + sync AoE templates (shared, not GM-gated)`.
+
+---
+
+## Task 6: `MapAoELayer` (render)
+
+**Files:**
+
+- Create: `app/components/mainview/tabletop/MapAoELayer.tsx`
+- Test: `tests/components/mainview/tabletop/MapAoELayer.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `aoeShapeGeometry` (Task 2), `MapAoEData`.
+- Produces: `MapAoELayer` (`{ visible, aoes, preview, effectiveScale, imageOffsetX, imageOffsetY, currentUserId, isGM, onSelect?, selectedId? }`).
+
+- [ ] **Step 1: `app/components/mainview/tabletop/MapAoELayer.tsx`** — one `pointer-events-none` SVG overlay (like `MapDrawingLayer`), each template converted from map-local geometry to DOM via `imageOffsetX + x*effectiveScale`. Semi-transparent fill.
+
+```tsx
+import type { MapAoEData } from '~/types/mapAoe';
+import { aoeShapeGeometry, type AoeInput } from './aoeGeometry';
+
+interface MapAoELayerProps {
+  visible: boolean;
+  aoes: MapAoEData[];
+  preview: (AoeInput & { color: string }) | null;
+  effectiveScale: number;
+  imageOffsetX: number;
+  imageOffsetY: number;
+  onSelect?: (id: string) => void;
+  selectedId?: string | null;
+  /** A template can be selected/deleted only by its author or the GM. */
+  canModify?: (a: MapAoEData) => boolean;
+}
+
+export function MapAoELayer({
+  visible,
+  aoes,
+  preview,
+  effectiveScale,
+  imageOffsetX,
+  imageOffsetY,
+  onSelect,
+  selectedId,
+  canModify,
+}: MapAoELayerProps) {
+  if (!visible) return null;
+  const toDomX = (x: number) => imageOffsetX + x * effectiveScale;
+  const toDomY = (y: number) => imageOffsetY + y * effectiveScale;
+
+  const renderShape = (
+    input: AoeInput,
+    color: string,
+    opts: { id?: string; interactive: boolean }
+  ) => {
+    const g = aoeShapeGeometry(input);
+    const selectable = opts.interactive && !!opts.id;
+    const common = {
+      'data-testid': opts.id ? 'map-aoe' : undefined,
+      'data-aoe-id': opts.id,
+      'data-aoe-shape': input.shape,
+      fill: color,
+      fillOpacity: 0.3,
+      stroke: color,
+      strokeOpacity: 0.9,
+      strokeWidth: Math.max(1, 2 * effectiveScale),
+      style: { pointerEvents: (selectable ? 'all' : 'none') as const, cursor: 'pointer' },
+      onPointerDown: selectable && opts.id ? () => onSelect?.(opts.id!) : undefined,
+      'aria-hidden': true as const,
+    };
+    if (g.kind === 'circle') {
+      return (
+        <circle
+          key={opts.id ?? 'preview'}
+          {...common}
+          cx={toDomX(g.cx)}
+          cy={toDomY(g.cy)}
+          r={g.r * effectiveScale}
+        />
+      );
+    }
+    if (g.kind === 'rect') {
+      return (
+        <rect
+          key={opts.id ?? 'preview'}
+          {...common}
+          x={toDomX(g.x)}
+          y={toDomY(g.y)}
+          width={g.w * effectiveScale}
+          height={g.h * effectiveScale}
+        />
+      );
+    }
+    const points = g.points.map((p) => `${toDomX(p.x)},${toDomY(p.y)}`).join(' ');
+    return <polygon key={opts.id ?? 'preview'} {...common} points={points} />;
+  };
+
+  return (
+    <svg
+      className="pointer-events-none absolute inset-0 z-10 h-full w-full"
+      data-testid="map-aoe-layer"
+      role="group"
+      aria-label="Spell area-of-effect templates"
+    >
+      {aoes.map((a) =>
+        renderShape(a, a.color, { id: a.id, interactive: !!canModify && canModify(a) })
+      )}
+      {preview && renderShape(preview, preview.color, { interactive: false })}
+    </svg>
+  );
+}
+```
+
+> `z-10` places AoE **below** the drawing layer (`z-20`) and tokens, so tokens/labels stay readable over the tint (per the spec).
+
+- [ ] **Step 2: `tests/components/mainview/tabletop/MapAoELayer.test.tsx`** — render with one of each shape (identity transform: `effectiveScale=1`, offsets `0`) and assert the right SVG element + `data-aoe-shape`:
+
+```tsx
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { MapAoELayer } from '~/components/mainview/tabletop/MapAoELayer';
+import type { MapAoEData } from '~/types/mapAoe';
+
+function aoe(over: Partial<MapAoEData>): MapAoEData {
+  return {
+    id: 'a',
+    mapId: 'm',
+    campaignId: 'c',
+    shape: 'sphere',
+    originX: 100,
+    originY: 100,
+    sizePx: 40,
+    rotation: 0,
+    color: '#ff0000',
+    createdBy: 'u',
+    createdAt: '',
+    updatedAt: '',
+    ...over,
+  };
+}
+
+describe('MapAoELayer', () => {
+  it('renders a circle for a sphere and a polygon for a cone', () => {
+    const { container } = render(
+      <MapAoELayer
+        visible
+        aoes={[aoe({ id: 's', shape: 'sphere' }), aoe({ id: 'k', shape: 'cone' })]}
+        preview={null}
+        effectiveScale={1}
+        imageOffsetX={0}
+        imageOffsetY={0}
+      />
+    );
+    expect(container.querySelector('[data-aoe-id="s"]')?.tagName.toLowerCase()).toBe('circle');
+    expect(container.querySelector('[data-aoe-id="k"]')?.tagName.toLowerCase()).toBe('polygon');
+    expect(container.querySelector('circle')?.getAttribute('fill-opacity')).toBe('0.3');
+  });
+  it('renders nothing when not visible', () => {
+    const { queryByTestId } = render(
+      <MapAoELayer
+        visible={false}
+        aoes={[aoe({})]}
+        preview={null}
+        effectiveScale={1}
+        imageOffsetX={0}
+        imageOffsetY={0}
+      />
+    );
+    expect(queryByTestId('map-aoe-layer')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 3:** run the test, typecheck/lint clean. Commit `feat(aoe): render semi-transparent AoE templates (MapAoELayer)`.
+
+---
+
+## Task 7: `useAoeTool` (placement)
+
+**Files:**
+
+- Create: `app/components/mainview/tabletop/useAoeTool.ts`
+- Test: `tests/components/mainview/tabletop/useAoeTool.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `domToImage`, `clamp` (`./ActiveMapStage.geometry`), scale + image bounds, the tool's current `shape`/`sizeFt`/`widthFt`/`color`, and `onCommit(aoe)`.
+- Produces: `{ preview, onPointerDown, onPointerMove, reset }` — a ruler-style hook. `preview` is an `AoeInput & { color }` (map-local) or null.
+
+- [ ] **Step 1: `app/components/mainview/tabletop/useAoeTool.ts`** — modeled on `useRulerTool` (Esc/reset/short-circuit). State: `origin: {x,y} | null`, `cursor: {x,y} | null`. Radial shapes commit on the first click; cone/line set origin on click 1, aim on move, commit on click 2.
+
+```ts
+import { useCallback, useEffect, useState, type PointerEvent as ReactPointerEvent } from 'react';
+import { clamp } from './ActiveMapStage.geometry';
+import { feetToPixels, type AoeInput } from './aoeGeometry';
+import type { AoeShape } from '~/types/mapAoe';
+
+interface Options {
+  aoeActive: boolean;
+  shape: AoeShape;
+  sizeFt: number;
+  widthFt: number;
+  color: string;
+  domToImage: (clientX: number, clientY: number) => { x: number; y: number } | null;
+  pixelsPerSquare: number;
+  feetPerSquare: number;
+  imageWidth: number;
+  imageHeight: number;
+  onCommit: (aoe: AoeInput & { color: string }) => void;
+}
+
+const RADIAL: AoeShape[] = ['sphere', 'cube', 'cylinder'];
+
+export function useAoeTool(o: Options) {
+  const [origin, setOrigin] = useState<{ x: number; y: number } | null>(null);
+  const [cursor, setCursor] = useState<{ x: number; y: number } | null>(null);
+
+  const reset = useCallback(() => {
+    setOrigin(null);
+    setCursor(null);
+  }, []);
+
+  useEffect(() => {
+    if (!o.aoeActive) reset();
+  }, [o.aoeActive, reset]);
+
+  // Esc cancels an in-progress directional placement.
+  useEffect(() => {
+    if (!o.aoeActive) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' || !origin) return;
+      const el = e.target as HTMLElement | null;
+      if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable))
+        return;
+      e.preventDefault();
+      reset();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [o.aoeActive, origin, reset]);
+
+  const sizePx = feetToPixels(o.sizeFt, o);
+  const widthPx = o.shape === 'line' ? feetToPixels(o.widthFt, o) : undefined;
+
+  const build = useCallback(
+    (ox: number, oy: number, rotation: number): AoeInput & { color: string } => ({
+      shape: o.shape,
+      originX: ox,
+      originY: oy,
+      sizePx,
+      widthPx,
+      rotation,
+      color: o.color,
+    }),
+    [o.shape, o.color, sizePx, widthPx]
+  );
+
+  const onPointerDown = useCallback(
+    (e: ReactPointerEvent<HTMLDivElement>) => {
+      const img = o.domToImage(e.clientX, e.clientY);
+      if (!img) return;
+      const p = { x: clamp(img.x, 0, o.imageWidth), y: clamp(img.y, 0, o.imageHeight) };
+      if (RADIAL.includes(o.shape)) {
+        o.onCommit(build(p.x, p.y, 0));
+        reset();
+        return;
+      }
+      if (!origin) {
+        setOrigin(p);
+        setCursor(p);
+      } else {
+        const rotation = Math.atan2(p.y - origin.y, p.x - origin.x);
+        o.onCommit(build(origin.x, origin.y, rotation));
+        reset();
+      }
+    },
+    [o, origin, build, reset]
+  );
+
+  const onPointerMove = useCallback(
+    (e: ReactPointerEvent<HTMLDivElement>) => {
+      if (!origin) return;
+      const img = o.domToImage(e.clientX, e.clientY);
+      if (img) setCursor(img);
+    },
+    [o, origin]
+  );
+
+  const preview: (AoeInput & { color: string }) | null = origin
+    ? build(origin.x, origin.y, cursor ? Math.atan2(cursor.y - origin.y, cursor.x - origin.x) : 0)
+    : null;
+
+  return { preview, onPointerDown, onPointerMove, reset };
+}
+```
+
+- [ ] **Step 2: `tests/components/mainview/tabletop/useAoeTool.test.tsx`** — drive the hook with `renderHook` + synthetic pointer events; assert:
+  - a **sphere** click commits immediately with the right `sizePx`/`originX`;
+  - a **cone** first click sets a preview (no commit), a move updates `preview.rotation`, a second click commits with that rotation;
+  - Esc after the first cone click clears `preview` and does not commit.
+    (Use a `domToImage` stub returning `{x: clientX, y: clientY}` and `onCommit = vi.fn()`.)
+
+- [ ] **Step 3:** run the test, typecheck/lint clean. Commit `feat(aoe): add AoE placement tool (origin + aim, ruler-style)`.
+
+---
+
+## Task 8: Tool UI — `AoeSettingsPanel` + tool registration
+
+**Files:**
+
+- Create: `app/components/mainview/tabletop/AoeSettingsPanel.tsx`
+- Modify: `app/components/mainview/tabletop/toolWindowState.ts` (add `'aoe'` to `ToolWindowId`)
+- Modify: the tabletop toolbar (add the AoE tool button — find where Draw/Text/Ruler buttons are registered; likely `ToolBar.tsx` / the tool-window opener in `ActiveMapStage`)
+
+**Interfaces:**
+
+- Produces: `AoeSettingsPanel` (`{ shape, onShape, sizeFt, onSizeFt, widthFt, onWidthFt, color, onColor, placing, onTogglePlacing, onClearAll, canClearAll }`); a registered `'aoe'` tool window.
+
+- [ ] **Step 1: `AoeSettingsPanel.tsx`** — clone `DrawingSettingsPanel.tsx`’s structure (shape buttons row, numeric field, `ColorPicker` from `~/components/shared/ColorPicker`). Five shape buttons (sphere/cone/cube/line/cylinder), a **Size (ft)** number input, a **Width (ft)** input shown only when `shape === 'line'`, the `ColorPicker`, a **"Place on map"** toggle button (armed state = `placing`), and a **"Clear all AoE"** button shown only when `canClearAll` (GM). Use the existing panel's tailwind classes.
+
+- [ ] **Step 2:** `toolWindowState.ts` — add `'aoe'` to the `ToolWindowId` union (and any tool list/labels/icons the file defines). Follow the existing `ruler`/`draw`/`text` entries.
+
+- [ ] **Step 3:** Register the toolbar button that opens the `'aoe'` tool window (mirror the Draw/Ruler buttons). Give it a lucide icon (e.g. `Hexagon` or `Cone` — pick an available one). **Ensure it is not GM-gated** — players must see it (contrast the Draw tool if that is GM-only).
+
+- [ ] **Step 4:** typecheck/lint clean; if a `ToolBar`/tool-window test enumerates tools (like `WikiPanel.test.tsx` did), update its expected set. Commit `feat(aoe): add Spell AoE tool window + toolbar entry`.
+
+---
+
+## Task 9: `ActiveMapStage` integration
+
+**Files:**
+
+- Modify: `app/components/mainview/tabletop/ActiveMapStage.tsx`
+- (Possibly) Modify: `TabletopView.tsx` if the tool's open-state lives there (as with other tool windows).
+
+**Interfaces:**
+
+- Consumes everything above; wires the tool into the live stage.
+
+- [ ] **Step 1:** Instantiate data + placement: `const { data: aoes = [] } = useMapAoE(campaignId, map.id)`; `const aoeMutations = useMapAoEMutations(campaignId, map.id)`; local tool state `aoeShape/aoeSizeFt/aoeWidthFt/aoeColor/aoePlacing` (or lift to the AoE settings panel). `const aoe = useAoeTool({ aoeActive: aoePlacing, shape, sizeFt, widthFt, color, domToImage, pixelsPerSquare: map.scale.pixelsPerSquare, feetPerSquare: map.scale.feetPerSquare, imageWidth: map.imageWidth, imageHeight: map.imageHeight, onCommit })` where `onCommit` calls `aoeMutations.create.mutate(aoeToCreateInput, { onSuccess: (res) => { applyAoeAddToCache(qc, campaignId, map.id, res.aoe); onBroadcast({ type: 'aoe:added', mapId: map.id, aoe: res.aoe }); } })`. Convert the placement `AoeInput` (map-local px) directly to the create payload.
+
+- [ ] **Step 2:** Short-circuit pointer handlers **before** pan/ruler, mirroring the ruler wiring (`ActiveMapStage.tsx` ~`:628-643`, `:971-974`, `:1307-1313`): when `aoePlacing`, route `onPanPointerDown`→`aoe.onPointerDown`, `onPointerMove`→`aoe.onPointerMove`, and `onDoubleClick`→`aoe.reset()`. Ensure ruler and AoE placement are mutually exclusive (only one tool armed).
+
+- [ ] **Step 3:** Render `<MapAoELayer visible={!hiddenLayers.has('spell-fx')} aoes={aoes} preview={aoe.preview} effectiveScale={effectiveScale} imageOffsetX={imageOffsetX} imageOffsetY={imageOffsetY} currentUserId={currentUserId} isGM={isGM} selectedId={selectedAoeId} onSelect={setSelectedAoeId} canModify={(a) => isGM || a.createdBy === currentUserId} />` in the compositing order **just above the grid, below `MapDrawingLayer`** (per the spec).
+
+- [ ] **Step 4:** Delete + clear: a keydown handler removes `selectedAoeId` when set (calling `aoeMutations.remove` + `applyAoeRemoveFromCache` + `onBroadcast({type:'aoe:removed', ...})`) — only when `canModify`. Wire the panel's `onClearAll` (GM) to `aoeMutations.clear` + `applyAoeClearToCache` + `onBroadcast({type:'aoe:cleared', mapId})`.
+
+- [ ] **Step 5:** Render the `AoeSettingsPanel` inside a `ToolWindow` when the `'aoe'` tool is open (mirror how `LayersPanel`/`DrawingSettingsPanel` are hosted at `ActiveMapStage.tsx:1504-1518`).
+
+- [ ] **Step 6:** `npm run typecheck && npm run lint` clean; `npm test` green (run the tabletop suite). Manually confirm nothing regressed in ruler/draw. Commit `feat(aoe): wire the Spell AoE tool into the tabletop stage`.
+
+---
+
+## Task 10: e2e + gates + dev
+
+**Files:**
+
+- Create: `e2e/spell-aoe.spec.ts` (follow existing tabletop e2e patterns/fixtures)
+
+- [ ] **Step 1:** e2e (adapt to the real harness): as a GM in a seeded campaign, open the tabletop → open the **Spell AoE** tool → pick **sphere**, size 20 → click the map → assert a `[data-testid="map-aoe"]` circle appears. Toggle the `spell-fx` layer off → it disappears. (Selectors/fixtures per the repo's tabletop e2e.)
+
+- [ ] **Step 2: Full gates:** `npm test`, `npm run typecheck`, `npm run lint` all clean.
+
+- [ ] **Step 3: Manual multiplayer check** (the whole point): with `npm run dev` (web + ws) running and the dev DB seeded, place an AoE as one user and confirm it appears for a second connected client. Reset dev per the `resetting-dev-data` skill if needed (no data regeneration required — Phase 3 adds a collection, not spell data).
+
+- [ ] **Step 4:** Open a PR to `dev` (never `main`).
+
+## Self-Review (author checklist)
+
+- [ ] **Spec coverage:** model+auth (T1,T3), geometry+scaling (T2), shared persistence/broadcast NOT GM-gated (T4,T5), semi-transparent render (T6), placement w/ aim+Esc (T7), tool UI + player-accessible (T8), stage wiring + delete-own/GM-clear (T9), e2e (T10).
+- [ ] **Type consistency:** `MapAoEData`/`AoeInput`/`AoeShape` and `applyAoe*ToCache` names identical across tasks; `aoe:*` message shapes match between party union (T5) and the broadcasts in the stage (T9).
+- [ ] **No new deps.** Tests under `tests/`. AoE is on the **text** (shared) sync path, not the drawing GM-gate.
+
+## Out of scope (this plan)
+
+- Drag-resize/move of placed templates; grid snapping; auto-fill from a spell's `areaOfEffect`; range enforcement; non-square grids (fall back to a default scale).

--- a/e2e/tabletop/tabletop-aoe.spec.ts
+++ b/e2e/tabletop/tabletop-aoe.spec.ts
@@ -247,3 +247,63 @@ test('the Layers panel eye toggle hides and shows the AoE layer', async ({ page 
   await expect(page.getByTestId('map-aoe-layer')).toHaveCount(1);
   await expect(page.getByTestId('map-aoe')).toHaveCount(1);
 });
+
+test('the per-viewer Show spell effects toggle hides and shows the AoE layer for everyone', async ({
+  page,
+}) => {
+  await gotoTabletop(page);
+  await selectAoeTool(page);
+
+  const box = await stageBox(page);
+  await page.mouse.click(box.x + box.width * 0.5, box.y + box.height * 0.5);
+  await expect(page.getByTestId('map-aoe')).toHaveCount(1);
+
+  // The map-control toggle (available to every viewer, not GM-gated) hides the
+  // AoE layer for this client without deleting anything.
+  const toggle = page.getByTestId('map-spell-effects-toggle');
+  await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+  await toggle.click();
+  await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+  await expect(page.getByTestId('map-aoe-layer')).toHaveCount(0);
+  await expect.poll(() => countAoes()).toBe(1);
+
+  await toggle.click();
+  await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.getByTestId('map-aoe')).toHaveCount(1);
+});
+
+test('the pointer tool drags a placed template to a new position (persisted)', async ({ page }) => {
+  await gotoTabletop(page);
+  await selectAoeTool(page);
+
+  const box = await stageBox(page);
+  await page.mouse.click(box.x + box.width * 0.5, box.y + box.height * 0.5);
+  await expect(page.getByTestId('map-aoe')).toHaveCount(1);
+  await expect.poll(() => countAoes()).toBe(1);
+
+  const before = await aoes().findOne({ mapId: new ObjectId(provisioned.mapId), shape: 'sphere' });
+  const startOriginX = (before as { originX?: number } | null)?.originX ?? 0;
+
+  // Switch to the pointer tool, then drag the template to the right.
+  await page.getByTestId('tool-pointer').click();
+  const circle = page.getByTestId('map-aoe');
+  const cbox = (await circle.boundingBox())!;
+  const cx = cbox.x + cbox.width / 2;
+  const cy = cbox.y + cbox.height / 2;
+  await page.mouse.move(cx, cy);
+  await page.mouse.down();
+  await page.mouse.move(cx + 140, cy, { steps: 10 });
+  await page.mouse.up();
+
+  // The move persists (owner/GM) — originX increased, still exactly one doc.
+  await expect
+    .poll(async () => {
+      const doc = await aoes().findOne({
+        mapId: new ObjectId(provisioned.mapId),
+        shape: 'sphere',
+      });
+      return (doc as { originX?: number } | null)?.originX ?? 0;
+    })
+    .toBeGreaterThan(startOriginX + 10);
+  await expect.poll(() => countAoes()).toBe(1);
+});

--- a/e2e/tabletop/tabletop-aoe.spec.ts
+++ b/e2e/tabletop/tabletop-aoe.spec.ts
@@ -1,0 +1,249 @@
+/**
+ * E2E for the Spell AoE tool:
+ *  - selecting the tool opens a settings popup (shape/size/width/color), sphere
+ *    selected by default
+ *  - clicking the map with the sphere shape commits a template immediately —
+ *    it renders as a `map-aoe` circle and persists
+ *  - the Layers panel's Spell FX eye toggle hides and shows the AoE layer
+ *    (a per-viewer visibility toggle, not a delete)
+ *
+ * The AoE tool is available to every campaign member (not GM-gated); the
+ * harness only has a GM session, so placement is exercised as the GM. The
+ * `spell-fx` layer toggle itself lives in the GM-only Layers panel, matching
+ * the pattern already covered for drawings in tabletop-drawing.spec.ts.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { test, expect, type Page } from '@playwright/test';
+import { MongoClient, ObjectId, type Db } from 'mongodb';
+import { decodeJwt } from 'jose';
+
+test.describe.configure({ mode: 'serial', timeout: 90_000 });
+
+const CAMPAIGN_NAME = 'E2E Spell AoE';
+const DATA_IMG =
+  'data:image/svg+xml;utf8,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024"><rect width="1024" height="1024" fill="#222"/></svg>'
+  );
+
+interface Provisioned {
+  campaignId: string;
+  mapId: string;
+  gmId: string;
+}
+
+let client: MongoClient;
+let provisioned: Provisioned;
+
+function db(): Db {
+  return process.env.MONGODB_DB ? client.db(process.env.MONGODB_DB) : client.db();
+}
+
+function aoes() {
+  return db().collection('mapAoE');
+}
+
+function countAoes(filter: Record<string, unknown> = {}) {
+  return aoes().countDocuments({ mapId: new ObjectId(provisioned.mapId), ...filter });
+}
+
+async function provision(database: Db): Promise<Provisioned> {
+  const storage = JSON.parse(
+    readFileSync(join(process.cwd(), 'e2e', '.auth', 'storageState.json'), 'utf-8')
+  ) as { cookies: Array<{ name: string; value: string }> };
+  const cookie = storage.cookies.find((c) => c.name === 'cartyx_session');
+  if (!cookie) throw new Error('No cartyx_session cookie — globalSetup did not run?');
+  const providerId = (decodeJwt(cookie.value) as { user?: { id?: string } }).user?.id;
+  const gm = await database.collection('users').findOne({ providerId });
+  if (!gm?._id) throw new Error('Session GM user not found');
+
+  const now = new Date();
+
+  const campaignId = (
+    await database.collection('campaigns').insertOne({
+      gameMasterId: gm._id,
+      name: CAMPAIGN_NAME,
+      description: 'E2E spell AoE tool test.',
+      status: 'active',
+      inviteCode: 'e2e-' + Math.random().toString(36).slice(2, 12),
+      maxPlayers: 6,
+      members: [{ userId: gm._id, role: 'gm', joinedAt: now }],
+      links: [],
+      createdAt: now,
+      updatedAt: now,
+    })
+  ).insertedId;
+
+  const mapId = (
+    await database.collection('map').insertOne({
+      campaignId,
+      createdBy: gm._id,
+      name: 'E2E Map',
+      tags: [],
+      imageKey: 'e2e/aoe-map.svg',
+      imageUrl: DATA_IMG,
+      imageWidth: 1024,
+      imageHeight: 1024,
+      locationId: null,
+      scale: { gridType: 'square', pixelsPerSquare: 50, feetPerSquare: 5 },
+      gridOverlay: { enabled: false, color: '#ffffff66' },
+      createdAt: now,
+      updatedAt: now,
+    })
+  ).insertedId;
+
+  await database.collection('tabletopscreen').insertOne({
+    campaignId,
+    name: 'Map',
+    tabOrder: 0,
+    createdBy: gm._id,
+    mode: 'grid',
+    gridStyle: 'dark',
+    gridSize: 50,
+    gridVisible: true,
+    gridScale: 5,
+    locationId: null,
+    battleMapImage: null,
+    activeMapId: mapId,
+    windows: [],
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  return {
+    campaignId: String(campaignId),
+    mapId: String(mapId),
+    gmId: String(gm._id),
+  };
+}
+
+async function gotoTabletop(page: Page) {
+  await page.goto(`/campaigns/${provisioned.campaignId}/play?tab=tabletop`);
+  const stage = page.getByTestId('active-map-stage');
+  try {
+    await expect(stage).toBeVisible({ timeout: 20000 });
+  } catch {
+    await page.reload();
+    await expect(stage).toBeVisible({ timeout: 20000 });
+  }
+}
+
+async function selectAoeTool(page: Page) {
+  await page.getByTestId('tool-aoe').click();
+  await expect(page.getByTestId('tool-window-aoe')).toBeVisible();
+  await expect(page.getByTestId('aoe-settings-panel')).toBeVisible();
+}
+
+async function stageBox(page: Page) {
+  return (await page.getByTestId('active-map-stage').boundingBox())!;
+}
+
+test.beforeAll(async () => {
+  try {
+    process.loadEnvFile('.env');
+  } catch {
+    /* env may be set externally */
+  }
+  const uri = process.env.MONGODB_URI;
+  if (!uri) throw new Error('MONGODB_URI not set');
+  client = new MongoClient(uri);
+  await client.connect();
+  provisioned = await provision(db());
+});
+
+test.afterEach(async () => {
+  // Keep tests independent: clear all AoE templates on the map between them.
+  if (provisioned?.mapId) {
+    await aoes().deleteMany({ mapId: new ObjectId(provisioned.mapId) });
+  }
+});
+
+test.afterAll(async () => {
+  if (!client) return;
+  if (provisioned?.campaignId) {
+    const cid = new ObjectId(provisioned.campaignId);
+    await aoes().deleteMany({ campaignId: cid });
+    await db().collection('tabletopscreen').deleteMany({ campaignId: cid });
+    await db().collection('map').deleteMany({ campaignId: cid });
+    await db().collection('campaigns').deleteMany({ _id: cid });
+  }
+  await client.close();
+});
+
+test('selecting the AoE tool opens a settings popup with sphere selected by default', async ({
+  page,
+}) => {
+  await gotoTabletop(page);
+  await selectAoeTool(page);
+
+  const panel = page.getByTestId('aoe-settings-panel');
+  await expect(panel.getByTestId('aoe-shape-sphere')).toHaveAttribute('aria-pressed', 'true');
+  await expect(panel.getByTestId('aoe-shape-cone')).toBeVisible();
+  await expect(panel.getByTestId('aoe-shape-cube')).toBeVisible();
+  await expect(panel.getByTestId('aoe-shape-line')).toBeVisible();
+  await expect(panel.getByTestId('aoe-shape-cylinder')).toBeVisible();
+  await expect(panel.getByTestId('aoe-size-input')).toHaveValue('20');
+  // Width input is line-only — hidden while sphere is selected.
+  await expect(panel.getByTestId('aoe-width-input')).toHaveCount(0);
+
+  // Unified chrome: grip + icon + title header, and a close X that closes the
+  // window and reverts the toolbar to pointer.
+  await expect(page.getByTestId('tool-window-aoe-header')).toContainText('Spell AoE');
+  await page.getByTestId('tool-window-aoe-close').click();
+  await expect(page.getByTestId('tool-window-aoe')).toHaveCount(0);
+  await expect(page.getByTestId('tool-pointer')).toHaveAttribute('aria-pressed', 'true');
+});
+
+test('clicking the map with the sphere shape places a template that renders and persists', async ({
+  page,
+}) => {
+  await gotoTabletop(page);
+  await selectAoeTool(page);
+
+  const box = await stageBox(page);
+  await page.mouse.click(box.x + box.width * 0.5, box.y + box.height * 0.5);
+
+  const circle = page.getByTestId('map-aoe');
+  await expect(circle).toHaveCount(1);
+  await expect(circle).toHaveAttribute('data-aoe-shape', 'sphere');
+  await expect(page.getByTestId('map-aoe-layer')).toBeVisible();
+
+  // Persisted with the default 20 ft size scaled by the map's 50 px / 5 ft
+  // grid → 200 map-local px, and no rotation (radial shape).
+  await expect.poll(() => countAoes({ shape: 'sphere' })).toBe(1);
+  const doc = await aoes().findOne({ mapId: new ObjectId(provisioned.mapId), shape: 'sphere' });
+  expect((doc as { sizePx?: number } | null)?.sizePx).toBe(200);
+  expect((doc as { rotation?: number } | null)?.rotation).toBe(0);
+});
+
+test('the Layers panel eye toggle hides and shows the AoE layer', async ({ page }) => {
+  await gotoTabletop(page);
+  await selectAoeTool(page);
+
+  const box = await stageBox(page);
+  await page.mouse.click(box.x + box.width * 0.5, box.y + box.height * 0.5);
+  await expect(page.getByTestId('map-aoe')).toHaveCount(1);
+  await expect.poll(() => countAoes()).toBe(1);
+
+  // Open the GM Layers panel and hide the Spell FX layer via its eye.
+  await page.getByTestId('tool-layer').click();
+  const panel = page.getByTestId('layers-panel');
+  await expect(panel).toBeVisible();
+  const eye = panel.getByTestId('layer-visibility-spell-fx');
+  await expect(eye).toHaveAttribute('aria-pressed', 'true'); // currently visible
+  await eye.click();
+  await expect(eye).toHaveAttribute('aria-pressed', 'false'); // now hidden
+
+  // The whole AoE layer disappears — but nothing is deleted: it's a
+  // per-viewer visibility toggle.
+  await expect(page.getByTestId('map-aoe')).toHaveCount(0);
+  await expect(page.getByTestId('map-aoe-layer')).toHaveCount(0);
+  await expect.poll(() => countAoes()).toBe(1);
+
+  // Toggling the eye back shows the layer + template again.
+  await eye.click();
+  await expect(eye).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.getByTestId('map-aoe-layer')).toHaveCount(1);
+  await expect(page.getByTestId('map-aoe')).toHaveCount(1);
+});

--- a/e2e/tabletop/tabletop-aoe.spec.ts
+++ b/e2e/tabletop/tabletop-aoe.spec.ts
@@ -248,6 +248,36 @@ test('the Layers panel eye toggle hides and shows the AoE layer', async ({ page 
   await expect(page.getByTestId('map-aoe')).toHaveCount(1);
 });
 
+test('a placed template shows the placer name and an optional label', async ({ page }) => {
+  await gotoTabletop(page);
+  await selectAoeTool(page);
+
+  // Provide an optional label (e.g. the spell name) before placing.
+  await page.getByTestId('aoe-label-input').fill('Fireball');
+
+  const box = await stageBox(page);
+  await page.mouse.click(box.x + box.width * 0.5, box.y + box.height * 0.5);
+  await expect(page.getByTestId('map-aoe')).toHaveCount(1);
+
+  // The label overlay renders the user label + the placer's name (denormalised
+  // onto the doc at create time).
+  const labelLayer = page.getByTestId('map-aoe-label-layer');
+  await expect(labelLayer).toBeVisible();
+  await expect(labelLayer.getByText('Fireball')).toBeVisible();
+
+  // The persisted doc carries both the label and a non-empty placer name.
+  await expect
+    .poll(async () => {
+      const doc = await aoes().findOne({ mapId: new ObjectId(provisioned.mapId) });
+      return (doc as { label?: string } | null)?.label ?? null;
+    })
+    .toBe('Fireball');
+  const doc = await aoes().findOne({ mapId: new ObjectId(provisioned.mapId) });
+  expect(((doc as { createdByName?: string } | null)?.createdByName ?? '').length).toBeGreaterThan(
+    0
+  );
+});
+
 test('the per-viewer Show spell effects toggle hides and shows the AoE layer for everyone', async ({
   page,
 }) => {

--- a/tests/components/Toast.test.tsx
+++ b/tests/components/Toast.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { Toast, showToast } from '~/components/Toast';
+
+describe('Toast', () => {
+  it('shows an error-variant toast with an assertive alert role', () => {
+    render(<Toast />);
+    act(() => showToast('Couldn’t place the spell effect. Please try again.', 'error'));
+    const el = screen.getByRole('alert');
+    expect(el).toHaveTextContent('Couldn’t place the spell effect');
+    expect(el).toHaveAttribute('aria-live', 'assertive');
+  });
+
+  it('defaults to the info variant (polite status role)', () => {
+    render(<Toast />);
+    act(() => showToast('Invite code copied'));
+    const el = screen.getByRole('status');
+    expect(el).toHaveTextContent('Invite code copied');
+    expect(el).toHaveAttribute('aria-live', 'polite');
+  });
+});

--- a/tests/components/mainview/ToolBar.test.tsx
+++ b/tests/components/mainview/ToolBar.test.tsx
@@ -11,6 +11,7 @@ const allTools: ToolType[] = [
   'drawing',
   'text',
   'ruler',
+  'aoe',
   'dice',
   'stamp',
   'layer',
@@ -29,7 +30,7 @@ function renderToolBar(props: Partial<React.ComponentProps<typeof ToolBar>> = {}
 }
 
 describe('ToolBar', () => {
-  it('renders all 8 tool buttons when expanded (GM)', () => {
+  it('renders all 9 tool buttons when expanded (GM)', () => {
     renderToolBar();
     for (const tool of allTools) {
       expect(screen.getByTestId(`tool-${tool}`)).toBeInTheDocument();

--- a/tests/components/mainview/tabletop/AoeSettingsPanel.test.tsx
+++ b/tests/components/mainview/tabletop/AoeSettingsPanel.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AoeSettingsPanel } from '~/components/mainview/tabletop/AoeSettingsPanel';
+import type { AoeShape } from '~/types/mapAoe';
+
+const SHAPES: AoeShape[] = ['sphere', 'cone', 'cube', 'line', 'cylinder'];
+
+function renderPanel(props: Partial<React.ComponentProps<typeof AoeSettingsPanel>> = {}) {
+  const defaults: React.ComponentProps<typeof AoeSettingsPanel> = {
+    shape: 'sphere',
+    onShape: vi.fn(),
+    sizeFt: 20,
+    onSizeFt: vi.fn(),
+    widthFt: 5,
+    onWidthFt: vi.fn(),
+    color: '#e74c3c',
+    onColor: vi.fn(),
+    onClearAll: vi.fn(),
+    canClearAll: false,
+  };
+  return render(<AoeSettingsPanel {...defaults} {...props} />);
+}
+
+describe('AoeSettingsPanel', () => {
+  it('renders the root panel', () => {
+    renderPanel();
+    expect(screen.getByTestId('aoe-settings-panel')).toBeInTheDocument();
+  });
+
+  it('renders all five shape buttons', () => {
+    renderPanel();
+    for (const shape of SHAPES) {
+      expect(screen.getByTestId(`aoe-shape-${shape}`)).toBeInTheDocument();
+    }
+  });
+
+  it('highlights the active shape', () => {
+    renderPanel({ shape: 'cone' });
+    expect(screen.getByTestId('aoe-shape-cone')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('aoe-shape-sphere')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('calls onShape when a shape button is clicked', async () => {
+    const user = userEvent.setup();
+    const onShape = vi.fn();
+    renderPanel({ onShape });
+    await user.click(screen.getByTestId('aoe-shape-cube'));
+    expect(onShape).toHaveBeenCalledWith('cube');
+  });
+
+  it('binds the Size (ft) input to sizeFt/onSizeFt', async () => {
+    const onSizeFt = vi.fn();
+    renderPanel({ sizeFt: 15, onSizeFt });
+    const input = screen.getByTestId('aoe-size-input') as HTMLInputElement;
+    expect(input.value).toBe('15');
+  });
+
+  it('hides the Width (ft) field unless shape is line', () => {
+    renderPanel({ shape: 'sphere' });
+    expect(screen.queryByTestId('aoe-width-input')).not.toBeInTheDocument();
+  });
+
+  it('shows the Width (ft) field when shape is line', () => {
+    renderPanel({ shape: 'line', widthFt: 10 });
+    const input = screen.getByTestId('aoe-width-input') as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.value).toBe('10');
+  });
+
+  it('hides the Clear all AoE button when canClearAll is false', () => {
+    renderPanel({ canClearAll: false });
+    expect(screen.queryByTestId('aoe-clear-all')).not.toBeInTheDocument();
+  });
+
+  it('shows the Clear all AoE button and calls onClearAll when canClearAll is true', async () => {
+    const user = userEvent.setup();
+    const onClearAll = vi.fn();
+    renderPanel({ canClearAll: true, onClearAll });
+    const button = screen.getByTestId('aoe-clear-all');
+    expect(button).toBeInTheDocument();
+    await user.click(button);
+    expect(onClearAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/components/mainview/tabletop/AoeSettingsPanel.test.tsx
+++ b/tests/components/mainview/tabletop/AoeSettingsPanel.test.tsx
@@ -17,6 +17,8 @@ function renderPanel(props: Partial<React.ComponentProps<typeof AoeSettingsPanel
     onWidthFt: vi.fn(),
     color: '#e74c3c',
     onColor: vi.fn(),
+    label: '',
+    onLabel: vi.fn(),
     onClearAll: vi.fn(),
     canClearAll: false,
   };
@@ -82,5 +84,15 @@ describe('AoeSettingsPanel', () => {
     expect(button).toBeInTheDocument();
     await user.click(button);
     expect(onClearAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('binds the optional Label input to label/onLabel', async () => {
+    const user = userEvent.setup();
+    const onLabel = vi.fn();
+    renderPanel({ label: '', onLabel });
+    const input = screen.getByTestId('aoe-label-input') as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    await user.type(input, 'F');
+    expect(onLabel).toHaveBeenCalledWith('F');
   });
 });

--- a/tests/components/mainview/tabletop/MapAoELayer.test.tsx
+++ b/tests/components/mainview/tabletop/MapAoELayer.test.tsx
@@ -52,4 +52,37 @@ describe('MapAoELayer', () => {
     );
     expect(queryByTestId('map-aoe-layer')).toBeNull();
   });
+  it('draws the placer name and optional label as semi-transparent text', () => {
+    const { getByTestId, getByText } = render(
+      <MapAoELayer
+        visible
+        aoes={[aoe({ id: 'x', createdByName: 'Ada Lovelace', label: 'Fireball' })]}
+        preview={null}
+        effectiveScale={1}
+        imageOffsetX={0}
+        imageOffsetY={0}
+      />
+    );
+    const labelLayer = getByTestId('map-aoe-label-layer');
+    expect(labelLayer).toBeTruthy();
+    const name = getByText('Ada Lovelace');
+    const spell = getByText('Fireball');
+    expect(name.tagName.toLowerCase()).toBe('text');
+    // Semi-transparent so tokens/terrain underneath stay visible.
+    expect(Number(name.getAttribute('fill-opacity'))).toBeLessThan(1);
+    expect(Number(spell.getAttribute('fill-opacity'))).toBeLessThan(1);
+  });
+  it('omits the label layer when a template has no name or label', () => {
+    const { queryByTestId } = render(
+      <MapAoELayer
+        visible
+        aoes={[aoe({ id: 'x', createdByName: '', label: undefined })]}
+        preview={null}
+        effectiveScale={1}
+        imageOffsetX={0}
+        imageOffsetY={0}
+      />
+    );
+    expect(queryByTestId('map-aoe-label-layer')).toBeNull();
+  });
 });

--- a/tests/components/mainview/tabletop/MapAoELayer.test.tsx
+++ b/tests/components/mainview/tabletop/MapAoELayer.test.tsx
@@ -72,6 +72,24 @@ describe('MapAoELayer', () => {
     expect(Number(name.getAttribute('fill-opacity'))).toBeLessThan(1);
     expect(Number(spell.getAttribute('fill-opacity'))).toBeLessThan(1);
   });
+  it('anchors a cone label at the centroid, not the apex/origin', () => {
+    // Cone: apex at origin (100,100), size 40, rotation 0 → centroid x = 100 +
+    // 2/3*40 ≈ 126.7 (away from the caster token at the apex).
+    const { getByText } = render(
+      <MapAoELayer
+        visible
+        aoes={[
+          aoe({ id: 'c', shape: 'cone', originX: 100, originY: 100, sizePx: 40, label: 'Cone' }),
+        ]}
+        preview={null}
+        effectiveScale={1}
+        imageOffsetX={0}
+        imageOffsetY={0}
+      />
+    );
+    const text = getByText('Cone');
+    expect(Number(text.getAttribute('x'))).toBeCloseTo(126.67, 1);
+  });
   it('omits the label layer when a template has no name or label', () => {
     const { queryByTestId } = render(
       <MapAoELayer

--- a/tests/components/mainview/tabletop/MapAoELayer.test.tsx
+++ b/tests/components/mainview/tabletop/MapAoELayer.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { MapAoELayer } from '~/components/mainview/tabletop/MapAoELayer';
+import type { MapAoEData } from '~/types/mapAoe';
+
+function aoe(over: Partial<MapAoEData>): MapAoEData {
+  return {
+    id: 'a',
+    mapId: 'm',
+    campaignId: 'c',
+    shape: 'sphere',
+    originX: 100,
+    originY: 100,
+    sizePx: 40,
+    rotation: 0,
+    color: '#ff0000',
+    createdBy: 'u',
+    createdAt: '',
+    updatedAt: '',
+    ...over,
+  };
+}
+
+describe('MapAoELayer', () => {
+  it('renders a circle for a sphere and a polygon for a cone', () => {
+    const { container } = render(
+      <MapAoELayer
+        visible
+        aoes={[aoe({ id: 's', shape: 'sphere' }), aoe({ id: 'k', shape: 'cone' })]}
+        preview={null}
+        effectiveScale={1}
+        imageOffsetX={0}
+        imageOffsetY={0}
+      />
+    );
+    expect(container.querySelector('[data-aoe-id="s"]')?.tagName.toLowerCase()).toBe('circle');
+    expect(container.querySelector('[data-aoe-id="k"]')?.tagName.toLowerCase()).toBe('polygon');
+    expect(container.querySelector('circle')?.getAttribute('fill-opacity')).toBe('0.3');
+  });
+  it('renders nothing when not visible', () => {
+    const { queryByTestId } = render(
+      <MapAoELayer
+        visible={false}
+        aoes={[aoe({})]}
+        preview={null}
+        effectiveScale={1}
+        imageOffsetX={0}
+        imageOffsetY={0}
+      />
+    );
+    expect(queryByTestId('map-aoe-layer')).toBeNull();
+  });
+});

--- a/tests/components/mainview/tabletop/MapAoELayer.test.tsx
+++ b/tests/components/mainview/tabletop/MapAoELayer.test.tsx
@@ -16,6 +16,7 @@ function aoe(over: Partial<MapAoEData>): MapAoEData {
     rotation: 0,
     color: '#ff0000',
     createdBy: 'u',
+    createdByName: '',
     createdAt: '',
     updatedAt: '',
     ...over,

--- a/tests/components/mainview/tabletop/aoeGeometry.test.ts
+++ b/tests/components/mainview/tabletop/aoeGeometry.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { feetToPixels, aoeShapeGeometry } from '~/components/mainview/tabletop/aoeGeometry';
+
+describe('feetToPixels', () => {
+  it('converts feet using the grid scale', () => {
+    // 20 ft on a 5-ft, 50px grid = 4 squares = 200 px
+    expect(feetToPixels(20, { pixelsPerSquare: 50, feetPerSquare: 5 })).toBe(200);
+  });
+});
+
+describe('aoeShapeGeometry', () => {
+  const base = { originX: 100, originY: 100, sizePx: 40, rotation: 0 };
+  it('sphere/cylinder → circle at origin', () => {
+    expect(aoeShapeGeometry({ ...base, shape: 'sphere' })).toEqual({
+      kind: 'circle',
+      cx: 100,
+      cy: 100,
+      r: 40,
+    });
+    expect(aoeShapeGeometry({ ...base, shape: 'cylinder' }).kind).toBe('circle');
+  });
+  it('cube → centered square', () => {
+    expect(aoeShapeGeometry({ ...base, shape: 'cube' })).toEqual({
+      kind: 'rect',
+      x: 80,
+      y: 80,
+      w: 40,
+      h: 40,
+    });
+  });
+  it('line at rotation 0 → rectangle extending +x', () => {
+    const g = aoeShapeGeometry({ ...base, shape: 'line', widthPx: 10 });
+    expect(g.kind).toBe('polygon');
+    if (g.kind === 'polygon') {
+      expect(g.points[0]).toEqual({ x: 100, y: 95 }); // (0,-5)
+      expect(g.points[1]).toEqual({ x: 140, y: 95 }); // (40,-5)
+      expect(g.points[2]).toEqual({ x: 140, y: 105 }); // (40,5)
+    }
+  });
+  it('cone at rotation 0 → apex at origin, base at x=origin+L', () => {
+    const g = aoeShapeGeometry({ ...base, shape: 'cone' });
+    if (g.kind === 'polygon') {
+      expect(g.points[0]).toEqual({ x: 100, y: 100 }); // apex
+      expect(g.points[1]).toEqual({ x: 140, y: 120 }); // (L, L/2)
+      expect(g.points[2]).toEqual({ x: 140, y: 80 }); // (L, -L/2)
+    }
+  });
+  it('rotates line/cone by rotation', () => {
+    const g = aoeShapeGeometry({ ...base, shape: 'cone', rotation: Math.PI / 2 });
+    if (g.kind === 'polygon') {
+      // apex unchanged; far edge now points +y
+      expect(g.points[0]).toEqual({ x: 100, y: 100 });
+      expect(g.points[1].y).toBeCloseTo(140);
+    }
+  });
+});

--- a/tests/components/mainview/tabletop/useAoeTool.test.tsx
+++ b/tests/components/mainview/tabletop/useAoeTool.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { PointerEvent as ReactPointerEvent } from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { useAoeTool } from '~/components/mainview/tabletop/useAoeTool';
+
+const domToImage = (x: number, y: number) => ({ x, y });
+
+const pointerEvt = (x: number, y: number) =>
+  ({ clientX: x, clientY: y }) as unknown as ReactPointerEvent<HTMLDivElement>;
+
+const pressEscape = (target?: EventTarget) => {
+  const evt = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
+  (target ?? window).dispatchEvent(evt);
+};
+
+const baseOpts = (overrides: Partial<Parameters<typeof useAoeTool>[0]> = {}) => ({
+  aoeActive: true,
+  shape: 'sphere' as const,
+  sizeFt: 20,
+  widthFt: 5,
+  color: '#ff2d55',
+  domToImage,
+  pixelsPerSquare: 50,
+  feetPerSquare: 5,
+  imageWidth: 1000,
+  imageHeight: 1000,
+  onCommit: vi.fn(),
+  ...overrides,
+});
+
+describe('useAoeTool', () => {
+  it('sphere (radial) commits immediately on the first click', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() => useAoeTool(baseOpts({ shape: 'sphere', onCommit })));
+
+    act(() => result.current.onPointerDown(pointerEvt(100, 120)));
+
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    const aoe = onCommit.mock.calls[0]![0];
+    expect(aoe.shape).toBe('sphere');
+    expect(aoe.originX).toBe(100);
+    expect(aoe.originY).toBe(120);
+    // feetToPixels(20, { pixelsPerSquare: 50, feetPerSquare: 5 }) = (20/5)*50 = 200
+    expect(aoe.sizePx).toBe(200);
+    expect(result.current.preview).toBeNull();
+  });
+
+  it('cone (directional) sets a preview on the first click, aims on move, commits on the second click', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() => useAoeTool(baseOpts({ shape: 'cone', onCommit })));
+
+    act(() => result.current.onPointerDown(pointerEvt(100, 100)));
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(result.current.preview).not.toBeNull();
+    expect(result.current.preview?.originX).toBe(100);
+    expect(result.current.preview?.originY).toBe(100);
+
+    act(() => result.current.onPointerMove(pointerEvt(100, 200)));
+    // origin (100,100) -> cursor (100,200): atan2(100, 0) = PI/2
+    expect(result.current.preview?.rotation).toBeCloseTo(Math.PI / 2);
+
+    act(() => result.current.onPointerDown(pointerEvt(100, 200)));
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    const aoe = onCommit.mock.calls[0]![0];
+    expect(aoe.originX).toBe(100);
+    expect(aoe.originY).toBe(100);
+    expect(aoe.rotation).toBeCloseTo(Math.PI / 2);
+    expect(result.current.preview).toBeNull();
+  });
+
+  it('Esc after the first cone click clears the preview without committing', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() => useAoeTool(baseOpts({ shape: 'cone', onCommit })));
+
+    act(() => result.current.onPointerDown(pointerEvt(100, 100)));
+    expect(result.current.preview).not.toBeNull();
+
+    act(() => pressEscape());
+
+    expect(result.current.preview).toBeNull();
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+});

--- a/tests/server/db/inspect.test.ts
+++ b/tests/server/db/inspect.test.ts
@@ -10,6 +10,9 @@ const {
   raceMock,
   mapMock,
   mapTokenMock,
+  mapTextMock,
+  mapDrawingMock,
+  mapAoeMock,
   monsterMock,
 } = vi.hoisted(() => {
   function make(
@@ -67,6 +70,9 @@ const {
       [{ mapId: 1 }, {}],
       [{ mapId: 1, sourceCollection: 1, sourceDocumentId: 1, instanceNumber: 1 }, { unique: true }],
     ]),
+    mapTextMock: make('MapText', 'mapText', [[{ mapId: 1, campaignId: 1 }, {}]]),
+    mapDrawingMock: make('MapDrawing', 'mapDrawing', [[{ mapId: 1, campaignId: 1 }, {}]]),
+    mapAoeMock: make('MapAoE', 'mapAoE', [[{ campaignId: 1, mapId: 1 }, {}]]),
     monsterMock: make('Monster', 'monsters', [
       [{ campaignId: 1, updatedAt: -1 }, {}],
       [{ campaignId: 1, name: 1 }, {}],
@@ -87,6 +93,9 @@ vi.mock('~/server/db/models/Note', () => ({ Note: noteMock }));
 vi.mock('~/server/db/models/Race', () => ({ Race: raceMock }));
 vi.mock('~/server/db/models/Map', () => ({ Map: mapMock }));
 vi.mock('~/server/db/models/MapToken', () => ({ MapToken: mapTokenMock }));
+vi.mock('~/server/db/models/MapText', () => ({ MapText: mapTextMock }));
+vi.mock('~/server/db/models/MapDrawing', () => ({ MapDrawing: mapDrawingMock }));
+vi.mock('~/server/db/models/MapAoE', () => ({ MapAoE: mapAoeMock }));
 vi.mock('~/server/db/models/Monster', () => ({ Monster: monsterMock }));
 
 import {
@@ -106,12 +115,20 @@ const allMocks = [
   raceMock,
   mapMock,
   mapTokenMock,
+  mapTextMock,
+  mapDrawingMock,
+  mapAoeMock,
   monsterMock,
 ];
 
 describe('ALL_MODELS', () => {
-  it('contains all ten models', () => {
-    expect(ALL_MODELS).toHaveLength(10);
+  it('contains all thirteen models', () => {
+    expect(ALL_MODELS).toHaveLength(13);
+  });
+
+  it('includes the shared map-object models for index governance', () => {
+    const names = ALL_MODELS.map((m) => m.modelName);
+    expect(names).toEqual(expect.arrayContaining(['MapText', 'MapDrawing', 'MapAoE']));
   });
 
   // Regression: Session and GMScreen are included in bootstrap (#302)
@@ -198,6 +215,18 @@ describe('inspectIndexes', () => {
       { key: { campaignId: 1, sessionId: 1 } },
       { key: { campaignId: 1, 'cr.value': 1 } },
       { key: { _fts: 'text', _ftsx: 1 } },
+    ]);
+    mapTextMock.listIndexes.mockResolvedValue([
+      { key: { _id: 1 } },
+      { key: { mapId: 1, campaignId: 1 } },
+    ]);
+    mapDrawingMock.listIndexes.mockResolvedValue([
+      { key: { _id: 1 } },
+      { key: { mapId: 1, campaignId: 1 } },
+    ]);
+    mapAoeMock.listIndexes.mockResolvedValue([
+      { key: { _id: 1 } },
+      { key: { campaignId: 1, mapId: 1 } },
     ]);
 
     const result = await inspectIndexes();

--- a/tests/server/db/mapaoe-model.test.ts
+++ b/tests/server/db/mapaoe-model.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+import { MapAoE } from '~/server/db/models/MapAoE';
+describe('MapAoE model', () => {
+  it('is exported and defined', () => {
+    expect(MapAoE).toBeDefined();
+  });
+});

--- a/tests/server/functions/mapAoE.test.ts
+++ b/tests/server/functions/mapAoE.test.ts
@@ -28,7 +28,13 @@ import { getSession } from '~/server/session';
 import { User } from '~/server/db/models/User';
 import { Campaign } from '~/server/db/models/Campaign';
 import { MapAoE } from '~/server/db/models/MapAoE';
-import { createMapAoE, listMapAoE, removeMapAoE, clearMapAoE } from '~/server/functions/mapAoE';
+import {
+  createMapAoE,
+  listMapAoE,
+  removeMapAoE,
+  clearMapAoE,
+  moveMapAoE,
+} from '~/server/functions/mapAoE';
 
 const mockSession = {
   id: 'session-user-1',
@@ -77,6 +83,10 @@ function makeAoE(overrides: Record<string, unknown> = {}) {
     createdAt: new Date('2026-03-01'),
     updatedAt: new Date('2026-03-01'),
     deleteOne: vi.fn(),
+    save: vi.fn(),
+    toObject: function (this: Record<string, unknown>) {
+      return this;
+    },
     ...overrides,
   };
 }
@@ -93,6 +103,9 @@ const _removeMapAoE = removeMapAoE as unknown as (args: {
 const _clearMapAoE = clearMapAoE as unknown as (args: {
   data: Record<string, unknown>;
 }) => Promise<{ success: boolean }>;
+const _moveMapAoE = moveMapAoE as unknown as (args: {
+  data: Record<string, unknown>;
+}) => Promise<{ aoe: Record<string, unknown> }>;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -239,6 +252,66 @@ describe('removeMapAoE', () => {
 
     await expect(
       _removeMapAoE({ data: { campaignId: 'camp-1', mapId: 'map-1', id: 'nonexistent' } })
+    ).rejects.toThrow('AoE not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// moveMapAoE
+// ---------------------------------------------------------------------------
+
+describe('moveMapAoE', () => {
+  it('allows a player to move their own AoE', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(mockPlayerCampaign);
+    const doc = makeAoE({ createdBy: 'dbuser-1' });
+    vi.mocked(MapAoE.findOne).mockResolvedValue(doc as never);
+
+    const result = await _moveMapAoE({
+      data: { campaignId: 'camp-1', mapId: 'map-1', id: 'aoe-1', originX: 300, originY: 400 },
+    });
+
+    expect(doc.originX).toBe(300);
+    expect(doc.originY).toBe(400);
+    expect(doc.save).toHaveBeenCalled();
+    expect(result.aoe.originX).toBe(300);
+    expect(result.aoe.originY).toBe(400);
+  });
+
+  it("throws Forbidden when a player moves another member's AoE, and does not save", async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(mockPlayerCampaign);
+    const doc = makeAoE({ createdBy: 'other' });
+    vi.mocked(MapAoE.findOne).mockResolvedValue(doc as never);
+
+    await expect(
+      _moveMapAoE({
+        data: { campaignId: 'camp-1', mapId: 'map-1', id: 'aoe-1', originX: 1, originY: 1 },
+      })
+    ).rejects.toThrow('Forbidden');
+
+    expect(doc.save).not.toHaveBeenCalled();
+  });
+
+  it("allows a GM to move anyone's AoE", async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(mockGMCampaign);
+    const doc = makeAoE({ createdBy: 'other' });
+    vi.mocked(MapAoE.findOne).mockResolvedValue(doc as never);
+
+    const result = await _moveMapAoE({
+      data: { campaignId: 'camp-1', mapId: 'map-1', id: 'aoe-1', originX: 50, originY: 60 },
+    });
+
+    expect(doc.save).toHaveBeenCalled();
+    expect(result.aoe.originX).toBe(50);
+    expect(result.aoe.originY).toBe(60);
+  });
+
+  it('throws when the AoE is not found', async () => {
+    vi.mocked(MapAoE.findOne).mockResolvedValue(null);
+
+    await expect(
+      _moveMapAoE({
+        data: { campaignId: 'camp-1', mapId: 'map-1', id: 'nonexistent', originX: 1, originY: 1 },
+      })
     ).rejects.toThrow('AoE not found');
   });
 });

--- a/tests/server/functions/mapAoE.test.ts
+++ b/tests/server/functions/mapAoE.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('~/server/session', () => ({ getSession: vi.fn() }));
+vi.mock('~/server/db/connection', () => ({
+  connectDB: vi.fn(),
+  isDBConnected: vi.fn(() => true),
+}));
+vi.mock('~/server/db/models/User', () => ({
+  User: { findOne: vi.fn() },
+}));
+vi.mock('~/server/db/models/Campaign', () => ({
+  Campaign: { findById: vi.fn() },
+}));
+vi.mock('~/server/db/models/MapAoE', () => ({
+  MapAoE: {
+    create: vi.fn(),
+    find: vi.fn(),
+    findOne: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+}));
+vi.mock('~/server/utils/telemetry', () => ({
+  serverCaptureException: vi.fn(),
+  serverCaptureEvent: vi.fn(),
+}));
+
+import { getSession } from '~/server/session';
+import { User } from '~/server/db/models/User';
+import { Campaign } from '~/server/db/models/Campaign';
+import { MapAoE } from '~/server/db/models/MapAoE';
+import { createMapAoE, listMapAoE, removeMapAoE, clearMapAoE } from '~/server/functions/mapAoE';
+
+const mockSession = {
+  id: 'session-user-1',
+  provider: 'google',
+  name: 'Test User',
+  email: 'test@example.com',
+  avatar: null,
+  role: 'player',
+  accessToken: null,
+  refreshToken: null,
+  tokenIssuedAt: 0,
+};
+const mockDbUser = { _id: 'dbuser-1', firstName: 'Test', lastName: 'User' };
+const mockGMCampaign = {
+  _id: 'camp-1',
+  gameMasterId: 'dbuser-1',
+  members: [{ userId: 'dbuser-1', role: 'gm' }],
+};
+const mockPlayerCampaign = {
+  _id: 'camp-1',
+  gameMasterId: 'someone-else',
+  members: [
+    { userId: 'someone-else', role: 'gm' },
+    { userId: 'dbuser-1', role: 'player' },
+  ],
+};
+const mockNonMemberCampaign = {
+  _id: 'camp-1',
+  gameMasterId: 'someone-else',
+  members: [{ userId: 'someone-else', role: 'gm' }],
+};
+
+function makeAoE(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: 'aoe-1',
+    campaignId: 'camp-1',
+    mapId: 'map-1',
+    shape: 'sphere',
+    originX: 100,
+    originY: 200,
+    sizePx: 50,
+    widthPx: undefined,
+    rotation: 0,
+    color: '#ff0000',
+    createdBy: 'dbuser-1',
+    createdAt: new Date('2026-03-01'),
+    updatedAt: new Date('2026-03-01'),
+    deleteOne: vi.fn(),
+    ...overrides,
+  };
+}
+
+const _createMapAoE = createMapAoE as unknown as (args: {
+  data: Record<string, unknown>;
+}) => Promise<{ aoe: Record<string, unknown> }>;
+const _listMapAoE = listMapAoE as unknown as (args: {
+  data: Record<string, unknown>;
+}) => Promise<{ aoes: Record<string, unknown>[] }>;
+const _removeMapAoE = removeMapAoE as unknown as (args: {
+  data: Record<string, unknown>;
+}) => Promise<{ success: boolean }>;
+const _clearMapAoE = clearMapAoE as unknown as (args: {
+  data: Record<string, unknown>;
+}) => Promise<{ success: boolean }>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getSession).mockResolvedValue(mockSession);
+  vi.mocked(User.findOne).mockResolvedValue(mockDbUser);
+  vi.mocked(Campaign.findById).mockResolvedValue(mockGMCampaign);
+});
+
+// ---------------------------------------------------------------------------
+// createMapAoE
+// ---------------------------------------------------------------------------
+
+describe('createMapAoE', () => {
+  it('sets createdBy to the member and returns the doc', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(mockPlayerCampaign);
+    const created = makeAoE();
+    vi.mocked(MapAoE.create).mockResolvedValue({
+      ...created,
+      toObject: () => created,
+    } as never);
+
+    const result = await _createMapAoE({
+      data: {
+        campaignId: 'camp-1',
+        mapId: 'map-1',
+        shape: 'sphere',
+        originX: 100,
+        originY: 200,
+        sizePx: 50,
+        rotation: 0,
+        color: '#ff0000',
+      },
+    });
+
+    expect(result.aoe.id).toBe('aoe-1');
+    expect(vi.mocked(MapAoE.create).mock.calls[0][0]).toMatchObject({
+      createdBy: 'dbuser-1',
+      campaignId: 'camp-1',
+      mapId: 'map-1',
+    });
+  });
+
+  it('rejects a non-member (via requireCampaignMember)', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(mockNonMemberCampaign);
+
+    await expect(
+      _createMapAoE({
+        data: {
+          campaignId: 'camp-1',
+          mapId: 'map-1',
+          shape: 'sphere',
+          originX: 0,
+          originY: 0,
+          sizePx: 10,
+          rotation: 0,
+          color: '#ff0000',
+        },
+      })
+    ).rejects.toThrow('Forbidden');
+
+    expect(MapAoE.create).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listMapAoE
+// ---------------------------------------------------------------------------
+
+describe('listMapAoE', () => {
+  function mockFind(docs: unknown[] = []) {
+    vi.mocked(MapAoE.find).mockReturnValue({
+      sort: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue(docs) }),
+    } as never);
+  }
+
+  it('returns docs to a player (non-GM) — not GM-gated', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(mockPlayerCampaign);
+    const docs = [makeAoE(), makeAoE({ _id: 'aoe-2', createdBy: 'someone-else' })];
+    mockFind(docs);
+
+    const result = await _listMapAoE({ data: { campaignId: 'camp-1', mapId: 'map-1' } });
+
+    expect(result.aoes).toHaveLength(2);
+    expect(result.aoes[0].id).toBe('aoe-1');
+    expect(result.aoes[1].id).toBe('aoe-2');
+  });
+
+  it('returns docs to a GM as well', async () => {
+    mockFind([makeAoE()]);
+
+    const result = await _listMapAoE({ data: { campaignId: 'camp-1', mapId: 'map-1' } });
+
+    expect(result.aoes).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeMapAoE
+// ---------------------------------------------------------------------------
+
+describe('removeMapAoE', () => {
+  it('allows a player to remove their own AoE', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(mockPlayerCampaign);
+    const doc = makeAoE({ createdBy: 'dbuser-1' });
+    vi.mocked(MapAoE.findOne).mockResolvedValue(doc as never);
+
+    const result = await _removeMapAoE({
+      data: { campaignId: 'camp-1', mapId: 'map-1', id: 'aoe-1' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(doc.deleteOne).toHaveBeenCalled();
+  });
+
+  it("throws Forbidden when a player removes another member's AoE", async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(mockPlayerCampaign);
+    const doc = makeAoE({ createdBy: 'other' });
+    vi.mocked(MapAoE.findOne).mockResolvedValue(doc as never);
+
+    await expect(
+      _removeMapAoE({ data: { campaignId: 'camp-1', mapId: 'map-1', id: 'aoe-1' } })
+    ).rejects.toThrow('Forbidden');
+
+    expect(doc.deleteOne).not.toHaveBeenCalled();
+  });
+
+  it("allows a GM to remove anyone's AoE", async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(mockGMCampaign);
+    const doc = makeAoE({ createdBy: 'other' });
+    vi.mocked(MapAoE.findOne).mockResolvedValue(doc as never);
+
+    const result = await _removeMapAoE({
+      data: { campaignId: 'camp-1', mapId: 'map-1', id: 'aoe-1' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(doc.deleteOne).toHaveBeenCalled();
+  });
+
+  it('throws when the AoE is not found', async () => {
+    vi.mocked(MapAoE.findOne).mockResolvedValue(null);
+
+    await expect(
+      _removeMapAoE({ data: { campaignId: 'camp-1', mapId: 'map-1', id: 'nonexistent' } })
+    ).rejects.toThrow('AoE not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clearMapAoE
+// ---------------------------------------------------------------------------
+
+describe('clearMapAoE', () => {
+  it('GM clears all AoEs on the map', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(mockGMCampaign);
+    vi.mocked(MapAoE.deleteMany).mockResolvedValue({ deletedCount: 3 } as never);
+
+    const result = await _clearMapAoE({ data: { campaignId: 'camp-1', mapId: 'map-1' } });
+
+    expect(result.success).toBe(true);
+    expect(MapAoE.deleteMany).toHaveBeenCalledWith({ campaignId: 'camp-1', mapId: 'map-1' });
+  });
+
+  it('throws Forbidden for a non-GM', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(mockPlayerCampaign);
+
+    await expect(_clearMapAoE({ data: { campaignId: 'camp-1', mapId: 'map-1' } })).rejects.toThrow(
+      'Forbidden'
+    );
+
+    expect(MapAoE.deleteMany).not.toHaveBeenCalled();
+  });
+});

--- a/tests/server/functions/mapAoE.test.ts
+++ b/tests/server/functions/mapAoE.test.ts
@@ -6,7 +6,7 @@ vi.mock('~/server/db/connection', () => ({
   isDBConnected: vi.fn(() => true),
 }));
 vi.mock('~/server/db/models/User', () => ({
-  User: { findOne: vi.fn() },
+  User: { findOne: vi.fn(), findById: vi.fn() },
 }));
 vi.mock('~/server/db/models/Campaign', () => ({
   Campaign: { findById: vi.fn() },
@@ -107,11 +107,18 @@ const _moveMapAoE = moveMapAoE as unknown as (args: {
   data: Record<string, unknown>;
 }) => Promise<{ aoe: Record<string, unknown> }>;
 
+function mockUserFindById(user: Record<string, unknown> | null) {
+  vi.mocked(User.findById).mockReturnValue({
+    select: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue(user) }),
+  } as never);
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getSession).mockResolvedValue(mockSession);
   vi.mocked(User.findOne).mockResolvedValue(mockDbUser);
   vi.mocked(Campaign.findById).mockResolvedValue(mockGMCampaign);
+  mockUserFindById({ firstName: 'Ada', lastName: 'Lovelace' });
 });
 
 // ---------------------------------------------------------------------------
@@ -119,9 +126,10 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('createMapAoE', () => {
-  it('sets createdBy to the member and returns the doc', async () => {
+  it('sets createdBy and createdByName (resolved from the placer) and returns the doc', async () => {
     vi.mocked(Campaign.findById).mockResolvedValue(mockPlayerCampaign);
-    const created = makeAoE();
+    mockUserFindById({ firstName: 'Ada', lastName: 'Lovelace' });
+    const created = makeAoE({ createdByName: 'Ada Lovelace' });
     vi.mocked(MapAoE.create).mockResolvedValue({
       ...created,
       toObject: () => created,
@@ -141,11 +149,67 @@ describe('createMapAoE', () => {
     });
 
     expect(result.aoe.id).toBe('aoe-1');
+    expect(result.aoe.createdByName).toBe('Ada Lovelace');
     expect(vi.mocked(MapAoE.create).mock.calls[0][0]).toMatchObject({
       createdBy: 'dbuser-1',
+      createdByName: 'Ada Lovelace',
       campaignId: 'camp-1',
       mapId: 'map-1',
     });
+  });
+
+  it('persists an optional label when provided', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(mockPlayerCampaign);
+    mockUserFindById({ firstName: 'Ada', lastName: 'Lovelace' });
+    const created = makeAoE({ createdByName: 'Ada Lovelace', label: 'Fireball' });
+    vi.mocked(MapAoE.create).mockResolvedValue({
+      ...created,
+      toObject: () => created,
+    } as never);
+
+    const result = await _createMapAoE({
+      data: {
+        campaignId: 'camp-1',
+        mapId: 'map-1',
+        shape: 'sphere',
+        originX: 100,
+        originY: 200,
+        sizePx: 50,
+        rotation: 0,
+        color: '#ff0000',
+        label: 'Fireball',
+      },
+    });
+
+    expect(result.aoe.label).toBe('Fireball');
+    expect(vi.mocked(MapAoE.create).mock.calls[0][0]).toMatchObject({
+      label: 'Fireball',
+    });
+  });
+
+  it('falls back to email, then Unknown, when the placer has no name', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(mockPlayerCampaign);
+    mockUserFindById({ email: 'ada@example.com' });
+    const created = makeAoE({ createdByName: 'ada@example.com' });
+    vi.mocked(MapAoE.create).mockResolvedValue({
+      ...created,
+      toObject: () => created,
+    } as never);
+
+    const result = await _createMapAoE({
+      data: {
+        campaignId: 'camp-1',
+        mapId: 'map-1',
+        shape: 'sphere',
+        originX: 100,
+        originY: 200,
+        sizePx: 50,
+        rotation: 0,
+        color: '#ff0000',
+      },
+    });
+
+    expect(result.aoe.createdByName).toBe('ada@example.com');
   });
 
   it('rejects a non-member (via requireCampaignMember)', async () => {

--- a/tests/server/functions/mapAoE.test.ts
+++ b/tests/server/functions/mapAoE.test.ts
@@ -164,7 +164,9 @@ describe('createMapAoE', () => {
 describe('listMapAoE', () => {
   function mockFind(docs: unknown[] = []) {
     vi.mocked(MapAoE.find).mockReturnValue({
-      sort: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue(docs) }),
+      sort: vi.fn().mockReturnValue({
+        limit: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue(docs) }),
+      }),
     } as never);
   }
 

--- a/tests/server/functions/mapAoE.test.ts
+++ b/tests/server/functions/mapAoE.test.ts
@@ -16,8 +16,12 @@ vi.mock('~/server/db/models/MapAoE', () => ({
     create: vi.fn(),
     find: vi.fn(),
     findOne: vi.fn(),
+    countDocuments: vi.fn(),
     deleteMany: vi.fn(),
   },
+}));
+vi.mock('~/server/db/models/Map', () => ({
+  Map: { findOne: vi.fn() },
 }));
 vi.mock('~/server/utils/telemetry', () => ({
   serverCaptureException: vi.fn(),
@@ -28,6 +32,7 @@ import { getSession } from '~/server/session';
 import { User } from '~/server/db/models/User';
 import { Campaign } from '~/server/db/models/Campaign';
 import { MapAoE } from '~/server/db/models/MapAoE';
+import { Map as MapModel } from '~/server/db/models/Map';
 import {
   createMapAoE,
   listMapAoE,
@@ -113,12 +118,20 @@ function mockUserFindById(user: Record<string, unknown> | null) {
   } as never);
 }
 
+function mockMapBounds(imageWidth = 1000, imageHeight = 1000) {
+  vi.mocked(MapModel.findOne).mockReturnValue({
+    lean: vi.fn().mockResolvedValue({ imageWidth, imageHeight }),
+  } as never);
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getSession).mockResolvedValue(mockSession);
   vi.mocked(User.findOne).mockResolvedValue(mockDbUser);
   vi.mocked(Campaign.findById).mockResolvedValue(mockGMCampaign);
   mockUserFindById({ firstName: 'Ada', lastName: 'Lovelace' });
+  mockMapBounds();
+  vi.mocked(MapAoE.countDocuments).mockResolvedValue(0 as never);
 });
 
 // ---------------------------------------------------------------------------
@@ -156,6 +169,52 @@ describe('createMapAoE', () => {
       campaignId: 'camp-1',
       mapId: 'map-1',
     });
+  });
+
+  it('clamps an out-of-bounds origin into the map image bounds', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(mockPlayerCampaign);
+    mockMapBounds(1000, 800);
+    const created = makeAoE();
+    vi.mocked(MapAoE.create).mockResolvedValue({ ...created, toObject: () => created } as never);
+
+    await _createMapAoE({
+      data: {
+        campaignId: 'camp-1',
+        mapId: 'map-1',
+        shape: 'sphere',
+        originX: 5000, // beyond width 1000
+        originY: -50, // below 0
+        sizePx: 50,
+        rotation: 0,
+        color: '#ff0000',
+      },
+    });
+
+    expect(vi.mocked(MapAoE.create).mock.calls[0][0]).toMatchObject({
+      originX: 1000,
+      originY: 0,
+    });
+  });
+
+  it('rejects creation when the map is already at the template cap', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(mockPlayerCampaign);
+    vi.mocked(MapAoE.countDocuments).mockResolvedValue(200 as never);
+
+    await expect(
+      _createMapAoE({
+        data: {
+          campaignId: 'camp-1',
+          mapId: 'map-1',
+          shape: 'sphere',
+          originX: 100,
+          originY: 100,
+          sizePx: 50,
+          rotation: 0,
+          color: '#ff0000',
+        },
+      })
+    ).rejects.toThrow(/maximum/i);
+    expect(MapAoE.create).not.toHaveBeenCalled();
   });
 
   it('persists an optional label when provided', async () => {

--- a/tests/types/schemas/tabletopMessage.test.ts
+++ b/tests/types/schemas/tabletopMessage.test.ts
@@ -65,7 +65,7 @@ describe('parseTabletopMapMessage', () => {
     originY: 5,
     sizePx: 100,
     rotation: 0,
-    color: '#f00',
+    color: '#ff0000',
     label: 'Fireball',
     createdBy: 'u1',
     createdByName: 'Ada Lovelace',
@@ -128,6 +128,17 @@ describe('parseTabletopMapMessage', () => {
       parseTabletopMapMessage({ type: 'aoe:removed', mapId: 'm1', aoeId: 'a1' })
     ).not.toBeNull();
     expect(parseTabletopMapMessage({ type: 'aoe:cleared', mapId: 'm1' })).not.toBeNull();
+  });
+
+  it('rejects an aoe:added frame with a degenerate size or non-hex color', () => {
+    // Non-positive radius — a forged frame can't inject a zero/negative shape.
+    expect(
+      parseTabletopMapMessage({ type: 'aoe:added', mapId: 'm1', aoe: { ...fullAoe, sizePx: 0 } })
+    ).toBeNull();
+    // Non-hex color must be rejected (matches the create schema).
+    expect(
+      parseTabletopMapMessage({ type: 'aoe:added', mapId: 'm1', aoe: { ...fullAoe, color: 'red' } })
+    ).toBeNull();
   });
 
   it('accepts a well-formed aoe:moved frame', () => {

--- a/tests/types/schemas/tabletopMessage.test.ts
+++ b/tests/types/schemas/tabletopMessage.test.ts
@@ -66,7 +66,9 @@ describe('parseTabletopMapMessage', () => {
     sizePx: 100,
     rotation: 0,
     color: '#f00',
+    label: 'Fireball',
     createdBy: 'u1',
+    createdByName: 'Ada Lovelace',
     createdAt: '2026-06-15T00:00:00Z',
     updatedAt: '2026-06-15T00:00:00Z',
   };
@@ -102,6 +104,23 @@ describe('parseTabletopMapMessage', () => {
     // useTabletopMapSync's inbound reducer.
     const msg = parseTabletopMapMessage({ type: 'aoe:added', mapId: 'm1', aoe: fullAoe });
     expect(msg).toMatchObject({ type: 'aoe:added', mapId: 'm1', aoe: fullAoe });
+  });
+
+  it('accepts an aoe:added frame missing createdByName (older sender), defaulting to empty string', () => {
+    // Robustness against senders on an older build that predates createdByName.
+    const noCreatedByName: Record<string, unknown> = { ...fullAoe };
+    delete noCreatedByName.createdByName;
+    const msg = parseTabletopMapMessage({ type: 'aoe:added', mapId: 'm1', aoe: noCreatedByName });
+    expect(msg).not.toBeNull();
+    expect((msg as { aoe: { createdByName: string } }).aoe.createdByName).toBe('');
+  });
+
+  it('accepts an aoe:added frame without the optional label', () => {
+    const noLabel: Record<string, unknown> = { ...fullAoe };
+    delete noLabel.label;
+    expect(
+      parseTabletopMapMessage({ type: 'aoe:added', mapId: 'm1', aoe: noLabel })
+    ).not.toBeNull();
   });
 
   it('accepts aoe:removed and aoe:cleared frames', () => {

--- a/tests/types/schemas/tabletopMessage.test.ts
+++ b/tests/types/schemas/tabletopMessage.test.ts
@@ -111,6 +111,46 @@ describe('parseTabletopMapMessage', () => {
     expect(parseTabletopMapMessage({ type: 'aoe:cleared', mapId: 'm1' })).not.toBeNull();
   });
 
+  it('accepts a well-formed aoe:moved frame', () => {
+    const msg = parseTabletopMapMessage({
+      type: 'aoe:moved',
+      mapId: 'm1',
+      aoeId: 'a1',
+      originX: 10,
+      originY: 20,
+      final: true,
+    });
+    expect(msg).toMatchObject({
+      type: 'aoe:moved',
+      mapId: 'm1',
+      aoeId: 'a1',
+      originX: 10,
+      originY: 20,
+      final: true,
+    });
+  });
+
+  it('rejects a malformed aoe:moved frame', () => {
+    // Missing originX.
+    expect(
+      parseTabletopMapMessage({ type: 'aoe:moved', mapId: 'm1', aoeId: 'a1', originY: 20 })
+    ).toBeNull();
+    // Non-finite originX.
+    expect(
+      parseTabletopMapMessage({
+        type: 'aoe:moved',
+        mapId: 'm1',
+        aoeId: 'a1',
+        originX: Infinity,
+        originY: 20,
+      })
+    ).toBeNull();
+    // Missing aoeId.
+    expect(
+      parseTabletopMapMessage({ type: 'aoe:moved', mapId: 'm1', originX: 1, originY: 2 })
+    ).toBeNull();
+  });
+
   it('rejects a malformed aoe:added frame', () => {
     // Missing required fields (shape, sizePx, rotation, etc).
     expect(

--- a/tests/types/schemas/tabletopMessage.test.ts
+++ b/tests/types/schemas/tabletopMessage.test.ts
@@ -56,6 +56,20 @@ describe('parseTabletopMapMessage', () => {
     createdAt: '2026-06-15T00:00:00Z',
     updatedAt: '2026-06-15T00:00:00Z',
   };
+  const fullAoe = {
+    id: 'a1',
+    mapId: 'm1',
+    campaignId: 'c1',
+    shape: 'cone',
+    originX: 5,
+    originY: 5,
+    sizePx: 100,
+    rotation: 0,
+    color: '#f00',
+    createdBy: 'u1',
+    createdAt: '2026-06-15T00:00:00Z',
+    updatedAt: '2026-06-15T00:00:00Z',
+  };
 
   it('accepts entity-bearing frames carrying a fully-shaped payload', () => {
     expect(
@@ -80,6 +94,36 @@ describe('parseTabletopMapMessage', () => {
     expect(
       parseTabletopMapMessage({ type: 'drawing:added', mapId: 'm1', drawing: { id: 'd1' } })
     ).toBeNull();
+  });
+
+  it('accepts a well-formed aoe:added frame (shared, not GM-gated)', () => {
+    // AoE templates are broadcast to all viewers (like map text), unlike
+    // drawings which are dropped for non-GM receivers — see
+    // useTabletopMapSync's inbound reducer.
+    const msg = parseTabletopMapMessage({ type: 'aoe:added', mapId: 'm1', aoe: fullAoe });
+    expect(msg).toMatchObject({ type: 'aoe:added', mapId: 'm1', aoe: fullAoe });
+  });
+
+  it('accepts aoe:removed and aoe:cleared frames', () => {
+    expect(
+      parseTabletopMapMessage({ type: 'aoe:removed', mapId: 'm1', aoeId: 'a1' })
+    ).not.toBeNull();
+    expect(parseTabletopMapMessage({ type: 'aoe:cleared', mapId: 'm1' })).not.toBeNull();
+  });
+
+  it('rejects a malformed aoe:added frame', () => {
+    // Missing required fields (shape, sizePx, rotation, etc).
+    expect(
+      parseTabletopMapMessage({ type: 'aoe:added', mapId: 'm1', aoe: { id: 'a1' } })
+    ).toBeNull();
+    // Invalid shape enum value.
+    const badShape = { ...fullAoe, shape: 'triangle' };
+    expect(parseTabletopMapMessage({ type: 'aoe:added', mapId: 'm1', aoe: badShape })).toBeNull();
+    // Non-finite originX.
+    const badOrigin = { ...fullAoe, originX: Infinity };
+    expect(parseTabletopMapMessage({ type: 'aoe:added', mapId: 'm1', aoe: badOrigin })).toBeNull();
+    // Missing aoeId on aoe:removed.
+    expect(parseTabletopMapMessage({ type: 'aoe:removed', mapId: 'm1' })).toBeNull();
   });
 
   it('accepts map:active-changed with null mapId', () => {


### PR DESCRIPTION
## Summary

Phase 3 of the Spells feature: a **Spell AoE** tabletop tool. Pick a shape (sphere / cone / cube / line / cylinder) and a size in feet, then place a **semi-transparent** area-of-effect template on the active map so the table can see where an effect (e.g. Fireball) lands.

Templates are **shared** — persisted and broadcast in real time to every connected player (the map-**text** model, not the GM-only drawing model), each in the placer's chosen **color**. Any member can place; templates behave like map text: **move/select/delete with the pointer tool** (owner or GM); the GM can also **clear all**. All authorization is server-enforced.

## What's included

- **Data model** — `MapAoE` type/Zod/Mongoose (map-local pixel geometry, per-object `createdBy`); `sizePx`/`widthPx` bounded (`MAX_AOE_PX`), coords `.finite()`.
- **Geometry** — pure `aoeGeometry` (feet→px via the grid scale; each shape → circle/rect/polygon, cone/line rotated to the aim).
- **Server fns** — `createMapAoE` (any member) / `listMapAoE` (all members, capped 2000) / `moveMapAoE` (owner-or-GM) / `removeMapAoE` (owner-or-GM) / `clearMapAoE` (GM-only).
- **Hook + cache** — `useMapAoE` / `useMapAoEMutations` (create/move/remove/clear) + `applyAoe{Add,Move,Remove,Clear}ToCache`.
- **Realtime** — `aoe:added|moved|removed|cleared` on the tabletop-map party; inbound sync applies for **all** viewers (outside the non-GM drop-gate — shared, unlike drawings).
- **Render** — `MapAoELayer` (z-10 SVG below drawings/tokens, `fillOpacity 0.3`) with an in-progress preview.
- **Placement** — `useAoeTool`: radial shapes commit on first click; cone/line set origin then rotate-to-cursor and commit on the second click; Esc cancels.
- **Move/select/delete (like map text)** — under the **pointer tool** (and the AoE tool), drag to relocate a template (optimistic + throttled `aoe:moved`, persisted on release), click to select, Delete/Backspace to remove (owner/GM). Selection auto-clears when leaving the pointer/AoE tools, so a stray Backspace elsewhere can't delete a template.
- **Tool UI** — `AoeSettingsPanel` (5 shapes, size/width ft, ColorPicker, GM-only "Clear all AoE") + a non-GM-gated toolbar entry.
- **Per-viewer visibility** — an always-visible **"Show spell effects"** toggle (Sparkles) in the map control cluster, available to **everyone**; hides/shows AoE for that viewer only (local, not broadcast). The GM's Spell FX layer toggle still works too.

## Testing

- Unit: **1592 pass** (geometry, server-fn auth incl. move, layer render, placement state machine, panel, message parser).
- Typecheck clean; lint 0 errors / 24 baseline warnings (no new).
- e2e: `tabletop-aoe.spec.ts` — place a sphere (renders + persists at correct px), GM layer toggle, per-viewer Show-spell-effects toggle, and **pointer-drag move (persisted)** — **5/5 pass**; tabletop e2e suite 0 failures.

## Reviews

Went through per-task reviews, a whole-branch review, an independent production-readiness review (led to bounding `sizePx`/origin against griefing), and a review of the move/toggle follow-up. Verdict: ship.

## Out of scope (this phase)

Drag-**resize** of templates, grid snapping, auto-fill from a spell's stored `areaOfEffect`, range enforcement, non-square grids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)