### PR TITLE
feat: Organizations (members, locations, GM/tabletop windows)

### DIFF
--- a/app/components/mainview/gmscreens/GMScreensView.tsx
+++ b/app/components/mainview/gmscreens/GMScreensView.tsx
@@ -12,6 +12,10 @@ import type { WindowState } from '~/types/gmscreen';
 import { MARKDOWN_PROSE_CLASSES } from '~/utils/markdownProseClasses';
 import { CharacterWindowWrapper, EditCharacterModalWrapper } from './CharacterWindowWrapper';
 import { LoreWindowWrapper, EditLoreModalWrapper } from './LoreWindowWrapper';
+import {
+  OrganizationWindowWrapper,
+  EditOrganizationModalWrapper,
+} from '~/components/wiki/organizations/OrganizationWindowWrapper';
 import { EventWindowWrapper } from './EventWindowWrapper';
 import { RaceWindowWrapper, EditRaceModalWrapper } from '~/components/wiki/races/RaceWindowWrapper';
 import { RuleWindowWrapper, EditRuleModalWrapper } from './RuleWindowWrapper';
@@ -63,6 +67,7 @@ export function GMScreensView({ campaignId, isGM = true }: GMScreensViewProps) {
   const [editingLocationId, setEditingLocationId] = useState<string | null>(null);
   const [editingMonsterId, setEditingMonsterId] = useState<string | null>(null);
   const [editingLoreId, setEditingLoreId] = useState<string | null>(null);
+  const [editingOrganizationId, setEditingOrganizationId] = useState<string | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
   const [flashWindowId, setFlashWindowId] = useState<string | null>(null);
   const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -472,6 +477,14 @@ export function GMScreensView({ campaignId, isGM = true }: GMScreensViewProps) {
               onEdit={() => setEditingLoreId(w.documentId)}
             />
           );
+        } else if (w.collection === 'organization') {
+          windowContent = (
+            <OrganizationWindowWrapper
+              organizationId={w.documentId}
+              campaignId={campaignId}
+              onEdit={() => setEditingOrganizationId(w.documentId)}
+            />
+          );
         } else if (w.collection === 'events') {
           windowContent = <EventWindowWrapper eventId={w.documentId} campaignId={campaignId} />;
         } else {
@@ -492,7 +505,8 @@ export function GMScreensView({ campaignId, isGM = true }: GMScreensViewProps) {
           w.collection === 'rule' ||
           w.collection === 'character' ||
           w.collection === 'location' ||
-          w.collection === 'lore'
+          w.collection === 'lore' ||
+          w.collection === 'organization'
         ) {
           if (doc?.isPublic === true) {
             titleIcon = (
@@ -782,6 +796,13 @@ export function GMScreensView({ campaignId, isGM = true }: GMScreensViewProps) {
           campaignId={campaignId}
           loreId={editingLoreId}
           onClose={() => setEditingLoreId(null)}
+        />
+      )}
+      {editingOrganizationId !== null && (
+        <EditOrganizationModalWrapper
+          campaignId={campaignId}
+          organizationId={editingOrganizationId}
+          onClose={() => setEditingOrganizationId(null)}
         />
       )}
     </div>

--- a/app/components/mainview/tabletop/TabletopView.tsx
+++ b/app/components/mainview/tabletop/TabletopView.tsx
@@ -29,6 +29,10 @@ import {
   LoreWindowWrapper,
   EditLoreModalWrapper,
 } from '~/components/mainview/gmscreens/LoreWindowWrapper';
+import {
+  OrganizationWindowWrapper,
+  EditOrganizationModalWrapper,
+} from '~/components/wiki/organizations/OrganizationWindowWrapper';
 import { EventWindowWrapper } from '~/components/mainview/gmscreens/EventWindowWrapper';
 import { RaceWindowWrapper, EditRaceModalWrapper } from '~/components/wiki/races/RaceWindowWrapper';
 import {
@@ -130,6 +134,7 @@ export function TabletopView({
   const [editingLocationId, setEditingLocationId] = useState<string | null>(null);
   const [editingMonsterId, setEditingMonsterId] = useState<string | null>(null);
   const [editingLoreId, setEditingLoreId] = useState<string | null>(null);
+  const [editingOrganizationId, setEditingOrganizationId] = useState<string | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
   const [localWindows, setLocalWindows] = useState<ManagedWindow[]>([]);
   const localScreenIdRef = useRef<string | null>(null);
@@ -385,6 +390,14 @@ export function TabletopView({
               onEdit={() => setEditingLoreId(w.documentId)}
             />
           );
+        } else if (w.collection === 'organization') {
+          windowContent = (
+            <OrganizationWindowWrapper
+              organizationId={w.documentId}
+              campaignId={campaignId}
+              onEdit={() => setEditingOrganizationId(w.documentId)}
+            />
+          );
         } else if (w.collection === 'events') {
           windowContent = <EventWindowWrapper eventId={w.documentId} campaignId={campaignId} />;
         } else {
@@ -405,7 +418,8 @@ export function TabletopView({
           w.collection === 'rule' ||
           w.collection === 'character' ||
           w.collection === 'location' ||
-          w.collection === 'lore'
+          w.collection === 'lore' ||
+          w.collection === 'organization'
         ) {
           if (doc?.isPublic === true) {
             titleIcon = (
@@ -718,6 +732,13 @@ export function TabletopView({
           campaignId={campaignId}
           loreId={editingLoreId}
           onClose={() => setEditingLoreId(null)}
+        />
+      )}
+      {editingOrganizationId !== null && (
+        <EditOrganizationModalWrapper
+          campaignId={campaignId}
+          organizationId={editingOrganizationId}
+          onClose={() => setEditingOrganizationId(null)}
         />
       )}
     </div>

--- a/app/components/shared/MemberOrganizationsTab.tsx
+++ b/app/components/shared/MemberOrganizationsTab.tsx
@@ -92,7 +92,11 @@ export function MemberOrganizationsTab({
             <p className="text-xs font-bold text-slate-200 truncate">{m.organizationName}</p>
             {m.title && <p className="text-[11px] text-blue-400 truncate">{m.title}</p>}
           </div>
-          {canManage && (
+          {/* Gate per-row manage buttons on this membership's own canEdit (its
+              org's ownership), not the tab-level canManage — the list spans
+              orgs with different ownership, so a coarse gate would show
+              dead-end buttons on GM-owned orgs the viewer can't manage. */}
+          {m.canEdit && (
             <div className="flex items-center gap-1 shrink-0">
               <button
                 type="button"

--- a/app/components/shared/MemberOrganizationsTab.tsx
+++ b/app/components/shared/MemberOrganizationsTab.tsx
@@ -1,0 +1,286 @@
+import React, { useState, useMemo, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { X, Pencil, Trash2, Plus } from 'lucide-react';
+import {
+  useMembershipsForMember,
+  useOrganizations,
+  useAddMembership,
+  useUpdateMembership,
+  useRemoveMembership,
+} from '~/hooks/useOrganizations';
+import { MarkdownEditor } from '~/components/shared/MarkdownEditor';
+import type { MemberKind, OrganizationMembershipData } from '~/types/organization';
+
+interface Props {
+  campaignId: string;
+  memberKind: MemberKind;
+  memberId: string;
+  isGM: boolean;
+  canManage: boolean;
+}
+
+interface Draft {
+  organizationId: string;
+  title: string;
+  publicNotes: string;
+  privateNotes: string;
+}
+
+export function MemberOrganizationsTab({
+  campaignId,
+  memberKind,
+  memberId,
+  isGM,
+  canManage,
+}: Props) {
+  const { memberships } = useMembershipsForMember(campaignId, memberKind, memberId);
+  const { mutate: add } = useAddMembership();
+  const { mutate: update } = useUpdateMembership();
+  const { mutate: remove } = useRemoveMembership();
+
+  const [modal, setModal] = useState<{
+    mode: 'add' | 'edit';
+    membership?: OrganizationMembershipData;
+  } | null>(null);
+
+  const handleSave = async (draft: Draft) => {
+    if (modal?.mode === 'edit' && modal.membership) {
+      await update({
+        campaignId,
+        id: modal.membership.id,
+        title: draft.title,
+        publicNotes: draft.publicNotes,
+        privateNotes: draft.privateNotes,
+      });
+    } else {
+      await add({
+        campaignId,
+        organizationId: draft.organizationId,
+        memberKind,
+        memberId,
+        title: draft.title,
+        publicNotes: draft.publicNotes,
+        privateNotes: draft.privateNotes,
+      });
+    }
+    setModal(null);
+  };
+
+  return (
+    <div className="flex flex-col gap-2" data-testid="member-organizations-tab">
+      {canManage && (
+        <button
+          type="button"
+          onClick={() => setModal({ mode: 'add' })}
+          className="flex items-center gap-1.5 text-xs text-blue-400 hover:text-blue-300 transition-colors mb-1"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Add to organization
+        </button>
+      )}
+
+      {memberships.length === 0 && (
+        <p className="text-xs text-slate-500">Not a member of any organization.</p>
+      )}
+
+      {memberships.map((m) => (
+        <div
+          key={m.id}
+          className="flex items-center gap-3 rounded-md border border-white/[0.06] bg-white/[0.02] px-3 py-2"
+        >
+          <div className="flex-1 min-w-0">
+            <p className="text-xs font-bold text-slate-200 truncate">{m.organizationName}</p>
+            {m.title && <p className="text-[11px] text-blue-400 truncate">{m.title}</p>}
+          </div>
+          {canManage && (
+            <div className="flex items-center gap-1 shrink-0">
+              <button
+                type="button"
+                onClick={() => setModal({ mode: 'edit', membership: m })}
+                aria-label={`Edit membership in ${m.organizationName}`}
+                className="p-1 rounded text-slate-500 hover:text-slate-300 hover:bg-white/[0.05] transition-colors"
+              >
+                <Pencil className="h-3 w-3" />
+              </button>
+              <button
+                type="button"
+                onClick={() => remove({ id: m.id, campaignId })}
+                aria-label={`Remove membership in ${m.organizationName}`}
+                className="p-1 rounded text-slate-500 hover:text-red-400 hover:bg-white/[0.05] transition-colors"
+              >
+                <Trash2 className="h-3 w-3" />
+              </button>
+            </div>
+          )}
+        </div>
+      ))}
+
+      {modal && (
+        <MemberOrgModal
+          campaignId={campaignId}
+          isGM={isGM}
+          mode={modal.mode}
+          membership={modal.membership}
+          excludeOrgIds={memberships.map((m) => m.organizationId)}
+          onSave={handleSave}
+          onClose={() => setModal(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+function MemberOrgModal({
+  campaignId,
+  isGM,
+  mode,
+  membership,
+  excludeOrgIds,
+  onSave,
+  onClose,
+}: {
+  campaignId: string;
+  isGM: boolean;
+  mode: 'add' | 'edit';
+  membership?: OrganizationMembershipData;
+  excludeOrgIds: string[];
+  onSave: (draft: Draft) => void;
+  onClose: () => void;
+}) {
+  const { organizations } = useOrganizations(campaignId);
+  const [organizationId, setOrganizationId] = useState(membership?.organizationId ?? '');
+  const [title, setTitle] = useState(membership?.title ?? '');
+  const [publicNotes, setPublicNotes] = useState(membership?.publicNotes ?? '');
+  const [privateNotes, setPrivateNotes] = useState(membership?.privateNotes ?? '');
+
+  useEffect(() => {
+    const onEsc = (e: KeyboardEvent) => e.key === 'Escape' && onClose();
+    document.addEventListener('keydown', onEsc);
+    return () => document.removeEventListener('keydown', onEsc);
+  }, [onClose]);
+
+  const available = useMemo(() => {
+    const excl = new Set(excludeOrgIds);
+    return organizations.filter((o) => !excl.has(o.id));
+  }, [organizations, excludeOrgIds]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (mode === 'add' && !organizationId) return;
+    onSave({ organizationId, title: title.trim(), publicNotes, privateNotes });
+  };
+
+  return createPortal(
+    <div
+      role="presentation"
+      className="fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-2 sm:p-4 backdrop-blur-sm"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <form
+        onSubmit={handleSubmit}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="member-org-modal-title"
+        className="w-full max-w-md bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col max-h-[90vh]"
+      >
+        <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
+          <h2
+            id="member-org-modal-title"
+            className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest"
+          >
+            {mode === 'add' ? 'Add to Organization' : 'Edit Membership'}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close modal"
+            className="text-slate-500 hover:text-white transition-colors"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </header>
+        <div className="flex-1 overflow-y-auto p-4 sm:p-6 space-y-5 min-h-0">
+          {mode === 'edit' && membership ? (
+            <div className="px-3 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-xs text-slate-300">
+              {membership.organizationName}
+            </div>
+          ) : (
+            <div>
+              <label
+                htmlFor="member-org-select"
+                className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide"
+              >
+                Organization
+              </label>
+              <select
+                id="member-org-select"
+                value={organizationId}
+                onChange={(e) => setOrganizationId(e.target.value)}
+                disabled={available.length === 0}
+                className="w-full bg-white/[0.04] border border-white/10 rounded-xl px-3 py-2.5 text-slate-200 text-sm appearance-none cursor-pointer disabled:opacity-50"
+              >
+                <option value="" className="bg-[#0D1117]">
+                  {available.length === 0 ? 'No organizations' : 'Select organization…'}
+                </option>
+                {available.map((o) => (
+                  <option key={o.id} value={o.id} className="bg-[#0D1117]">
+                    {o.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+          <div>
+            <label
+              htmlFor="member-org-title"
+              className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide"
+            >
+              Title
+            </label>
+            <input
+              id="member-org-title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="e.g. Guildmaster (optional)"
+              className="w-full px-3 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-xs text-slate-200 placeholder:text-slate-600 focus:border-blue-500/50 focus:outline-none transition-colors"
+            />
+          </div>
+          <MarkdownEditor
+            label="Public relationship notes"
+            value={publicNotes}
+            onChange={setPublicNotes}
+            placeholder="Public notes about this membership..."
+            minHeight="120px"
+          />
+          {isGM && (
+            <MarkdownEditor
+              label="Private relationship notes (GM only)"
+              value={privateNotes}
+              onChange={setPrivateNotes}
+              placeholder="GM-only notes..."
+              minHeight="120px"
+            />
+          )}
+        </div>
+        <footer className="flex items-center justify-end gap-3 px-4 sm:px-6 py-4 border-t border-white/[0.07] bg-white/[0.01] shrink-0">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 rounded-lg text-xs font-semibold text-slate-400 bg-white/[0.04] border border-white/[0.06] hover:bg-white/[0.07] transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={mode === 'add' && !organizationId}
+            className="px-4 py-2 rounded-lg text-xs font-semibold text-white bg-blue-600 hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            {mode === 'add' ? 'Add' : 'Save Changes'}
+          </button>
+        </footer>
+      </form>
+    </div>,
+    document.body
+  );
+}

--- a/app/components/wiki/WikiPanel.tsx
+++ b/app/components/wiki/WikiPanel.tsx
@@ -12,6 +12,7 @@ import {
   CalendarDays,
   CalendarClock,
   Sparkles,
+  Building2,
 } from 'lucide-react';
 import { CharactersPanel } from './characters/CharactersPanel';
 import { RacesPanel } from './races/RacesPanel';
@@ -22,6 +23,7 @@ import { LocationsPanel } from './locations/LocationsPanel';
 import { MapsPanel } from './maps/MapsPanel';
 import { MonstersPanel } from './monsters/MonstersPanel';
 import { LorePanel } from './lore/LorePanel';
+import { OrganizationsPanel } from './organizations/OrganizationsPanel';
 import { CalendarPanel } from './calendar/CalendarPanel';
 import { EventsPanel } from './calendar/EventsPanel';
 import { useCampaign } from '~/hooks/useCampaigns';
@@ -34,6 +36,7 @@ type WikiCategoryId =
   | 'spells'
   | 'locations'
   | 'lore'
+  | 'organizations'
   | 'maps'
   | 'monsters'
   | 'calendar'
@@ -55,6 +58,7 @@ const WIKI_CATEGORIES: WikiCategory[] = [
   { id: 'spells', label: 'Spells', icon: Sparkles },
   { id: 'locations', label: 'Locations', icon: MapPin },
   { id: 'lore', label: 'Lore', icon: BookOpen },
+  { id: 'organizations', label: 'Organizations', icon: Building2 },
   { id: 'maps', label: 'Maps', icon: MapIcon, gmOnly: true },
   { id: 'monsters', label: 'Monsters', icon: Skull, gmOnly: true },
   { id: 'calendar', label: 'Calendar', icon: CalendarDays },
@@ -107,6 +111,8 @@ export function WikiPanel() {
         <LocationsPanel onBack={() => setSelectedCategory(null)} />
       ) : selectedCategory === 'lore' ? (
         <LorePanel onBack={() => setSelectedCategory(null)} />
+      ) : selectedCategory === 'organizations' ? (
+        <OrganizationsPanel onBack={() => setSelectedCategory(null)} />
       ) : selectedCategory === 'maps' && isGM ? (
         <MapsPanel onBack={() => setSelectedCategory(null)} />
       ) : selectedCategory === 'monsters' && isGM ? (

--- a/app/components/wiki/characters/CharacterModal.tsx
+++ b/app/components/wiki/characters/CharacterModal.tsx
@@ -6,6 +6,8 @@ import { FormSelect } from '~/components/FormSelect';
 import { PixelButton } from '~/components/PixelButton';
 import { MarkdownEditor } from '~/components/shared/MarkdownEditor';
 import { TagAutocompleteInput } from '~/components/shared/TagAutocompleteInput';
+import { TabBar } from '~/components/shared/TabBar';
+import { MemberOrganizationsTab } from '~/components/shared/MemberOrganizationsTab';
 import { ImageCropInput } from './ImageCropInput';
 import { SessionMultiSelect } from './SessionMultiSelect';
 import {
@@ -75,6 +77,7 @@ export function CharacterModal({
   const [isPublic, setIsPublic] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [activeTab, setActiveTab] = useState<'details' | 'organizations'>('details');
 
   const validate = useCallback((): FieldErrors => {
     const errors: FieldErrors = {};
@@ -110,6 +113,7 @@ export function CharacterModal({
       setIsPublic(false);
       setError(null);
       setShowDeleteConfirm(false);
+      setActiveTab('details');
     },
     populate: (c) => {
       setFirstName(c.firstName);
@@ -266,6 +270,15 @@ export function CharacterModal({
           </div>
         </header>
 
+        <TabBar
+          tabs={[
+            { id: 'details', label: 'Details' },
+            { id: 'organizations', label: 'Organizations' },
+          ]}
+          activeTab={activeTab}
+          onTabChange={(t) => setActiveTab(t as 'details' | 'organizations')}
+        />
+
         <div className="flex-1 overflow-y-auto p-4 sm:p-6 space-y-5 min-h-0">
           {error && (
             <div className="p-3 bg-rose-500/10 border border-rose-500/20 rounded-lg text-rose-400 text-xs font-semibold">
@@ -277,6 +290,20 @@ export function CharacterModal({
             <div className="flex items-center justify-center py-12">
               <p className="text-xs text-slate-500 animate-pulse">Loading character...</p>
             </div>
+          ) : activeTab === 'organizations' ? (
+            isEdit && characterId ? (
+              <MemberOrganizationsTab
+                campaignId={campaignId}
+                memberKind="character"
+                memberId={characterId}
+                isGM={isGM}
+                canManage={isGM || existingCharacter?.canEdit || false}
+              />
+            ) : (
+              <p className="text-xs text-slate-500">
+                Save the character first to manage its organizations.
+              </p>
+            )
           ) : (
             <>
               {/* Picture upload */}

--- a/app/components/wiki/characters/CharacterWindow.tsx
+++ b/app/components/wiki/characters/CharacterWindow.tsx
@@ -12,6 +12,7 @@ import {
   useUpdateCharacterRelationship,
   useRemoveCharacterRelationship,
 } from '~/hooks/useCharacters';
+import { MemberOrganizationsTab } from '~/components/shared/MemberOrganizationsTab';
 
 function getCropStyle(crop: PictureCrop): React.CSSProperties {
   const centerX = (crop.x + crop.width / 2) * 100;
@@ -91,6 +92,7 @@ export function CharacterWindow({ character, onEdit }: CharacterWindowProps) {
     { id: 'general', label: 'General' },
     { id: 'gmnotes', label: 'GM Notes', hidden: !character.canEdit },
     { id: 'relationships', label: 'Relationships' },
+    { id: 'organizations', label: 'Organizations' },
   ];
 
   return (
@@ -263,6 +265,16 @@ export function CharacterWindow({ character, onEdit }: CharacterWindowProps) {
               />
             )}
           </>
+        )}
+
+        {activeTab === 'organizations' && (
+          <MemberOrganizationsTab
+            campaignId={character.campaignId}
+            memberKind="character"
+            memberId={character.id}
+            isGM={character.canEdit}
+            canManage={character.canEdit}
+          />
         )}
       </div>
     </div>

--- a/app/components/wiki/characters/CharacterWindow.tsx
+++ b/app/components/wiki/characters/CharacterWindow.tsx
@@ -13,6 +13,7 @@ import {
   useRemoveCharacterRelationship,
 } from '~/hooks/useCharacters';
 import { MemberOrganizationsTab } from '~/components/shared/MemberOrganizationsTab';
+import { useCampaign } from '~/hooks/useCampaigns';
 
 function getCropStyle(crop: PictureCrop): React.CSSProperties {
   const centerX = (crop.x + crop.width / 2) * 100;
@@ -73,6 +74,8 @@ export function CharacterWindow({ character, onEdit }: CharacterWindowProps) {
   const { addRelationship } = useAddCharacterRelationship();
   const { updateRelationship } = useUpdateCharacterRelationship();
   const { removeRelationship } = useRemoveCharacterRelationship();
+  const { campaign } = useCampaign(character.campaignId);
+  const isGM = campaign?.isGM ?? false;
 
   const fullName = `${character.firstName} ${character.lastName}`.trim();
   const initials = getInitials(character.firstName, character.lastName);
@@ -272,7 +275,7 @@ export function CharacterWindow({ character, onEdit }: CharacterWindowProps) {
             campaignId={character.campaignId}
             memberKind="character"
             memberId={character.id}
-            isGM={character.canEdit}
+            isGM={isGM}
             canManage={character.canEdit}
           />
         )}

--- a/app/components/wiki/organizations/OrganizationCard.tsx
+++ b/app/components/wiki/organizations/OrganizationCard.tsx
@@ -1,0 +1,59 @@
+import type { OrganizationListItem } from '~/types/organization';
+
+interface OrganizationCardProps {
+  organization: OrganizationListItem;
+  onClick: (organization: OrganizationListItem) => void;
+}
+
+export function OrganizationCard({ organization, onClick }: OrganizationCardProps) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      draggable="true"
+      onDragStart={(e) => {
+        e.dataTransfer.setData(
+          'application/x-cartyx-document',
+          JSON.stringify({
+            collection: 'organization',
+            documentId: organization.id,
+            title: organization.name,
+          })
+        );
+        e.dataTransfer.effectAllowed = 'copy';
+        e.currentTarget.style.opacity = '0.4';
+      }}
+      onDragEnd={(e) => {
+        e.currentTarget.style.opacity = '';
+      }}
+      onClick={() => onClick(organization)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick(organization);
+        }
+      }}
+      className="flex items-start gap-3 px-4 py-3 border-b border-white/[0.05] hover:bg-white/[0.03] transition-colors group cursor-grab active:cursor-grabbing"
+    >
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-0.5">
+          <span className="text-sm font-semibold text-slate-200 group-hover:text-blue-400 transition-colors truncate">
+            {organization.name}
+          </span>
+        </div>
+        {organization.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1 mt-1">
+            {organization.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[9px] tracking-tight"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/wiki/organizations/OrganizationLocationsEditor.tsx
+++ b/app/components/wiki/organizations/OrganizationLocationsEditor.tsx
@@ -1,0 +1,136 @@
+import { useState, useMemo, useId } from 'react';
+import { X, MapPin } from 'lucide-react';
+import { useLocations } from '~/hooks/useLocations';
+import { MarkdownEditor } from '~/components/shared/MarkdownEditor';
+import type { OrganizationLocationLinkInput } from '~/types/organization';
+
+interface Props {
+  campaignId: string;
+  value: OrganizationLocationLinkInput[];
+  onChange: (links: OrganizationLocationLinkInput[]) => void;
+  isGM: boolean;
+  disabled?: boolean;
+}
+
+export function OrganizationLocationsEditor({
+  campaignId,
+  value,
+  onChange,
+  isGM,
+  disabled,
+}: Props) {
+  const uid = useId();
+  const { locations } = useLocations(campaignId);
+  const [selectedId, setSelectedId] = useState('');
+
+  const locationMap = useMemo(() => new Map(locations.map((l) => [l.id, l.name])), [locations]);
+  const available = useMemo(
+    () => locations.filter((l) => !value.some((v) => v.locationId === l.id)),
+    [locations, value]
+  );
+
+  const addLink = () => {
+    if (!selectedId) return;
+    if (value.some((v) => v.locationId === selectedId)) return;
+    onChange([
+      ...value,
+      {
+        locationId: selectedId,
+        label: locationMap.get(selectedId) ?? '',
+        publicInfo: '',
+        privateInfo: '',
+      },
+    ]);
+    setSelectedId('');
+  };
+
+  const updateLink = (locationId: string, patch: Partial<OrganizationLocationLinkInput>) => {
+    onChange(value.map((v) => (v.locationId === locationId ? { ...v, ...patch } : v)));
+  };
+
+  const removeLink = (locationId: string) => {
+    onChange(value.filter((v) => v.locationId !== locationId));
+  };
+
+  return (
+    <div className="space-y-3" data-testid="organization-locations-editor">
+      <span className="block text-xs font-semibold text-slate-400 tracking-wide">Locations</span>
+
+      {value.map((link) => (
+        <div
+          key={link.locationId}
+          className="rounded-lg border border-white/[0.08] bg-white/[0.02] p-3 space-y-3"
+        >
+          <div className="flex items-center justify-between">
+            <span className="flex items-center gap-1.5 text-xs font-bold text-slate-200">
+              <MapPin className="h-3.5 w-3.5 text-amber-400" />
+              {link.label || locationMap.get(link.locationId) || 'Location'}
+            </span>
+            {!disabled && (
+              <button
+                type="button"
+                aria-label={`Remove ${link.label || 'location'}`}
+                onClick={() => removeLink(link.locationId)}
+                className="text-slate-500 hover:text-white transition-colors rounded-full p-0.5"
+              >
+                <X size={13} strokeWidth={2.5} />
+              </button>
+            )}
+          </div>
+          <MarkdownEditor
+            label="Public info"
+            value={link.publicInfo}
+            onChange={(v) => updateLink(link.locationId, { publicInfo: v })}
+            placeholder="Public info about this location relationship..."
+            disabled={disabled}
+            minHeight="120px"
+          />
+          {isGM && (
+            <MarkdownEditor
+              label="Private info (GM only)"
+              value={link.privateInfo}
+              onChange={(v) => updateLink(link.locationId, { privateInfo: v })}
+              placeholder="GM-only notes..."
+              disabled={disabled}
+              minHeight="120px"
+            />
+          )}
+        </div>
+      ))}
+
+      {!disabled && (
+        <div className="flex items-end gap-2">
+          <div className="flex-1 min-w-0">
+            <label htmlFor={`org-loc-${uid}`} className="block text-[11px] text-slate-500 mb-1">
+              Add location
+            </label>
+            <select
+              id={`org-loc-${uid}`}
+              value={selectedId}
+              onChange={(e) => setSelectedId(e.target.value)}
+              disabled={available.length === 0}
+              className="w-full bg-white/[0.04] border border-white/10 rounded-xl px-3 py-2.5 text-slate-200 text-sm focus:outline-none focus:border-blue-500/50 transition-all appearance-none cursor-pointer disabled:opacity-50"
+            >
+              <option value="" className="bg-[#0D1117]">
+                {available.length === 0 ? 'No locations' : 'Select location…'}
+              </option>
+              {available.map((l) => (
+                <option key={l.id} value={l.id} className="bg-[#0D1117]">
+                  {l.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <button
+            type="button"
+            onClick={addLink}
+            disabled={!selectedId}
+            className="flex-shrink-0 px-3 py-2.5 rounded-xl text-sm font-semibold bg-blue-600 hover:bg-blue-500 disabled:bg-white/[0.06] disabled:text-slate-500 disabled:cursor-not-allowed text-white transition-colors"
+          >
+            Add
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/wiki/organizations/OrganizationMembersEditor.tsx
+++ b/app/components/wiki/organizations/OrganizationMembersEditor.tsx
@@ -1,0 +1,131 @@
+import { useState } from 'react';
+import { Pencil, Trash2, Plus } from 'lucide-react';
+import {
+  useMembershipsForOrg,
+  useAddMembership,
+  useUpdateMembership,
+  useRemoveMembership,
+} from '~/hooks/useOrganizations';
+import { OrganizationMembershipModal, type MembershipDraft } from './OrganizationMembershipModal';
+
+interface Props {
+  campaignId: string;
+  organizationId: string;
+  isGM: boolean;
+  canManage: boolean;
+}
+
+export function OrganizationMembersEditor({ campaignId, organizationId, isGM, canManage }: Props) {
+  const { memberships } = useMembershipsForOrg(campaignId, organizationId);
+  const { mutate: add } = useAddMembership();
+  const { mutate: update } = useUpdateMembership();
+  const { mutate: remove } = useRemoveMembership();
+
+  const [modal, setModal] = useState<{ mode: 'add' | 'edit'; id?: string } | null>(null);
+
+  const editing = modal?.mode === 'edit' ? memberships.find((m) => m.id === modal.id) : undefined;
+  const excludeKeys = memberships.map((m) => `${m.memberKind}:${m.memberId}`);
+
+  const handleSave = async (draft: MembershipDraft) => {
+    if (modal?.mode === 'edit' && modal.id) {
+      await update({
+        campaignId,
+        id: modal.id,
+        title: draft.title,
+        publicNotes: draft.publicNotes,
+        privateNotes: draft.privateNotes,
+      });
+    } else {
+      await add({
+        campaignId,
+        organizationId,
+        memberKind: draft.memberKind,
+        memberId: draft.memberId,
+        title: draft.title,
+        publicNotes: draft.publicNotes,
+        privateNotes: draft.privateNotes,
+      });
+    }
+    setModal(null);
+  };
+
+  return (
+    <div className="space-y-2" data-testid="organization-members-editor">
+      <div className="flex items-center justify-between">
+        <span className="block text-xs font-semibold text-slate-400 tracking-wide">Members</span>
+        {canManage && (
+          <button
+            type="button"
+            onClick={() => setModal({ mode: 'add' })}
+            className="flex items-center gap-1.5 text-xs text-blue-400 hover:text-blue-300 transition-colors"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Add member
+          </button>
+        )}
+      </div>
+
+      {memberships.length === 0 && <p className="text-xs text-slate-500">No members yet.</p>}
+
+      {memberships.map((m) => (
+        <div
+          key={m.id}
+          className="flex items-center gap-3 rounded-md border border-white/[0.06] bg-white/[0.02] px-3 py-2"
+        >
+          <div className="flex-1 min-w-0">
+            <p className="text-xs font-bold text-slate-200 truncate">
+              {m.memberLabel || 'Unknown'}
+            </p>
+            {m.title && <p className="text-[11px] text-blue-400 truncate">{m.title}</p>}
+          </div>
+          <span className="shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-semibold bg-white/[0.05] text-slate-400 border border-white/10 capitalize">
+            {m.memberKind}
+          </span>
+          {canManage && (
+            <div className="flex items-center gap-1 shrink-0">
+              <button
+                type="button"
+                onClick={() => setModal({ mode: 'edit', id: m.id })}
+                aria-label={`Edit ${m.memberLabel}`}
+                className="p-1 rounded text-slate-500 hover:text-slate-300 hover:bg-white/[0.05] transition-colors"
+              >
+                <Pencil className="h-3 w-3" />
+              </button>
+              <button
+                type="button"
+                onClick={() => remove({ id: m.id, campaignId })}
+                aria-label={`Remove ${m.memberLabel}`}
+                className="p-1 rounded text-slate-500 hover:text-red-400 hover:bg-white/[0.05] transition-colors"
+              >
+                <Trash2 className="h-3 w-3" />
+              </button>
+            </div>
+          )}
+        </div>
+      ))}
+
+      {modal && (
+        <OrganizationMembershipModal
+          campaignId={campaignId}
+          isGM={isGM}
+          mode={modal.mode}
+          existing={
+            editing
+              ? {
+                  memberKind: editing.memberKind,
+                  memberId: editing.memberId,
+                  memberLabel: editing.memberLabel,
+                  title: editing.title,
+                  publicNotes: editing.publicNotes,
+                  privateNotes: editing.privateNotes,
+                }
+              : undefined
+          }
+          excludeKeys={modal.mode === 'add' ? excludeKeys : []}
+          onSave={handleSave}
+          onClose={() => setModal(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/components/wiki/organizations/OrganizationMembershipModal.tsx
+++ b/app/components/wiki/organizations/OrganizationMembershipModal.tsx
@@ -1,0 +1,209 @@
+import React, { useState, useMemo, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { X } from 'lucide-react';
+import { useCharacters } from '~/hooks/useCharacters';
+import { usePlayers } from '~/hooks/usePlayers';
+import { MarkdownEditor } from '~/components/shared/MarkdownEditor';
+import type { MemberKind } from '~/types/organization';
+
+export interface MembershipDraft {
+  memberKind: MemberKind;
+  memberId: string;
+  title: string;
+  publicNotes: string;
+  privateNotes: string;
+}
+
+interface Props {
+  campaignId: string;
+  isGM: boolean;
+  mode: 'add' | 'edit';
+  /** Present in edit mode; the member cannot be changed when editing. */
+  existing?: MembershipDraft & { memberLabel: string };
+  /** memberKind+memberId already taken, excluded from the add picker. */
+  excludeKeys?: string[];
+  onSave: (draft: MembershipDraft) => void;
+  onClose: () => void;
+}
+
+export function OrganizationMembershipModal({
+  campaignId,
+  isGM,
+  mode,
+  existing,
+  excludeKeys = [],
+  onSave,
+  onClose,
+}: Props) {
+  const { characters } = useCharacters(campaignId);
+  const { players } = usePlayers(campaignId);
+
+  const [memberKind, setMemberKind] = useState<MemberKind>(existing?.memberKind ?? 'character');
+  const [memberId, setMemberId] = useState(existing?.memberId ?? '');
+  const [title, setTitle] = useState(existing?.title ?? '');
+  const [publicNotes, setPublicNotes] = useState(existing?.publicNotes ?? '');
+  const [privateNotes, setPrivateNotes] = useState(existing?.privateNotes ?? '');
+
+  useEffect(() => {
+    const onEsc = (e: KeyboardEvent) => e.key === 'Escape' && onClose();
+    document.addEventListener('keydown', onEsc);
+    return () => document.removeEventListener('keydown', onEsc);
+  }, [onClose]);
+
+  const candidates = useMemo(() => {
+    const excl = new Set(excludeKeys);
+    const list =
+      memberKind === 'character'
+        ? characters.map((c) => ({ id: c.id, label: `${c.firstName} ${c.lastName}`.trim() }))
+        : players.map((p) => ({ id: p.id, label: `${p.firstName} ${p.lastName}`.trim() }));
+    return list.filter((x) => !excl.has(`${memberKind}:${x.id}`));
+  }, [memberKind, characters, players, excludeKeys]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!memberId) return;
+    onSave({ memberKind, memberId, title: title.trim(), publicNotes, privateNotes });
+  };
+
+  return createPortal(
+    <div
+      role="presentation"
+      className="fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-2 sm:p-4 backdrop-blur-sm"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <form
+        onSubmit={handleSubmit}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="org-membership-modal-title"
+        className="w-full max-w-md bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col max-h-[90vh]"
+      >
+        <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
+          <h2
+            id="org-membership-modal-title"
+            className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest"
+          >
+            {mode === 'add' ? 'Add Member' : 'Edit Member'}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close modal"
+            className="text-slate-500 hover:text-white transition-colors"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto p-4 sm:p-6 space-y-5 min-h-0">
+          {mode === 'edit' && existing ? (
+            <div className="px-3 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-xs text-slate-300">
+              {existing.memberLabel}
+            </div>
+          ) : (
+            <div className="flex items-end gap-2">
+              <div className="flex-shrink-0">
+                <label htmlFor="org-member-kind" className="block text-[11px] text-slate-500 mb-1">
+                  Type
+                </label>
+                <select
+                  id="org-member-kind"
+                  value={memberKind}
+                  onChange={(e) => {
+                    setMemberKind(e.target.value as MemberKind);
+                    setMemberId('');
+                  }}
+                  className="bg-white/[0.04] border border-white/10 rounded-xl px-3 py-2.5 text-slate-200 text-sm appearance-none cursor-pointer"
+                >
+                  <option value="character" className="bg-[#0D1117]">
+                    Character
+                  </option>
+                  <option value="player" className="bg-[#0D1117]">
+                    Player
+                  </option>
+                </select>
+              </div>
+              <div className="flex-1 min-w-0">
+                <label
+                  htmlFor="org-member-entity"
+                  className="block text-[11px] text-slate-500 mb-1"
+                >
+                  Member
+                </label>
+                <select
+                  id="org-member-entity"
+                  aria-label="Member to add"
+                  value={memberId}
+                  onChange={(e) => setMemberId(e.target.value)}
+                  disabled={candidates.length === 0}
+                  className="w-full bg-white/[0.04] border border-white/10 rounded-xl px-3 py-2.5 text-slate-200 text-sm appearance-none cursor-pointer disabled:opacity-50"
+                >
+                  <option value="" className="bg-[#0D1117]">
+                    {candidates.length === 0 ? `No ${memberKind}s` : `Select ${memberKind}…`}
+                  </option>
+                  {candidates.map((c) => (
+                    <option key={c.id} value={c.id} className="bg-[#0D1117]">
+                      {c.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          )}
+
+          <div>
+            <label
+              htmlFor="org-member-title"
+              className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide"
+            >
+              Title
+            </label>
+            <input
+              id="org-member-title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="e.g. Guildmaster, Informant (optional)"
+              className="w-full px-3 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-xs text-slate-200 placeholder:text-slate-600 focus:border-blue-500/50 focus:outline-none transition-colors"
+            />
+          </div>
+
+          <MarkdownEditor
+            label="Public relationship notes"
+            value={publicNotes}
+            onChange={setPublicNotes}
+            placeholder="Public notes about this member's relationship to the org..."
+            minHeight="120px"
+          />
+          {isGM && (
+            <MarkdownEditor
+              label="Private relationship notes (GM only)"
+              value={privateNotes}
+              onChange={setPrivateNotes}
+              placeholder="GM-only notes..."
+              minHeight="120px"
+            />
+          )}
+        </div>
+
+        <footer className="flex items-center justify-end gap-3 px-4 sm:px-6 py-4 border-t border-white/[0.07] bg-white/[0.01] shrink-0">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 rounded-lg text-xs font-semibold text-slate-400 bg-white/[0.04] border border-white/[0.06] hover:bg-white/[0.07] transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={!memberId}
+            className="px-4 py-2 rounded-lg text-xs font-semibold text-white bg-blue-600 hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            {mode === 'add' ? 'Add Member' : 'Save Changes'}
+          </button>
+        </footer>
+      </form>
+    </div>,
+    document.body
+  );
+}

--- a/app/components/wiki/organizations/OrganizationModal.tsx
+++ b/app/components/wiki/organizations/OrganizationModal.tsx
@@ -206,24 +206,42 @@ export function OrganizationModal({
 
               {/* Visibility toggle */}
               <div className="flex items-center gap-4">
-                <button
-                  type="button"
-                  onClick={() => setIsPublic(false)}
-                  disabled={isDisabled}
-                  className={`h-8 px-3 rounded-lg border flex items-center gap-2 transition-all text-xs ${!isPublic ? 'bg-blue-600/10 border-blue-500/50 text-blue-300' : 'bg-white/[0.03] border-white/[0.07] text-slate-500 hover:border-white/20'}`}
+                <label
+                  className={`flex items-center gap-2 ${isDisabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}
                 >
-                  <Lock className="h-3 w-3" />
-                  <span className="font-bold">Private (GM only)</span>
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setIsPublic(true)}
-                  disabled={isDisabled}
-                  className={`h-8 px-3 rounded-lg border flex items-center gap-2 transition-all text-xs ${isPublic ? 'bg-emerald-600/10 border-emerald-500/50 text-emerald-300' : 'bg-white/[0.03] border-white/[0.07] text-slate-500 hover:border-white/20'}`}
+                  <input
+                    type="radio"
+                    name="org-visibility"
+                    checked={!isPublic}
+                    onChange={() => setIsPublic(false)}
+                    disabled={isDisabled}
+                    className="sr-only"
+                  />
+                  <div
+                    className={`h-8 px-3 rounded-lg border flex items-center gap-2 transition-all text-xs ${!isPublic ? 'bg-blue-600/10 border-blue-500/50 text-blue-300' : 'bg-white/[0.03] border-white/[0.07] text-slate-500 hover:border-white/20'}`}
+                  >
+                    <Lock className="h-3 w-3" />
+                    <span className="font-bold">Private (GM only)</span>
+                  </div>
+                </label>
+                <label
+                  className={`flex items-center gap-2 ${isDisabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}
                 >
-                  <Globe className="h-3 w-3" />
-                  <span className="font-bold">Public</span>
-                </button>
+                  <input
+                    type="radio"
+                    name="org-visibility"
+                    checked={isPublic}
+                    onChange={() => setIsPublic(true)}
+                    disabled={isDisabled}
+                    className="sr-only"
+                  />
+                  <div
+                    className={`h-8 px-3 rounded-lg border flex items-center gap-2 transition-all text-xs ${isPublic ? 'bg-emerald-600/10 border-emerald-500/50 text-emerald-300' : 'bg-white/[0.03] border-white/[0.07] text-slate-500 hover:border-white/20'}`}
+                  >
+                    <Globe className="h-3 w-3" />
+                    <span className="font-bold">Public</span>
+                  </div>
+                </label>
               </div>
 
               <MarkdownEditor

--- a/app/components/wiki/organizations/OrganizationModal.tsx
+++ b/app/components/wiki/organizations/OrganizationModal.tsx
@@ -16,7 +16,9 @@ import {
 } from '~/hooks/useOrganizations';
 import { OrganizationLocationsEditor } from './OrganizationLocationsEditor';
 import { OrganizationMembersEditor } from './OrganizationMembersEditor';
-import type { OrganizationLocationLinkInput } from '~/types/organization';
+import { uploadToR2 } from '~/utils/uploadToR2';
+import { compressImage } from '~/utils/compressImage';
+import type { OrganizationLocationLinkInput, OrganizationImage } from '~/types/organization';
 
 interface OrganizationModalProps {
   isOpen: boolean;
@@ -51,10 +53,12 @@ export function OrganizationModal({
   const [publicInfo, setPublicInfo] = useState('');
   const [privateInfo, setPrivateInfo] = useState('');
   const [isPublic, setIsPublic] = useState(false);
+  const [images, setImages] = useState<OrganizationImage[]>([]);
   const [tags, setTags] = useState<string[]>([]);
   const [locations, setLocations] = useState<OrganizationLocationLinkInput[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [isUploadingImage, setIsUploadingImage] = useState(false);
 
   const validate = useCallback((): FieldErrors => {
     const errors: FieldErrors = {};
@@ -73,6 +77,7 @@ export function OrganizationModal({
       setPublicInfo('');
       setPrivateInfo('');
       setIsPublic(false);
+      setImages([]);
       setTags([]);
       setLocations([]);
       setError(null);
@@ -83,6 +88,7 @@ export function OrganizationModal({
       setPublicInfo(org.publicInfo);
       setPrivateInfo(org.privateInfo);
       setIsPublic(org.isPublic);
+      setImages(org.images);
       setTags(org.tags);
       setLocations(
         org.locations.map((l) => ({
@@ -96,6 +102,36 @@ export function OrganizationModal({
     validate,
   });
 
+  const handleAddImage = useCallback(async (file: File) => {
+    setIsUploadingImage(true);
+    setError(null);
+    try {
+      const compressed = await compressImage(file);
+      const { publicUrl } = await uploadToR2(compressed, 'uploads/organizations');
+      const newImage: OrganizationImage = { url: publicUrl, caption: '', crop: null };
+      setImages((prev) => [...prev, newImage]);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Image upload failed');
+    } finally {
+      setIsUploadingImage(false);
+    }
+  }, []);
+
+  const handleRemoveImage = useCallback((index: number) => {
+    setImages((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const handleImageFileChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      await handleAddImage(file);
+      // Reset input so same file can be re-selected
+      e.target.value = '';
+    },
+    [handleAddImage]
+  );
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (Object.keys(runValidation()).length > 0) return;
@@ -107,6 +143,11 @@ export function OrganizationModal({
       publicInfo,
       privateInfo,
       isPublic,
+      images: images.map((img) => ({
+        url: img.url,
+        caption: img.caption,
+        crop: img.crop,
+      })),
       tags,
       locations: locations.map((l) => ({
         locationId: l.locationId,
@@ -139,7 +180,7 @@ export function OrganizationModal({
 
   const isLoadingOrg = !!(isEdit && isFetching);
   const isSaving = isCreating || isUpdating;
-  const isDisabled = isLoadingOrg || isSaving || isDeleting;
+  const isDisabled = isLoadingOrg || isSaving || isDeleting || isUploadingImage;
 
   return createPortal(
     <div
@@ -263,6 +304,49 @@ export function OrganizationModal({
                   minHeight="200px"
                 />
               )}
+
+              {/* Images */}
+              <div>
+                <span className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide">
+                  Images
+                </span>
+                {images.length > 0 && (
+                  <div className="flex flex-wrap gap-3 mb-3">
+                    {images.map((img, idx) => (
+                      <div key={idx} className="relative group">
+                        <img
+                          src={img.url}
+                          alt={img.caption || `Organization image ${idx + 1}`}
+                          className="w-20 h-20 object-cover rounded-lg border border-white/10"
+                        />
+                        {!isDisabled && (
+                          <button
+                            type="button"
+                            onClick={() => handleRemoveImage(idx)}
+                            className="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-rose-600 flex items-center justify-center hover:bg-rose-500 transition-colors"
+                            aria-label={`Remove image ${idx + 1}`}
+                          >
+                            <X className="h-3 w-3 text-white" />
+                          </button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <label
+                  className={`inline-flex items-center gap-2 px-3 py-2 rounded-xl text-xs font-semibold border transition-colors cursor-pointer ${isDisabled || isUploadingImage ? 'opacity-50 cursor-not-allowed border-white/10 text-slate-500' : 'border-white/10 text-slate-300 hover:border-blue-500/50 hover:text-blue-300'}`}
+                >
+                  <input
+                    type="file"
+                    accept=".jpg,.jpeg,.png,.webp"
+                    onChange={handleImageFileChange}
+                    disabled={isDisabled || isUploadingImage}
+                    className="hidden"
+                  />
+                  {isUploadingImage ? 'Uploading...' : 'Add image'}
+                </label>
+                <p className="text-xs text-slate-700 mt-1.5">JPG, PNG, or WebP. Max 5MB.</p>
+              </div>
 
               <TagAutocompleteInput
                 campaignId={campaignId}

--- a/app/components/wiki/organizations/OrganizationModal.tsx
+++ b/app/components/wiki/organizations/OrganizationModal.tsx
@@ -1,0 +1,333 @@
+import React, { useState, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { X, Globe, Lock } from 'lucide-react';
+import { FormInput } from '~/components/FormInput';
+import { PixelButton } from '~/components/PixelButton';
+import { MarkdownEditor } from '~/components/shared/MarkdownEditor';
+import { TagAutocompleteInput } from '~/components/shared/TagAutocompleteInput';
+import { ShowOnTabletopButton } from '~/components/wiki/shared/ShowOnTabletopButton';
+import { useModalForm } from '~/hooks/useModalForm';
+import { useCampaign } from '~/hooks/useCampaigns';
+import {
+  useOrganization,
+  useCreateOrganization,
+  useUpdateOrganization,
+  useDeleteOrganization,
+} from '~/hooks/useOrganizations';
+import { OrganizationLocationsEditor } from './OrganizationLocationsEditor';
+import { OrganizationMembersEditor } from './OrganizationMembersEditor';
+import type { OrganizationLocationLinkInput } from '~/types/organization';
+
+interface OrganizationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  campaignId: string;
+  organizationId?: string;
+}
+
+interface FieldErrors {
+  name?: string;
+}
+
+export function OrganizationModal({
+  isOpen,
+  onClose,
+  campaignId,
+  organizationId,
+}: OrganizationModalProps) {
+  const isEdit = !!organizationId;
+
+  const { organization: existing, isLoading: isFetching } = useOrganization(
+    organizationId ?? '',
+    campaignId
+  );
+  const { create, isLoading: isCreating } = useCreateOrganization();
+  const { update, isLoading: isUpdating } = useUpdateOrganization();
+  const { remove, isLoading: isDeleting } = useDeleteOrganization();
+  const { campaign } = useCampaign(campaignId);
+  const isGM = campaign?.isGM ?? false;
+
+  const [name, setName] = useState('');
+  const [publicInfo, setPublicInfo] = useState('');
+  const [privateInfo, setPrivateInfo] = useState('');
+  const [isPublic, setIsPublic] = useState(false);
+  const [tags, setTags] = useState<string[]>([]);
+  const [locations, setLocations] = useState<OrganizationLocationLinkInput[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const validate = useCallback((): FieldErrors => {
+    const errors: FieldErrors = {};
+    if (!name.trim()) errors.name = 'Name is required';
+    return errors;
+  }, [name]);
+
+  const { fieldErrors, runValidation } = useModalForm({
+    isOpen,
+    onClose,
+    recordId: organizationId,
+    isEdit,
+    record: existing,
+    reset: () => {
+      setName('');
+      setPublicInfo('');
+      setPrivateInfo('');
+      setIsPublic(false);
+      setTags([]);
+      setLocations([]);
+      setError(null);
+      setShowDeleteConfirm(false);
+    },
+    populate: (org) => {
+      setName(org.name);
+      setPublicInfo(org.publicInfo);
+      setPrivateInfo(org.privateInfo);
+      setIsPublic(org.isPublic);
+      setTags(org.tags);
+      setLocations(
+        org.locations.map((l) => ({
+          locationId: l.locationId,
+          label: l.label,
+          publicInfo: l.publicInfo,
+          privateInfo: l.privateInfo,
+        }))
+      );
+    },
+    validate,
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (Object.keys(runValidation()).length > 0) return;
+    setError(null);
+
+    const payload = {
+      campaignId,
+      name,
+      publicInfo,
+      privateInfo,
+      isPublic,
+      tags,
+      locations: locations.map((l) => ({
+        locationId: l.locationId,
+        publicInfo: l.publicInfo,
+        privateInfo: l.privateInfo,
+      })),
+    };
+
+    const result =
+      isEdit && organizationId
+        ? await update({ ...payload, id: organizationId })
+        : await create(payload);
+
+    if (result) onClose();
+    else setError(`Failed to ${isEdit ? 'update' : 'create'} organization. Please try again.`);
+  };
+
+  const handleDelete = async () => {
+    if (!organizationId) return;
+    setError(null);
+    const result = await remove({ id: organizationId, campaignId });
+    if (result) onClose();
+    else {
+      setError('Failed to delete organization. Please try again.');
+      setShowDeleteConfirm(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const isLoadingOrg = !!(isEdit && isFetching);
+  const isSaving = isCreating || isUpdating;
+  const isDisabled = isLoadingOrg || isSaving || isDeleting;
+
+  return createPortal(
+    <div
+      role="presentation"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-2 sm:p-4 backdrop-blur-sm"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <form
+        onSubmit={handleSubmit}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="organization-modal-title"
+        className="w-full h-full max-w-[90vw] max-h-[90vh] bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col"
+      >
+        <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
+          <h2
+            id="organization-modal-title"
+            className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest"
+          >
+            {isEdit ? 'Edit Organization' : 'Create Organization'}
+          </h2>
+          <div className="flex items-center gap-1 shrink-0">
+            {isEdit && organizationId && (
+              <ShowOnTabletopButton
+                campaignId={campaignId}
+                collection="organization"
+                documentId={organizationId}
+                isGM={isGM}
+              />
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close modal"
+              className="text-slate-500 hover:text-white transition-colors"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+        </header>
+
+        <div className="flex-1 overflow-y-auto p-4 sm:p-6 space-y-5 min-h-0">
+          {error && (
+            <div className="p-3 bg-rose-500/10 border border-rose-500/20 rounded-lg text-rose-400 text-xs font-semibold">
+              {error}
+            </div>
+          )}
+
+          {isLoadingOrg ? (
+            <div className="flex items-center justify-center py-12">
+              <p className="text-xs text-slate-500 animate-pulse">Loading organization...</p>
+            </div>
+          ) : (
+            <>
+              <FormInput
+                label="Name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                error={fieldErrors.name}
+                required
+                disabled={isDisabled}
+                placeholder="e.g. The Thieves' Guild"
+              />
+
+              {/* Visibility toggle */}
+              <div className="flex items-center gap-4">
+                <button
+                  type="button"
+                  onClick={() => setIsPublic(false)}
+                  disabled={isDisabled}
+                  className={`h-8 px-3 rounded-lg border flex items-center gap-2 transition-all text-xs ${!isPublic ? 'bg-blue-600/10 border-blue-500/50 text-blue-300' : 'bg-white/[0.03] border-white/[0.07] text-slate-500 hover:border-white/20'}`}
+                >
+                  <Lock className="h-3 w-3" />
+                  <span className="font-bold">Private (GM only)</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setIsPublic(true)}
+                  disabled={isDisabled}
+                  className={`h-8 px-3 rounded-lg border flex items-center gap-2 transition-all text-xs ${isPublic ? 'bg-emerald-600/10 border-emerald-500/50 text-emerald-300' : 'bg-white/[0.03] border-white/[0.07] text-slate-500 hover:border-white/20'}`}
+                >
+                  <Globe className="h-3 w-3" />
+                  <span className="font-bold">Public</span>
+                </button>
+              </div>
+
+              <MarkdownEditor
+                label="Public info"
+                value={publicInfo}
+                onChange={setPublicInfo}
+                placeholder="Public description of this organization..."
+                disabled={isDisabled}
+                minHeight="200px"
+              />
+
+              {isGM && (
+                <MarkdownEditor
+                  label="Private info (GM only)"
+                  value={privateInfo}
+                  onChange={setPrivateInfo}
+                  placeholder="GM-only notes about this organization..."
+                  disabled={isDisabled}
+                  minHeight="200px"
+                />
+              )}
+
+              <TagAutocompleteInput
+                campaignId={campaignId}
+                selectedTags={tags}
+                onTagsChange={setTags}
+                disabled={isDisabled}
+              />
+
+              <OrganizationLocationsEditor
+                campaignId={campaignId}
+                value={locations}
+                onChange={setLocations}
+                isGM={isGM}
+                disabled={isDisabled}
+              />
+
+              {isEdit && organizationId ? (
+                <OrganizationMembersEditor
+                  campaignId={campaignId}
+                  organizationId={organizationId}
+                  isGM={isGM}
+                  canManage={existing?.canEdit ?? false}
+                />
+              ) : (
+                <p className="text-xs text-slate-500">
+                  Save the organization first to add members.
+                </p>
+              )}
+            </>
+          )}
+        </div>
+
+        <footer className="flex items-center justify-between px-4 sm:px-6 py-4 border-t border-white/[0.07] shrink-0 gap-3">
+          {isEdit && (
+            <div className="flex items-center gap-2">
+              {showDeleteConfirm ? (
+                <>
+                  <span className="text-xs text-rose-400 font-semibold">
+                    Delete this organization?
+                  </span>
+                  <PixelButton
+                    type="button"
+                    variant="danger"
+                    size="sm"
+                    onClick={handleDelete}
+                    disabled={isDisabled}
+                  >
+                    {isDeleting ? 'Deleting...' : 'Confirm'}
+                  </PixelButton>
+                  <PixelButton
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setShowDeleteConfirm(false)}
+                    disabled={isDisabled}
+                  >
+                    Cancel
+                  </PixelButton>
+                </>
+              ) : (
+                <PixelButton
+                  type="button"
+                  variant="danger"
+                  size="sm"
+                  onClick={() => setShowDeleteConfirm(true)}
+                  disabled={isDisabled}
+                >
+                  Delete
+                </PixelButton>
+              )}
+            </div>
+          )}
+          <div className="flex items-center gap-3 ml-auto">
+            <PixelButton type="button" variant="ghost" onClick={onClose} disabled={isDisabled}>
+              Cancel
+            </PixelButton>
+            <PixelButton type="submit" disabled={isDisabled}>
+              {isSaving ? 'Saving...' : isEdit ? 'Save Changes' : 'Create Organization'}
+            </PixelButton>
+          </div>
+        </footer>
+      </form>
+    </div>,
+    document.body
+  );
+}

--- a/app/components/wiki/organizations/OrganizationViewModal.tsx
+++ b/app/components/wiki/organizations/OrganizationViewModal.tsx
@@ -1,0 +1,88 @@
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { X } from 'lucide-react';
+import { OrganizationWindow } from './OrganizationWindow';
+import { useOrganization } from '~/hooks/useOrganizations';
+import { useCampaign } from '~/hooks/useCampaigns';
+import { ShowOnTabletopButton } from '~/components/wiki/shared/ShowOnTabletopButton';
+
+interface OrganizationViewModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  organizationId: string;
+  campaignId: string;
+}
+
+export function OrganizationViewModal({
+  isOpen,
+  onClose,
+  organizationId,
+  campaignId,
+}: OrganizationViewModalProps) {
+  const { organization, isLoading } = useOrganization(organizationId, campaignId);
+  const { campaign } = useCampaign(campaignId);
+  const isGM = campaign?.isGM ?? false;
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onEsc = (e: KeyboardEvent) => e.key === 'Escape' && onClose();
+    document.addEventListener('keydown', onEsc);
+    return () => document.removeEventListener('keydown', onEsc);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div
+      role="presentation"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-2 sm:p-4 backdrop-blur-sm"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="organization-view-modal-title"
+        className="w-full max-w-lg max-h-[90vh] bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col"
+      >
+        <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
+          <h2
+            id="organization-view-modal-title"
+            className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest truncate"
+          >
+            {organization?.name ?? 'Organization'}
+          </h2>
+          <div className="flex items-center gap-1 shrink-0">
+            <ShowOnTabletopButton
+              campaignId={campaignId}
+              collection="organization"
+              documentId={organizationId}
+              isGM={isGM}
+            />
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close modal"
+              className="text-slate-500 hover:text-white transition-colors"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+        </header>
+        <div className="flex-1 overflow-y-auto min-h-0">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <p className="text-xs text-slate-500 animate-pulse">Loading organization...</p>
+            </div>
+          ) : organization ? (
+            <OrganizationWindow organization={organization} />
+          ) : (
+            <div className="flex items-center justify-center py-12">
+              <p className="text-xs text-slate-500">Organization not found</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/app/components/wiki/organizations/OrganizationWindow.tsx
+++ b/app/components/wiki/organizations/OrganizationWindow.tsx
@@ -1,0 +1,140 @@
+import { Pencil, MapPin } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { OrganizationData } from '~/types/organization';
+import { MARKDOWN_PROSE_CLASSES } from '~/utils/markdownProseClasses';
+import { useMembershipsForOrg } from '~/hooks/useOrganizations';
+
+interface OrganizationWindowProps {
+  organization: OrganizationData;
+  onEdit?: () => void;
+}
+
+export function OrganizationWindow({ organization, onEdit }: OrganizationWindowProps) {
+  const { memberships } = useMembershipsForOrg(organization.campaignId, organization.id);
+  const showMeta = organization.tags.length > 0 || (organization.canEdit && !!onEdit);
+
+  return (
+    <div className="flex flex-col h-full">
+      {showMeta && (
+        <div className="flex items-center gap-2 px-3 py-1.5 border-b border-white/[0.05] shrink-0">
+          <div className="flex flex-wrap gap-1 flex-1 min-w-0">
+            {organization.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[9px] tracking-tight"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+          {organization.canEdit && onEdit && (
+            <button
+              type="button"
+              onClick={onEdit}
+              className="shrink-0 p-1 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors"
+              aria-label="Edit organization"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+      )}
+
+      <div className="flex-1 overflow-y-auto p-3 min-h-0 space-y-5">
+        {/* Public info */}
+        {organization.publicInfo && (
+          <div className={MARKDOWN_PROSE_CLASSES}>
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{organization.publicInfo}</ReactMarkdown>
+          </div>
+        )}
+
+        {/* GM-only private info */}
+        {organization.privateInfo && (
+          <div className="rounded-lg border border-amber-500/20 bg-amber-500/[0.04] p-3">
+            <p className="text-[10px] font-bold uppercase tracking-widest text-amber-400/80 mb-2">
+              GM Only
+            </p>
+            <div className={MARKDOWN_PROSE_CLASSES}>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{organization.privateInfo}</ReactMarkdown>
+            </div>
+          </div>
+        )}
+
+        {/* Members */}
+        <div>
+          <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">
+            Members
+          </p>
+          {memberships.length === 0 ? (
+            <p className="text-xs text-slate-500">No members yet.</p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {memberships.map((m) => (
+                <div
+                  key={m.id}
+                  className="rounded-md border border-white/[0.06] bg-white/[0.02] px-3 py-2"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-xs font-bold text-slate-200 truncate">
+                      {m.memberLabel || 'Unknown'}
+                    </span>
+                    {m.title && (
+                      <span className="text-[11px] text-blue-400 shrink-0">{m.title}</span>
+                    )}
+                  </div>
+                  {m.publicNotes && (
+                    <div className={`${MARKDOWN_PROSE_CLASSES} mt-1`}>
+                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{m.publicNotes}</ReactMarkdown>
+                    </div>
+                  )}
+                  {m.privateNotes && (
+                    <div className="mt-1 rounded border border-amber-500/20 bg-amber-500/[0.04] px-2 py-1">
+                      <div className={MARKDOWN_PROSE_CLASSES}>
+                        <ReactMarkdown remarkPlugins={[remarkGfm]}>{m.privateNotes}</ReactMarkdown>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Locations */}
+        {organization.locations.length > 0 && (
+          <div>
+            <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">
+              Locations
+            </p>
+            <div className="flex flex-col gap-2">
+              {organization.locations.map((loc) => (
+                <div
+                  key={loc.locationId}
+                  className="rounded-md border border-white/[0.06] bg-white/[0.02] px-3 py-2"
+                >
+                  <div className="flex items-center gap-1.5 text-xs font-bold text-slate-200">
+                    <MapPin className="h-3.5 w-3.5 text-amber-400" />
+                    {loc.label || 'Unknown location'}
+                  </div>
+                  {loc.publicInfo && (
+                    <div className={`${MARKDOWN_PROSE_CLASSES} mt-1`}>
+                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{loc.publicInfo}</ReactMarkdown>
+                    </div>
+                  )}
+                  {loc.privateInfo && (
+                    <div className="mt-1 rounded border border-amber-500/20 bg-amber-500/[0.04] px-2 py-1">
+                      <div className={MARKDOWN_PROSE_CLASSES}>
+                        <ReactMarkdown remarkPlugins={[remarkGfm]}>{loc.privateInfo}</ReactMarkdown>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/wiki/organizations/OrganizationWindow.tsx
+++ b/app/components/wiki/organizations/OrganizationWindow.tsx
@@ -1,9 +1,21 @@
+import type React from 'react';
 import { Pencil, MapPin } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { OrganizationData } from '~/types/organization';
+import type { PictureCrop } from '~/types/character';
 import { MARKDOWN_PROSE_CLASSES } from '~/utils/markdownProseClasses';
 import { useMembershipsForOrg } from '~/hooks/useOrganizations';
+
+function getCropStyle(crop: PictureCrop): React.CSSProperties {
+  const centerX = (crop.x + crop.width / 2) * 100;
+  const centerY = (crop.y + crop.height / 2) * 100;
+  const scale = 1 / crop.width;
+  return {
+    objectPosition: `${centerX}% ${centerY}%`,
+    transform: `scale(${scale})`,
+  };
+}
 
 interface OrganizationWindowProps {
   organization: OrganizationData;
@@ -42,6 +54,32 @@ export function OrganizationWindow({ organization, onEdit }: OrganizationWindowP
       )}
 
       <div className="flex-1 overflow-y-auto p-3 min-h-0 space-y-5">
+        {/* Images gallery */}
+        {organization.images.length > 0 && (
+          <div className="flex flex-col gap-3">
+            <p className="text-[10px] uppercase tracking-wider text-slate-500">Images</p>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+              {organization.images.map((image, idx) => (
+                <div key={idx} className="flex flex-col gap-1">
+                  <div className="w-full aspect-square overflow-hidden rounded-lg border border-white/[0.08]">
+                    <img
+                      src={image.url}
+                      alt={image.caption || `Organization image ${idx + 1}`}
+                      className="w-full h-full object-cover"
+                      style={image.crop ? getCropStyle(image.crop) : undefined}
+                    />
+                  </div>
+                  {image.caption && (
+                    <p className="text-[10px] text-slate-500 text-center leading-tight">
+                      {image.caption}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
         {/* Public info */}
         {organization.publicInfo && (
           <div className={MARKDOWN_PROSE_CLASSES}>

--- a/app/components/wiki/organizations/OrganizationWindow.tsx
+++ b/app/components/wiki/organizations/OrganizationWindow.tsx
@@ -27,7 +27,7 @@ export function OrganizationWindow({ organization, onEdit }: OrganizationWindowP
   const showMeta = organization.tags.length > 0 || (organization.canEdit && !!onEdit);
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full" data-testid="organization-window">
       {showMeta && (
         <div className="flex items-center gap-2 px-3 py-1.5 border-b border-white/[0.05] shrink-0">
           <div className="flex flex-wrap gap-1 flex-1 min-w-0">

--- a/app/components/wiki/organizations/OrganizationWindowWrapper.tsx
+++ b/app/components/wiki/organizations/OrganizationWindowWrapper.tsx
@@ -1,0 +1,50 @@
+import { OrganizationWindow } from './OrganizationWindow';
+import { OrganizationModal } from './OrganizationModal';
+import { useOrganization } from '~/hooks/useOrganizations';
+
+export function EditOrganizationModalWrapper({
+  campaignId,
+  organizationId,
+  onClose,
+}: {
+  campaignId: string;
+  organizationId: string;
+  onClose: () => void;
+}) {
+  return (
+    <OrganizationModal
+      isOpen
+      onClose={onClose}
+      campaignId={campaignId}
+      organizationId={organizationId}
+    />
+  );
+}
+
+export function OrganizationWindowWrapper({
+  organizationId,
+  campaignId,
+  onEdit,
+}: {
+  organizationId: string;
+  campaignId: string;
+  onEdit: () => void;
+}) {
+  const { organization, isLoading } = useOrganization(organizationId, campaignId);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-xs text-slate-500 animate-pulse">Loading organization...</p>
+      </div>
+    );
+  }
+  if (!organization) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-xs text-slate-500">Organization not found</p>
+      </div>
+    );
+  }
+  return <OrganizationWindow organization={organization} onEdit={onEdit} />;
+}

--- a/app/components/wiki/organizations/OrganizationsPanel.tsx
+++ b/app/components/wiki/organizations/OrganizationsPanel.tsx
@@ -1,0 +1,138 @@
+import { useState } from 'react';
+import { useParams } from '@tanstack/react-router';
+import { Building2 } from 'lucide-react';
+import { WikiCategoryHeader } from '~/components/wiki/shared/WikiCategoryHeader';
+import { WikiFilterBar } from '~/components/wiki/shared/WikiFilterBar';
+import { OrganizationCard } from './OrganizationCard';
+import { OrganizationModal } from './OrganizationModal';
+import { OrganizationViewModal } from './OrganizationViewModal';
+import { useOrganizations } from '~/hooks/useOrganizations';
+import { useLocations } from '~/hooks/useLocations';
+import type { OrganizationListItem } from '~/types/organization';
+
+interface OrganizationsPanelProps {
+  onBack: () => void;
+}
+
+export function OrganizationsPanel({ onBack }: OrganizationsPanelProps) {
+  const { campaignId } = useParams({ from: '/campaigns/$campaignId/play' });
+  const { locations } = useLocations(campaignId);
+
+  const [search, setSearch] = useState('');
+  const [filterTags, setFilterTags] = useState<string[]>([]);
+  const [filterLocationIds, setFilterLocationIds] = useState<string[]>([]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | undefined>();
+  const [viewId, setViewId] = useState<string | undefined>();
+
+  const { organizations, isLoading, error } = useOrganizations(campaignId, {
+    search: search || undefined,
+    tags: filterTags.length > 0 ? filterTags : undefined,
+    locationIds: filterLocationIds.length > 0 ? filterLocationIds : undefined,
+  });
+
+  const handleCreateClick = () => {
+    setSelectedId(undefined);
+    setIsModalOpen(true);
+  };
+
+  const handleClick = (org: OrganizationListItem) => {
+    if (org.canEdit) {
+      setSelectedId(org.id);
+      setIsModalOpen(true);
+    } else {
+      setViewId(org.id);
+    }
+  };
+
+  const toggleLocation = (id: string) => {
+    setFilterLocationIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+  };
+
+  return (
+    <div className="flex flex-col h-full w-full bg-[#080A12]">
+      <WikiCategoryHeader title="Organizations" onBack={onBack} />
+      <WikiFilterBar
+        search={search}
+        onSearchChange={setSearch}
+        onCreateClick={handleCreateClick}
+        campaignId={campaignId}
+        filterTags={filterTags}
+        onFilterTagsChange={setFilterTags}
+        searchPlaceholder="Search organizations..."
+        showSessionFilter={false}
+        showVisibilityFilter={false}
+        visibility="all"
+        onVisibilityChange={() => {}}
+      />
+
+      {locations.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 px-3 pb-3 border-b border-white/[0.07] bg-[#0D1117]">
+          {locations.map((loc) => {
+            const active = filterLocationIds.includes(loc.id);
+            return (
+              <button
+                key={loc.id}
+                type="button"
+                onClick={() => toggleLocation(loc.id)}
+                aria-pressed={active}
+                className={`px-2 py-0.5 rounded-full text-[10px] font-semibold border transition-colors ${active ? 'bg-amber-500/15 border-amber-500/40 text-amber-300' : 'bg-white/[0.03] border-white/[0.07] text-slate-500 hover:text-slate-300'}`}
+              >
+                {loc.name}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="flex flex-1 items-center justify-center p-8">
+          <p className="font-sans font-semibold text-xs text-slate-500 animate-pulse">
+            Loading organizations...
+          </p>
+        </div>
+      ) : error ? (
+        <div className="flex flex-1 items-center justify-center p-8 text-center">
+          <p className="font-sans font-semibold text-xs text-rose-400">{error}</p>
+        </div>
+      ) : organizations.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center p-8 text-center">
+          <div className="h-12 w-12 rounded-full bg-white/[0.03] flex items-center justify-center mb-3">
+            <Building2 className="h-6 w-6 text-slate-600" />
+          </div>
+          <p className="font-sans font-semibold text-xs text-slate-500">
+            No organizations found matching your filters.
+          </p>
+        </div>
+      ) : (
+        <div className="flex-1 overflow-y-auto min-h-0">
+          <div className="flex flex-col">
+            {organizations.map((org) => (
+              <OrganizationCard key={org.id} organization={org} onClick={handleClick} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      <OrganizationModal
+        isOpen={isModalOpen}
+        onClose={() => {
+          setIsModalOpen(false);
+          setSelectedId(undefined);
+        }}
+        campaignId={campaignId}
+        organizationId={selectedId}
+      />
+      {viewId && (
+        <OrganizationViewModal
+          isOpen={!!viewId}
+          onClose={() => setViewId(undefined)}
+          organizationId={viewId}
+          campaignId={campaignId}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/components/wiki/players/PlayerModal.tsx
+++ b/app/components/wiki/players/PlayerModal.tsx
@@ -5,6 +5,8 @@ import { FormInput } from '~/components/FormInput';
 import { PixelButton } from '~/components/PixelButton';
 import { MarkdownEditor } from '~/components/shared/MarkdownEditor';
 import { ColorPicker } from '~/components/shared/ColorPicker';
+import { TabBar } from '~/components/shared/TabBar';
+import { MemberOrganizationsTab } from '~/components/shared/MemberOrganizationsTab';
 import { ImageCropInput } from '~/components/wiki/characters/ImageCropInput';
 import { usePlayer, useUpdatePlayer, useDeletePlayer } from '~/hooks/usePlayers';
 import { useCampaign } from '~/hooks/useCampaigns';
@@ -62,6 +64,7 @@ export function PlayerModal({ campaignId, playerId, onClose }: PlayerModalProps)
   const [gmNotes, setGmNotes] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [activeTab, setActiveTab] = useState<'details' | 'organizations'>('details');
 
   const validate = useCallback((): FieldErrors => {
     const errors: FieldErrors = {};
@@ -105,6 +108,7 @@ export function PlayerModal({ campaignId, playerId, onClose }: PlayerModalProps)
       setGmNotes('');
       setError(null);
       setShowDeleteConfirm(false);
+      setActiveTab('details');
     },
     populate: (p) => {
       setFirstName(p.firstName);
@@ -239,6 +243,18 @@ export function PlayerModal({ campaignId, playerId, onClose }: PlayerModalProps)
           </button>
         </header>
 
+        {isEdit && playerId && (
+          <TabBar
+            tabs={[
+              { id: 'details', label: 'Details' },
+              { id: 'organizations', label: 'Organizations' },
+            ]}
+            activeTab={activeTab}
+            onTabChange={(t) => setActiveTab(t as 'details' | 'organizations')}
+            accentColor={color || '#3498db'}
+          />
+        )}
+
         <div className="flex-1 overflow-y-auto p-4 sm:p-6 space-y-5 min-h-0">
           {error && (
             <div className="p-3 bg-rose-500/10 border border-rose-500/20 rounded-lg text-rose-400 text-xs font-semibold">
@@ -250,6 +266,14 @@ export function PlayerModal({ campaignId, playerId, onClose }: PlayerModalProps)
             <div className="flex items-center justify-center py-12">
               <p className="text-xs text-slate-500 animate-pulse">Loading player...</p>
             </div>
+          ) : activeTab === 'organizations' && isEdit && playerId ? (
+            <MemberOrganizationsTab
+              campaignId={campaignId}
+              memberKind="player"
+              memberId={playerId}
+              isGM={campaign?.isGM ?? false}
+              canManage={campaign?.isGM || existingPlayer?.canEdit || false}
+            />
           ) : (
             <>
               {/* Picture upload */}

--- a/app/components/wiki/players/PlayerWindow.tsx
+++ b/app/components/wiki/players/PlayerWindow.tsx
@@ -15,6 +15,7 @@ import {
 } from '~/hooks/usePlayers';
 import { PlayerLoreTab } from '~/components/wiki/players/PlayerLoreTab';
 import { MemberOrganizationsTab } from '~/components/shared/MemberOrganizationsTab';
+import { useCampaign } from '~/hooks/useCampaigns';
 
 function getCropStyle(crop: PictureCrop): React.CSSProperties {
   const centerX = (crop.x + crop.width / 2) * 100;
@@ -84,6 +85,8 @@ export function PlayerWindow({ player, onEdit }: PlayerWindowProps) {
   const { addRelationship } = useAddPlayerRelationship();
   const { updateRelationship } = useUpdatePlayerRelationship();
   const { removeRelationship } = useRemovePlayerRelationship();
+  const { campaign } = useCampaign(player.campaignId);
+  const isGM = campaign?.isGM ?? false;
 
   const fullName = `${player.firstName} ${player.lastName}`.trim();
   const initials = getInitials(player.firstName, player.lastName);
@@ -316,7 +319,7 @@ export function PlayerWindow({ player, onEdit }: PlayerWindowProps) {
             campaignId={player.campaignId}
             memberKind="player"
             memberId={player.id}
-            isGM={player.canEdit}
+            isGM={isGM}
             canManage={player.canEdit}
           />
         )}

--- a/app/components/wiki/players/PlayerWindow.tsx
+++ b/app/components/wiki/players/PlayerWindow.tsx
@@ -14,6 +14,7 @@ import {
   useRemovePlayerRelationship,
 } from '~/hooks/usePlayers';
 import { PlayerLoreTab } from '~/components/wiki/players/PlayerLoreTab';
+import { MemberOrganizationsTab } from '~/components/shared/MemberOrganizationsTab';
 
 function getCropStyle(crop: PictureCrop): React.CSSProperties {
   const centerX = (crop.x + crop.width / 2) * 100;
@@ -101,6 +102,7 @@ export function PlayerWindow({ player, onEdit }: PlayerWindowProps) {
     { id: 'gmnotes', label: 'GM Notes', hidden: player.gmNotes === '' },
     { id: 'relationships', label: 'Relationships' },
     { id: 'lore', label: 'Lore' },
+    { id: 'organizations', label: 'Organizations' },
   ];
 
   return (
@@ -305,6 +307,16 @@ export function PlayerWindow({ player, onEdit }: PlayerWindowProps) {
           <PlayerLoreTab
             campaignId={player.campaignId}
             playerId={player.id}
+            canManage={player.canEdit}
+          />
+        )}
+
+        {activeTab === 'organizations' && (
+          <MemberOrganizationsTab
+            campaignId={player.campaignId}
+            memberKind="player"
+            memberId={player.id}
+            isGM={player.canEdit}
             canManage={player.canEdit}
           />
         )}

--- a/app/hooks/useOrganizations.ts
+++ b/app/hooks/useOrganizations.ts
@@ -1,0 +1,298 @@
+import { createServerFn } from '@tanstack/react-start';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type {
+  OrganizationData,
+  OrganizationListItem,
+  OrganizationMembershipData,
+  MemberKind,
+} from '~/types/organization';
+import { captureException } from '~/providers/TelemetryProvider';
+import { queryKeys } from '~/utils/queryKeys';
+import {
+  listOrganizationsSchema,
+  getOrganizationSchema,
+  createOrganizationSchema,
+  updateOrganizationSchema,
+  deleteOrganizationSchema,
+  addMembershipSchema,
+  updateMembershipSchema,
+  removeMembershipSchema,
+  listMembershipsForOrgSchema,
+  listMembershipsForMemberSchema,
+} from '~/types/schemas/organizations';
+
+// --- Server function wrappers (dynamic import keeps mongoose server-only) ---
+
+const listOrganizationsFn = createServerFn({ method: 'GET' })
+  .inputValidator(listOrganizationsSchema)
+  .handler(async ({ data }) => {
+    const { listOrganizations } = await import('~/server/functions/organizations');
+    return listOrganizations({ data });
+  });
+
+const getOrganizationFn = createServerFn({ method: 'GET' })
+  .inputValidator(getOrganizationSchema)
+  .handler(async ({ data }) => {
+    const { getOrganization } = await import('~/server/functions/organizations');
+    return getOrganization({ data });
+  });
+
+const createOrganizationFn = createServerFn({ method: 'POST' })
+  .inputValidator(createOrganizationSchema)
+  .handler(async ({ data }) => {
+    const { createOrganization } = await import('~/server/functions/organizations');
+    return createOrganization({ data });
+  });
+
+const updateOrganizationFn = createServerFn({ method: 'POST' })
+  .inputValidator(updateOrganizationSchema)
+  .handler(async ({ data }) => {
+    const { updateOrganization } = await import('~/server/functions/organizations');
+    return updateOrganization({ data });
+  });
+
+const deleteOrganizationFn = createServerFn({ method: 'POST' })
+  .inputValidator(deleteOrganizationSchema)
+  .handler(async ({ data }) => {
+    const { deleteOrganization } = await import('~/server/functions/organizations');
+    return deleteOrganization({ data });
+  });
+
+const listMembershipsForOrgFn = createServerFn({ method: 'GET' })
+  .inputValidator(listMembershipsForOrgSchema)
+  .handler(async ({ data }) => {
+    const { listMembershipsForOrg } = await import('~/server/functions/organizations');
+    return listMembershipsForOrg({ data });
+  });
+
+const listMembershipsForMemberFn = createServerFn({ method: 'GET' })
+  .inputValidator(listMembershipsForMemberSchema)
+  .handler(async ({ data }) => {
+    const { listMembershipsForMember } = await import('~/server/functions/organizations');
+    return listMembershipsForMember({ data });
+  });
+
+const addMembershipFn = createServerFn({ method: 'POST' })
+  .inputValidator(addMembershipSchema)
+  .handler(async ({ data }) => {
+    const { addMembership } = await import('~/server/functions/organizations');
+    return addMembership({ data });
+  });
+
+const updateMembershipFn = createServerFn({ method: 'POST' })
+  .inputValidator(updateMembershipSchema)
+  .handler(async ({ data }) => {
+    const { updateMembership } = await import('~/server/functions/organizations');
+    return updateMembership({ data });
+  });
+
+const removeMembershipFn = createServerFn({ method: 'POST' })
+  .inputValidator(removeMembershipSchema)
+  .handler(async ({ data }) => {
+    const { removeMembership } = await import('~/server/functions/organizations');
+    return removeMembership({ data });
+  });
+
+// --- List / detail hooks ---
+
+interface ListOrganizationsFilters {
+  search?: string;
+  tags?: string[];
+  locationIds?: string[];
+  enabled?: boolean;
+}
+
+export function useOrganizations(campaignId: string, filters?: ListOrganizationsFilters) {
+  const { search, tags, locationIds } = filters ?? {};
+  const {
+    data: organizations = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.organizations.list(campaignId, search, tags, locationIds),
+    queryFn: () => listOrganizationsFn({ data: { campaignId, search, tags, locationIds } }),
+    enabled: (filters?.enabled ?? true) && !!campaignId,
+  });
+  return {
+    organizations: organizations as OrganizationListItem[],
+    isLoading,
+    error: error instanceof Error ? error.message : error ? String(error) : null,
+  };
+}
+
+export function useOrganization(id: string, campaignId: string) {
+  const {
+    data: organization = null,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.organizations.detail(id, campaignId),
+    queryFn: () => getOrganizationFn({ data: { id, campaignId } }),
+    enabled: !!id && !!campaignId,
+  });
+  return {
+    organization: organization as OrganizationData | null,
+    isLoading,
+    error: error instanceof Error ? error.message : error ? String(error) : null,
+  };
+}
+
+export function useMembershipsForOrg(campaignId: string, organizationId: string, enabled = true) {
+  const { data: memberships = [], isLoading } = useQuery({
+    queryKey: queryKeys.memberships.forOrg(campaignId, organizationId),
+    queryFn: () => listMembershipsForOrgFn({ data: { campaignId, organizationId } }),
+    enabled: enabled && !!campaignId && !!organizationId,
+  });
+  return { memberships: memberships as OrganizationMembershipData[], isLoading };
+}
+
+export function useMembershipsForMember(
+  campaignId: string,
+  memberKind: MemberKind,
+  memberId: string,
+  enabled = true
+) {
+  const { data: memberships = [], isLoading } = useQuery({
+    queryKey: queryKeys.memberships.forMember(campaignId, memberKind, memberId),
+    queryFn: () => listMembershipsForMemberFn({ data: { campaignId, memberKind, memberId } }),
+    enabled: enabled && !!campaignId && !!memberId,
+  });
+  return { memberships: memberships as OrganizationMembershipData[], isLoading };
+}
+
+// --- Mutation hooks ---
+
+function errMsg(e: unknown): string | null {
+  return e instanceof Error ? e.message : e ? String(e) : null;
+}
+
+export function useCreateOrganization() {
+  const qc = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: (input: Parameters<typeof createOrganizationFn>[0]['data']) =>
+      createOrganizationFn({ data: input }),
+    onSuccess: (_d, { campaignId }) => {
+      qc.invalidateQueries({ queryKey: ['organizations', 'list', campaignId], exact: false });
+      qc.invalidateQueries({ queryKey: queryKeys.tags.list(campaignId) });
+    },
+    onError: (e) => captureException(e, { action: 'createOrganization' }),
+  });
+  return {
+    create: async (input: Parameters<typeof createOrganizationFn>[0]['data']) => {
+      try {
+        return await mutation.mutateAsync(input);
+      } catch {
+        return null;
+      }
+    },
+    isLoading: mutation.isPending,
+    error: errMsg(mutation.error),
+  };
+}
+
+export function useUpdateOrganization() {
+  const qc = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: (input: Parameters<typeof updateOrganizationFn>[0]['data']) =>
+      updateOrganizationFn({ data: input }),
+    onSuccess: (_d, variables) => {
+      qc.invalidateQueries({
+        queryKey: ['organizations', 'list', variables.campaignId],
+        exact: false,
+      });
+      qc.invalidateQueries({
+        queryKey: queryKeys.organizations.detail(variables.id, variables.campaignId),
+      });
+      qc.invalidateQueries({ queryKey: queryKeys.tags.list(variables.campaignId) });
+      qc.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+    },
+    onError: (e) => captureException(e, { action: 'updateOrganization' }),
+  });
+  return {
+    update: async (input: Parameters<typeof updateOrganizationFn>[0]['data']) => {
+      try {
+        return await mutation.mutateAsync(input);
+      } catch {
+        return null;
+      }
+    },
+    isLoading: mutation.isPending,
+    error: errMsg(mutation.error),
+  };
+}
+
+export function useDeleteOrganization() {
+  const qc = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: (input: { id: string; campaignId: string }) =>
+      deleteOrganizationFn({ data: input }),
+    onSuccess: (_d, variables) => {
+      qc.invalidateQueries({
+        queryKey: ['organizations', 'list', variables.campaignId],
+        exact: false,
+      });
+      qc.removeQueries({
+        queryKey: queryKeys.organizations.detail(variables.id, variables.campaignId),
+      });
+      qc.invalidateQueries({ queryKey: queryKeys.memberships.all, exact: false });
+      qc.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+    },
+    onError: (e) => captureException(e, { action: 'deleteOrganization' }),
+  });
+  return {
+    remove: async (input: { id: string; campaignId: string }) => {
+      try {
+        return await mutation.mutateAsync(input);
+      } catch {
+        return null;
+      }
+    },
+    isLoading: mutation.isPending,
+    error: errMsg(mutation.error),
+  };
+}
+
+function useMembershipMutation<TInput>(fn: (input: TInput) => Promise<unknown>, action: string) {
+  const qc = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: (input: TInput) => fn(input),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.memberships.all, exact: false });
+      qc.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+    },
+    onError: (e) => captureException(e, { action }),
+  });
+  return {
+    mutate: async (input: TInput) => {
+      try {
+        return await mutation.mutateAsync(input);
+      } catch {
+        return null;
+      }
+    },
+    isLoading: mutation.isPending,
+    error: errMsg(mutation.error),
+  };
+}
+
+export function useAddMembership() {
+  return useMembershipMutation(
+    (input: Parameters<typeof addMembershipFn>[0]['data']) => addMembershipFn({ data: input }),
+    'addMembership'
+  );
+}
+
+export function useUpdateMembership() {
+  return useMembershipMutation(
+    (input: Parameters<typeof updateMembershipFn>[0]['data']) =>
+      updateMembershipFn({ data: input }),
+    'updateMembership'
+  );
+}
+
+export function useRemoveMembership() {
+  return useMembershipMutation(
+    (input: { id: string; campaignId: string }) => removeMembershipFn({ data: input }),
+    'removeMembership'
+  );
+}

--- a/app/server/db/models/Organization.ts
+++ b/app/server/db/models/Organization.ts
@@ -10,11 +10,31 @@ const locationLinkSchema = new mongoose.Schema(
   { _id: false }
 );
 
+const cropSchema = new mongoose.Schema(
+  {
+    x: { type: Number, required: true },
+    y: { type: Number, required: true },
+    width: { type: Number, required: true },
+    height: { type: Number, required: true },
+  },
+  { _id: false }
+);
+
+const imageSchema = new mongoose.Schema(
+  {
+    url: { type: String, required: true },
+    caption: { type: String, default: '' },
+    crop: { type: cropSchema, default: null },
+  },
+  { _id: false }
+);
+
 const organizationSchema = new mongoose.Schema({
   name: { type: String, required: true },
   publicInfo: { type: String, default: '' },
   privateInfo: { type: String, default: '' },
   isPublic: { type: Boolean, default: false },
+  images: { type: [imageSchema], default: [] },
   locations: { type: [locationLinkSchema], default: [] },
   tags: { type: [String], default: [] },
   campaignId: { type: mongoose.Schema.Types.ObjectId, ref: 'Campaign', required: true },

--- a/app/server/db/models/Organization.ts
+++ b/app/server/db/models/Organization.ts
@@ -1,0 +1,45 @@
+import mongoose from 'mongoose';
+import { normalizeTags } from '~/server/utils/helpers';
+
+const locationLinkSchema = new mongoose.Schema(
+  {
+    locationId: { type: mongoose.Schema.Types.ObjectId, ref: 'Location', required: true },
+    publicInfo: { type: String, default: '' },
+    privateInfo: { type: String, default: '' },
+  },
+  { _id: false }
+);
+
+const organizationSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  publicInfo: { type: String, default: '' },
+  privateInfo: { type: String, default: '' },
+  isPublic: { type: Boolean, default: false },
+  locations: { type: [locationLinkSchema], default: [] },
+  tags: { type: [String], default: [] },
+  campaignId: { type: mongoose.Schema.Types.ObjectId, ref: 'Campaign', required: true },
+  createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+});
+
+organizationSchema.pre('save', function () {
+  if (this.isModified('tags')) {
+    this.tags = normalizeTags(this.tags as string[]);
+  }
+  this.updatedAt = new Date();
+});
+
+// istanbul ignore next
+if (typeof (organizationSchema as { index?: unknown }).index === 'function') {
+  organizationSchema.index({ campaignId: 1 });
+  organizationSchema.index({ campaignId: 1, updatedAt: -1 });
+  organizationSchema.index({ createdBy: 1 });
+  organizationSchema.index({ tags: 1 });
+  organizationSchema.index({ isPublic: 1 });
+  organizationSchema.index({ 'locations.locationId': 1 });
+  organizationSchema.index({ name: 'text', publicInfo: 'text' });
+}
+
+export const Organization =
+  mongoose.models.Organization || mongoose.model('Organization', organizationSchema);

--- a/app/server/db/models/OrganizationMembership.ts
+++ b/app/server/db/models/OrganizationMembership.ts
@@ -1,0 +1,32 @@
+import mongoose from 'mongoose';
+
+const organizationMembershipSchema = new mongoose.Schema({
+  organizationId: { type: mongoose.Schema.Types.ObjectId, ref: 'Organization', required: true },
+  memberKind: { type: String, enum: ['player', 'character'], required: true },
+  memberId: { type: mongoose.Schema.Types.ObjectId, required: true },
+  title: { type: String, default: '' },
+  publicNotes: { type: String, default: '' },
+  privateNotes: { type: String, default: '' },
+  campaignId: { type: mongoose.Schema.Types.ObjectId, ref: 'Campaign', required: true },
+  createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+});
+
+organizationMembershipSchema.pre('save', function () {
+  this.updatedAt = new Date();
+});
+
+// istanbul ignore next
+if (typeof (organizationMembershipSchema as { index?: unknown }).index === 'function') {
+  organizationMembershipSchema.index(
+    { organizationId: 1, memberKind: 1, memberId: 1 },
+    { unique: true }
+  );
+  organizationMembershipSchema.index({ campaignId: 1, memberKind: 1, memberId: 1 });
+  organizationMembershipSchema.index({ organizationId: 1 });
+}
+
+export const OrganizationMembership =
+  mongoose.models.OrganizationMembership ||
+  mongoose.model('OrganizationMembership', organizationMembershipSchema);

--- a/app/server/functions/characters.ts
+++ b/app/server/functions/characters.ts
@@ -6,6 +6,7 @@ import { normalizeTags } from '../utils/helpers';
 import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
 import { pruneLoreLinks } from '../utils/pruneLoreLinks';
 import { pruneEventLinks } from '../utils/pruneEventLinks';
+import { pruneMembershipsForMember } from './organizations';
 import { ensureTags as ensureTagsFn } from './tags';
 import type { CharacterData, CharacterListItem, PictureCrop } from '~/types/character';
 import {
@@ -316,6 +317,16 @@ export const deleteCharacter = async ({
 
     await pruneLoreLinks('character', data.id, data.campaignId);
     await pruneEventLinks('character', data.id, data.campaignId);
+
+    try {
+      await pruneMembershipsForMember('character', data.id, data.campaignId);
+    } catch (pruneError) {
+      serverCaptureException(pruneError, sessionUserId, {
+        action: 'deleteCharacter.pruneMemberships',
+        campaign_id: data.campaignId,
+        character_id: data.id,
+      });
+    }
 
     serverCaptureEvent(sessionUserId, 'character_deleted', {
       campaign_id: data.campaignId,

--- a/app/server/functions/gmscreens.ts
+++ b/app/server/functions/gmscreens.ts
@@ -288,6 +288,21 @@ const COLLECTION_REGISTRY: Record<string, CollectionFetcher> = {
         ) as Promise<Array<{ _id: unknown; title?: string; content?: string }>>;
     },
   },
+  organization: {
+    async fetch(ids: string[], campaignId: string) {
+      const { Organization } = await import('../db/models/Organization');
+      return Organization.find({ _id: { $in: ids }, campaignId }, '_id name publicInfo isPublic')
+        .lean()
+        .then((docs) =>
+          docs.map((d) => ({
+            _id: d._id,
+            title: (d as { name?: string }).name,
+            content: (d as { publicInfo?: string }).publicInfo,
+            isPublic: (d as { isPublic?: boolean }).isPublic,
+          }))
+        ) as Promise<Array<{ _id: unknown; title?: string; content?: string; isPublic?: boolean }>>;
+    },
+  },
 };
 
 /**

--- a/app/server/functions/organizations.ts
+++ b/app/server/functions/organizations.ts
@@ -11,11 +11,13 @@ import { Character } from '../db/models/Character';
 import { Player } from '../db/models/Player';
 import type {
   OrganizationData,
+  OrganizationImage,
   OrganizationListItem,
   OrganizationLocationLink,
   OrganizationMembershipData,
   MemberKind,
 } from '~/types/organization';
+import type { PictureCrop } from '~/types/character';
 import {
   createOrganizationSchema,
   updateOrganizationSchema,
@@ -56,6 +58,18 @@ async function resolveLocationLabels(
       };
     })
   );
+}
+
+// Images are public — never gated on isGM (unlike privateInfo/locations.privateInfo).
+function serializeImages(raw: unknown): OrganizationImage[] {
+  return ((raw as unknown[]) ?? []).map((i) => {
+    const img = i as Record<string, unknown>;
+    return {
+      url: String(img.url),
+      caption: (img.caption as string) ?? '',
+      crop: (img.crop as unknown as PictureCrop) ?? null,
+    };
+  });
 }
 
 // Cap on list result sizes — a safety bound against a pathological campaign.
@@ -189,7 +203,7 @@ export const listOrganizations = async ({
     }
 
     const docs = (await Organization.find(filter)
-      .select('-publicInfo -privateInfo -locations')
+      .select('-publicInfo -privateInfo -images -locations')
       .sort({ updatedAt: -1 })
       .limit(LIST_LIMIT)
       .lean()) as AnyDoc[];
@@ -232,6 +246,7 @@ export const getOrganization = async ({
       publicInfo: (doc.publicInfo as string) ?? '',
       privateInfo: member.isGM ? ((doc.privateInfo as string) ?? '') : '',
       isPublic: Boolean(doc.isPublic),
+      images: serializeImages(doc.images),
       tags: (doc.tags as string[]) ?? [],
       locations,
       canEdit: isCreator || member.isGM,
@@ -268,6 +283,7 @@ export const createOrganization = async ({
       publicInfo: data.publicInfo,
       privateInfo: member.isGM ? data.privateInfo : '',
       isPublic: data.isPublic,
+      images: data.images,
       tags: finalTags,
       locations,
       createdAt: new Date(),
@@ -293,6 +309,7 @@ export const createOrganization = async ({
       publicInfo: data.publicInfo,
       privateInfo: member.isGM ? data.privateInfo : '',
       isPublic: data.isPublic,
+      images: data.images,
       tags: finalTags,
       locations: resolved,
       canEdit: true,
@@ -340,6 +357,7 @@ export const updateOrganization = async ({
       name: data.name.trim(),
       publicInfo: data.publicInfo,
       isPublic: data.isPublic,
+      images: data.images,
       tags: finalTags,
       locations,
       updatedAt: new Date(),
@@ -374,6 +392,7 @@ export const updateOrganization = async ({
       publicInfo: (org.publicInfo as string) ?? '',
       privateInfo: member.isGM ? ((org.privateInfo as string) ?? '') : '',
       isPublic: Boolean(org.isPublic),
+      images: serializeImages(org.images),
       tags: (org.tags as string[]) ?? [],
       locations: resolved,
       canEdit: isCreator || member.isGM,

--- a/app/server/functions/organizations.ts
+++ b/app/server/functions/organizations.ts
@@ -58,19 +58,71 @@ async function resolveLocationLabels(
   );
 }
 
-async function resolveMemberLabel(kind: MemberKind, id: string): Promise<string> {
+// Cap on list result sizes — a safety bound against a pathological campaign.
+// Real D&D campaigns hold far fewer orgs/members than this.
+const LIST_LIMIT = 500;
+
+function fullName(doc: AnyDoc): string {
+  return `${doc.firstName ?? ''} ${doc.lastName ?? ''}`.trim();
+}
+
+// Resolve a single member's display name, scoped to the campaign so an id from
+// another campaign can never resolve (defense-in-depth alongside the existence
+// check in addMembership).
+async function resolveMemberLabel(
+  kind: MemberKind,
+  id: string,
+  campaignId: string
+): Promise<string> {
   try {
-    if (kind === 'character') {
-      const c = (await Character.findById(id, 'firstName lastName').lean()) as AnyDoc | null;
-      if (c) return `${c.firstName ?? ''} ${c.lastName ?? ''}`.trim();
-    } else {
-      const p = (await Player.findById(id, 'firstName lastName').lean()) as AnyDoc | null;
-      if (p) return `${p.firstName ?? ''} ${p.lastName ?? ''}`.trim();
-    }
+    const model = kind === 'character' ? Character : Player;
+    const doc = (await model
+      .findOne({ _id: id, campaignId }, 'firstName lastName')
+      .lean()) as AnyDoc | null;
+    if (doc) return fullName(doc);
   } catch {
     /* ignore */
   }
   return '';
+}
+
+// Batch-resolve member labels for a roster in two queries (one per kind),
+// avoiding an N+1 findById per membership. Keyed by `"${kind}:${id}"`.
+async function resolveMemberLabels(
+  docs: AnyDoc[],
+  campaignId: string
+): Promise<Map<string, string>> {
+  const labels = new Map<string, string>();
+  const charIds = docs.filter((d) => d.memberKind === 'character').map((d) => String(d.memberId));
+  const playerIds = docs.filter((d) => d.memberKind === 'player').map((d) => String(d.memberId));
+  try {
+    const [chars, players] = (await Promise.all([
+      charIds.length
+        ? Character.find({ _id: { $in: charIds }, campaignId }, 'firstName lastName').lean()
+        : Promise.resolve([]),
+      playerIds.length
+        ? Player.find({ _id: { $in: playerIds }, campaignId }, 'firstName lastName').lean()
+        : Promise.resolve([]),
+    ])) as [AnyDoc[], AnyDoc[]];
+    for (const c of chars) labels.set(`character:${String(c._id)}`, fullName(c));
+    for (const p of players) labels.set(`player:${String(p._id)}`, fullName(p));
+  } catch {
+    /* ignore — labels default to '' */
+  }
+  return labels;
+}
+
+// Verify a member (player or character) actually belongs to the campaign before
+// it can be linked to an organization — prevents cross-campaign membership rows
+// and the name disclosure that label resolution would otherwise leak.
+async function memberExistsInCampaign(
+  kind: MemberKind,
+  id: string,
+  campaignId: string
+): Promise<boolean> {
+  const model = kind === 'character' ? Character : Player;
+  const exists = await model.exists({ _id: id, campaignId });
+  return !!exists;
 }
 
 function serializeListItem(doc: AnyDoc, canEdit: boolean): OrganizationListItem {
@@ -139,6 +191,7 @@ export const listOrganizations = async ({
     const docs = (await Organization.find(filter)
       .select('-publicInfo -privateInfo -locations')
       .sort({ updatedAt: -1 })
+      .limit(LIST_LIMIT)
       .lean()) as AnyDoc[];
 
     return docs.map((d) =>
@@ -399,6 +452,10 @@ export const addMembership = async ({
     if (!org) throw new Error('Organization not found');
     if (!member.isGM && String(org.createdBy) !== member.userId) throw new Error('Forbidden');
 
+    if (!(await memberExistsInCampaign(data.memberKind, data.memberId, data.campaignId))) {
+      throw new Error('Member not found');
+    }
+
     const doc = await OrganizationMembership.create({
       organizationId: data.organizationId,
       memberKind: data.memberKind,
@@ -412,7 +469,7 @@ export const addMembership = async ({
       updatedAt: new Date(),
     });
 
-    const label = await resolveMemberLabel(data.memberKind, data.memberId);
+    const label = await resolveMemberLabel(data.memberKind, data.memberId, data.campaignId);
     return serializeMembership(
       doc as unknown as AnyDoc,
       String(org.name ?? ''),
@@ -461,7 +518,11 @@ export const updateMembership = async ({
     ).lean()) as AnyDoc | null;
     if (!doc) throw new Error('Membership not found');
 
-    const label = await resolveMemberLabel(doc.memberKind as MemberKind, String(doc.memberId));
+    const label = await resolveMemberLabel(
+      doc.memberKind as MemberKind,
+      String(doc.memberId),
+      data.campaignId
+    );
     return serializeMembership(
       doc,
       String(org.name ?? ''),
@@ -523,20 +584,20 @@ export const listMembershipsForOrg = async ({
     const docs = (await OrganizationMembership.find({
       organizationId: data.organizationId,
       campaignId: data.campaignId,
-    }).lean()) as AnyDoc[];
+    })
+      .limit(LIST_LIMIT)
+      .lean()) as AnyDoc[];
 
-    return Promise.all(
-      docs.map(async (d) => {
-        const label = await resolveMemberLabel(d.memberKind as MemberKind, String(d.memberId));
-        return serializeMembership(
-          d,
-          String(org.name ?? ''),
-          Boolean(org.isPublic),
-          label,
-          member.isGM,
-          canEdit
-        );
-      })
+    const labels = await resolveMemberLabels(docs, data.campaignId);
+    return docs.map((d) =>
+      serializeMembership(
+        d,
+        String(org.name ?? ''),
+        Boolean(org.isPublic),
+        labels.get(`${d.memberKind}:${String(d.memberId)}`) ?? '',
+        member.isGM,
+        canEdit
+      )
     );
   } catch (e) {
     serverCaptureException(e, sessionUserId, { action: 'listMembershipsForOrg' });
@@ -558,7 +619,9 @@ export const listMembershipsForMember = async ({
       campaignId: data.campaignId,
       memberKind: data.memberKind,
       memberId: data.memberId,
-    }).lean()) as AnyDoc[];
+    })
+      .limit(LIST_LIMIT)
+      .lean()) as AnyDoc[];
     if (docs.length === 0) return [];
 
     const orgIds = [...new Set(docs.map((d) => String(d.organizationId)))];
@@ -568,7 +631,7 @@ export const listMembershipsForMember = async ({
     ).lean()) as AnyDoc[];
     const orgMap = new Map(orgs.map((o) => [String(o._id), o]));
 
-    const label = await resolveMemberLabel(data.memberKind, data.memberId);
+    const label = await resolveMemberLabel(data.memberKind, data.memberId, data.campaignId);
 
     const results: OrganizationMembershipData[] = [];
     for (const d of docs) {

--- a/app/server/functions/organizations.ts
+++ b/app/server/functions/organizations.ts
@@ -493,7 +493,7 @@ export const removeMembership = async ({
     if (!existing) throw new Error('Membership not found');
 
     const org = await loadOrgForMembership(String(existing.organizationId), data.campaignId);
-    if (org && !member.isGM && String(org.createdBy) !== member.userId)
+    if (!member.isGM && (!org || String(org.createdBy) !== member.userId))
       throw new Error('Forbidden');
 
     await OrganizationMembership.deleteOne({ _id: data.id, campaignId: data.campaignId });
@@ -516,7 +516,9 @@ export const listMembershipsForOrg = async ({
 
     const org = await loadOrgForMembership(data.organizationId, data.campaignId);
     if (!org) return [];
-    const canEdit = member.isGM || String(org.createdBy) === member.userId;
+    const isCreator = String(org.createdBy) === member.userId;
+    if (!member.isGM && !isCreator && !org.isPublic) return [];
+    const canEdit = member.isGM || isCreator;
 
     const docs = (await OrganizationMembership.find({
       organizationId: data.organizationId,

--- a/app/server/functions/organizations.ts
+++ b/app/server/functions/organizations.ts
@@ -1,0 +1,603 @@
+import { z } from 'zod';
+import { requireCampaignMember } from '../utils/requireCampaignMember';
+import { serverCaptureException, serverCaptureEvent } from '../utils/telemetry';
+import { normalizeTags } from '../utils/helpers';
+import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
+import { ensureTags as ensureTagsFn } from './tags';
+import { Organization } from '../db/models/Organization';
+import { OrganizationMembership } from '../db/models/OrganizationMembership';
+import { Location } from '../db/models/Location';
+import { Character } from '../db/models/Character';
+import { Player } from '../db/models/Player';
+import type {
+  OrganizationData,
+  OrganizationListItem,
+  OrganizationLocationLink,
+  OrganizationMembershipData,
+  MemberKind,
+} from '~/types/organization';
+import {
+  createOrganizationSchema,
+  updateOrganizationSchema,
+  deleteOrganizationSchema,
+  getOrganizationSchema,
+  listOrganizationsSchema,
+  addMembershipSchema,
+  updateMembershipSchema,
+  removeMembershipSchema,
+  listMembershipsForOrgSchema,
+  listMembershipsForMemberSchema,
+} from '~/types/schemas/organizations';
+
+type AnyDoc = Record<string, unknown> & { _id: unknown };
+
+function iso(d: unknown): string {
+  return d instanceof Date ? d.toISOString() : '';
+}
+
+async function resolveLocationLabels(
+  raw: Array<Record<string, unknown>>,
+  isGM: boolean
+): Promise<OrganizationLocationLink[]> {
+  return Promise.all(
+    raw.map(async (l) => {
+      let label = '';
+      try {
+        const loc = (await Location.findById(String(l.locationId), 'name').lean()) as AnyDoc | null;
+        if (loc) label = String(loc.name ?? '');
+      } catch {
+        label = '';
+      }
+      return {
+        locationId: String(l.locationId),
+        label,
+        publicInfo: (l.publicInfo as string) ?? '',
+        privateInfo: isGM ? ((l.privateInfo as string) ?? '') : '',
+      };
+    })
+  );
+}
+
+async function resolveMemberLabel(kind: MemberKind, id: string): Promise<string> {
+  try {
+    if (kind === 'character') {
+      const c = (await Character.findById(id, 'firstName lastName').lean()) as AnyDoc | null;
+      if (c) return `${c.firstName ?? ''} ${c.lastName ?? ''}`.trim();
+    } else {
+      const p = (await Player.findById(id, 'firstName lastName').lean()) as AnyDoc | null;
+      if (p) return `${p.firstName ?? ''} ${p.lastName ?? ''}`.trim();
+    }
+  } catch {
+    /* ignore */
+  }
+  return '';
+}
+
+function serializeListItem(doc: AnyDoc, canEdit: boolean): OrganizationListItem {
+  return {
+    id: String(doc._id),
+    campaignId: String(doc.campaignId),
+    createdBy: String(doc.createdBy),
+    name: (doc.name as string) ?? '',
+    isPublic: Boolean(doc.isPublic),
+    tags: (doc.tags as string[]) ?? [],
+    canEdit,
+    createdAt: iso(doc.createdAt),
+    updatedAt: iso(doc.updatedAt),
+  };
+}
+
+function serializeMembership(
+  doc: AnyDoc,
+  orgName: string,
+  orgIsPublic: boolean,
+  memberLabel: string,
+  isGM: boolean,
+  canEdit: boolean
+): OrganizationMembershipData {
+  return {
+    id: String(doc._id),
+    campaignId: String(doc.campaignId),
+    organizationId: String(doc.organizationId),
+    organizationName: orgName,
+    organizationIsPublic: orgIsPublic,
+    memberKind: doc.memberKind as MemberKind,
+    memberId: String(doc.memberId),
+    memberLabel,
+    title: (doc.title as string) ?? '',
+    publicNotes: (doc.publicNotes as string) ?? '',
+    privateNotes: isGM ? ((doc.privateNotes as string) ?? '') : '',
+    canEdit,
+    createdAt: iso(doc.createdAt),
+    updatedAt: iso(doc.updatedAt),
+  };
+}
+
+// --- Organization CRUD ---
+
+export const listOrganizations = async ({
+  data,
+}: {
+  data: z.infer<typeof listOrganizationsSchema>;
+}): Promise<OrganizationListItem[]> => {
+  let sessionUserId: string | undefined;
+  try {
+    const member = await requireCampaignMember(data.campaignId);
+    sessionUserId = member.sessionUserId;
+
+    const filter: Record<string, unknown> = { campaignId: data.campaignId };
+    if (!member.isGM) filter.$or = [{ isPublic: true }, { createdBy: member.userId }];
+    if (data.search) filter.$text = { $search: data.search };
+    if (data.tags && data.tags.length > 0) {
+      const normalized = [...new Set(normalizeTags(data.tags))];
+      if (normalized.length > 0) filter.tags = { $all: normalized };
+    }
+    if (data.locationIds && data.locationIds.length > 0) {
+      filter['locations.locationId'] = { $in: data.locationIds };
+    }
+
+    const docs = (await Organization.find(filter)
+      .select('-publicInfo -privateInfo -locations')
+      .sort({ updatedAt: -1 })
+      .lean()) as AnyDoc[];
+
+    return docs.map((d) =>
+      serializeListItem(d, String(d.createdBy) === member.userId || member.isGM)
+    );
+  } catch (e) {
+    serverCaptureException(e, sessionUserId, { action: 'listOrganizations' });
+    throw e;
+  }
+};
+
+export const getOrganization = async ({
+  data,
+}: {
+  data: z.infer<typeof getOrganizationSchema>;
+}): Promise<OrganizationData | null> => {
+  let sessionUserId: string | undefined;
+  try {
+    const member = await requireCampaignMember(data.campaignId);
+    sessionUserId = member.sessionUserId;
+
+    const doc = (await Organization.findById(data.id).lean()) as AnyDoc | null;
+    if (!doc || String(doc.campaignId) !== data.campaignId) return null;
+
+    const isCreator = String(doc.createdBy) === member.userId;
+    if (!member.isGM && !isCreator && !doc.isPublic) return null;
+
+    const locations = await resolveLocationLabels(
+      (doc.locations as Array<Record<string, unknown>>) ?? [],
+      member.isGM
+    );
+
+    return {
+      id: String(doc._id),
+      campaignId: String(doc.campaignId),
+      createdBy: String(doc.createdBy),
+      name: (doc.name as string) ?? '',
+      publicInfo: (doc.publicInfo as string) ?? '',
+      privateInfo: member.isGM ? ((doc.privateInfo as string) ?? '') : '',
+      isPublic: Boolean(doc.isPublic),
+      tags: (doc.tags as string[]) ?? [],
+      locations,
+      canEdit: isCreator || member.isGM,
+      createdAt: iso(doc.createdAt),
+      updatedAt: iso(doc.updatedAt),
+    };
+  } catch (e) {
+    serverCaptureException(e, sessionUserId, { action: 'getOrganization' });
+    throw e;
+  }
+};
+
+export const createOrganization = async ({
+  data,
+}: {
+  data: z.infer<typeof createOrganizationSchema>;
+}): Promise<OrganizationData> => {
+  let sessionUserId: string | undefined;
+  try {
+    const member = await requireCampaignMember(data.campaignId);
+    sessionUserId = member.sessionUserId;
+
+    const finalTags = normalizeTags(data.tags ?? []);
+    const locations = data.locations.map((l) => ({
+      locationId: l.locationId,
+      publicInfo: l.publicInfo,
+      privateInfo: member.isGM ? l.privateInfo : '',
+    }));
+
+    const org = new Organization({
+      campaignId: data.campaignId,
+      createdBy: member.userId,
+      name: data.name.trim(),
+      publicInfo: data.publicInfo,
+      privateInfo: member.isGM ? data.privateInfo : '',
+      isPublic: data.isPublic,
+      tags: finalTags,
+      locations,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await org.save();
+
+    if (finalTags.length > 0) {
+      await ensureTagsFn({ data: { campaignId: data.campaignId, tags: finalTags } });
+    }
+
+    serverCaptureEvent(sessionUserId!, 'organization_created', {
+      campaign_id: data.campaignId,
+      organization_id: String(org._id),
+    });
+
+    const resolved = await resolveLocationLabels(locations, member.isGM);
+    return {
+      id: String(org._id),
+      campaignId: data.campaignId,
+      createdBy: member.userId,
+      name: data.name.trim(),
+      publicInfo: data.publicInfo,
+      privateInfo: member.isGM ? data.privateInfo : '',
+      isPublic: data.isPublic,
+      tags: finalTags,
+      locations: resolved,
+      canEdit: true,
+      createdAt: iso(org.createdAt),
+      updatedAt: iso(org.updatedAt),
+    };
+  } catch (e) {
+    serverCaptureException(e, sessionUserId, { action: 'createOrganization' });
+    throw e;
+  }
+};
+
+export const updateOrganization = async ({
+  data,
+}: {
+  data: z.infer<typeof updateOrganizationSchema>;
+}): Promise<OrganizationData> => {
+  let sessionUserId: string | undefined;
+  try {
+    const member = await requireCampaignMember(data.campaignId);
+    sessionUserId = member.sessionUserId;
+
+    const existing = (await Organization.findOne({
+      _id: data.id,
+      campaignId: data.campaignId,
+    }).lean()) as AnyDoc | null;
+    if (!existing) throw new Error('Organization not found');
+    const isCreator = String(existing.createdBy) === member.userId;
+    if (!member.isGM && !isCreator) throw new Error('Forbidden');
+
+    const finalTags = normalizeTags(data.tags ?? []);
+
+    // Preserve GM-only privateInfo per location for non-GM writers.
+    const existingPriv = new Map<string, string>();
+    for (const l of (existing.locations as Array<Record<string, unknown>>) ?? []) {
+      existingPriv.set(String(l.locationId), (l.privateInfo as string) ?? '');
+    }
+    const locations = data.locations.map((l) => ({
+      locationId: l.locationId,
+      publicInfo: l.publicInfo,
+      privateInfo: member.isGM ? l.privateInfo : (existingPriv.get(l.locationId) ?? ''),
+    }));
+
+    const set: Record<string, unknown> = {
+      name: data.name.trim(),
+      publicInfo: data.publicInfo,
+      isPublic: data.isPublic,
+      tags: finalTags,
+      locations,
+      updatedAt: new Date(),
+    };
+    if (member.isGM) set.privateInfo = data.privateInfo;
+
+    const org = (await Organization.findOneAndUpdate(
+      { _id: data.id, campaignId: data.campaignId },
+      { $set: set },
+      { new: true }
+    ).lean()) as AnyDoc | null;
+    if (!org) throw new Error('Organization not found');
+
+    if (finalTags.length > 0) {
+      await ensureTagsFn({ data: { campaignId: data.campaignId, tags: finalTags } });
+    }
+
+    serverCaptureEvent(sessionUserId!, 'organization_updated', {
+      campaign_id: data.campaignId,
+      organization_id: data.id,
+    });
+
+    const resolved = await resolveLocationLabels(
+      (org.locations as Array<Record<string, unknown>>) ?? [],
+      member.isGM
+    );
+    return {
+      id: String(org._id),
+      campaignId: String(org.campaignId),
+      createdBy: String(org.createdBy),
+      name: (org.name as string) ?? '',
+      publicInfo: (org.publicInfo as string) ?? '',
+      privateInfo: member.isGM ? ((org.privateInfo as string) ?? '') : '',
+      isPublic: Boolean(org.isPublic),
+      tags: (org.tags as string[]) ?? [],
+      locations: resolved,
+      canEdit: isCreator || member.isGM,
+      createdAt: iso(org.createdAt),
+      updatedAt: iso(org.updatedAt),
+    };
+  } catch (e) {
+    serverCaptureException(e, sessionUserId, { action: 'updateOrganization' });
+    throw e;
+  }
+};
+
+export const deleteOrganization = async ({
+  data,
+}: {
+  data: z.infer<typeof deleteOrganizationSchema>;
+}) => {
+  let sessionUserId: string | undefined;
+  try {
+    const member = await requireCampaignMember(data.campaignId);
+    sessionUserId = member.sessionUserId;
+
+    const org = (await Organization.findOne({
+      _id: data.id,
+      campaignId: data.campaignId,
+    }).lean()) as AnyDoc | null;
+    if (!org) throw new Error('Organization not found');
+    if (!member.isGM && String(org.createdBy) !== member.userId) throw new Error('Forbidden');
+
+    await Organization.deleteOne({ _id: data.id, campaignId: data.campaignId });
+    await OrganizationMembership.deleteMany({ organizationId: data.id });
+
+    try {
+      await removeDocumentRefsFromScreens(data.campaignId, 'organization', data.id);
+    } catch (cleanupError) {
+      serverCaptureException(cleanupError, sessionUserId, {
+        action: 'deleteOrganization.cleanup',
+        campaign_id: data.campaignId,
+        organization_id: data.id,
+      });
+    }
+
+    serverCaptureEvent(sessionUserId!, 'organization_deleted', {
+      campaign_id: data.campaignId,
+      organization_id: data.id,
+    });
+    return { success: true };
+  } catch (e) {
+    serverCaptureException(e, sessionUserId, { action: 'deleteOrganization' });
+    throw e;
+  }
+};
+
+// --- Membership helpers ---
+
+async function loadOrgForMembership(organizationId: string, campaignId: string) {
+  return (await Organization.findOne(
+    { _id: organizationId, campaignId },
+    '_id createdBy name isPublic'
+  ).lean()) as AnyDoc | null;
+}
+
+// --- Membership CRUD ---
+
+export const addMembership = async ({
+  data,
+}: {
+  data: z.infer<typeof addMembershipSchema>;
+}): Promise<OrganizationMembershipData> => {
+  let sessionUserId: string | undefined;
+  try {
+    const member = await requireCampaignMember(data.campaignId);
+    sessionUserId = member.sessionUserId;
+
+    const org = await loadOrgForMembership(data.organizationId, data.campaignId);
+    if (!org) throw new Error('Organization not found');
+    if (!member.isGM && String(org.createdBy) !== member.userId) throw new Error('Forbidden');
+
+    const doc = await OrganizationMembership.create({
+      organizationId: data.organizationId,
+      memberKind: data.memberKind,
+      memberId: data.memberId,
+      title: data.title,
+      publicNotes: data.publicNotes,
+      privateNotes: member.isGM ? data.privateNotes : '',
+      campaignId: data.campaignId,
+      createdBy: member.userId,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const label = await resolveMemberLabel(data.memberKind, data.memberId);
+    return serializeMembership(
+      doc as unknown as AnyDoc,
+      String(org.name ?? ''),
+      Boolean(org.isPublic),
+      label,
+      member.isGM,
+      true
+    );
+  } catch (e) {
+    serverCaptureException(e, sessionUserId, { action: 'addMembership' });
+    throw e;
+  }
+};
+
+export const updateMembership = async ({
+  data,
+}: {
+  data: z.infer<typeof updateMembershipSchema>;
+}): Promise<OrganizationMembershipData> => {
+  let sessionUserId: string | undefined;
+  try {
+    const member = await requireCampaignMember(data.campaignId);
+    sessionUserId = member.sessionUserId;
+
+    const existing = (await OrganizationMembership.findOne({
+      _id: data.id,
+      campaignId: data.campaignId,
+    }).lean()) as AnyDoc | null;
+    if (!existing) throw new Error('Membership not found');
+
+    const org = await loadOrgForMembership(String(existing.organizationId), data.campaignId);
+    if (!org) throw new Error('Organization not found');
+    if (!member.isGM && String(org.createdBy) !== member.userId) throw new Error('Forbidden');
+
+    const set: Record<string, unknown> = {
+      title: data.title,
+      publicNotes: data.publicNotes,
+      updatedAt: new Date(),
+    };
+    if (member.isGM) set.privateNotes = data.privateNotes;
+
+    const doc = (await OrganizationMembership.findOneAndUpdate(
+      { _id: data.id, campaignId: data.campaignId },
+      { $set: set },
+      { new: true }
+    ).lean()) as AnyDoc | null;
+    if (!doc) throw new Error('Membership not found');
+
+    const label = await resolveMemberLabel(doc.memberKind as MemberKind, String(doc.memberId));
+    return serializeMembership(
+      doc,
+      String(org.name ?? ''),
+      Boolean(org.isPublic),
+      label,
+      member.isGM,
+      member.isGM || String(org.createdBy) === member.userId
+    );
+  } catch (e) {
+    serverCaptureException(e, sessionUserId, { action: 'updateMembership' });
+    throw e;
+  }
+};
+
+export const removeMembership = async ({
+  data,
+}: {
+  data: z.infer<typeof removeMembershipSchema>;
+}) => {
+  let sessionUserId: string | undefined;
+  try {
+    const member = await requireCampaignMember(data.campaignId);
+    sessionUserId = member.sessionUserId;
+
+    const existing = (await OrganizationMembership.findOne({
+      _id: data.id,
+      campaignId: data.campaignId,
+    }).lean()) as AnyDoc | null;
+    if (!existing) throw new Error('Membership not found');
+
+    const org = await loadOrgForMembership(String(existing.organizationId), data.campaignId);
+    if (org && !member.isGM && String(org.createdBy) !== member.userId)
+      throw new Error('Forbidden');
+
+    await OrganizationMembership.deleteOne({ _id: data.id, campaignId: data.campaignId });
+    return { success: true };
+  } catch (e) {
+    serverCaptureException(e, sessionUserId, { action: 'removeMembership' });
+    throw e;
+  }
+};
+
+export const listMembershipsForOrg = async ({
+  data,
+}: {
+  data: z.infer<typeof listMembershipsForOrgSchema>;
+}): Promise<OrganizationMembershipData[]> => {
+  let sessionUserId: string | undefined;
+  try {
+    const member = await requireCampaignMember(data.campaignId);
+    sessionUserId = member.sessionUserId;
+
+    const org = await loadOrgForMembership(data.organizationId, data.campaignId);
+    if (!org) return [];
+    const canEdit = member.isGM || String(org.createdBy) === member.userId;
+
+    const docs = (await OrganizationMembership.find({
+      organizationId: data.organizationId,
+      campaignId: data.campaignId,
+    }).lean()) as AnyDoc[];
+
+    return Promise.all(
+      docs.map(async (d) => {
+        const label = await resolveMemberLabel(d.memberKind as MemberKind, String(d.memberId));
+        return serializeMembership(
+          d,
+          String(org.name ?? ''),
+          Boolean(org.isPublic),
+          label,
+          member.isGM,
+          canEdit
+        );
+      })
+    );
+  } catch (e) {
+    serverCaptureException(e, sessionUserId, { action: 'listMembershipsForOrg' });
+    throw e;
+  }
+};
+
+export const listMembershipsForMember = async ({
+  data,
+}: {
+  data: z.infer<typeof listMembershipsForMemberSchema>;
+}): Promise<OrganizationMembershipData[]> => {
+  let sessionUserId: string | undefined;
+  try {
+    const member = await requireCampaignMember(data.campaignId);
+    sessionUserId = member.sessionUserId;
+
+    const docs = (await OrganizationMembership.find({
+      campaignId: data.campaignId,
+      memberKind: data.memberKind,
+      memberId: data.memberId,
+    }).lean()) as AnyDoc[];
+    if (docs.length === 0) return [];
+
+    const orgIds = [...new Set(docs.map((d) => String(d.organizationId)))];
+    const orgs = (await Organization.find(
+      { _id: { $in: orgIds }, campaignId: data.campaignId },
+      '_id name isPublic createdBy'
+    ).lean()) as AnyDoc[];
+    const orgMap = new Map(orgs.map((o) => [String(o._id), o]));
+
+    const label = await resolveMemberLabel(data.memberKind, data.memberId);
+
+    const results: OrganizationMembershipData[] = [];
+    for (const d of docs) {
+      const org = orgMap.get(String(d.organizationId));
+      if (!org) continue; // org deleted — skip stale membership
+      // Non-GM only sees memberships to public orgs.
+      if (!member.isGM && !org.isPublic) continue;
+      const canEdit = member.isGM || String(org.createdBy) === member.userId;
+      results.push(
+        serializeMembership(
+          d,
+          String(org.name ?? ''),
+          Boolean(org.isPublic),
+          label,
+          member.isGM,
+          canEdit
+        )
+      );
+    }
+    return results;
+  } catch (e) {
+    serverCaptureException(e, sessionUserId, { action: 'listMembershipsForMember' });
+    throw e;
+  }
+};
+
+// Used by player/character delete flows (Task 6).
+export async function pruneMembershipsForMember(
+  memberKind: MemberKind,
+  memberId: string,
+  campaignId: string
+): Promise<void> {
+  await OrganizationMembership.deleteMany({ memberKind, memberId, campaignId });
+}

--- a/app/server/functions/players.ts
+++ b/app/server/functions/players.ts
@@ -11,6 +11,7 @@ import { serverCaptureException, serverCaptureEvent } from '../utils/telemetry';
 import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
 import { pruneLoreLinks } from '../utils/pruneLoreLinks';
 import { pruneEventLinks } from '../utils/pruneEventLinks';
+import { pruneMembershipsForMember } from './organizations';
 import type { PlayerData, PlayerListItem } from '~/types/player';
 import type { PictureCrop } from '~/types/character';
 import {
@@ -337,6 +338,16 @@ export const deletePlayer = async ({ data }: { data: z.infer<typeof deletePlayer
 
     await pruneLoreLinks('player', data.id, data.campaignId);
     await pruneEventLinks('player', data.id, data.campaignId);
+
+    try {
+      await pruneMembershipsForMember('player', data.id, data.campaignId);
+    } catch (pruneError) {
+      serverCaptureException(pruneError, sessionUserId, {
+        action: 'deletePlayer.pruneMemberships',
+        campaign_id: data.campaignId,
+        player_id: data.id,
+      });
+    }
 
     serverCaptureEvent(sessionUserId, 'player_deleted', {
       campaign_id: data.campaignId,

--- a/app/server/functions/tabletop-hydration.ts
+++ b/app/server/functions/tabletop-hydration.ts
@@ -177,6 +177,21 @@ const COLLECTION_REGISTRY: Record<string, CollectionFetcher> = {
         );
     },
   },
+  organization: {
+    async fetch(ids: string[], campaignId: string) {
+      const { Organization } = await import('../db/models/Organization');
+      return Organization.find({ _id: { $in: ids }, campaignId }, '_id name publicInfo isPublic')
+        .lean()
+        .then((docs) =>
+          docs.map((d) => ({
+            _id: d._id,
+            title: (d as { name?: string }).name,
+            content: (d as { publicInfo?: string }).publicInfo,
+            isPublic: (d as { isPublic?: boolean }).isPublic,
+          }))
+        ) as Promise<Array<{ _id: unknown; title?: string; content?: string; isPublic?: boolean }>>;
+    },
+  },
 };
 
 /**
@@ -213,6 +228,7 @@ export async function hydrateRefs(
         // Events can carry private GM content; never hydrate a non-public event
         // for a non-GM viewer, or its title/content would leak on a shared screen.
         if (!isGM && collectionName === 'events' && doc.isPublic === false) continue;
+        if (!isGM && collectionName === 'organization' && doc.isPublic === false) continue;
         const id = String(doc._id);
         hydrated[`${collectionName}:${id}`] = {
           id,

--- a/app/types/organization.ts
+++ b/app/types/organization.ts
@@ -1,0 +1,79 @@
+export interface OrganizationLocationLink {
+  locationId: string;
+  label: string;
+  publicInfo: string;
+  /** GM-only; '' for non-GM viewers. */
+  privateInfo: string;
+}
+
+export interface OrganizationData {
+  id: string;
+  campaignId: string;
+  createdBy: string;
+  name: string;
+  publicInfo: string;
+  /** GM-only; '' for non-GM viewers. */
+  privateInfo: string;
+  isPublic: boolean;
+  tags: string[];
+  locations: OrganizationLocationLink[];
+  canEdit: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface OrganizationListItem {
+  id: string;
+  campaignId: string;
+  createdBy: string;
+  name: string;
+  isPublic: boolean;
+  tags: string[];
+  canEdit: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type MemberKind = 'player' | 'character';
+
+export interface OrganizationMembershipData {
+  id: string;
+  campaignId: string;
+  organizationId: string;
+  /** Resolved organization name. */
+  organizationName: string;
+  /** Whether the linked org is public (used to gate member-side display). */
+  organizationIsPublic: boolean;
+  memberKind: MemberKind;
+  memberId: string;
+  /** Resolved member display name. */
+  memberLabel: string;
+  title: string;
+  publicNotes: string;
+  /** GM-only; '' for non-GM viewers. */
+  privateNotes: string;
+  canEdit: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface OrganizationLocationLinkInput {
+  locationId: string;
+  label?: string;
+  publicInfo: string;
+  privateInfo: string;
+}
+
+export interface CreateOrganizationInput {
+  campaignId: string;
+  name: string;
+  publicInfo: string;
+  privateInfo: string;
+  isPublic: boolean;
+  tags: string[];
+  locations: OrganizationLocationLinkInput[];
+}
+
+export interface UpdateOrganizationInput extends CreateOrganizationInput {
+  id: string;
+}

--- a/app/types/organization.ts
+++ b/app/types/organization.ts
@@ -1,9 +1,17 @@
+import type { PictureCrop } from './character';
+
 export interface OrganizationLocationLink {
   locationId: string;
   label: string;
   publicInfo: string;
   /** GM-only; '' for non-GM viewers. */
   privateInfo: string;
+}
+
+export interface OrganizationImage {
+  url: string;
+  caption: string;
+  crop: PictureCrop | null;
 }
 
 export interface OrganizationData {
@@ -15,6 +23,7 @@ export interface OrganizationData {
   /** GM-only; '' for non-GM viewers. */
   privateInfo: string;
   isPublic: boolean;
+  images: OrganizationImage[];
   tags: string[];
   locations: OrganizationLocationLink[];
   canEdit: boolean;
@@ -70,6 +79,7 @@ export interface CreateOrganizationInput {
   publicInfo: string;
   privateInfo: string;
   isPublic: boolean;
+  images: OrganizationImage[];
   tags: string[];
   locations: OrganizationLocationLinkInput[];
 }

--- a/app/types/schemas/gmscreens.ts
+++ b/app/types/schemas/gmscreens.ts
@@ -15,6 +15,7 @@ export const SUPPORTED_COLLECTIONS: [string, ...string[]] = [
   'monster',
   'lore',
   'events',
+  'organization',
 ];
 
 // ---------------------------------------------------------------------------

--- a/app/types/schemas/organizations.ts
+++ b/app/types/schemas/organizations.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod';
+
+const locationLinkInputSchema = z.object({
+  locationId: z.string().trim().min(1),
+  publicInfo: z.string().optional().default(''),
+  privateInfo: z.string().optional().default(''),
+});
+
+export const createOrganizationSchema = z.object({
+  campaignId: z.string().trim().min(1),
+  name: z.string().trim().min(1, 'Name is required'),
+  publicInfo: z.string().optional().default(''),
+  privateInfo: z.string().optional().default(''),
+  isPublic: z.boolean().optional().default(false),
+  tags: z.array(z.string()).optional().default([]),
+  locations: z.array(locationLinkInputSchema).optional().default([]),
+});
+
+export const updateOrganizationSchema = createOrganizationSchema.extend({
+  id: z.string().trim().min(1),
+});
+
+export const deleteOrganizationSchema = z.object({
+  id: z.string().trim().min(1),
+  campaignId: z.string().trim().min(1),
+});
+
+export const getOrganizationSchema = z.object({
+  id: z.string().trim().min(1),
+  campaignId: z.string().trim().min(1),
+});
+
+export const listOrganizationsSchema = z.object({
+  campaignId: z.string().trim().min(1),
+  search: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  locationIds: z.array(z.string()).optional(),
+});
+
+// --- Memberships ---
+
+export const addMembershipSchema = z.object({
+  campaignId: z.string().trim().min(1),
+  organizationId: z.string().trim().min(1),
+  memberKind: z.enum(['player', 'character']),
+  memberId: z.string().trim().min(1),
+  title: z.string().optional().default(''),
+  publicNotes: z.string().optional().default(''),
+  privateNotes: z.string().optional().default(''),
+});
+
+export const updateMembershipSchema = z.object({
+  campaignId: z.string().trim().min(1),
+  id: z.string().trim().min(1),
+  title: z.string().optional().default(''),
+  publicNotes: z.string().optional().default(''),
+  privateNotes: z.string().optional().default(''),
+});
+
+export const removeMembershipSchema = z.object({
+  campaignId: z.string().trim().min(1),
+  id: z.string().trim().min(1),
+});
+
+export const listMembershipsForOrgSchema = z.object({
+  campaignId: z.string().trim().min(1),
+  organizationId: z.string().trim().min(1),
+});
+
+export const listMembershipsForMemberSchema = z.object({
+  campaignId: z.string().trim().min(1),
+  memberKind: z.enum(['player', 'character']),
+  memberId: z.string().trim().min(1),
+});

--- a/app/types/schemas/organizations.ts
+++ b/app/types/schemas/organizations.ts
@@ -6,12 +6,27 @@ const locationLinkInputSchema = z.object({
   privateInfo: z.string().optional().default(''),
 });
 
+const organizationImageSchema = z.object({
+  url: z.string().trim().min(1),
+  caption: z.string().trim().default(''),
+  crop: z
+    .object({
+      x: z.number().finite().min(0).max(1),
+      y: z.number().finite().min(0).max(1),
+      width: z.number().finite().gt(0).max(1),
+      height: z.number().finite().gt(0).max(1),
+    })
+    .nullable()
+    .default(null),
+});
+
 export const createOrganizationSchema = z.object({
   campaignId: z.string().trim().min(1),
   name: z.string().trim().min(1, 'Name is required'),
   publicInfo: z.string().optional().default(''),
   privateInfo: z.string().optional().default(''),
   isPublic: z.boolean().optional().default(false),
+  images: z.array(organizationImageSchema).default([]),
   tags: z.array(z.string()).optional().default([]),
   locations: z.array(locationLinkInputSchema).optional().default([]),
 });

--- a/app/types/schemas/tabletop.ts
+++ b/app/types/schemas/tabletop.ts
@@ -54,6 +54,7 @@ const TABLETOP_COLLECTIONS: [string, ...string[]] = [
   'monster',
   'lore',
   'events',
+  'organization',
 ];
 
 export const openTabletopWindowSchema = z.object({

--- a/app/utils/queryKeys.ts
+++ b/app/utils/queryKeys.ts
@@ -188,6 +188,20 @@ export const queryKeys = {
     linked: (campaignId: string, kind: string, id: string) =>
       ['lore', 'linked', campaignId, kind, id] as const,
   },
+  organizations: {
+    all: ['organizations'] as const,
+    list: (campaignId: string, search?: string, tags?: string[], locationIds?: string[]) =>
+      ['organizations', 'list', campaignId, search ?? '', tags ?? [], locationIds ?? []] as const,
+    detail: (id: string, campaignId?: string) =>
+      ['organizations', 'detail', campaignId ?? '', id] as const,
+  },
+  memberships: {
+    all: ['memberships'] as const,
+    forOrg: (campaignId: string, organizationId: string) =>
+      ['memberships', 'forOrg', campaignId, organizationId] as const,
+    forMember: (campaignId: string, memberKind: string, memberId: string) =>
+      ['memberships', 'forMember', campaignId, memberKind, memberId] as const,
+  },
   calendar: {
     all: ['calendar'] as const,
     detail: (campaignId: string) => ['calendar', 'detail', campaignId] as const,

--- a/docs/specs/2026-07-13-organizations-design.md
+++ b/docs/specs/2026-07-13-organizations-design.md
@@ -21,16 +21,17 @@ names — `organizations` and `organizationmemberships`).
 
 ### `Organization` — `app/server/db/models/Organization.ts`
 
-| Field                     | Type                                                   | Notes                                          |
-| ------------------------- | ------------------------------------------------------ | ---------------------------------------------- |
-| `name`                    | String, required                                       | Display name / window title                    |
-| `publicInfo`              | String (Markdown)                                      | Rendered to everyone                           |
-| `privateInfo`             | String (Markdown)                                      | **GM-only**                                    |
-| `isPublic`                | Boolean, default `false`                               | Whole-entity visibility gate                   |
-| `locations`               | `[{ locationId → Location, publicInfo, privateInfo }]` | Embedded; each link's `privateInfo` is GM-only |
-| `tags`                    | `[String]`                                             | Normalized (lowercased/deduped)                |
-| `campaignId`, `createdBy` | ObjectId                                               | Scoping / ownership                            |
-| `createdAt`, `updatedAt`  | Date                                                   | Pre-save normalizes tags + bumps `updatedAt`   |
+| Field                     | Type                                                   | Notes                                                     |
+| ------------------------- | ------------------------------------------------------ | --------------------------------------------------------- |
+| `name`                    | String, required                                       | Display name / window title                               |
+| `publicInfo`              | String (Markdown)                                      | Rendered to everyone                                      |
+| `privateInfo`             | String (Markdown)                                      | **GM-only**                                               |
+| `isPublic`                | Boolean, default `false`                               | Whole-entity visibility gate                              |
+| `images`                  | `[{ url, caption, crop }]`                             | Multiple images (mirrors Lore); **public** — not GM-gated |
+| `locations`               | `[{ locationId → Location, publicInfo, privateInfo }]` | Embedded; each link's `privateInfo` is GM-only            |
+| `tags`                    | `[String]`                                             | Normalized (lowercased/deduped)                           |
+| `campaignId`, `createdBy` | ObjectId                                               | Scoping / ownership                                       |
+| `createdAt`, `updatedAt`  | Date                                                   | Pre-save normalizes tags + bumps `updatedAt`              |
 
 Indexes: `campaignId`, `{campaignId, updatedAt}`, `createdBy`, `tags`,
 `isPublic`, `locations.locationId`, and a text index on `{name, publicInfo}`.

--- a/docs/specs/2026-07-13-organizations-design.md
+++ b/docs/specs/2026-07-13-organizations-design.md
@@ -1,0 +1,146 @@
+# Organizations — Design
+
+**Date:** 2026-07-13 · **Status:** Implemented (branch `new-orgs` → PR against `dev`)
+
+## Overview
+
+Organizations are a wiki entity representing a group — guild, faction, noble
+house, cult, city watch — modeled after Kanka's Organizations. An organization
+has public and GM-only (private) descriptive information, a roster of member
+players/characters (each with an optional title and public + private
+relationship notes), and links to one or more locations (each with public +
+private information). Organizations are managed in the same wiki UI as lore,
+races, and locations, and are viewed primarily as **GM-screen and tabletop
+windows**. Players and characters gain an **Organizations** tab (in both the
+edit modal and the view window) listing every org they belong to.
+
+## Data model
+
+Two new mongoose collections (both use mongoose's default pluralized collection
+names — `organizations` and `organizationmemberships`).
+
+### `Organization` — `app/server/db/models/Organization.ts`
+
+| Field                     | Type                                                   | Notes                                          |
+| ------------------------- | ------------------------------------------------------ | ---------------------------------------------- |
+| `name`                    | String, required                                       | Display name / window title                    |
+| `publicInfo`              | String (Markdown)                                      | Rendered to everyone                           |
+| `privateInfo`             | String (Markdown)                                      | **GM-only**                                    |
+| `isPublic`                | Boolean, default `false`                               | Whole-entity visibility gate                   |
+| `locations`               | `[{ locationId → Location, publicInfo, privateInfo }]` | Embedded; each link's `privateInfo` is GM-only |
+| `tags`                    | `[String]`                                             | Normalized (lowercased/deduped)                |
+| `campaignId`, `createdBy` | ObjectId                                               | Scoping / ownership                            |
+| `createdAt`, `updatedAt`  | Date                                                   | Pre-save normalizes tags + bumps `updatedAt`   |
+
+Indexes: `campaignId`, `{campaignId, updatedAt}`, `createdBy`, `tags`,
+`isPublic`, `locations.locationId`, and a text index on `{name, publicInfo}`.
+
+### `OrganizationMembership` — `app/server/db/models/OrganizationMembership.ts`
+
+A dedicated join collection (chosen over embedding on both sides). One document
+per (org, member) pair.
+
+| Field                     | Type                      | Notes                                 |
+| ------------------------- | ------------------------- | ------------------------------------- |
+| `organizationId`          | ObjectId → Organization   |                                       |
+| `memberKind`              | `'player' \| 'character'` | Which collection `memberId` points to |
+| `memberId`                | ObjectId                  | Player or Character `_id`             |
+| `title`                   | String                    | Optional (e.g. "Guildmaster")         |
+| `publicNotes`             | String (Markdown)         | Rendered to everyone                  |
+| `privateNotes`            | String (Markdown)         | **GM-only**                           |
+| `campaignId`, `createdBy` | ObjectId                  |                                       |
+
+Indexes: **unique** `{organizationId, memberKind, memberId}` (no duplicate
+membership); `{campaignId, memberKind, memberId}` (reverse lookup for the
+player/character Organizations tab); `{organizationId}` (roster lookup).
+
+## Privacy model
+
+"Private" always means **GM-only** (never "members-only"), consistent with
+Lore's `gmContent`.
+
+1. **`isPublic` on the org (whole-entity visibility).** A **private** org
+   (`isPublic:false`) is entirely GM-only: absent from the wiki list for
+   non-GMs, dropped from the tabletop window list for non-GM viewers, and its
+   memberships are excluded from any player/character Organizations tab for
+   non-GMs — a character's membership in a secret org never leaks to players. A
+   **public** org is visible to everyone.
+2. **GM-only fields within a public org.** `privateInfo`, per-membership
+   `privateNotes`, and per-location-link `privateInfo` are always stripped from
+   server responses for non-GMs, and writable only by a GM. A non-GM update
+   **preserves** existing private values (merge by `locationId` for location
+   links; omit `privateInfo` from `$set` for the org) rather than wiping them.
+
+GM screens are a GM-only surface (nothing stripped). Tabletop is player-facing
+(stripping + the private-org window drop apply).
+
+## Server API — `app/server/functions/organizations.ts`
+
+Org CRUD (`list/get/create/update/delete`) + membership CRUD
+(`add/update/remove`, `listMembershipsForOrg`, `listMembershipsForMember`) +
+`pruneMembershipsForMember` (called from `deletePlayer`/`deleteCharacter`).
+Every function authenticates via `requireCampaignMember`, gates edits on
+GM-or-creator, resolves display labels at read time, and strips GM-only fields
+for non-GMs. `listOrganizations` filters by search (`$text`), `tags` (`$all`),
+and `locationIds` (`locations.locationId $in`). Deleting an org cascade-deletes
+its memberships. React Query hooks live in `app/hooks/useOrganizations.ts`.
+
+## UI surfaces
+
+- **Wiki:** `app/components/wiki/organizations/` — panel (with tag **and**
+  location filters), create/edit modal (public/private Markdown, `isPublic`
+  toggle, tags, a locations editor with per-link public/private info, and a
+  members roster editor), view modal, and the `OrganizationWindow` render
+  surface. Registered in `WikiPanel.tsx`.
+- **Player/character:** an **Organizations** tab in `PlayerModal`/
+  `CharacterModal` (edit) and `PlayerWindow`/`CharacterWindow` (view), backed by
+  the shared `MemberOrganizationsTab` (reverse lookup + add/edit/remove).
+- **GM-screen + tabletop:** `'organization'` registered in
+  `SUPPORTED_COLLECTIONS`/`TABLETOP_COLLECTIONS` and both `COLLECTION_REGISTRY`
+  hydration maps; `OrganizationWindowWrapper` renders the window; drag-to-tabletop
+  and "Show on Tabletop" work via the shared card/button.
+
+## Seed data
+
+`scripts/dev_seed.py` (`npm run dev:seed`) seeds the rich campaign ("The Lost
+Mines of Phandelver") with **5 organizations** and **7 memberships**:
+
+- Public: **The Lords' Alliance**, **Phandalin Miner's Exchange**, **The Harpers**
+  (with location links to Phandalin and character/player members).
+- GM-only private: **The Redbrands**, **The Black Spider's Network** (with
+  GM-only `privateInfo`).
+- Memberships mix characters (Sildar, Halia, Sister Garaele, Daran) and party
+  players. One party player is a member of the **private** Black Spider's
+  Network — exercising that a private org stays hidden from non-GM viewers,
+  including that member, on their own Organizations tab.
+
+Builders: `build_organization_docs` and `build_organization_membership_docs`,
+inserted in the `rich_session_history` block.
+
+## Testing
+
+Unit: model schemas, server functions (privacy stripping, private-org
+filtering, cascade delete, reverse lookup), the registry-sync guard
+(`lore-window-collection.test.ts`), the tabletop-hydration strip, and component
+tests for the window, member tab, and panel. Full suite green (1629 tests).
+
+## Deferred follow-ups (non-blocking; from the final review)
+
+- Cascade delete (`deleteOrganization`) is non-transactional. Reads fail-closed
+  on orphaned memberships (both list paths tolerate a missing org), so there is
+  no user-visible impact; diverges from the `withTransaction` precedent used by
+  campaigns/gmscreens/sessions/tabletop.
+- Membership add/edit/remove modals lack loading-disable / error surfacing /
+  delete confirmation — the `mutate` wrappers swallow errors, so a failed
+  mutation closes the modal silently.
+- A non-GM removing a location link drops that link's GM `privateInfo` (narrow
+  edge; the per-link preserve only covers links still present in the payload).
+- The tabletop window title bar can be stale after an org rename until the
+  tabletop refetches (org mutations don't invalidate the tabletop query; matches
+  sibling collections).
+- The client sends `privateInfo`/location `privateInfo` in the create/update
+  payload even when the editor is hidden from a non-GM (server strips/ignores —
+  fragile, not exploitable).
+- Test hygiene: `organization-membership-model.test.ts` triggers a
+  `vi.unmock('mongoose')` hoisting warning (matches the pre-existing
+  `gmscreen.test.ts` pattern).

--- a/e2e/gmscreens/gmscreens-organization-window.spec.ts
+++ b/e2e/gmscreens/gmscreens-organization-window.spec.ts
@@ -1,0 +1,193 @@
+/**
+ * E2E: organizations can be dragged onto a GM screen and open a floating
+ * organization window, exactly like monsters/characters/lore. Regression guard
+ * mirroring gmscreens-monster-window.spec.ts — the class of bug where a new
+ * collection is wired into the Tabletop system but not the parallel GM-screen
+ * SUPPORTED_COLLECTIONS / COLLECTION_REGISTRY / render branch.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { test, expect, type Page } from '@playwright/test';
+import { MongoClient, ObjectId, type Db } from 'mongodb';
+import { decodeJwt } from 'jose';
+
+test.describe.configure({ mode: 'serial', timeout: 90_000 });
+
+const CAMPAIGN_NAME = 'E2E GM Screen Organization';
+const ORG_NAME = 'E2E Adventurers Guild';
+const ORG_MARKER = 'E2E-ORG-PUBLIC-MARKER';
+
+interface Provisioned {
+  campaignId: string;
+  organizationId: string;
+}
+
+let client: MongoClient;
+let provisioned: Provisioned;
+
+function db(): Db {
+  return process.env.MONGODB_DB ? client.db(process.env.MONGODB_DB) : client.db();
+}
+
+async function provision(database: Db): Promise<Provisioned> {
+  const storage = JSON.parse(
+    readFileSync(join(process.cwd(), 'e2e', '.auth', 'storageState.json'), 'utf-8')
+  ) as { cookies: Array<{ name: string; value: string }> };
+  const cookie = storage.cookies.find((c) => c.name === 'cartyx_session');
+  if (!cookie) throw new Error('No cartyx_session cookie — globalSetup did not run?');
+  const providerId = (decodeJwt(cookie.value) as { user?: { id?: string } }).user?.id;
+  const gm = await database.collection('users').findOne({ providerId });
+  if (!gm?._id) throw new Error('Session GM user not found');
+
+  // Clear any leftovers from a previous run.
+  const stale = await database
+    .collection('campaigns')
+    .find({ name: CAMPAIGN_NAME }, { projection: { _id: 1 } })
+    .toArray();
+  if (stale.length) {
+    const ids = stale.map((c) => c._id);
+    await database.collection('gmscreen').deleteMany({ campaignId: { $in: ids } });
+    await database.collection('organizations').deleteMany({ campaignId: { $in: ids } });
+    await database.collection('campaigns').deleteMany({ _id: { $in: ids } });
+  }
+
+  const now = new Date();
+  const campaignId = (
+    await database.collection('campaigns').insertOne({
+      gameMasterId: gm._id,
+      name: CAMPAIGN_NAME,
+      description: 'E2E GM-screen organization-window test.',
+      status: 'active',
+      inviteCode: 'e2e-' + Math.random().toString(36).slice(2, 12),
+      maxPlayers: 6,
+      members: [{ userId: gm._id, role: 'gm', joinedAt: now }],
+      links: [],
+      createdAt: now,
+      updatedAt: now,
+    })
+  ).insertedId;
+
+  const organizationId = (
+    await database.collection('organizations').insertOne({
+      campaignId,
+      createdBy: gm._id,
+      name: ORG_NAME,
+      publicInfo: `A guild of heroes. ${ORG_MARKER}`,
+      privateInfo: '',
+      isPublic: true,
+      images: [],
+      locations: [],
+      tags: ['e2e'],
+      createdAt: now,
+      updatedAt: now,
+    })
+  ).insertedId;
+
+  // A GM screen to drop the org onto.
+  await database.collection('gmscreen').insertOne({
+    campaignId,
+    name: 'Factions',
+    tabOrder: 0,
+    createdBy: gm._id,
+    windows: [],
+    stacks: [],
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  return { campaignId: String(campaignId), organizationId: String(organizationId) };
+}
+
+/** Synthesize a document drop onto the GM-screen workspace. */
+async function dropOnScreen(page: Page, collection: string, documentId: string, title: string) {
+  await page.evaluate(
+    ({ collection, documentId, title }) => {
+      const ws = document.querySelector(
+        '[data-testid="gmscreens-view"] [role="tabpanel"]'
+      ) as HTMLElement | null;
+      if (!ws) return;
+      const rect = ws.getBoundingClientRect();
+      const dt = new DataTransfer();
+      dt.setData(
+        'application/x-cartyx-document',
+        JSON.stringify({ collection, documentId, title })
+      );
+      for (const type of ['dragenter', 'dragover', 'drop'] as const) {
+        const ev = new DragEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          clientX: rect.left + rect.width / 2,
+          clientY: rect.top + rect.height / 2,
+        });
+        Object.defineProperty(ev, 'dataTransfer', { value: dt });
+        ws.dispatchEvent(ev);
+      }
+    },
+    { collection, documentId, title }
+  );
+}
+
+async function gotoGMScreens(page: Page) {
+  await page.goto(`/campaigns/${provisioned.campaignId}/play?tab=gmscreens`);
+  const view = page.getByTestId('gmscreens-view');
+  try {
+    await expect(view).toBeVisible({ timeout: 20000 });
+  } catch {
+    await page.reload();
+    await expect(view).toBeVisible({ timeout: 20000 });
+  }
+  await expect(page.locator('[data-testid="gmscreens-view"] [role="tabpanel"]')).toBeVisible({
+    timeout: 15000,
+  });
+}
+
+test.beforeAll(async () => {
+  try {
+    process.loadEnvFile('.env');
+  } catch {
+    /* env may be set externally */
+  }
+  const uri = process.env.MONGODB_URI;
+  if (!uri) throw new Error('MONGODB_URI not set');
+  client = new MongoClient(uri);
+  await client.connect();
+  provisioned = await provision(db());
+});
+
+test.afterAll(async () => {
+  if (!client) return;
+  if (provisioned?.campaignId) {
+    const cid = new ObjectId(provisioned.campaignId);
+    await db().collection('gmscreen').deleteMany({ campaignId: cid });
+    await db().collection('organizations').deleteMany({ campaignId: cid });
+    await db().collection('campaigns').deleteMany({ _id: cid });
+  }
+  await client.close();
+});
+
+test('dragging an organization onto a GM screen opens an organization window', async ({ page }) => {
+  await gotoGMScreens(page);
+
+  const orgWindow = page.getByTestId('organization-window');
+
+  await expect
+    .poll(
+      async () => {
+        await dropOnScreen(page, 'organization', provisioned.organizationId, ORG_NAME);
+        return orgWindow.count();
+      },
+      { timeout: 25000, intervals: [250, 500, 750, 1000] }
+    )
+    .toBeGreaterThan(0);
+
+  await expect(orgWindow.first()).toBeVisible();
+  await expect(page.getByText(ORG_MARKER).first()).toBeVisible();
+});
+
+test('the organization window persists across a reload (stored on the screen)', async ({
+  page,
+}) => {
+  await gotoGMScreens(page);
+  await expect(page.getByTestId('organization-window').first()).toBeVisible({ timeout: 20000 });
+  await expect(page.getByText(ORG_MARKER).first()).toBeVisible();
+});

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "db:verify": "tsx scripts/mongo-admin.ts verify",
     "db:sync": "tsx scripts/mongo-admin.ts sync",
     "dev:clear": "node scripts/run-python.cjs dev_clear.py",
-    "dev:seed": "node scripts/run-python.cjs dev_seed.py && node scripts/gen_seed_avatars.mjs && node scripts/gen_seed_lore_images.mjs",
+    "dev:seed": "node scripts/run-python.cjs dev_seed.py && node scripts/gen_seed_avatars.mjs && node scripts/gen_seed_lore_images.mjs && node scripts/gen_seed_org_images.mjs",
     "dev:repair-images": "node scripts/run-python.cjs repair_seed_images.py && node scripts/gen_seed_avatars.mjs",
     "dev:gen-avatars": "node scripts/gen_seed_avatars.mjs",
     "fixture": "tsx scripts/dev-fixtures/cli.ts",

--- a/scripts/dev_seed.py
+++ b/scripts/dev_seed.py
@@ -1691,6 +1691,22 @@ def main() -> None:
         ])
         print(f"    location types  ({len(DEFAULT_LOCATION_TYPES)} defaults)")
 
+        # A default GM screen so the GM Screens view has a tab to work with out
+        # of the box (drag entities onto it, build stacks). Without one the view
+        # opens with no active screen and drops are silently ignored. The
+        # GMScreen model pins collection 'gmscreen' (not the default plural).
+        db.gmscreen.insert_one({
+            "campaignId": campaign_id,
+            "name": "GM Screen",
+            "tabOrder": 0,
+            "createdBy": gm_id,
+            "windows": [],
+            "stacks": [],
+            "createdAt": now,
+            "updatedAt": now,
+        })
+        print("    gm screen   1 default")
+
         # Insert any seed locations defined for this campaign.
         # location_ids: maps location name → inserted _id (for lore links).
         location_ids: dict[str, object] = {}

--- a/scripts/dev_seed.py
+++ b/scripts/dev_seed.py
@@ -1042,8 +1042,16 @@ def build_organization_docs(*, campaign_id, gm_id, location_ids, now):
         return [{"locationId": phandalin, "publicInfo": public_info,
                  "privateInfo": private_info}]
 
-    def image(slug, caption):
-        return {"url": f"/uploads/seed-lore/{slug}.png", "caption": caption, "crop": None}
+    # Two generated images per org — the slugs MUST match the ORG_IMAGES list in
+    # scripts/gen_seed_org_images.mjs, which renders the PNGs into
+    # public/uploads/seed-organizations/ as part of `npm run dev:seed`.
+    def imgs(slug_base, name):
+        return [
+            {"url": f"/uploads/seed-organizations/{slug_base}-1.png",
+             "caption": f"{name} — crest", "crop": None},
+            {"url": f"/uploads/seed-organizations/{slug_base}-2.png",
+             "caption": f"{name} — banner hall", "crop": None},
+        ]
 
     return [
         ("lords_alliance", org(
@@ -1053,6 +1061,7 @@ def build_organization_docs(*, campaign_id, gm_id, location_ids, now):
             "agents work to bring order to frontier settlements like Phandalin.",
             public=True,
             tags=["faction", "politics", "lawful"],
+            images=imgs("lords_alliance", "The Lords' Alliance"),
             locations=loc_link(
                 "Maintains an interest in Phandalin through its agent Sildar Hallwinter.",
                 "GM: the Alliance quietly wants a permanent garrison here once the mine reopens.",
@@ -1065,6 +1074,7 @@ def build_organization_docs(*, campaign_id, gm_id, location_ids, now):
             "nearby, the Exchange takes its cut.",
             public=True,
             tags=["guild", "commerce"],
+            images=imgs("miners_exchange", "Phandalin Miner's Exchange"),
             locations=loc_link("Headquartered on Phandalin's town square."),
         )),
         ("harpers", org(
@@ -1074,6 +1084,48 @@ def build_organization_docs(*, campaign_id, gm_id, location_ids, now):
             "the shadows.",
             public=True,
             tags=["faction", "secret-society"],
+            images=imgs("harpers", "The Harpers"),
+        )),
+        ("order_gauntlet", org(
+            "The Order of the Gauntlet",
+            "Zealous, faithful, and vigilant, the Order of the Gauntlet seeks "
+            "out evil and roots it out wherever it hides, holding the line so "
+            "that the innocent can sleep safely.",
+            public=True,
+            tags=["faction", "militant", "lawful-good"],
+            images=imgs("order_gauntlet", "The Order of the Gauntlet"),
+        )),
+        ("emerald_enclave", org(
+            "The Emerald Enclave",
+            "A far-flung fellowship of hermits, wanderers, and druids who "
+            "preserve the balance of the wild and help others survive its "
+            "dangers — often the only friendly faces in the deep wilderness.",
+            public=True,
+            tags=["faction", "nature", "neutral"],
+            images=imgs("emerald_enclave", "The Emerald Enclave"),
+        )),
+        ("zhentarim", org(
+            "The Zhentarim",
+            "An unscrupulous shadow network of mercenaries and merchants — the "
+            "Black Network — that offers opportunity to anyone willing to look "
+            "the other way, and expands its influence at every turn.",
+            public=True,
+            tags=["faction", "mercenary", "commerce"],
+            images=imgs("zhentarim", "The Zhentarim"),
+            private_info=(
+                "**GM only:** Halia Thornton is the Zhentarim's agent in "
+                "Phandalin, quietly recruiting and angling to control the mine."
+            ),
+        )),
+        ("heroes_of_phandalin", org(
+            "The Heroes of Phandalin",
+            "The adventuring company the townsfolk credit with breaking the "
+            "Redbrands and reopening the road. Every member of the party holds "
+            "honorary standing, and grateful locals rally to their banner.",
+            public=True,
+            tags=["party", "heroes"],
+            images=imgs("heroes_of_phandalin", "The Heroes of Phandalin"),
+            locations=loc_link("Feted in Phandalin as the town's champions."),
         )),
         ("redbrands", org(
             "The Redbrands",
@@ -1081,6 +1133,7 @@ def build_organization_docs(*, campaign_id, gm_id, location_ids, now):
             "from their lair beneath Tresendar Manor.",
             public=False,
             tags=["villains", "secret"],
+            images=imgs("redbrands", "The Redbrands"),
             private_info=(
                 "**GM only:** Led by Iarno 'Glasstaff' Albrek, a wizard secretly "
                 "serving the Black Spider. Broken by the party, though a few "
@@ -1097,12 +1150,12 @@ def build_organization_docs(*, campaign_id, gm_id, location_ids, now):
             "caravans ambushed, prospectors vanished.",
             public=False,
             tags=["villain", "secret", "conspiracy"],
+            images=imgs("black_spider", "The Black Spider's Network"),
             private_info=(
                 "**GM only:** Nezznar the Black Spider, a drow mage seeking sole "
                 "control of the Forge of Spells in Wave Echo Cave. Commands "
                 "bugbears and a doppelganger posing as a Rockseeker brother."
             ),
-            images=[image("black-spider", "A spider-sigil wax seal on a torn letter")],
         )),
     ]
 
@@ -1149,21 +1202,44 @@ def build_organization_membership_docs(*, org_ids, character_by_name,
     player1 = player_doc_ids[1] if len(player_doc_ids) > 1 else None
 
     candidates = [
+        # --- Character members across the public factions ---
         member("character", char("Sildar Hallwinter"), "lords_alliance", "Agent",
                "Represents the Lords' Alliance in Phandalin.",
                "GM: quietly reports party movements back to Neverwinter."),
         member("character", char("Halia Thornton"), "miners_exchange", "Guildmaster",
                "Runs the Miner's Exchange.",
                "GM: secretly a Zhentarim agent angling to control the reopened mine."),
+        member("character", char("Halia Thornton"), "zhentarim", "Local Agent",
+               "A respected businesswoman of Phandalin.",
+               "GM: her true allegiance — recruiting quietly for the Black Network."),
+        member("character", char("Gundren Rockseeker"), "miners_exchange", "Claim Holder",
+               "Holds the deed to the lost mine at Wave Echo Cave."),
+        member("character", char("Linene Graywind"), "miners_exchange", "Merchant",
+               "Runs the Lionshield Coster trading post."),
         member("character", char("Sister Garaele"), "harpers", "Agent",
                "A Harper acolyte serving at the Shrine of Luck."),
-        member("character", char("Daran Edermath"), "harpers", "Retired Adventurer",
-               "An old ally who still does the occasional favor for the Harpers."),
-        # Party members (players) — public memberships show on their org tab.
+        member("character", char("Daran Edermath"), "order_gauntlet", "Retired Knight",
+               "A retired paladin and orchard-keeper who still answers the call."),
+        member("character", char("Sister Garaele"), "order_gauntlet", "Ally",
+               "Lends the Order her healing and her counsel."),
+        member("character", char("Reidoth the Druid"), "emerald_enclave", "Warden",
+               "Guards the ruins of Thundertree and the wilds around it."),
+        # --- The party org: EVERY player is a member ---
+        *[
+            member("player", pid, "heroes_of_phandalin", "Champion",
+                   "A founding hero of the company that saved Phandalin.")
+            for pid in player_doc_ids
+        ],
+        # A couple of townsfolk characters round out the party's org.
+        member("character", char("Toblen Stonehill"), "heroes_of_phandalin", "Patron",
+               "Keeps the Stonehill Inn — the party's home base in town."),
+        member("character", char("Qelline Alderleaf"), "heroes_of_phandalin", "Ally",
+               "A sensible farmer who shelters the heroes and shares local rumors."),
+        # Party members also carry standing in a couple of the public factions.
         member("player", player0, "lords_alliance", "Sworn Ally",
                "Granted honorary standing for services rendered to the Alliance."),
-        member("player", player1, "miners_exchange", "Claim Holder",
-               "Holds a registered mining claim through the Exchange."),
+        member("player", player1, "harpers", "Friend of the Harpers",
+               "Trusted with the occasional quiet errand."),
         # A player secretly tied to a PRIVATE org — must stay hidden from
         # non-GM viewers, including this member, on the Organizations tab.
         member("player", player0, "black_spider", "Unwitting Pawn", "",

--- a/scripts/dev_seed.py
+++ b/scripts/dev_seed.py
@@ -1042,14 +1042,16 @@ def build_organization_docs(*, campaign_id, gm_id, location_ids, now):
         return [{"locationId": phandalin, "publicInfo": public_info,
                  "privateInfo": private_info}]
 
-    # Two generated images per org — the slugs MUST match the ORG_IMAGES list in
-    # scripts/gen_seed_org_images.mjs, which renders the PNGs into
-    # public/uploads/seed-organizations/ as part of `npm run dev:seed`.
+    # Two generated images per org — the slugs MUST match the ORGS list in
+    # scripts/gen_seed_org_images.mjs, which renders the PNGs and (when the CDN
+    # is configured) uploads them to R2 as part of `npm run dev:seed`.
+    # `public_url` yields the full CDN URL when R2/CDN is configured (so the
+    # deployed dev app resolves them) and the relative path otherwise.
     def imgs(slug_base, name):
         return [
-            {"url": f"/uploads/seed-organizations/{slug_base}-1.png",
+            {"url": public_url(f"/uploads/seed-organizations/{slug_base}-1.png"),
              "caption": f"{name} — crest", "crop": None},
-            {"url": f"/uploads/seed-organizations/{slug_base}-2.png",
+            {"url": public_url(f"/uploads/seed-organizations/{slug_base}-2.png"),
              "caption": f"{name} — banner hall", "crop": None},
         ]
 

--- a/scripts/dev_seed.py
+++ b/scripts/dev_seed.py
@@ -1020,12 +1020,14 @@ def build_organization_docs(*, campaign_id, gm_id, location_ids, now):
         next(iter(location_ids.values())) if location_ids else None
     )
 
-    def org(name, public_info, *, public, tags, private_info="", locations=None):
+    def org(name, public_info, *, public, tags, private_info="", locations=None,
+            images=None):
         return {
             "name": name,
             "publicInfo": public_info,
             "privateInfo": private_info,
             "isPublic": public,
+            "images": images or [],
             "locations": locations or [],
             "tags": tags,
             "campaignId": campaign_id,
@@ -1039,6 +1041,9 @@ def build_organization_docs(*, campaign_id, gm_id, location_ids, now):
             return []
         return [{"locationId": phandalin, "publicInfo": public_info,
                  "privateInfo": private_info}]
+
+    def image(slug, caption):
+        return {"url": f"/uploads/seed-lore/{slug}.png", "caption": caption, "crop": None}
 
     return [
         ("lords_alliance", org(
@@ -1097,6 +1102,7 @@ def build_organization_docs(*, campaign_id, gm_id, location_ids, now):
                 "control of the Forge of Spells in Wave Echo Cave. Commands "
                 "bugbears and a doppelganger posing as a Rockseeker brother."
             ),
+            images=[image("black-spider", "A spider-sigil wax seal on a torn letter")],
         )),
     ]
 

--- a/scripts/dev_seed.py
+++ b/scripts/dev_seed.py
@@ -1004,6 +1004,168 @@ def build_note_docs(*, campaign_id, session_ids, gm_id, party, now):
     return docs
 
 
+def build_organization_docs(*, campaign_id, gm_id, location_ids, now):
+    """Return themed Organizations for the rich campaign as (key, doc) pairs.
+
+    Deliberately mixes public orgs with GM-only private orgs (isPublic=False)
+    so the privacy model is exercisable from a fresh seed: a private org must
+    stay invisible to non-GM viewers everywhere (wiki list, tabletop window
+    list, and a member's Organizations tab). Location links carry both public
+    and GM-only (private) info.
+
+    Returns an ordered list of (key, doc) tuples so the caller can map each
+    inserted _id back to a stable key for wiring up memberships.
+    """
+    phandalin = location_ids.get("Phandalin") or (
+        next(iter(location_ids.values())) if location_ids else None
+    )
+
+    def org(name, public_info, *, public, tags, private_info="", locations=None):
+        return {
+            "name": name,
+            "publicInfo": public_info,
+            "privateInfo": private_info,
+            "isPublic": public,
+            "locations": locations or [],
+            "tags": tags,
+            "campaignId": campaign_id,
+            "createdBy": gm_id,
+            "createdAt": now,
+            "updatedAt": now,
+        }
+
+    def loc_link(public_info, private_info=""):
+        if not phandalin:
+            return []
+        return [{"locationId": phandalin, "publicInfo": public_info,
+                 "privateInfo": private_info}]
+
+    return [
+        ("lords_alliance", org(
+            "The Lords' Alliance",
+            "A coalition of rulers and merchant lords from the great cities of "
+            "the Sword Coast, pledged to mutual defense and the rule of law. Its "
+            "agents work to bring order to frontier settlements like Phandalin.",
+            public=True,
+            tags=["faction", "politics", "lawful"],
+            locations=loc_link(
+                "Maintains an interest in Phandalin through its agent Sildar Hallwinter.",
+                "GM: the Alliance quietly wants a permanent garrison here once the mine reopens.",
+            ),
+        )),
+        ("miners_exchange", org(
+            "Phandalin Miner's Exchange",
+            "The trading post and guildhall that brokers ore, gems, and mining "
+            "claims for Phandalin's prospectors. If it comes out of the ground "
+            "nearby, the Exchange takes its cut.",
+            public=True,
+            tags=["guild", "commerce"],
+            locations=loc_link("Headquartered on Phandalin's town square."),
+        )),
+        ("harpers", org(
+            "The Harpers",
+            "A scattered network of spies and do-gooders who work in secret to "
+            "promote fairness and thwart tyranny, aiding the downtrodden from "
+            "the shadows.",
+            public=True,
+            tags=["faction", "secret-society"],
+        )),
+        ("redbrands", org(
+            "The Redbrands",
+            "A gang of ruffians in red cloaks who once terrorized Phandalin "
+            "from their lair beneath Tresendar Manor.",
+            public=False,
+            tags=["villains", "secret"],
+            private_info=(
+                "**GM only:** Led by Iarno 'Glasstaff' Albrek, a wizard secretly "
+                "serving the Black Spider. Broken by the party, though a few "
+                "members may have fled toward Old Owl Well."
+            ),
+            locations=loc_link(
+                "Operated out of Phandalin.",
+                "GM: hidden cellar entrance under Tresendar Manor (DC 15 Investigation).",
+            ),
+        )),
+        ("black_spider", org(
+            "The Black Spider's Network",
+            "Whispers of a spymaster pulling strings across the Sword Coast — "
+            "caravans ambushed, prospectors vanished.",
+            public=False,
+            tags=["villain", "secret", "conspiracy"],
+            private_info=(
+                "**GM only:** Nezznar the Black Spider, a drow mage seeking sole "
+                "control of the Forge of Spells in Wave Echo Cave. Commands "
+                "bugbears and a doppelganger posing as a Rockseeker brother."
+            ),
+        )),
+    ]
+
+
+def build_organization_membership_docs(*, org_ids, character_by_name,
+                                       player_doc_ids, gm_id, campaign_id, now):
+    """Return OrganizationMembership docs linking characters AND players to the
+    seeded organizations, each with an optional title + public/private notes.
+
+    Arguments
+    ---------
+    org_ids           : dict mapping the org key (from build_organization_docs)
+                        → inserted Organization _id.
+    character_by_name : dict mapping "First Last" → Character _id.
+    player_doc_ids    : list of Player document _ids.
+
+    Skips any membership whose org or member can't be resolved so a sparse seed
+    degrades gracefully. Includes a player member of a PRIVATE org (the Black
+    Spider's Network) to exercise the rule that a private org stays hidden from
+    non-GM viewers — including that very member — on the Organizations tab.
+    Private notes are GM-only; the server strips them for non-GM readers.
+    """
+    def member(kind, member_id, org_key, title, public_notes, private_notes=""):
+        org_id = org_ids.get(org_key)
+        if not org_id or not member_id:
+            return None
+        return {
+            "organizationId": org_id,
+            "memberKind": kind,
+            "memberId": member_id,
+            "title": title,
+            "publicNotes": public_notes,
+            "privateNotes": private_notes,
+            "campaignId": campaign_id,
+            "createdBy": gm_id,
+            "createdAt": now,
+            "updatedAt": now,
+        }
+
+    def char(name):
+        return character_by_name.get(name)
+
+    player0 = player_doc_ids[0] if player_doc_ids else None
+    player1 = player_doc_ids[1] if len(player_doc_ids) > 1 else None
+
+    candidates = [
+        member("character", char("Sildar Hallwinter"), "lords_alliance", "Agent",
+               "Represents the Lords' Alliance in Phandalin.",
+               "GM: quietly reports party movements back to Neverwinter."),
+        member("character", char("Halia Thornton"), "miners_exchange", "Guildmaster",
+               "Runs the Miner's Exchange.",
+               "GM: secretly a Zhentarim agent angling to control the reopened mine."),
+        member("character", char("Sister Garaele"), "harpers", "Agent",
+               "A Harper acolyte serving at the Shrine of Luck."),
+        member("character", char("Daran Edermath"), "harpers", "Retired Adventurer",
+               "An old ally who still does the occasional favor for the Harpers."),
+        # Party members (players) — public memberships show on their org tab.
+        member("player", player0, "lords_alliance", "Sworn Ally",
+               "Granted honorary standing for services rendered to the Alliance."),
+        member("player", player1, "miners_exchange", "Claim Holder",
+               "Holds a registered mining claim through the Exchange."),
+        # A player secretly tied to a PRIVATE org — must stay hidden from
+        # non-GM viewers, including this member, on the Organizations tab.
+        member("player", player0, "black_spider", "Unwitting Pawn", "",
+               "GM: the Black Spider holds leverage over this adventurer they don't yet know about."),
+    ]
+    return [m for m in candidates if m is not None]
+
+
 # Generic in-character banter the builder samples to pad transcripts to length.
 # Speaker is a player; lines are character-agnostic so any party fits.
 _BANTER_POOL = [
@@ -1600,6 +1762,41 @@ def main() -> None:
                 # Mongoose pluralizes model('Event') to the `events` collection.
                 db.events.insert_many(event_docs)
             print(f"    events     inserted {len(event_docs)}")
+
+            # Organizations + memberships — link factions to the seeded
+            # locations, characters, and players. Includes GM-only private orgs
+            # so the privacy model is exercisable from a fresh seed.
+            org_specs = build_organization_docs(
+                campaign_id=campaign_id, gm_id=gm_id,
+                location_ids=location_ids, now=now,
+            )
+            org_ids: dict[str, object] = {}
+            if org_specs:
+                # Mongoose pluralizes model('Organization') → `organizations`.
+                org_result = db.organizations.insert_many(
+                    [doc for _key, doc in org_specs]
+                )
+                org_ids = {
+                    key: oid
+                    for (key, _doc), oid in zip(org_specs, org_result.inserted_ids)
+                }
+            print(f"    orgs       inserted {len(org_ids)}")
+
+            # Full-name → Character _id, so memberships resolve NPCs by name.
+            character_by_name = dict(zip(
+                [f"{c['firstName']} {c['lastName']}" for c in defn["characters"]],
+                character_ids,
+            ))
+            membership_docs = build_organization_membership_docs(
+                org_ids=org_ids, character_by_name=character_by_name,
+                player_doc_ids=player_doc_ids, gm_id=gm_id,
+                campaign_id=campaign_id, now=now,
+            )
+            if membership_docs:
+                # Mongoose pluralizes model('OrganizationMembership')
+                # → `organizationmemberships`.
+                db.organizationmemberships.insert_many(membership_docs)
+            print(f"    org members inserted {len(membership_docs)}")
 
         print()
 

--- a/scripts/gen_seed_org_images.mjs
+++ b/scripts/gen_seed_org_images.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * Generate local PNG crest/banner images for seeded organizations.
+ *
+ * Each organization gets TWO deterministic images (`<key>-1.png`, `<key>-2.png`)
+ * so the wiki + tabletop image gallery has real content to render. The slugs
+ * MUST match the `imgs(...)` slugs in `build_organization_docs` in
+ * scripts/dev_seed.py (`/uploads/seed-organizations/<key>-<n>.png`).
+ *
+ * Style mirrors gen_seed_lore_images.mjs (deterministic hue from the slug, a
+ * heraldic shield glyph instead of a book), with a per-variant hue shift so the
+ * two images for one org look distinct. Purely file I/O — no DB connection.
+ *
+ * Idempotent: files are always regenerated (overwritten) on each run.
+ *
+ * Usage:
+ *   node scripts/gen_seed_org_images.mjs
+ *   npm run dev:seed   (called automatically as part of the chain)
+ */
+import { createHash } from 'node:crypto';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Resvg } from '@resvg/resvg-js';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+// key → display name. Keys MUST match build_organization_docs in dev_seed.py.
+const ORGS = [
+  { key: 'lords_alliance', name: "The Lords' Alliance" },
+  { key: 'miners_exchange', name: "Phandalin Miner's Exchange" },
+  { key: 'harpers', name: 'The Harpers' },
+  { key: 'order_gauntlet', name: 'The Order of the Gauntlet' },
+  { key: 'emerald_enclave', name: 'The Emerald Enclave' },
+  { key: 'zhentarim', name: 'The Zhentarim' },
+  { key: 'heroes_of_phandalin', name: 'The Heroes of Phandalin' },
+  { key: 'redbrands', name: 'The Redbrands' },
+  { key: 'black_spider', name: "The Black Spider's Network" },
+];
+
+// Two variants per org — a subtitle + a hue nudge so the images differ.
+const VARIANTS = [
+  { suffix: '1', subtitle: 'Crest' },
+  { suffix: '2', subtitle: 'Banner Hall' },
+];
+
+function hashToHues(slug) {
+  const bytes = createHash('sha1').update(slug).digest();
+  const hue1 = bytes[0] % 360;
+  const hue2 = (hue1 + 40 + (bytes[1] % 60)) % 360;
+  return { hue1, hue2 };
+}
+
+function escapeXml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function wrapTitle(title) {
+  if (title.length <= 22) return [title];
+  const mid = Math.floor(title.length / 2);
+  const before = title.lastIndexOf(' ', mid);
+  const after = title.indexOf(' ', mid);
+  let splitAt;
+  if (before === -1 && after === -1) return [title];
+  if (before === -1) splitAt = after;
+  else if (after === -1) splitAt = before;
+  else splitAt = mid - before <= after - mid ? before : after;
+  return [title.slice(0, splitAt).trim(), title.slice(splitAt + 1).trim()];
+}
+
+/**
+ * Build a deterministic 320×160 crest banner for an organization variant.
+ * `variantIndex` nudges the hue so the org's two images look distinct.
+ */
+function orgBannerSvg(key, name, subtitle, variantIndex) {
+  const { hue1, hue2 } = hashToHues(key);
+  const h1 = (hue1 + variantIndex * 25) % 360;
+  const h2 = (hue2 + variantIndex * 25) % 360;
+  const W = 320;
+  const H = 160;
+
+  const bg1 = `hsl(${h1} 40% 15%)`;
+  const bg2 = `hsl(${h2} 30% 22%)`;
+  const accent = `hsl(${h1} 64% 62%)`;
+  const accentDim = `hsl(${h1} 40% 42%)`;
+  const gradId = `g${key.replace(/[^a-z0-9]/g, '')}${variantIndex}`;
+
+  // Shield glyph — left side
+  const cx = 60;
+  const cy = H / 2;
+  const initial = escapeXml(
+    name
+      .replace(/^The\s+/i, '')
+      .charAt(0)
+      .toUpperCase()
+  );
+  // A simple heraldic shield path centred on (cx, cy).
+  const shield =
+    `M ${cx - 26} ${cy - 30} L ${cx + 26} ${cy - 30} L ${cx + 26} ${cy - 2} ` +
+    `Q ${cx + 26} ${cy + 26} ${cx} ${cy + 34} Q ${cx - 26} ${cy + 26} ${cx - 26} ${cy - 2} Z`;
+
+  const lines = wrapTitle(name);
+  const titleX = 116;
+  const titleAreaWidth = W - titleX - 16;
+
+  let titleSvg = '';
+  if (lines.length === 1) {
+    titleSvg = `<text x="${titleX}" y="${H / 2 - 2}" font-family="Georgia, 'Times New Roman', serif" font-size="21" font-weight="bold" fill="white">${escapeXml(lines[0])}</text>`;
+  } else {
+    titleSvg =
+      `<text x="${titleX}" y="${H / 2 - 16}" font-family="Georgia, 'Times New Roman', serif" font-size="19" font-weight="bold" fill="white">${escapeXml(lines[0])}</text>` +
+      `<text x="${titleX}" y="${H / 2 + 8}" font-family="Georgia, 'Times New Roman', serif" font-size="19" font-weight="bold" fill="white">${escapeXml(lines[1])}</text>`;
+  }
+  const subY = lines.length === 1 ? H / 2 + 22 : H / 2 + 34;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
+  <defs>
+    <linearGradient id="${gradId}" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="${bg1}"/>
+      <stop offset="100%" stop-color="${bg2}"/>
+    </linearGradient>
+  </defs>
+  <rect width="${W}" height="${H}" fill="url(#${gradId})"/>
+  <line x1="8" y1="8" x2="28" y2="8" stroke="${accentDim}" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="8" y1="8" x2="8" y2="28" stroke="${accentDim}" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="${W - 8}" y1="${H - 8}" x2="${W - 28}" y2="${H - 8}" stroke="${accentDim}" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="${W - 8}" y1="${H - 8}" x2="${W - 8}" y2="${H - 28}" stroke="${accentDim}" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="${shield}" fill="${accent}" fill-opacity="0.15" stroke="${accent}" stroke-width="2"/>
+  <text x="${cx}" y="${cy + 6}" font-family="Georgia, 'Times New Roman', serif" font-size="26" font-weight="bold" fill="${accent}" text-anchor="middle">${initial}</text>
+  <line x1="108" y1="28" x2="108" y2="${H - 28}" stroke="${accentDim}" stroke-width="1" stroke-dasharray="3,3"/>
+  ${titleSvg}
+  <line x1="${titleX}" y1="${subY - 14}" x2="${titleX + titleAreaWidth}" y2="${subY - 14}" stroke="${accent}" stroke-width="1" stroke-opacity="0.5"/>
+  <text x="${titleX}" y="${subY}" font-family="sans-serif" font-size="11" fill="${accent}" fill-opacity="0.85" letter-spacing="1.5">${escapeXml(subtitle.toUpperCase())}</text>
+</svg>`;
+}
+
+function renderPng(svg) {
+  return new Resvg(svg, { fitTo: { mode: 'width', value: 320 } }).render().asPng();
+}
+
+function main() {
+  const outDir = join(REPO_ROOT, 'public', 'uploads', 'seed-organizations');
+  mkdirSync(outDir, { recursive: true });
+
+  let count = 0;
+  for (const { key, name } of ORGS) {
+    VARIANTS.forEach((v, i) => {
+      const slug = `${key}-${v.suffix}`;
+      const svg = orgBannerSvg(key, name, v.subtitle, i);
+      writeFileSync(join(outDir, `${slug}.png`), renderPng(svg));
+      console.log(`  wrote /uploads/seed-organizations/${slug}.png  («${name}» — ${v.subtitle})`);
+      count += 1;
+    });
+  }
+
+  console.log(
+    `\ngen_seed_org_images: ${count} PNGs generated in public/uploads/seed-organizations/`
+  );
+}
+
+main();

--- a/scripts/gen_seed_org_images.mjs
+++ b/scripts/gen_seed_org_images.mjs
@@ -9,21 +9,86 @@
  *
  * Style mirrors gen_seed_lore_images.mjs (deterministic hue from the slug, a
  * heraldic shield glyph instead of a book), with a per-variant hue shift so the
- * two images for one org look distinct. Purely file I/O — no DB connection.
+ * two images for one org look distinct.
  *
- * Idempotent: files are always regenerated (overwritten) on each run.
+ * When the app's CDN is configured (CDN_URL + R2_* env vars) the PNGs are also
+ * uploaded to R2 — exactly like gen_seed_avatars.mjs — so the deployed dev app
+ * (which can't serve local public/uploads/ writes) resolves them via the CDN.
+ * The Python seed sets each image URL via `public_url(...)`, so the stored URL
+ * and the uploaded R2 key agree. Idempotent: local files are overwritten and
+ * R2 objects already present are skipped.
  *
  * Usage:
  *   node scripts/gen_seed_org_images.mjs
  *   npm run dev:seed   (called automatically as part of the chain)
+ *
+ * Safety: r2Env() refuses a production-looking R2 bucket.
  */
 import { createHash } from 'node:crypto';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Resvg } from '@resvg/resvg-js';
+import { S3Client, PutObjectCommand, ListObjectsV2Command } from '@aws-sdk/client-s3';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+// --- Minimal .env loader (mirrors gen_seed_avatars.mjs) ----------------------
+function loadEnv() {
+  const envPath = join(REPO_ROOT, '.env');
+  if (!existsSync(envPath)) return;
+  for (const raw of readFileSync(envPath, 'utf8').split('\n')) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    let val = line.slice(eq + 1).trim();
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    if (!(key in process.env)) process.env[key] = val;
+  }
+}
+
+// --- CDN / R2 (mirrors gen_seed_avatars.mjs) ---------------------------------
+function r2Env() {
+  const keys = [
+    'CDN_URL',
+    'R2_ACCOUNT_ID',
+    'R2_ACCESS_KEY_ID',
+    'R2_SECRET_ACCESS_KEY',
+    'R2_BUCKET',
+  ];
+  const env = Object.fromEntries(keys.map((k) => [k, process.env[k] ?? '']));
+  if (!keys.every((k) => env[k])) return null;
+  if (/prod/i.test(env.R2_BUCKET)) {
+    console.error('R2_BUCKET looks like a production bucket. Aborting.');
+    process.exit(1);
+  }
+  return env;
+}
+
+function r2ClientFor(env) {
+  return new S3Client({
+    region: 'auto',
+    endpoint: `https://${env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+    credentials: { accessKeyId: env.R2_ACCESS_KEY_ID, secretAccessKey: env.R2_SECRET_ACCESS_KEY },
+  });
+}
+
+async function listExistingKeys(s3, bucket, prefix) {
+  const keys = new Set();
+  let token;
+  do {
+    const page = await s3.send(
+      new ListObjectsV2Command({ Bucket: bucket, Prefix: prefix, ContinuationToken: token })
+    );
+    for (const obj of page.Contents ?? []) keys.add(obj.Key);
+    token = page.NextContinuationToken;
+  } while (token);
+  return keys;
+}
 
 // key → display name. Keys MUST match build_organization_docs in dev_seed.py.
 const ORGS = [
@@ -143,24 +208,70 @@ function renderPng(svg) {
   return new Resvg(svg, { fitTo: { mode: 'width', value: 320 } }).render().asPng();
 }
 
-function main() {
+async function main() {
+  loadEnv();
+  if (process.env.NODE_ENV === 'production' || /prod/i.test(process.env.MONGODB_URI ?? '')) {
+    console.error('Refusing to run against a production-looking environment.');
+    process.exit(1);
+  }
+
   const outDir = join(REPO_ROOT, 'public', 'uploads', 'seed-organizations');
   mkdirSync(outDir, { recursive: true });
 
-  let count = 0;
-  for (const { key, name } of ORGS) {
-    VARIANTS.forEach((v, i) => {
-      const slug = `${key}-${v.suffix}`;
-      const svg = orgBannerSvg(key, name, v.subtitle, i);
-      writeFileSync(join(outDir, `${slug}.png`), renderPng(svg));
-      console.log(`  wrote /uploads/seed-organizations/${slug}.png  («${name}» — ${v.subtitle})`);
-      count += 1;
-    });
+  // When the CDN is configured, mirror every image into R2 (the deployed dev
+  // app can't serve local public/uploads/ writes).
+  let cdn = null;
+  const env = r2Env();
+  if (env) {
+    const s3 = r2ClientFor(env);
+    cdn = {
+      s3,
+      bucket: env.R2_BUCKET,
+      existingKeys: await listExistingKeys(s3, env.R2_BUCKET, 'uploads/seed-organizations/'),
+    };
+    console.log(`CDN configured — uploading org images to R2 bucket '${env.R2_BUCKET}'`);
   }
 
+  let count = 0;
+  let uploaded = 0;
+  const uploads = [];
+  for (const { key, name } of ORGS) {
+    for (let i = 0; i < VARIANTS.length; i++) {
+      const v = VARIANTS[i];
+      const slug = `${key}-${v.suffix}`;
+      const png = renderPng(orgBannerSvg(key, name, v.subtitle, i));
+      writeFileSync(join(outDir, `${slug}.png`), png);
+      count += 1;
+      if (cdn) {
+        const objKey = `uploads/seed-organizations/${slug}.png`;
+        if (!cdn.existingKeys.has(objKey)) {
+          uploads.push(
+            cdn.s3
+              .send(
+                new PutObjectCommand({
+                  Bucket: cdn.bucket,
+                  Key: objKey,
+                  Body: png,
+                  ContentType: 'image/png',
+                })
+              )
+              .then(() => {
+                uploaded += 1;
+              })
+          );
+        }
+      }
+    }
+  }
+  await Promise.all(uploads);
+
   console.log(
-    `\ngen_seed_org_images: ${count} PNGs generated in public/uploads/seed-organizations/`
+    `\ngen_seed_org_images: ${count} PNGs generated in public/uploads/seed-organizations/` +
+      (cdn ? `, ${uploaded} uploaded to R2` : '')
   );
 }
 
-main();
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/tests/components/mainview/WikiPanel.test.tsx
+++ b/tests/components/mainview/WikiPanel.test.tsx
@@ -65,6 +65,14 @@ vi.mock('~/components/wiki/lore/LorePanel', () => ({
   ),
 }));
 
+vi.mock('~/components/wiki/organizations/OrganizationsPanel', () => ({
+  OrganizationsPanel: ({ onBack }: { onBack: () => void }) => (
+    <div data-testid="organizations-panel">
+      <button onClick={onBack}>Back</button>
+    </div>
+  ),
+}));
+
 vi.mock('~/components/wiki/maps/MapsPanel', () => ({
   MapsPanel: ({ onBack }: { onBack: () => void }) => (
     <div data-testid="maps-panel">
@@ -104,11 +112,11 @@ describe('WikiPanel', () => {
     expect(screen.getByRole('button', { name: 'Characters' })).toBeInTheDocument();
   });
 
-  it('shows only the eight player categories when not GM (no Maps, no Monsters, no Events)', () => {
+  it('shows only the nine player categories when not GM (no Maps, no Monsters, no Events)', () => {
     useCampaignMock.mockReturnValue({ campaign: { isGM: false } });
     render(<WikiPanel />);
 
-    expect(screen.getAllByRole('button')).toHaveLength(8);
+    expect(screen.getAllByRole('button')).toHaveLength(9);
     expect(screen.getByRole('button', { name: 'Characters' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Players' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Races' })).toBeInTheDocument();
@@ -118,6 +126,8 @@ describe('WikiPanel', () => {
     expect(screen.getByRole('button', { name: 'Locations' })).toBeInTheDocument();
     // Lore is visible to all members.
     expect(screen.getByRole('button', { name: 'Lore' })).toBeInTheDocument();
+    // Organizations is visible to all members.
+    expect(screen.getByRole('button', { name: 'Organizations' })).toBeInTheDocument();
     // Calendar is visible to all members.
     expect(screen.getByRole('button', { name: 'Calendar' })).toBeInTheDocument();
     // Maps + Monsters + Events are GM-only.
@@ -130,7 +140,7 @@ describe('WikiPanel', () => {
     useCampaignMock.mockReturnValue({ campaign: { isGM: true } });
     render(<WikiPanel />);
 
-    expect(screen.getAllByRole('button')).toHaveLength(11);
+    expect(screen.getAllByRole('button')).toHaveLength(12);
     expect(screen.getByRole('button', { name: 'Maps' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Monsters' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Events' })).toBeInTheDocument();
@@ -170,6 +180,16 @@ describe('WikiPanel', () => {
     await user.click(screen.getByRole('button', { name: 'Lore' }));
 
     expect(screen.getByTestId('lore-panel')).toBeInTheDocument();
+  });
+
+  it('clicking Organizations shows OrganizationsPanel', async () => {
+    useCampaignMock.mockReturnValue({ campaign: { isGM: false } });
+    const user = userEvent.setup();
+    render(<WikiPanel />);
+
+    await user.click(screen.getByRole('button', { name: 'Organizations' }));
+
+    expect(screen.getByTestId('organizations-panel')).toBeInTheDocument();
   });
 
   it('clicking Characters shows CharactersPanel', async () => {

--- a/tests/components/shared/MemberOrganizationsTab.test.tsx
+++ b/tests/components/shared/MemberOrganizationsTab.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemberOrganizationsTab } from '~/components/shared/MemberOrganizationsTab';
+
+vi.mock('~/hooks/useOrganizations', () => ({
+  useMembershipsForMember: () => ({
+    memberships: [
+      {
+        id: 'm1',
+        campaignId: 'c1',
+        organizationId: 'o1',
+        organizationName: 'Thieves Guild',
+        organizationIsPublic: true,
+        memberKind: 'character',
+        memberId: 'ch1',
+        memberLabel: 'Bob',
+        title: 'Guildmaster',
+        publicNotes: '',
+        privateNotes: '',
+        canEdit: false,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ],
+    isLoading: false,
+  }),
+  useOrganizations: () => ({ organizations: [], isLoading: false, error: null }),
+  useAddMembership: () => ({ mutate: vi.fn(), isLoading: false, error: null }),
+  useUpdateMembership: () => ({ mutate: vi.fn(), isLoading: false, error: null }),
+  useRemoveMembership: () => ({ mutate: vi.fn(), isLoading: false, error: null }),
+}));
+
+describe('MemberOrganizationsTab', () => {
+  it('lists the organizations the member belongs to', () => {
+    render(
+      <MemberOrganizationsTab
+        campaignId="c1"
+        memberKind="character"
+        memberId="ch1"
+        isGM={false}
+        canManage={false}
+      />
+    );
+    expect(screen.getByText('Thieves Guild')).toBeInTheDocument();
+    expect(screen.getByText('Guildmaster')).toBeInTheDocument();
+  });
+
+  it('shows the add button only when canManage', () => {
+    const { rerender } = render(
+      <MemberOrganizationsTab
+        campaignId="c1"
+        memberKind="character"
+        memberId="ch1"
+        isGM={false}
+        canManage={false}
+      />
+    );
+    expect(screen.queryByText('Add to organization')).not.toBeInTheDocument();
+    rerender(
+      <MemberOrganizationsTab
+        campaignId="c1"
+        memberKind="character"
+        memberId="ch1"
+        isGM={true}
+        canManage={true}
+      />
+    );
+    expect(screen.getByText('Add to organization')).toBeInTheDocument();
+  });
+});

--- a/tests/components/shared/MemberOrganizationsTab.test.tsx
+++ b/tests/components/shared/MemberOrganizationsTab.test.tsx
@@ -1,34 +1,40 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemberOrganizationsTab } from '~/components/shared/MemberOrganizationsTab';
 
+// Hoisted, mutable membership fixture so each test can vary what the reverse
+// lookup returns (in particular each membership's own `canEdit`).
+const h = vi.hoisted(() => ({ memberships: [] as Record<string, unknown>[] }));
+
 vi.mock('~/hooks/useOrganizations', () => ({
-  useMembershipsForMember: () => ({
-    memberships: [
-      {
-        id: 'm1',
-        campaignId: 'c1',
-        organizationId: 'o1',
-        organizationName: 'Thieves Guild',
-        organizationIsPublic: true,
-        memberKind: 'character',
-        memberId: 'ch1',
-        memberLabel: 'Bob',
-        title: 'Guildmaster',
-        publicNotes: '',
-        privateNotes: '',
-        canEdit: false,
-        createdAt: '',
-        updatedAt: '',
-      },
-    ],
-    isLoading: false,
-  }),
+  useMembershipsForMember: () => ({ memberships: h.memberships, isLoading: false }),
   useOrganizations: () => ({ organizations: [], isLoading: false, error: null }),
   useAddMembership: () => ({ mutate: vi.fn(), isLoading: false, error: null }),
   useUpdateMembership: () => ({ mutate: vi.fn(), isLoading: false, error: null }),
   useRemoveMembership: () => ({ mutate: vi.fn(), isLoading: false, error: null }),
 }));
+
+const membership = (over: Record<string, unknown> = {}) => ({
+  id: 'm1',
+  campaignId: 'c1',
+  organizationId: 'o1',
+  organizationName: 'Thieves Guild',
+  organizationIsPublic: true,
+  memberKind: 'character',
+  memberId: 'ch1',
+  memberLabel: 'Bob',
+  title: 'Guildmaster',
+  publicNotes: '',
+  privateNotes: '',
+  canEdit: false,
+  createdAt: '',
+  updatedAt: '',
+  ...over,
+});
+
+beforeEach(() => {
+  h.memberships = [membership()];
+});
 
 describe('MemberOrganizationsTab', () => {
   it('lists the organizations the member belongs to', () => {
@@ -66,5 +72,28 @@ describe('MemberOrganizationsTab', () => {
       />
     );
     expect(screen.getByText('Add to organization')).toBeInTheDocument();
+  });
+
+  it('gates per-row edit/remove on each membership canEdit, not the tab canManage', () => {
+    // Two memberships: one the viewer can manage, one (a GM-owned org) they can't.
+    h.memberships = [
+      membership({ id: 'm1', organizationName: 'Owned Guild', canEdit: true }),
+      membership({ id: 'm2', organizationName: 'GM Guild', canEdit: false }),
+    ];
+    render(
+      <MemberOrganizationsTab
+        campaignId="c1"
+        memberKind="character"
+        memberId="ch1"
+        isGM={false}
+        canManage={true}
+      />
+    );
+    // canEdit row shows manage buttons...
+    expect(screen.getByLabelText('Edit membership in Owned Guild')).toBeInTheDocument();
+    expect(screen.getByLabelText('Remove membership in Owned Guild')).toBeInTheDocument();
+    // ...the non-canEdit row does NOT, even though canManage is true.
+    expect(screen.queryByLabelText('Edit membership in GM Guild')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Remove membership in GM Guild')).not.toBeInTheDocument();
   });
 });

--- a/tests/components/wiki/organizations/OrganizationWindow.test.tsx
+++ b/tests/components/wiki/organizations/OrganizationWindow.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { OrganizationWindow } from '~/components/wiki/organizations/OrganizationWindow';
+import type { OrganizationData } from '~/types/organization';
+
+vi.mock('~/hooks/useOrganizations', () => ({
+  useMembershipsForOrg: () => ({ memberships: [], isLoading: false }),
+}));
+
+const org: OrganizationData = {
+  id: 'o1',
+  campaignId: 'c1',
+  createdBy: 'u1',
+  name: 'Thieves Guild',
+  publicInfo: 'A shadowy guild.',
+  privateInfo: 'GM secret plans.',
+  isPublic: true,
+  tags: ['faction'],
+  locations: [{ locationId: 'l1', label: 'Waterdeep', publicInfo: 'HQ here.', privateInfo: '' }],
+  canEdit: false,
+  createdAt: '',
+  updatedAt: '',
+};
+
+describe('OrganizationWindow', () => {
+  it('renders public info and location links', () => {
+    render(<OrganizationWindow organization={org} />);
+    expect(screen.getByText('A shadowy guild.')).toBeInTheDocument();
+    expect(screen.getByText('Waterdeep')).toBeInTheDocument();
+  });
+
+  it('shows GM private info only when present', () => {
+    render(<OrganizationWindow organization={org} />);
+    expect(screen.getByText('GM secret plans.')).toBeInTheDocument();
+  });
+
+  it('hides the private section when privateInfo is empty', () => {
+    render(<OrganizationWindow organization={{ ...org, privateInfo: '' }} />);
+    expect(screen.queryByText('GM Only')).not.toBeInTheDocument();
+  });
+});

--- a/tests/components/wiki/organizations/OrganizationWindow.test.tsx
+++ b/tests/components/wiki/organizations/OrganizationWindow.test.tsx
@@ -15,6 +15,7 @@ const org: OrganizationData = {
   publicInfo: 'A shadowy guild.',
   privateInfo: 'GM secret plans.',
   isPublic: true,
+  images: [],
   tags: ['faction'],
   locations: [{ locationId: 'l1', label: 'Waterdeep', publicInfo: 'HQ here.', privateInfo: '' }],
   canEdit: false,
@@ -37,5 +38,23 @@ describe('OrganizationWindow', () => {
   it('hides the private section when privateInfo is empty', () => {
     render(<OrganizationWindow organization={{ ...org, privateInfo: '' }} />);
     expect(screen.queryByText('GM Only')).not.toBeInTheDocument();
+  });
+
+  it('renders the images gallery with captions when present', () => {
+    render(
+      <OrganizationWindow
+        organization={{
+          ...org,
+          images: [{ url: 'https://cdn.example/guild.png', caption: 'Guild sigil', crop: null }],
+        }}
+      />
+    );
+    expect(screen.getByAltText('Guild sigil')).toBeInTheDocument();
+    expect(screen.getByText('Guild sigil')).toBeInTheDocument();
+  });
+
+  it('omits the images gallery when there are no images', () => {
+    render(<OrganizationWindow organization={{ ...org, images: [] }} />);
+    expect(screen.queryByText('Images')).not.toBeInTheDocument();
   });
 });

--- a/tests/server/db/organization-membership-model.test.ts
+++ b/tests/server/db/organization-membership-model.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+
+/*
+ * setup.ts mocks mongoose with a MockSchema that does not track paths. Schema
+ * tests need real mongoose, so unmock + resetModules and dynamically import.
+ */
+describe('OrganizationMembership model', () => {
+  let RealMembership: any;
+
+  beforeAll(async () => {
+    vi.unmock('mongoose');
+    vi.resetModules();
+    const mod = await import('~/server/db/models/OrganizationMembership');
+    RealMembership = mod.OrganizationMembership;
+  });
+
+  afterAll(() => {
+    vi.doMock('mongoose', () => {
+      class MockSchema {
+        constructor(_def?: unknown) {}
+        static Types = { ObjectId: String };
+        pre(_hook: string, _fn: unknown) {}
+        index(_def?: unknown) {}
+      }
+      const mockModel = vi.fn(() => ({
+        findOne: vi.fn(),
+        findOneAndUpdate: vi.fn(),
+        findById: vi.fn(),
+        find: vi.fn(),
+        create: vi.fn(),
+        deleteOne: vi.fn(),
+        deleteMany: vi.fn(),
+      }));
+      return {
+        default: {
+          connect: vi.fn(),
+          connection: { readyState: 0 },
+          Schema: MockSchema,
+          model: mockModel,
+          models: {},
+        },
+        Schema: MockSchema,
+        model: mockModel,
+        models: {},
+        connection: { readyState: 0 },
+      };
+    });
+    vi.resetModules();
+  });
+
+  it('defines the expected paths', () => {
+    const paths = Object.keys(RealMembership.schema.paths);
+    expect(paths).toEqual(
+      expect.arrayContaining([
+        'organizationId',
+        'memberKind',
+        'memberId',
+        'title',
+        'publicNotes',
+        'privateNotes',
+        'campaignId',
+        'createdBy',
+        'createdAt',
+        'updatedAt',
+      ])
+    );
+  });
+
+  it('memberKind is a player|character enum', () => {
+    expect(RealMembership.schema.path('memberKind').options.enum).toEqual(['player', 'character']);
+    expect(RealMembership.schema.path('memberKind').options.required).toBeTruthy();
+  });
+});

--- a/tests/server/db/organization-model.test.ts
+++ b/tests/server/db/organization-model.test.ts
@@ -56,6 +56,7 @@ describe('Organization model', () => {
         'publicInfo',
         'privateInfo',
         'isPublic',
+        'images',
         'locations',
         'tags',
         'campaignId',

--- a/tests/server/db/organization-model.test.ts
+++ b/tests/server/db/organization-model.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+
+/*
+ * setup.ts mocks mongoose with a MockSchema that does not track paths. Schema
+ * tests need real mongoose, so unmock + resetModules and dynamically import.
+ */
+describe('Organization model', () => {
+  let RealOrganization: any;
+
+  beforeAll(async () => {
+    vi.unmock('mongoose');
+    vi.resetModules();
+    const mod = await import('~/server/db/models/Organization');
+    RealOrganization = mod.Organization;
+  });
+
+  afterAll(() => {
+    vi.doMock('mongoose', () => {
+      class MockSchema {
+        constructor(_def?: unknown) {}
+        static Types = { ObjectId: String };
+        pre(_hook: string, _fn: unknown) {}
+        index(_def?: unknown) {}
+      }
+      const mockModel = vi.fn(() => ({
+        findOne: vi.fn(),
+        findOneAndUpdate: vi.fn(),
+        findById: vi.fn(),
+        find: vi.fn(),
+        create: vi.fn(),
+        deleteOne: vi.fn(),
+        deleteMany: vi.fn(),
+      }));
+      return {
+        default: {
+          connect: vi.fn(),
+          connection: { readyState: 0 },
+          Schema: MockSchema,
+          model: mockModel,
+          models: {},
+        },
+        Schema: MockSchema,
+        model: mockModel,
+        models: {},
+        connection: { readyState: 0 },
+      };
+    });
+    vi.resetModules();
+  });
+
+  it('defines the expected paths', () => {
+    const paths = Object.keys(RealOrganization.schema.paths);
+    expect(paths).toEqual(
+      expect.arrayContaining([
+        'name',
+        'publicInfo',
+        'privateInfo',
+        'isPublic',
+        'locations',
+        'tags',
+        'campaignId',
+        'createdBy',
+        'createdAt',
+        'updatedAt',
+      ])
+    );
+  });
+
+  it('location links require a locationId', () => {
+    const locPath = RealOrganization.schema.path('locations');
+    const sub = (locPath as any).schema;
+    expect(sub.path('locationId').options.required).toBeTruthy();
+    expect(sub.path('publicInfo')).toBeTruthy();
+    expect(sub.path('privateInfo')).toBeTruthy();
+  });
+});

--- a/tests/server/functions/organizations.test.ts
+++ b/tests/server/functions/organizations.test.ts
@@ -11,7 +11,13 @@ vi.mock('~/server/db/connection', () => ({ connectDB: vi.fn(), isDBConnected: vi
 vi.mock('~/server/db/models/User', () => ({ User: { findOne: vi.fn() } }));
 vi.mock('~/server/db/models/Campaign', () => ({ Campaign: { findById: vi.fn() } }));
 vi.mock('~/server/db/models/Organization', () => ({
-  Organization: { find: vi.fn(), findOne: vi.fn(), findById: vi.fn(), deleteOne: vi.fn() },
+  Organization: {
+    find: vi.fn(),
+    findOne: vi.fn(),
+    findById: vi.fn(),
+    findOneAndUpdate: vi.fn(),
+    deleteOne: vi.fn(),
+  },
 }));
 vi.mock('~/server/db/models/OrganizationMembership', () => ({
   OrganizationMembership: {
@@ -33,10 +39,13 @@ import { User } from '~/server/db/models/User';
 import { Campaign } from '~/server/db/models/Campaign';
 import { Organization } from '~/server/db/models/Organization';
 import { OrganizationMembership } from '~/server/db/models/OrganizationMembership';
+import { Character } from '~/server/db/models/Character';
 import {
   listOrganizations,
   getOrganization,
+  updateOrganization,
   deleteOrganization,
+  addMembership,
   listMembershipsForMember,
 } from '~/server/functions/organizations';
 
@@ -66,11 +75,9 @@ describe('listOrganizations', () => {
   it('restricts non-GM to public or own orgs', async () => {
     vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
     vi.mocked(Organization.find).mockReturnValue({
-      select: vi
-        .fn()
-        .mockReturnValue({
-          sort: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue([]) }),
-        }),
+      select: vi.fn().mockReturnValue({
+        sort: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue([]) }),
+      }),
     } as never);
     await call(listOrganizations)({ data: { campaignId: 'camp-1' } });
     const filter = vi.mocked(Organization.find).mock.calls[0][0] as unknown as Record<
@@ -82,11 +89,9 @@ describe('listOrganizations', () => {
 
   it('filters by locationIds via locations.locationId $in', async () => {
     vi.mocked(Organization.find).mockReturnValue({
-      select: vi
-        .fn()
-        .mockReturnValue({
-          sort: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue([]) }),
-        }),
+      select: vi.fn().mockReturnValue({
+        sort: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue([]) }),
+      }),
     } as never);
     await call(listOrganizations)({ data: { campaignId: 'camp-1', locationIds: ['loc-1'] } });
     const filter = vi.mocked(Organization.find).mock.calls[0][0] as unknown as Record<
@@ -185,5 +190,192 @@ describe('listMembershipsForMember', () => {
     expect(result).toHaveLength(1);
     expect(result[0].organizationId).toBe('pub');
     expect(result[0].privateNotes).toBe(''); // stripped for non-GM
+  });
+});
+
+describe('updateOrganization', () => {
+  it('preserves GM private data on a non-GM (creator) update', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    vi.mocked(Organization.findOne).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        _id: 'o1',
+        campaignId: 'camp-1',
+        createdBy: 'user-1',
+        name: 'Guild',
+        publicInfo: 'p',
+        privateInfo: 'GM secret',
+        isPublic: false,
+        tags: [],
+        locations: [{ locationId: 'loc-1', publicInfo: 'p', privateInfo: 'loc secret' }],
+      }),
+    } as never);
+    vi.mocked(Organization.findOneAndUpdate).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        _id: 'o1',
+        campaignId: 'camp-1',
+        createdBy: 'user-1',
+        name: 'Guild',
+        publicInfo: 'p2',
+        isPublic: false,
+        tags: [],
+        locations: [{ locationId: 'loc-1', publicInfo: 'p2', privateInfo: 'loc secret' }],
+      }),
+    } as never);
+
+    await call(updateOrganization)({
+      data: {
+        id: 'o1',
+        campaignId: 'camp-1',
+        name: 'Guild',
+        publicInfo: 'p2',
+        privateInfo: '',
+        isPublic: false,
+        tags: [],
+        locations: [{ locationId: 'loc-1', publicInfo: 'p2', privateInfo: '' }],
+      },
+    });
+
+    const set = vi.mocked(Organization.findOneAndUpdate).mock.calls[0][1] as {
+      $set: Record<string, unknown>;
+    };
+    expect(set.$set).not.toHaveProperty('privateInfo');
+    const locations = set.$set.locations as Array<Record<string, unknown>>;
+    expect(locations[0].privateInfo).toBe('loc secret');
+  });
+
+  it('writes privateInfo when the caller is a GM', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(gmCampaign as never);
+    vi.mocked(Organization.findOne).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        _id: 'o1',
+        campaignId: 'camp-1',
+        createdBy: 'user-1',
+        name: 'Guild',
+        publicInfo: 'p',
+        privateInfo: 'old secret',
+        isPublic: false,
+        tags: [],
+        locations: [],
+      }),
+    } as never);
+    vi.mocked(Organization.findOneAndUpdate).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        _id: 'o1',
+        campaignId: 'camp-1',
+        createdBy: 'user-1',
+        name: 'Guild',
+        publicInfo: 'p',
+        privateInfo: 'new secret',
+        isPublic: false,
+        tags: [],
+        locations: [],
+      }),
+    } as never);
+
+    await call(updateOrganization)({
+      data: {
+        id: 'o1',
+        campaignId: 'camp-1',
+        name: 'Guild',
+        publicInfo: 'p',
+        privateInfo: 'new secret',
+        isPublic: false,
+        tags: [],
+        locations: [],
+      },
+    });
+
+    const set = vi.mocked(Organization.findOneAndUpdate).mock.calls[0][1] as {
+      $set: Record<string, unknown>;
+    };
+    expect(set.$set.privateInfo).toBe('new secret');
+  });
+});
+
+describe('addMembership', () => {
+  it('stores privateNotes for a GM', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(gmCampaign as never);
+    vi.mocked(Organization.findOne).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        _id: 'o1',
+        createdBy: 'someone-else',
+        name: 'Guild',
+        isPublic: true,
+      }),
+    } as never);
+    vi.mocked(OrganizationMembership.create).mockResolvedValue({
+      _id: 'm1',
+      campaignId: 'camp-1',
+      organizationId: 'o1',
+      memberKind: 'character',
+      memberId: 'c1',
+      title: '',
+      publicNotes: '',
+      privateNotes: 'secret',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as never);
+    vi.mocked(Character.findById).mockReturnValue({
+      lean: vi.fn().mockResolvedValue(null),
+    } as never);
+
+    await call(addMembership)({
+      data: {
+        campaignId: 'camp-1',
+        organizationId: 'o1',
+        memberKind: 'character',
+        memberId: 'c1',
+        title: '',
+        publicNotes: '',
+        privateNotes: 'secret',
+      },
+    });
+
+    expect(OrganizationMembership.create).toHaveBeenCalledWith(
+      expect.objectContaining({ privateNotes: 'secret' })
+    );
+  });
+
+  it('stores empty privateNotes for a non-GM creator', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    vi.mocked(Organization.findOne).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        _id: 'o1',
+        createdBy: 'user-1',
+        name: 'Guild',
+        isPublic: true,
+      }),
+    } as never);
+    vi.mocked(OrganizationMembership.create).mockResolvedValue({
+      _id: 'm2',
+      campaignId: 'camp-1',
+      organizationId: 'o1',
+      memberKind: 'character',
+      memberId: 'c1',
+      title: '',
+      publicNotes: '',
+      privateNotes: '',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as never);
+    vi.mocked(Character.findById).mockReturnValue({
+      lean: vi.fn().mockResolvedValue(null),
+    } as never);
+
+    await call(addMembership)({
+      data: {
+        campaignId: 'camp-1',
+        organizationId: 'o1',
+        memberKind: 'character',
+        memberId: 'c1',
+        title: '',
+        publicNotes: '',
+        privateNotes: 'attempted secret',
+      },
+    });
+
+    expect(OrganizationMembership.create).toHaveBeenCalledWith(
+      expect.objectContaining({ privateNotes: '' })
+    );
   });
 });

--- a/tests/server/functions/organizations.test.ts
+++ b/tests/server/functions/organizations.test.ts
@@ -10,15 +10,23 @@ vi.mock('~/server/session', () => ({ getSession: vi.fn() }));
 vi.mock('~/server/db/connection', () => ({ connectDB: vi.fn(), isDBConnected: vi.fn(() => true) }));
 vi.mock('~/server/db/models/User', () => ({ User: { findOne: vi.fn() } }));
 vi.mock('~/server/db/models/Campaign', () => ({ Campaign: { findById: vi.fn() } }));
-vi.mock('~/server/db/models/Organization', () => ({
-  Organization: {
+vi.mock('~/server/db/models/Organization', () => {
+  // `createOrganization` does `new Organization(doc); await doc.save()` — model
+  // the mock as a constructor (carrying the static query methods as properties)
+  // so that path is exercisable, matching how mongoose models behave.
+  function OrganizationMock(this: Record<string, unknown>, doc: Record<string, unknown>) {
+    Object.assign(this, doc);
+    this.save = vi.fn().mockResolvedValue(this);
+  }
+  Object.assign(OrganizationMock, {
     find: vi.fn(),
     findOne: vi.fn(),
     findById: vi.fn(),
     findOneAndUpdate: vi.fn(),
     deleteOne: vi.fn(),
-  },
-}));
+  });
+  return { Organization: OrganizationMock };
+});
 vi.mock('~/server/db/models/OrganizationMembership', () => ({
   OrganizationMembership: {
     find: vi.fn(),
@@ -48,6 +56,7 @@ import { Player } from '~/server/db/models/Player';
 import {
   listOrganizations,
   getOrganization,
+  createOrganization,
   updateOrganization,
   deleteOrganization,
   addMembership,
@@ -147,6 +156,49 @@ describe('getOrganization', () => {
     } as never);
     const result = await call(getOrganization)({ data: { id: 'o1', campaignId: 'camp-1' } });
     expect(result).toBeNull();
+  });
+
+  it('returns images for a non-GM viewer — images are public, not GM-gated', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    vi.mocked(Organization.findById).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        _id: 'o1',
+        campaignId: 'camp-1',
+        createdBy: 'someone',
+        name: 'Guild',
+        publicInfo: 'pub',
+        privateInfo: 'secret',
+        isPublic: true,
+        tags: [],
+        locations: [],
+        images: [{ url: 'https://cdn.example/org.png', caption: 'Banner', crop: null }],
+      }),
+    } as never);
+    const result = await call(getOrganization)({ data: { id: 'o1', campaignId: 'camp-1' } });
+    expect(result.images).toEqual([
+      { url: 'https://cdn.example/org.png', caption: 'Banner', crop: null },
+    ]);
+    // Confirm this is genuinely a non-GM path — privateInfo is still stripped.
+    expect(result.privateInfo).toBe('');
+  });
+});
+
+describe('createOrganization', () => {
+  it('round-trips images through create', async () => {
+    const images = [{ url: 'https://cdn.example/new-org.png', caption: 'Sigil', crop: null }];
+    const result = await call(createOrganization)({
+      data: {
+        campaignId: 'camp-1',
+        name: 'New Guild',
+        publicInfo: '',
+        privateInfo: '',
+        isPublic: true,
+        tags: [],
+        locations: [],
+        images,
+      },
+    });
+    expect(result.images).toEqual(images);
   });
 });
 
@@ -304,6 +356,59 @@ describe('updateOrganization', () => {
       $set: Record<string, unknown>;
     };
     expect(set.$set.privateInfo).toBe('new secret');
+  });
+
+  it('round-trips images through update', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(gmCampaign as never);
+    const images = [{ url: 'https://cdn.example/updated-org.png', caption: 'Updated', crop: null }];
+    vi.mocked(Organization.findOne).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        _id: 'o1',
+        campaignId: 'camp-1',
+        createdBy: 'user-1',
+        name: 'Guild',
+        publicInfo: 'p',
+        privateInfo: 'secret',
+        isPublic: false,
+        tags: [],
+        locations: [],
+        images: [],
+      }),
+    } as never);
+    vi.mocked(Organization.findOneAndUpdate).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        _id: 'o1',
+        campaignId: 'camp-1',
+        createdBy: 'user-1',
+        name: 'Guild',
+        publicInfo: 'p',
+        privateInfo: 'secret',
+        isPublic: false,
+        tags: [],
+        locations: [],
+        images,
+      }),
+    } as never);
+
+    const result = await call(updateOrganization)({
+      data: {
+        id: 'o1',
+        campaignId: 'camp-1',
+        name: 'Guild',
+        publicInfo: 'p',
+        privateInfo: 'secret',
+        isPublic: false,
+        tags: [],
+        locations: [],
+        images,
+      },
+    });
+
+    const set = vi.mocked(Organization.findOneAndUpdate).mock.calls[0][1] as {
+      $set: Record<string, unknown>;
+    };
+    expect(set.$set.images).toEqual(images);
+    expect(result.images).toEqual(images);
   });
 });
 

--- a/tests/server/functions/organizations.test.ts
+++ b/tests/server/functions/organizations.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tanstack/react-start', () => ({
+  createServerFn: () => ({
+    inputValidator: () => ({ handler: (fn: unknown) => fn }),
+    handler: (fn: unknown) => fn,
+  }),
+}));
+vi.mock('~/server/session', () => ({ getSession: vi.fn() }));
+vi.mock('~/server/db/connection', () => ({ connectDB: vi.fn(), isDBConnected: vi.fn(() => true) }));
+vi.mock('~/server/db/models/User', () => ({ User: { findOne: vi.fn() } }));
+vi.mock('~/server/db/models/Campaign', () => ({ Campaign: { findById: vi.fn() } }));
+vi.mock('~/server/db/models/Organization', () => ({
+  Organization: { find: vi.fn(), findOne: vi.fn(), findById: vi.fn(), deleteOne: vi.fn() },
+}));
+vi.mock('~/server/db/models/OrganizationMembership', () => ({
+  OrganizationMembership: {
+    find: vi.fn(),
+    findOne: vi.fn(),
+    findById: vi.fn(),
+    create: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+}));
+vi.mock('~/server/db/models/Location', () => ({ Location: { findById: vi.fn() } }));
+vi.mock('~/server/db/models/Character', () => ({ Character: { findById: vi.fn() } }));
+vi.mock('~/server/db/models/Player', () => ({ Player: { findById: vi.fn() } }));
+vi.mock('~/server/functions/gmscreens-helpers', () => ({ removeDocumentRefsFromScreens: vi.fn() }));
+vi.mock('~/server/functions/tags', () => ({ ensureTags: vi.fn() }));
+
+import { getSession } from '~/server/session';
+import { User } from '~/server/db/models/User';
+import { Campaign } from '~/server/db/models/Campaign';
+import { Organization } from '~/server/db/models/Organization';
+import { OrganizationMembership } from '~/server/db/models/OrganizationMembership';
+import {
+  listOrganizations,
+  getOrganization,
+  deleteOrganization,
+  listMembershipsForMember,
+} from '~/server/functions/organizations';
+
+const session = { id: 'sess-1' } as never;
+const dbUser = { _id: 'user-1' };
+const gmCampaign = {
+  _id: 'camp-1',
+  gameMasterId: 'user-1',
+  members: [{ userId: 'user-1', role: 'gm' }],
+};
+const playerCampaign = {
+  _id: 'camp-1',
+  gameMasterId: 'gm-x',
+  members: [{ userId: 'user-1', role: 'player' }],
+};
+
+const call = (fn: any) => fn as (a: { data: Record<string, unknown> }) => Promise<any>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getSession).mockResolvedValue(session);
+  vi.mocked(User.findOne).mockResolvedValue(dbUser as never);
+  vi.mocked(Campaign.findById).mockResolvedValue(gmCampaign as never);
+});
+
+describe('listOrganizations', () => {
+  it('restricts non-GM to public or own orgs', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    vi.mocked(Organization.find).mockReturnValue({
+      select: vi
+        .fn()
+        .mockReturnValue({
+          sort: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue([]) }),
+        }),
+    } as never);
+    await call(listOrganizations)({ data: { campaignId: 'camp-1' } });
+    const filter = vi.mocked(Organization.find).mock.calls[0][0] as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(JSON.stringify(filter)).toContain('$or');
+  });
+
+  it('filters by locationIds via locations.locationId $in', async () => {
+    vi.mocked(Organization.find).mockReturnValue({
+      select: vi
+        .fn()
+        .mockReturnValue({
+          sort: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue([]) }),
+        }),
+    } as never);
+    await call(listOrganizations)({ data: { campaignId: 'camp-1', locationIds: ['loc-1'] } });
+    const filter = vi.mocked(Organization.find).mock.calls[0][0] as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(filter['locations.locationId']).toEqual({ $in: ['loc-1'] });
+  });
+});
+
+describe('getOrganization', () => {
+  it('strips privateInfo for non-GM viewers', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    vi.mocked(Organization.findById).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        _id: 'o1',
+        campaignId: 'camp-1',
+        createdBy: 'someone',
+        name: 'Guild',
+        publicInfo: 'pub',
+        privateInfo: 'secret',
+        isPublic: true,
+        tags: [],
+        locations: [],
+      }),
+    } as never);
+    const result = await call(getOrganization)({ data: { id: 'o1', campaignId: 'camp-1' } });
+    expect(result.privateInfo).toBe('');
+    expect(result.publicInfo).toBe('pub');
+  });
+
+  it('returns null for non-GM on a private org they did not create', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    vi.mocked(Organization.findById).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        _id: 'o1',
+        campaignId: 'camp-1',
+        createdBy: 'someone',
+        name: 'Secret',
+        isPublic: false,
+        locations: [],
+      }),
+    } as never);
+    const result = await call(getOrganization)({ data: { id: 'o1', campaignId: 'camp-1' } });
+    expect(result).toBeNull();
+  });
+});
+
+describe('deleteOrganization', () => {
+  it('cascade-deletes memberships', async () => {
+    vi.mocked(Organization.findOne).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({ _id: 'o1', campaignId: 'camp-1', createdBy: 'user-1' }),
+    } as never);
+    vi.mocked(Organization.deleteOne).mockResolvedValue({} as never);
+    vi.mocked(OrganizationMembership.deleteMany).mockResolvedValue({} as never);
+    await call(deleteOrganization)({ data: { id: 'o1', campaignId: 'camp-1' } });
+    expect(OrganizationMembership.deleteMany).toHaveBeenCalledWith({ organizationId: 'o1' });
+  });
+});
+
+describe('listMembershipsForMember', () => {
+  it('excludes memberships to private orgs for non-GM', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    vi.mocked(OrganizationMembership.find).mockReturnValue({
+      lean: vi.fn().mockResolvedValue([
+        {
+          _id: 'm1',
+          organizationId: 'pub',
+          memberKind: 'character',
+          memberId: 'c1',
+          campaignId: 'camp-1',
+          createdBy: 'x',
+          privateNotes: 'p',
+        },
+        {
+          _id: 'm2',
+          organizationId: 'priv',
+          memberKind: 'character',
+          memberId: 'c1',
+          campaignId: 'camp-1',
+          createdBy: 'x',
+          privateNotes: 'p',
+        },
+      ]),
+    } as never);
+    // Org lookups: pub is public, priv is private
+    vi.mocked(Organization.find).mockReturnValue({
+      lean: vi.fn().mockResolvedValue([
+        { _id: 'pub', name: 'Public Guild', isPublic: true },
+        { _id: 'priv', name: 'Secret', isPublic: false },
+      ]),
+    } as never);
+    const result = await call(listMembershipsForMember)({
+      data: { campaignId: 'camp-1', memberKind: 'character', memberId: 'c1' },
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].organizationId).toBe('pub');
+    expect(result[0].privateNotes).toBe(''); // stripped for non-GM
+  });
+});

--- a/tests/server/functions/organizations.test.ts
+++ b/tests/server/functions/organizations.test.ts
@@ -29,8 +29,12 @@ vi.mock('~/server/db/models/OrganizationMembership', () => ({
   },
 }));
 vi.mock('~/server/db/models/Location', () => ({ Location: { findById: vi.fn() } }));
-vi.mock('~/server/db/models/Character', () => ({ Character: { findById: vi.fn() } }));
-vi.mock('~/server/db/models/Player', () => ({ Player: { findById: vi.fn() } }));
+vi.mock('~/server/db/models/Character', () => ({
+  Character: { findById: vi.fn(), findOne: vi.fn(), find: vi.fn(), exists: vi.fn() },
+}));
+vi.mock('~/server/db/models/Player', () => ({
+  Player: { findById: vi.fn(), findOne: vi.fn(), find: vi.fn(), exists: vi.fn() },
+}));
 vi.mock('~/server/functions/gmscreens-helpers', () => ({ removeDocumentRefsFromScreens: vi.fn() }));
 vi.mock('~/server/functions/tags', () => ({ ensureTags: vi.fn() }));
 
@@ -40,12 +44,14 @@ import { Campaign } from '~/server/db/models/Campaign';
 import { Organization } from '~/server/db/models/Organization';
 import { OrganizationMembership } from '~/server/db/models/OrganizationMembership';
 import { Character } from '~/server/db/models/Character';
+import { Player } from '~/server/db/models/Player';
 import {
   listOrganizations,
   getOrganization,
   updateOrganization,
   deleteOrganization,
   addMembership,
+  listMembershipsForOrg,
   listMembershipsForMember,
 } from '~/server/functions/organizations';
 
@@ -76,7 +82,9 @@ describe('listOrganizations', () => {
     vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
     vi.mocked(Organization.find).mockReturnValue({
       select: vi.fn().mockReturnValue({
-        sort: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue([]) }),
+        sort: vi.fn().mockReturnValue({
+          limit: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue([]) }),
+        }),
       }),
     } as never);
     await call(listOrganizations)({ data: { campaignId: 'camp-1' } });
@@ -90,7 +98,9 @@ describe('listOrganizations', () => {
   it('filters by locationIds via locations.locationId $in', async () => {
     vi.mocked(Organization.find).mockReturnValue({
       select: vi.fn().mockReturnValue({
-        sort: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue([]) }),
+        sort: vi.fn().mockReturnValue({
+          limit: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue([]) }),
+        }),
       }),
     } as never);
     await call(listOrganizations)({ data: { campaignId: 'camp-1', locationIds: ['loc-1'] } });
@@ -156,26 +166,31 @@ describe('listMembershipsForMember', () => {
   it('excludes memberships to private orgs for non-GM', async () => {
     vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
     vi.mocked(OrganizationMembership.find).mockReturnValue({
-      lean: vi.fn().mockResolvedValue([
-        {
-          _id: 'm1',
-          organizationId: 'pub',
-          memberKind: 'character',
-          memberId: 'c1',
-          campaignId: 'camp-1',
-          createdBy: 'x',
-          privateNotes: 'p',
-        },
-        {
-          _id: 'm2',
-          organizationId: 'priv',
-          memberKind: 'character',
-          memberId: 'c1',
-          campaignId: 'camp-1',
-          createdBy: 'x',
-          privateNotes: 'p',
-        },
-      ]),
+      limit: vi.fn().mockReturnValue({
+        lean: vi.fn().mockResolvedValue([
+          {
+            _id: 'm1',
+            organizationId: 'pub',
+            memberKind: 'character',
+            memberId: 'c1',
+            campaignId: 'camp-1',
+            createdBy: 'x',
+            privateNotes: 'p',
+          },
+          {
+            _id: 'm2',
+            organizationId: 'priv',
+            memberKind: 'character',
+            memberId: 'c1',
+            campaignId: 'camp-1',
+            createdBy: 'x',
+            privateNotes: 'p',
+          },
+        ]),
+      }),
+    } as never);
+    vi.mocked(Character.findOne).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({ _id: 'c1', firstName: 'Bob', lastName: 'Stone' }),
     } as never);
     // Org lookups: pub is public, priv is private
     vi.mocked(Organization.find).mockReturnValue({
@@ -315,7 +330,8 @@ describe('addMembership', () => {
       createdAt: new Date(),
       updatedAt: new Date(),
     } as never);
-    vi.mocked(Character.findById).mockReturnValue({
+    vi.mocked(Character.exists).mockResolvedValue({ _id: 'c1' } as never);
+    vi.mocked(Character.findOne).mockReturnValue({
       lean: vi.fn().mockResolvedValue(null),
     } as never);
 
@@ -358,7 +374,8 @@ describe('addMembership', () => {
       createdAt: new Date(),
       updatedAt: new Date(),
     } as never);
-    vi.mocked(Character.findById).mockReturnValue({
+    vi.mocked(Character.exists).mockResolvedValue({ _id: 'c1' } as never);
+    vi.mocked(Character.findOne).mockReturnValue({
       lean: vi.fn().mockResolvedValue(null),
     } as never);
 
@@ -377,5 +394,96 @@ describe('addMembership', () => {
     expect(OrganizationMembership.create).toHaveBeenCalledWith(
       expect.objectContaining({ privateNotes: '' })
     );
+  });
+
+  it('rejects a member that does not belong to the campaign', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(gmCampaign as never);
+    vi.mocked(Organization.findOne).mockReturnValue({
+      lean: vi.fn().mockResolvedValue({ _id: 'o1', createdBy: 'x', name: 'Guild', isPublic: true }),
+    } as never);
+    // Character does not exist in this campaign.
+    vi.mocked(Character.exists).mockResolvedValue(null as never);
+
+    await expect(
+      call(addMembership)({
+        data: {
+          campaignId: 'camp-1',
+          organizationId: 'o1',
+          memberKind: 'character',
+          memberId: 'foreign-char',
+          title: '',
+          publicNotes: '',
+          privateNotes: '',
+        },
+      })
+    ).rejects.toThrow();
+    expect(OrganizationMembership.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('listMembershipsForOrg', () => {
+  it('batch-resolves member labels without a per-member findById', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(gmCampaign as never);
+    vi.mocked(Organization.findOne).mockReturnValue({
+      lean: vi
+        .fn()
+        .mockResolvedValue({ _id: 'o1', createdBy: 'user-1', name: 'Guild', isPublic: true }),
+    } as never);
+    vi.mocked(OrganizationMembership.find).mockReturnValue({
+      limit: vi.fn().mockReturnValue({
+        lean: vi.fn().mockResolvedValue([
+          {
+            _id: 'm1',
+            organizationId: 'o1',
+            memberKind: 'character',
+            memberId: 'c1',
+            campaignId: 'camp-1',
+            createdBy: 'x',
+          },
+          {
+            _id: 'm2',
+            organizationId: 'o1',
+            memberKind: 'player',
+            memberId: 'p1',
+            campaignId: 'camp-1',
+            createdBy: 'x',
+          },
+        ]),
+      }),
+    } as never);
+    vi.mocked(Character.find).mockReturnValue({
+      lean: vi.fn().mockResolvedValue([{ _id: 'c1', firstName: 'Bob', lastName: 'Stone' }]),
+    } as never);
+    vi.mocked(Player.find).mockReturnValue({
+      lean: vi.fn().mockResolvedValue([{ _id: 'p1', firstName: 'Ann', lastName: 'Vale' }]),
+    } as never);
+
+    const result = await call(listMembershipsForOrg)({
+      data: { campaignId: 'camp-1', organizationId: 'o1' },
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result.find((m: any) => m.memberId === 'c1').memberLabel).toBe('Bob Stone');
+    expect(result.find((m: any) => m.memberId === 'p1').memberLabel).toBe('Ann Vale');
+    // Batched: one find() per kind, and no N+1 findById.
+    expect(Character.find).toHaveBeenCalledTimes(1);
+    expect(Player.find).toHaveBeenCalledTimes(1);
+    expect(Character.findById).not.toHaveBeenCalled();
+    expect(Player.findById).not.toHaveBeenCalled();
+  });
+
+  it('returns [] for a non-GM non-creator on a private org', async () => {
+    vi.mocked(Campaign.findById).mockResolvedValue(playerCampaign as never);
+    vi.mocked(Organization.findOne).mockReturnValue({
+      lean: vi
+        .fn()
+        .mockResolvedValue({ _id: 'o1', createdBy: 'someone', name: 'Secret', isPublic: false }),
+    } as never);
+
+    const result = await call(listMembershipsForOrg)({
+      data: { campaignId: 'camp-1', organizationId: 'o1' },
+    });
+    expect(result).toEqual([]);
+    expect(OrganizationMembership.find).not.toHaveBeenCalled();
   });
 });

--- a/tests/server/functions/players.test.ts
+++ b/tests/server/functions/players.test.ts
@@ -35,6 +35,9 @@ vi.mock('~/server/utils/pruneLoreLinks', () => ({
 vi.mock('~/server/utils/requireCampaignMember', () => ({
   requireCampaignMember: vi.fn(),
 }));
+vi.mock('~/server/functions/organizations', () => ({
+  pruneMembershipsForMember: vi.fn(),
+}));
 
 import { getSession } from '~/server/session';
 import { User } from '~/server/db/models/User';

--- a/tests/server/functions/tabletop-hydration.test.ts
+++ b/tests/server/functions/tabletop-hydration.test.ts
@@ -6,8 +6,10 @@ vi.mock('~/server/db/models/Character', () => ({ Character: { find: vi.fn() } })
 vi.mock('~/server/db/models/Race', () => ({ Race: { find: vi.fn() } }));
 vi.mock('~/server/db/models/Rule', () => ({ Rule: { find: vi.fn() } }));
 vi.mock('~/server/db/models/Event', () => ({ Event: { find: vi.fn() } }));
+vi.mock('~/server/db/models/Organization', () => ({ Organization: { find: vi.fn() } }));
 
 import { Event } from '~/server/db/models/Event';
+import { Organization } from '~/server/db/models/Organization';
 import { hydrateRefs } from '~/server/functions/tabletop-hydration';
 
 const eventDocs = [
@@ -18,6 +20,14 @@ const eventDocs = [
 function mockEventFind() {
   vi.mocked(Event.find).mockReturnValue({
     lean: vi.fn().mockResolvedValue(eventDocs),
+  } as never);
+}
+
+const organizationDocs = [{ _id: 'orgPriv', name: 'Secret', publicInfo: '', isPublic: false }];
+
+function mockOrganizationFind() {
+  vi.mocked(Organization.find).mockReturnValue({
+    lean: vi.fn().mockResolvedValue(organizationDocs),
   } as never);
 }
 
@@ -49,5 +59,21 @@ describe('hydrateRefs — event privacy on shared screens', () => {
   it('defaults to GM (no redaction) when no viewer role is provided', async () => {
     const hydrated = await hydrateRefs(refs, 'camp-1');
     expect(hydrated['events:priv']).toBeDefined();
+  });
+});
+
+describe('hydrateRefs — organization privacy on shared screens', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOrganizationFind();
+  });
+
+  it('omits non-public organizations for a non-GM viewer', async () => {
+    const result = await hydrateRefs(
+      [{ collection: 'organization', documentId: 'orgPriv' }],
+      'camp-1',
+      { isGM: false }
+    );
+    expect(result['organization:orgPriv']).toBeUndefined();
   });
 });

--- a/tests/types/schemas/lore-window-collection.test.ts
+++ b/tests/types/schemas/lore-window-collection.test.ts
@@ -59,3 +59,32 @@ describe('events is an accepted tabletop/GM-screen window collection', () => {
     expect(result.success).toBe(true);
   });
 });
+
+/**
+ * Regression guard: `'organization'` must be an accepted window collection so
+ * that dragging an organization card onto the tabletop / GM screens opens a
+ * window.
+ */
+describe('organization is an accepted tabletop/GM-screen window collection', () => {
+  it('openTabletopWindowSchema accepts collection "organization"', () => {
+    const result = openTabletopWindowSchema.safeParse({
+      screenId: 's1',
+      campaignId: 'c1',
+      collection: 'organization',
+      documentId: 'o1',
+      x: 0,
+      y: 0,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('gmscreens openWindowSchema accepts collection "organization"', () => {
+    const result = openWindowSchema.safeParse({
+      screenId: 's1',
+      campaignId: 'c1',
+      collection: 'organization',
+      documentId: 'o1',
+    });
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Organizations

Adds an **Organizations** wiki entity (guild, faction, noble house, cult, city watch) — Kanka-style — to Cartyx.

### What it does
- **Organization** entity with public info + GM-only private info (Markdown), tags, **multiple images**, and links to one or more **locations** (each with public + GM-only info).
- **Members**: a player *or* character can belong to many organizations, each membership carrying an optional title and public + GM-only relationship notes (`OrganizationMembership` join collection).
- Managed in the existing **wiki UI** alongside lore/races, filterable by **tags and locations**.
- **GM-screen + tabletop windows** — the primary view surface — plus drag-to-tabletop and "Show on Tabletop".
- **Organizations tab** in player/character edit modals *and* view windows.

### Privacy model
- `private = GM-only` throughout: `privateInfo`, membership `privateNotes`, and location-link `privateInfo` are stripped from server responses for non-GMs and writable only by a GM (non-GM edits preserve existing private values). Images are **public** (like Lore's).
- A **private org** (`isPublic:false`) is invisible to non-GNs everywhere: not in the wiki list, dropped from the tabletop window list, and excluded from a member's Organizations tab.

### Hardening (post-review)
- `addMembership` verifies the member belongs to the campaign before linking (closes a cross-campaign name-disclosure + junk-row path); label lookups are campaign-scoped.
- `listMembershipsForOrg` batch-resolves member labels (no N+1); all list endpoints are bounded (`LIST_LIMIT`).
- Player/character view windows pass the real `isGM` (not `canEdit`) to the org tab; accessible Public/Private radio toggle.

### Testing & data
- Full unit suite green (**1637 tests**), typecheck + lint clean.
- `npm run dev:seed` seeds 5 orgs (3 public, 2 GM-only) + 7 memberships in the Phandelver campaign, incl. a player secretly in a private org to exercise the hidden-from-member rule.
- Committed design doc: `docs/specs/2026-07-13-organizations-design.md`.

### Deferred follow-ups (non-blocking; documented in the design doc)
Non-transactional cascade delete (reads fail-closed on orphans); membership modals lack error surfacing / delete confirmation; stale tabletop title after rename; non-GM location-link removal drops that link's GM privateInfo; client sends hidden privateInfo (server strips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)