### PR TITLE
feat(quests): Kanka-style Quests wiki entity

### DIFF
--- a/app/components/mainview/gmscreens/GMScreensView.tsx
+++ b/app/components/mainview/gmscreens/GMScreensView.tsx
@@ -16,6 +16,10 @@ import {
   OrganizationWindowWrapper,
   EditOrganizationModalWrapper,
 } from '~/components/wiki/organizations/OrganizationWindowWrapper';
+import {
+  QuestWindowWrapper,
+  EditQuestModalWrapper,
+} from '~/components/wiki/quests/QuestWindowWrapper';
 import { EventWindowWrapper } from './EventWindowWrapper';
 import { RaceWindowWrapper, EditRaceModalWrapper } from '~/components/wiki/races/RaceWindowWrapper';
 import { RuleWindowWrapper, EditRuleModalWrapper } from './RuleWindowWrapper';
@@ -68,6 +72,7 @@ export function GMScreensView({ campaignId, isGM = true }: GMScreensViewProps) {
   const [editingMonsterId, setEditingMonsterId] = useState<string | null>(null);
   const [editingLoreId, setEditingLoreId] = useState<string | null>(null);
   const [editingOrganizationId, setEditingOrganizationId] = useState<string | null>(null);
+  const [editingQuestId, setEditingQuestId] = useState<string | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
   const [flashWindowId, setFlashWindowId] = useState<string | null>(null);
   const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -485,6 +490,14 @@ export function GMScreensView({ campaignId, isGM = true }: GMScreensViewProps) {
               onEdit={() => setEditingOrganizationId(w.documentId)}
             />
           );
+        } else if (w.collection === 'quest') {
+          windowContent = (
+            <QuestWindowWrapper
+              questId={w.documentId}
+              campaignId={campaignId}
+              onEdit={() => setEditingQuestId(w.documentId)}
+            />
+          );
         } else if (w.collection === 'events') {
           windowContent = <EventWindowWrapper eventId={w.documentId} campaignId={campaignId} />;
         } else {
@@ -803,6 +816,13 @@ export function GMScreensView({ campaignId, isGM = true }: GMScreensViewProps) {
           campaignId={campaignId}
           organizationId={editingOrganizationId}
           onClose={() => setEditingOrganizationId(null)}
+        />
+      )}
+      {editingQuestId !== null && (
+        <EditQuestModalWrapper
+          campaignId={campaignId}
+          questId={editingQuestId}
+          onClose={() => setEditingQuestId(null)}
         />
       )}
     </div>

--- a/app/components/mainview/gmscreens/GMScreensView.tsx
+++ b/app/components/mainview/gmscreens/GMScreensView.tsx
@@ -519,7 +519,8 @@ export function GMScreensView({ campaignId, isGM = true }: GMScreensViewProps) {
           w.collection === 'character' ||
           w.collection === 'location' ||
           w.collection === 'lore' ||
-          w.collection === 'organization'
+          w.collection === 'organization' ||
+          w.collection === 'quest'
         ) {
           if (doc?.isPublic === true) {
             titleIcon = (

--- a/app/components/mainview/tabletop/TabletopView.tsx
+++ b/app/components/mainview/tabletop/TabletopView.tsx
@@ -33,6 +33,10 @@ import {
   OrganizationWindowWrapper,
   EditOrganizationModalWrapper,
 } from '~/components/wiki/organizations/OrganizationWindowWrapper';
+import {
+  QuestWindowWrapper,
+  EditQuestModalWrapper,
+} from '~/components/wiki/quests/QuestWindowWrapper';
 import { EventWindowWrapper } from '~/components/mainview/gmscreens/EventWindowWrapper';
 import { RaceWindowWrapper, EditRaceModalWrapper } from '~/components/wiki/races/RaceWindowWrapper';
 import {
@@ -135,6 +139,7 @@ export function TabletopView({
   const [editingMonsterId, setEditingMonsterId] = useState<string | null>(null);
   const [editingLoreId, setEditingLoreId] = useState<string | null>(null);
   const [editingOrganizationId, setEditingOrganizationId] = useState<string | null>(null);
+  const [editingQuestId, setEditingQuestId] = useState<string | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
   const [localWindows, setLocalWindows] = useState<ManagedWindow[]>([]);
   const localScreenIdRef = useRef<string | null>(null);
@@ -396,6 +401,14 @@ export function TabletopView({
               organizationId={w.documentId}
               campaignId={campaignId}
               onEdit={() => setEditingOrganizationId(w.documentId)}
+            />
+          );
+        } else if (w.collection === 'quest') {
+          windowContent = (
+            <QuestWindowWrapper
+              questId={w.documentId}
+              campaignId={campaignId}
+              onEdit={() => setEditingQuestId(w.documentId)}
             />
           );
         } else if (w.collection === 'events') {
@@ -739,6 +752,13 @@ export function TabletopView({
           campaignId={campaignId}
           organizationId={editingOrganizationId}
           onClose={() => setEditingOrganizationId(null)}
+        />
+      )}
+      {editingQuestId !== null && (
+        <EditQuestModalWrapper
+          campaignId={campaignId}
+          questId={editingQuestId}
+          onClose={() => setEditingQuestId(null)}
         />
       )}
     </div>

--- a/app/components/mainview/tabletop/TabletopView.tsx
+++ b/app/components/mainview/tabletop/TabletopView.tsx
@@ -432,7 +432,8 @@ export function TabletopView({
           w.collection === 'character' ||
           w.collection === 'location' ||
           w.collection === 'lore' ||
-          w.collection === 'organization'
+          w.collection === 'organization' ||
+          w.collection === 'quest'
         ) {
           if (doc?.isPublic === true) {
             titleIcon = (

--- a/app/components/shared/EntityQuestsTab.tsx
+++ b/app/components/shared/EntityQuestsTab.tsx
@@ -1,0 +1,40 @@
+import { useQuestsForEntity } from '~/hooks/useQuests';
+import type { QuestLinkKind, QuestStatus } from '~/types/quest';
+
+const STATUS_LABELS: Record<QuestStatus, string> = {
+  not_started: 'Not started',
+  active: 'Active',
+  on_hold: 'On hold',
+  completed: 'Completed',
+  failed: 'Failed',
+};
+
+interface Props {
+  campaignId: string;
+  kind: QuestLinkKind;
+  id: string;
+}
+
+export function EntityQuestsTab({ campaignId, kind, id }: Props) {
+  const { quests, isLoading } = useQuestsForEntity(campaignId, kind, id);
+
+  if (isLoading) return <div className="p-4 text-sm text-slate-400">Loading quests…</div>;
+  if (quests.length === 0)
+    return <div className="p-4 text-sm text-slate-500">No linked quests.</div>;
+
+  return (
+    <div data-testid="entity-quests-tab" className="space-y-2 p-2">
+      {quests.map((q) => (
+        <div
+          key={q.id}
+          className="flex items-center justify-between rounded-lg border border-white/10 bg-white/[0.03] px-3 py-2"
+        >
+          <span className="text-sm text-slate-200">{q.name}</span>
+          <span className="rounded-full bg-white/[0.06] px-2 py-0.5 text-[10px] font-semibold text-slate-300">
+            {STATUS_LABELS[q.status]}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/components/wiki/WikiPanel.tsx
+++ b/app/components/wiki/WikiPanel.tsx
@@ -13,6 +13,7 @@ import {
   CalendarClock,
   Sparkles,
   Building2,
+  Swords,
 } from 'lucide-react';
 import { CharactersPanel } from './characters/CharactersPanel';
 import { RacesPanel } from './races/RacesPanel';
@@ -24,6 +25,7 @@ import { MapsPanel } from './maps/MapsPanel';
 import { MonstersPanel } from './monsters/MonstersPanel';
 import { LorePanel } from './lore/LorePanel';
 import { OrganizationsPanel } from './organizations/OrganizationsPanel';
+import { QuestsPanel } from './quests/QuestsPanel';
 import { CalendarPanel } from './calendar/CalendarPanel';
 import { EventsPanel } from './calendar/EventsPanel';
 import { useCampaign } from '~/hooks/useCampaigns';
@@ -37,6 +39,7 @@ type WikiCategoryId =
   | 'locations'
   | 'lore'
   | 'organizations'
+  | 'quests'
   | 'maps'
   | 'monsters'
   | 'calendar'
@@ -59,6 +62,7 @@ const WIKI_CATEGORIES: WikiCategory[] = [
   { id: 'locations', label: 'Locations', icon: MapPin },
   { id: 'lore', label: 'Lore', icon: BookOpen },
   { id: 'organizations', label: 'Organizations', icon: Building2 },
+  { id: 'quests', label: 'Quests', icon: Swords },
   { id: 'maps', label: 'Maps', icon: MapIcon, gmOnly: true },
   { id: 'monsters', label: 'Monsters', icon: Skull, gmOnly: true },
   { id: 'calendar', label: 'Calendar', icon: CalendarDays },
@@ -113,6 +117,8 @@ export function WikiPanel() {
         <LorePanel onBack={() => setSelectedCategory(null)} />
       ) : selectedCategory === 'organizations' ? (
         <OrganizationsPanel onBack={() => setSelectedCategory(null)} />
+      ) : selectedCategory === 'quests' ? (
+        <QuestsPanel onBack={() => setSelectedCategory(null)} />
       ) : selectedCategory === 'maps' && isGM ? (
         <MapsPanel onBack={() => setSelectedCategory(null)} />
       ) : selectedCategory === 'monsters' && isGM ? (

--- a/app/components/wiki/characters/CharacterModal.tsx
+++ b/app/components/wiki/characters/CharacterModal.tsx
@@ -8,6 +8,7 @@ import { MarkdownEditor } from '~/components/shared/MarkdownEditor';
 import { TagAutocompleteInput } from '~/components/shared/TagAutocompleteInput';
 import { TabBar } from '~/components/shared/TabBar';
 import { MemberOrganizationsTab } from '~/components/shared/MemberOrganizationsTab';
+import { EntityQuestsTab } from '~/components/shared/EntityQuestsTab';
 import { ImageCropInput } from './ImageCropInput';
 import { SessionMultiSelect } from './SessionMultiSelect';
 import {
@@ -77,7 +78,7 @@ export function CharacterModal({
   const [isPublic, setIsPublic] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-  const [activeTab, setActiveTab] = useState<'details' | 'organizations'>('details');
+  const [activeTab, setActiveTab] = useState<'details' | 'organizations' | 'quests'>('details');
 
   const validate = useCallback((): FieldErrors => {
     const errors: FieldErrors = {};
@@ -274,9 +275,10 @@ export function CharacterModal({
           tabs={[
             { id: 'details', label: 'Details' },
             { id: 'organizations', label: 'Organizations' },
+            { id: 'quests', label: 'Quests' },
           ]}
           activeTab={activeTab}
-          onTabChange={(t) => setActiveTab(t as 'details' | 'organizations')}
+          onTabChange={(t) => setActiveTab(t as 'details' | 'organizations' | 'quests')}
         />
 
         <div className="flex-1 overflow-y-auto p-4 sm:p-6 space-y-5 min-h-0">
@@ -302,6 +304,14 @@ export function CharacterModal({
             ) : (
               <p className="text-xs text-slate-500">
                 Save the character first to manage its organizations.
+              </p>
+            )
+          ) : activeTab === 'quests' ? (
+            isEdit && characterId ? (
+              <EntityQuestsTab campaignId={campaignId} kind="character" id={characterId} />
+            ) : (
+              <p className="text-xs text-slate-500">
+                Save the character first to see linked quests.
               </p>
             )
           ) : (

--- a/app/components/wiki/characters/CharacterWindow.tsx
+++ b/app/components/wiki/characters/CharacterWindow.tsx
@@ -13,6 +13,7 @@ import {
   useRemoveCharacterRelationship,
 } from '~/hooks/useCharacters';
 import { MemberOrganizationsTab } from '~/components/shared/MemberOrganizationsTab';
+import { EntityQuestsTab } from '~/components/shared/EntityQuestsTab';
 import { useCampaign } from '~/hooks/useCampaigns';
 
 function getCropStyle(crop: PictureCrop): React.CSSProperties {
@@ -96,6 +97,7 @@ export function CharacterWindow({ character, onEdit }: CharacterWindowProps) {
     { id: 'gmnotes', label: 'GM Notes', hidden: !character.canEdit },
     { id: 'relationships', label: 'Relationships' },
     { id: 'organizations', label: 'Organizations' },
+    { id: 'quests', label: 'Quests' },
   ];
 
   return (
@@ -278,6 +280,10 @@ export function CharacterWindow({ character, onEdit }: CharacterWindowProps) {
             isGM={isGM}
             canManage={character.canEdit}
           />
+        )}
+
+        {activeTab === 'quests' && (
+          <EntityQuestsTab campaignId={character.campaignId} kind="character" id={character.id} />
         )}
       </div>
     </div>

--- a/app/components/wiki/locations/LocationModal.tsx
+++ b/app/components/wiki/locations/LocationModal.tsx
@@ -17,6 +17,7 @@ import type { LocationRef } from '~/types/location';
 import { LocationImageUpload } from './LocationImageUpload';
 import { ShowOnTabletopButton } from '~/components/wiki/shared/ShowOnTabletopButton';
 import { TagAutocompleteInput } from '~/components/shared/TagAutocompleteInput';
+import { EntityQuestsTab } from '~/components/shared/EntityQuestsTab';
 
 interface LocationModalProps {
   isOpen: boolean;
@@ -458,6 +459,16 @@ export function LocationModal({ isOpen, onClose, campaignId, locationId }: Locat
               </div>
             </label>
           </div>
+
+          {/* Linked Quests — edit mode only */}
+          {locationId && (
+            <div>
+              <h3 className="text-xs font-semibold text-slate-400 mb-2 tracking-wide">
+                Linked Quests
+              </h3>
+              <EntityQuestsTab campaignId={campaignId} kind="location" id={locationId} />
+            </div>
+          )}
         </div>
 
         <footer className="flex items-center justify-between px-4 sm:px-6 py-4 border-t border-white/[0.07] bg-white/[0.01] shrink-0">

--- a/app/components/wiki/locations/LocationWindow.tsx
+++ b/app/components/wiki/locations/LocationWindow.tsx
@@ -5,6 +5,7 @@ import remarkGfm from 'remark-gfm';
 import type { LocationData } from '~/types/location';
 import { MARKDOWN_PROSE_CLASSES } from '~/utils/markdownProseClasses';
 import { LocationGallery } from './LocationGallery';
+import { EntityQuestsTab } from '~/components/shared/EntityQuestsTab';
 
 interface LocationWindowProps {
   location: LocationData;
@@ -13,7 +14,7 @@ interface LocationWindowProps {
   onOpenLocation?: (locationId: string) => void;
 }
 
-type Tab = 'general' | 'gallery' | 'gm-notes' | 'hierarchy';
+type Tab = 'general' | 'gallery' | 'gm-notes' | 'hierarchy' | 'quests';
 
 export function LocationWindow({ location, isGM, onEdit, onOpenLocation }: LocationWindowProps) {
   const [activeTab, setActiveTab] = useState<Tab>('general');
@@ -23,6 +24,7 @@ export function LocationWindow({ location, isGM, onEdit, onOpenLocation }: Locat
     { id: 'gallery', label: 'Gallery' },
     ...(isGM ? [{ id: 'gm-notes' as Tab, label: 'GM Notes' }] : []),
     { id: 'hierarchy', label: 'Hierarchy' },
+    { id: 'quests', label: 'Quests' },
   ];
 
   return (
@@ -165,6 +167,10 @@ export function LocationWindow({ location, isGM, onEdit, onOpenLocation }: Locat
               <p className="text-xs text-slate-600 italic">No location hierarchy configured yet.</p>
             )}
           </div>
+        )}
+
+        {activeTab === 'quests' && (
+          <EntityQuestsTab campaignId={location.campaignId} kind="location" id={location.id} />
         )}
       </div>
     </div>

--- a/app/components/wiki/organizations/OrganizationModal.tsx
+++ b/app/components/wiki/organizations/OrganizationModal.tsx
@@ -16,6 +16,7 @@ import {
 } from '~/hooks/useOrganizations';
 import { OrganizationLocationsEditor } from './OrganizationLocationsEditor';
 import { OrganizationMembersEditor } from './OrganizationMembersEditor';
+import { EntityQuestsTab } from '~/components/shared/EntityQuestsTab';
 import { uploadToR2 } from '~/utils/uploadToR2';
 import { compressImage } from '~/utils/compressImage';
 import type { OrganizationLocationLinkInput, OrganizationImage } from '~/types/organization';
@@ -374,6 +375,19 @@ export function OrganizationModal({
                 <p className="text-xs text-slate-500">
                   Save the organization first to add members.
                 </p>
+              )}
+
+              {isEdit && organizationId && (
+                <div>
+                  <span className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide">
+                    Linked Quests
+                  </span>
+                  <EntityQuestsTab
+                    campaignId={campaignId}
+                    kind="organization"
+                    id={organizationId}
+                  />
+                </div>
               )}
             </>
           )}

--- a/app/components/wiki/organizations/OrganizationWindow.tsx
+++ b/app/components/wiki/organizations/OrganizationWindow.tsx
@@ -6,6 +6,7 @@ import type { OrganizationData } from '~/types/organization';
 import type { PictureCrop } from '~/types/character';
 import { MARKDOWN_PROSE_CLASSES } from '~/utils/markdownProseClasses';
 import { useMembershipsForOrg } from '~/hooks/useOrganizations';
+import { EntityQuestsTab } from '~/components/shared/EntityQuestsTab';
 
 function getCropStyle(crop: PictureCrop): React.CSSProperties {
   const centerX = (crop.x + crop.width / 2) * 100;
@@ -172,6 +173,18 @@ export function OrganizationWindow({ organization, onEdit }: OrganizationWindowP
             </div>
           </div>
         )}
+
+        {/* Linked Quests */}
+        <div>
+          <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">
+            Linked Quests
+          </p>
+          <EntityQuestsTab
+            campaignId={organization.campaignId}
+            kind="organization"
+            id={organization.id}
+          />
+        </div>
       </div>
     </div>
   );

--- a/app/components/wiki/players/PlayerModal.tsx
+++ b/app/components/wiki/players/PlayerModal.tsx
@@ -7,6 +7,7 @@ import { MarkdownEditor } from '~/components/shared/MarkdownEditor';
 import { ColorPicker } from '~/components/shared/ColorPicker';
 import { TabBar } from '~/components/shared/TabBar';
 import { MemberOrganizationsTab } from '~/components/shared/MemberOrganizationsTab';
+import { EntityQuestsTab } from '~/components/shared/EntityQuestsTab';
 import { ImageCropInput } from '~/components/wiki/characters/ImageCropInput';
 import { usePlayer, useUpdatePlayer, useDeletePlayer } from '~/hooks/usePlayers';
 import { useCampaign } from '~/hooks/useCampaigns';
@@ -64,7 +65,7 @@ export function PlayerModal({ campaignId, playerId, onClose }: PlayerModalProps)
   const [gmNotes, setGmNotes] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-  const [activeTab, setActiveTab] = useState<'details' | 'organizations'>('details');
+  const [activeTab, setActiveTab] = useState<'details' | 'organizations' | 'quests'>('details');
 
   const validate = useCallback((): FieldErrors => {
     const errors: FieldErrors = {};
@@ -248,9 +249,10 @@ export function PlayerModal({ campaignId, playerId, onClose }: PlayerModalProps)
             tabs={[
               { id: 'details', label: 'Details' },
               { id: 'organizations', label: 'Organizations' },
+              { id: 'quests', label: 'Quests' },
             ]}
             activeTab={activeTab}
-            onTabChange={(t) => setActiveTab(t as 'details' | 'organizations')}
+            onTabChange={(t) => setActiveTab(t as 'details' | 'organizations' | 'quests')}
             accentColor={color || '#3498db'}
           />
         )}
@@ -274,6 +276,8 @@ export function PlayerModal({ campaignId, playerId, onClose }: PlayerModalProps)
               isGM={campaign?.isGM ?? false}
               canManage={campaign?.isGM || existingPlayer?.canEdit || false}
             />
+          ) : activeTab === 'quests' && isEdit && playerId ? (
+            <EntityQuestsTab campaignId={campaignId} kind="player" id={playerId} />
           ) : (
             <>
               {/* Picture upload */}

--- a/app/components/wiki/players/PlayerWindow.tsx
+++ b/app/components/wiki/players/PlayerWindow.tsx
@@ -15,6 +15,7 @@ import {
 } from '~/hooks/usePlayers';
 import { PlayerLoreTab } from '~/components/wiki/players/PlayerLoreTab';
 import { MemberOrganizationsTab } from '~/components/shared/MemberOrganizationsTab';
+import { EntityQuestsTab } from '~/components/shared/EntityQuestsTab';
 import { useCampaign } from '~/hooks/useCampaigns';
 
 function getCropStyle(crop: PictureCrop): React.CSSProperties {
@@ -106,6 +107,7 @@ export function PlayerWindow({ player, onEdit }: PlayerWindowProps) {
     { id: 'relationships', label: 'Relationships' },
     { id: 'lore', label: 'Lore' },
     { id: 'organizations', label: 'Organizations' },
+    { id: 'quests', label: 'Quests' },
   ];
 
   return (
@@ -322,6 +324,10 @@ export function PlayerWindow({ player, onEdit }: PlayerWindowProps) {
             isGM={isGM}
             canManage={player.canEdit}
           />
+        )}
+
+        {activeTab === 'quests' && (
+          <EntityQuestsTab campaignId={player.campaignId} kind="player" id={player.id} />
         )}
       </div>
     </div>

--- a/app/components/wiki/quests/QuestCard.tsx
+++ b/app/components/wiki/quests/QuestCard.tsx
@@ -1,0 +1,73 @@
+import type { QuestListItem, QuestStatus } from '~/types/quest';
+
+const STATUS_LABELS: Record<QuestStatus, string> = {
+  not_started: 'Not started',
+  active: 'Active',
+  on_hold: 'On hold',
+  completed: 'Completed',
+  failed: 'Failed',
+};
+
+interface QuestCardProps {
+  quest: QuestListItem;
+  onClick: (quest: QuestListItem) => void;
+}
+
+export function QuestCard({ quest, onClick }: QuestCardProps) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      draggable="true"
+      onDragStart={(e) => {
+        e.dataTransfer.setData(
+          'application/x-cartyx-document',
+          JSON.stringify({
+            collection: 'quest',
+            documentId: quest.id,
+            title: quest.name,
+          })
+        );
+        e.dataTransfer.effectAllowed = 'copy';
+        e.currentTarget.style.opacity = '0.4';
+      }}
+      onDragEnd={(e) => {
+        e.currentTarget.style.opacity = '';
+      }}
+      onClick={() => onClick(quest)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick(quest);
+        }
+      }}
+      className="flex items-start gap-3 px-4 py-3 border-b border-white/[0.05] hover:bg-white/[0.03] transition-colors group cursor-grab active:cursor-grabbing"
+    >
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-0.5">
+          <span className="text-sm font-semibold text-slate-200 group-hover:text-blue-400 transition-colors truncate">
+            {quest.name}
+          </span>
+        </div>
+        <div className="flex items-center gap-2 mt-0.5">
+          <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-white/[0.05] border border-white/[0.08] text-slate-400 font-sans font-bold text-[9px] uppercase tracking-tight">
+            {STATUS_LABELS[quest.status]}
+          </span>
+          {quest.type && <span className="text-[10px] text-slate-500 truncate">{quest.type}</span>}
+        </div>
+        {quest.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1 mt-1">
+            {quest.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[9px] tracking-tight"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/wiki/quests/QuestEventsEditor.tsx
+++ b/app/components/wiki/quests/QuestEventsEditor.tsx
@@ -1,0 +1,128 @@
+import { useState, useId } from 'react';
+import { X } from 'lucide-react';
+import { useEvents } from '~/hooks/useEvents';
+import type { QuestEventLinkInput } from '~/types/quest';
+
+interface Props {
+  campaignId: string;
+  events: QuestEventLinkInput[];
+  onChange: (events: QuestEventLinkInput[]) => void;
+  disabled?: boolean;
+  isGM: boolean;
+}
+
+export function QuestEventsEditor({ campaignId, events, onChange, disabled, isGM }: Props) {
+  const uid = useId();
+  const entitySelectId = `quest-events-entity-${uid}`;
+
+  const [selectedId, setSelectedId] = useState('');
+
+  const { events: candidates } = useEvents(campaignId);
+
+  const labelFor = (e: QuestEventLinkInput): string => {
+    return candidates.find((x) => x.id === e.eventId)?.title ?? e.eventId;
+  };
+
+  const addEvent = () => {
+    if (!selectedId) return;
+    if (events.some((e) => e.eventId === selectedId)) return;
+    onChange([...events, { eventId: selectedId, role: '', publicInfo: '', privateInfo: '' }]);
+    setSelectedId('');
+  };
+
+  const patch = (i: number, part: Partial<QuestEventLinkInput>) => {
+    onChange(events.map((e, idx) => (idx === i ? { ...e, ...part } : e)));
+  };
+  const remove = (i: number) => onChange(events.filter((_, idx) => idx !== i));
+
+  return (
+    <div data-testid="quest-events-editor" className="space-y-3">
+      <span className="block text-xs font-semibold text-slate-400 tracking-wide">
+        Linked Events
+      </span>
+
+      {events.map((e, i) => (
+        <div
+          key={e.eventId}
+          className="rounded-xl border border-white/10 bg-white/[0.03] p-3 space-y-2"
+        >
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-slate-200">{labelFor(e)}</span>
+            {!disabled && (
+              <button
+                type="button"
+                aria-label={`Remove ${labelFor(e)}`}
+                onClick={() => remove(i)}
+                className="text-slate-500 hover:text-white transition-colors"
+              >
+                <X size={14} />
+              </button>
+            )}
+          </div>
+          <input
+            type="text"
+            value={e.role}
+            disabled={disabled}
+            onChange={(ev) => patch(i, { role: ev.target.value })}
+            placeholder="Role (e.g. Trigger, Aftermath)"
+            className="w-full bg-white/[0.04] border border-white/10 rounded-lg px-2.5 py-1.5 text-sm text-slate-200"
+          />
+          <textarea
+            value={e.publicInfo}
+            disabled={disabled}
+            onChange={(ev) => patch(i, { publicInfo: ev.target.value })}
+            placeholder="Public notes"
+            rows={2}
+            className="w-full bg-white/[0.04] border border-white/10 rounded-lg px-2.5 py-1.5 text-sm text-slate-200"
+          />
+          {isGM && (
+            <textarea
+              value={e.privateInfo}
+              disabled={disabled}
+              onChange={(ev) => patch(i, { privateInfo: ev.target.value })}
+              placeholder="GM-only notes"
+              rows={2}
+              className="w-full bg-amber-500/[0.04] border border-amber-500/20 rounded-lg px-2.5 py-1.5 text-sm text-amber-100"
+            />
+          )}
+        </div>
+      ))}
+
+      {!disabled && (
+        <div className="flex items-end gap-2">
+          <div className="flex-1 min-w-0">
+            <label htmlFor={entitySelectId} className="block text-[11px] text-slate-500 mb-1">
+              Event
+            </label>
+            <select
+              id={entitySelectId}
+              aria-label="Event to link"
+              value={selectedId}
+              onChange={(e) => setSelectedId(e.target.value)}
+              disabled={candidates.length === 0}
+              className="w-full bg-white/[0.04] border border-white/10 rounded-xl px-3 py-2.5 text-slate-200 text-sm focus:outline-none focus:border-blue-500/50 transition-all appearance-none cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <option value="" className="bg-[#0D1117]">
+                {candidates.length === 0 ? 'No events' : 'Select event…'}
+              </option>
+              {candidates.map((c) => (
+                <option key={c.id} value={c.id} className="bg-[#0D1117]">
+                  {c.title}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <button
+            type="button"
+            onClick={addEvent}
+            disabled={!selectedId}
+            className="flex-shrink-0 px-3 py-2.5 rounded-xl text-sm font-semibold bg-blue-600 hover:bg-blue-500 disabled:bg-white/[0.06] disabled:text-slate-500 disabled:cursor-not-allowed text-white transition-colors"
+          >
+            Add event
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/wiki/quests/QuestLinksEditor.tsx
+++ b/app/components/wiki/quests/QuestLinksEditor.tsx
@@ -1,0 +1,202 @@
+import { useState, useMemo, useId } from 'react';
+import { X } from 'lucide-react';
+import { useCharacters } from '~/hooks/useCharacters';
+import { usePlayers } from '~/hooks/usePlayers';
+import { useLocations } from '~/hooks/useLocations';
+import { useOrganizations } from '~/hooks/useOrganizations';
+import type { QuestLinkInput, QuestLinkKind } from '~/types/quest';
+
+interface Candidate {
+  id: string;
+  label: string;
+}
+
+const KIND_LABELS: Record<QuestLinkKind, string> = {
+  character: 'Character',
+  player: 'Player',
+  location: 'Location',
+  organization: 'Organization',
+};
+
+interface Props {
+  campaignId: string;
+  links: QuestLinkInput[];
+  onChange: (links: QuestLinkInput[]) => void;
+  disabled?: boolean;
+  isGM: boolean;
+}
+
+export function QuestLinksEditor({ campaignId, links, onChange, disabled, isGM }: Props) {
+  const uid = useId();
+  const kindSelectId = `quest-links-kind-${uid}`;
+  const entitySelectId = `quest-links-entity-${uid}`;
+
+  const [kind, setKind] = useState<QuestLinkKind>('character');
+  const [selectedId, setSelectedId] = useState('');
+
+  const { characters } = useCharacters(campaignId);
+  const { players } = usePlayers(campaignId);
+  const { locations } = useLocations(campaignId);
+  const { organizations } = useOrganizations(campaignId);
+
+  const candidates: Candidate[] = useMemo(() => {
+    switch (kind) {
+      case 'character':
+        return characters.map((c) => ({ id: c.id, label: `${c.firstName} ${c.lastName}`.trim() }));
+      case 'player':
+        return players.map((p) => ({ id: p.id, label: `${p.firstName} ${p.lastName}`.trim() }));
+      case 'location':
+        return locations.map((l) => ({ id: l.id, label: l.name }));
+      case 'organization':
+        return organizations.map((o) => ({ id: o.id, label: o.name }));
+    }
+  }, [kind, characters, players, locations, organizations]);
+
+  const labelFor = (l: QuestLinkInput): string => {
+    switch (l.kind) {
+      case 'character': {
+        const c = characters.find((x) => x.id === l.id);
+        return c ? `${c.firstName} ${c.lastName}`.trim() : l.id;
+      }
+      case 'player': {
+        const p = players.find((x) => x.id === l.id);
+        return p ? `${p.firstName} ${p.lastName}`.trim() : l.id;
+      }
+      case 'location':
+        return locations.find((x) => x.id === l.id)?.name ?? l.id;
+      case 'organization':
+        return organizations.find((x) => x.id === l.id)?.name ?? l.id;
+    }
+  };
+
+  const handleKindChange = (newKind: QuestLinkKind) => {
+    setKind(newKind);
+    setSelectedId('');
+  };
+
+  const addLink = () => {
+    if (!selectedId) return;
+    if (links.some((l) => l.kind === kind && l.id === selectedId)) return;
+    onChange([...links, { kind, id: selectedId, role: '', publicInfo: '', privateInfo: '' }]);
+    setSelectedId('');
+  };
+
+  const patch = (i: number, part: Partial<QuestLinkInput>) => {
+    onChange(links.map((l, idx) => (idx === i ? { ...l, ...part } : l)));
+  };
+  const remove = (i: number) => onChange(links.filter((_, idx) => idx !== i));
+
+  return (
+    <div data-testid="quest-links-editor" className="space-y-3">
+      <span className="block text-xs font-semibold text-slate-400 tracking-wide">
+        Linked Entities
+      </span>
+
+      {links.map((l, i) => (
+        <div
+          key={`${l.kind}-${l.id}`}
+          className="rounded-xl border border-white/10 bg-white/[0.03] p-3 space-y-2"
+        >
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-slate-200">
+              {labelFor(l)}{' '}
+              <span className="text-[10px] text-slate-500">({KIND_LABELS[l.kind]})</span>
+            </span>
+            {!disabled && (
+              <button
+                type="button"
+                aria-label={`Remove ${labelFor(l)}`}
+                onClick={() => remove(i)}
+                className="text-slate-500 hover:text-white transition-colors"
+              >
+                <X size={14} />
+              </button>
+            )}
+          </div>
+          <input
+            type="text"
+            value={l.role}
+            disabled={disabled}
+            onChange={(e) => patch(i, { role: e.target.value })}
+            placeholder="Role (e.g. Target, Ally, Reward)"
+            className="w-full bg-white/[0.04] border border-white/10 rounded-lg px-2.5 py-1.5 text-sm text-slate-200"
+          />
+          <textarea
+            value={l.publicInfo}
+            disabled={disabled}
+            onChange={(e) => patch(i, { publicInfo: e.target.value })}
+            placeholder="Public notes"
+            rows={2}
+            className="w-full bg-white/[0.04] border border-white/10 rounded-lg px-2.5 py-1.5 text-sm text-slate-200"
+          />
+          {isGM && (
+            <textarea
+              value={l.privateInfo}
+              disabled={disabled}
+              onChange={(e) => patch(i, { privateInfo: e.target.value })}
+              placeholder="GM-only notes"
+              rows={2}
+              className="w-full bg-amber-500/[0.04] border border-amber-500/20 rounded-lg px-2.5 py-1.5 text-sm text-amber-100"
+            />
+          )}
+        </div>
+      ))}
+
+      {!disabled && (
+        <div className="flex items-end gap-2">
+          <div className="flex-shrink-0">
+            <label htmlFor={kindSelectId} className="block text-[11px] text-slate-500 mb-1">
+              Type
+            </label>
+            <select
+              id={kindSelectId}
+              value={kind}
+              onChange={(e) => handleKindChange(e.target.value as QuestLinkKind)}
+              className="bg-white/[0.04] border border-white/10 rounded-xl px-3 py-2.5 text-slate-200 text-sm focus:outline-none focus:border-blue-500/50 transition-all appearance-none cursor-pointer"
+            >
+              {(Object.keys(KIND_LABELS) as QuestLinkKind[]).map((k) => (
+                <option key={k} value={k} className="bg-[#0D1117]">
+                  {KIND_LABELS[k]}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex-1 min-w-0">
+            <label htmlFor={entitySelectId} className="block text-[11px] text-slate-500 mb-1">
+              Entity
+            </label>
+            <select
+              id={entitySelectId}
+              aria-label="Entity to link"
+              value={selectedId}
+              onChange={(e) => setSelectedId(e.target.value)}
+              disabled={candidates.length === 0}
+              className="w-full bg-white/[0.04] border border-white/10 rounded-xl px-3 py-2.5 text-slate-200 text-sm focus:outline-none focus:border-blue-500/50 transition-all appearance-none cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <option value="" className="bg-[#0D1117]">
+                {candidates.length === 0
+                  ? `No ${KIND_LABELS[kind].toLowerCase()}s`
+                  : `Select ${KIND_LABELS[kind].toLowerCase()}…`}
+              </option>
+              {candidates.map((c) => (
+                <option key={c.id} value={c.id} className="bg-[#0D1117]">
+                  {c.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <button
+            type="button"
+            onClick={addLink}
+            disabled={!selectedId}
+            className="flex-shrink-0 px-3 py-2.5 rounded-xl text-sm font-semibold bg-blue-600 hover:bg-blue-500 disabled:bg-white/[0.06] disabled:text-slate-500 disabled:cursor-not-allowed text-white transition-colors"
+          >
+            Add link
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/wiki/quests/QuestModal.tsx
+++ b/app/components/wiki/quests/QuestModal.tsx
@@ -1,0 +1,620 @@
+import React, { useState, useCallback, useMemo } from 'react';
+import { createPortal } from 'react-dom';
+import { X, Globe, Lock } from 'lucide-react';
+import { FormInput } from '~/components/FormInput';
+import { PixelButton } from '~/components/PixelButton';
+import { MarkdownEditor } from '~/components/shared/MarkdownEditor';
+import { TagAutocompleteInput } from '~/components/shared/TagAutocompleteInput';
+import { ShowOnTabletopButton } from '~/components/wiki/shared/ShowOnTabletopButton';
+import { useModalForm } from '~/hooks/useModalForm';
+import { useCampaign } from '~/hooks/useCampaigns';
+import { useCharacters } from '~/hooks/useCharacters';
+import { usePlayers } from '~/hooks/usePlayers';
+import { useOrganizations } from '~/hooks/useOrganizations';
+import {
+  useQuest,
+  useQuests,
+  useCreateQuest,
+  useUpdateQuest,
+  useDeleteQuest,
+} from '~/hooks/useQuests';
+import { QuestLinksEditor } from './QuestLinksEditor';
+import { QuestEventsEditor } from './QuestEventsEditor';
+import { uploadToR2 } from '~/utils/uploadToR2';
+import { compressImage } from '~/utils/compressImage';
+import type {
+  QuestImage,
+  QuestStatus,
+  QuestGiverKind,
+  QuestLinkInput,
+  QuestEventLinkInput,
+} from '~/types/quest';
+
+interface QuestModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  campaignId: string;
+  questId?: string;
+}
+
+interface FieldErrors {
+  name?: string;
+}
+
+const STATUS_OPTIONS: { value: QuestStatus; label: string }[] = [
+  { value: 'not_started', label: 'Not started' },
+  { value: 'active', label: 'Active' },
+  { value: 'on_hold', label: 'On hold' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'failed', label: 'Failed' },
+];
+
+const GIVER_KIND_LABELS: Record<QuestGiverKind, string> = {
+  character: 'Character',
+  player: 'Player',
+  organization: 'Organization',
+};
+
+export function QuestModal({ isOpen, onClose, campaignId, questId }: QuestModalProps) {
+  const isEdit = !!questId;
+
+  const { quest: existing, isLoading: isFetching } = useQuest(questId ?? '', campaignId);
+  const { create, isLoading: isCreating } = useCreateQuest();
+  const { update, isLoading: isUpdating } = useUpdateQuest();
+  const { remove, isLoading: isDeleting } = useDeleteQuest();
+  const { campaign } = useCampaign(campaignId);
+  const isGM = campaign?.isGM ?? false;
+
+  const { characters } = useCharacters(campaignId);
+  const { players } = usePlayers(campaignId);
+  const { organizations } = useOrganizations(campaignId);
+  const { quests } = useQuests(campaignId);
+
+  const [name, setName] = useState('');
+  const [type, setType] = useState('');
+  const [status, setStatus] = useState<QuestStatus>('not_started');
+  const [publicInfo, setPublicInfo] = useState('');
+  const [privateInfo, setPrivateInfo] = useState('');
+  const [isPublic, setIsPublic] = useState(false);
+  const [images, setImages] = useState<QuestImage[]>([]);
+  const [tags, setTags] = useState<string[]>([]);
+  const [giverKind, setGiverKind] = useState<QuestGiverKind>('character');
+  const [giverId, setGiverId] = useState('');
+  const [parentQuestId, setParentQuestId] = useState('');
+  const [links, setLinks] = useState<QuestLinkInput[]>([]);
+  const [events, setEvents] = useState<QuestEventLinkInput[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [isUploadingImage, setIsUploadingImage] = useState(false);
+
+  const giverCandidates = useMemo<{ id: string; label: string }[]>(() => {
+    switch (giverKind) {
+      case 'character':
+        return characters.map((c) => ({ id: c.id, label: `${c.firstName} ${c.lastName}`.trim() }));
+      case 'player':
+        return players.map((p) => ({ id: p.id, label: `${p.firstName} ${p.lastName}`.trim() }));
+      case 'organization':
+        return organizations.map((o) => ({ id: o.id, label: o.name }));
+    }
+  }, [giverKind, characters, players, organizations]);
+
+  const parentQuestOptions = useMemo(
+    () => quests.filter((q) => q.id !== questId),
+    [quests, questId]
+  );
+
+  const validate = useCallback((): FieldErrors => {
+    const errors: FieldErrors = {};
+    if (!name.trim()) errors.name = 'Name is required';
+    return errors;
+  }, [name]);
+
+  const { fieldErrors, runValidation } = useModalForm({
+    isOpen,
+    onClose,
+    recordId: questId,
+    isEdit,
+    record: existing,
+    reset: () => {
+      setName('');
+      setType('');
+      setStatus('not_started');
+      setPublicInfo('');
+      setPrivateInfo('');
+      setIsPublic(false);
+      setImages([]);
+      setTags([]);
+      setGiverKind('character');
+      setGiverId('');
+      setParentQuestId('');
+      setLinks([]);
+      setEvents([]);
+      setError(null);
+      setShowDeleteConfirm(false);
+    },
+    populate: (q) => {
+      setName(q.name);
+      setType(q.type);
+      setStatus(q.status);
+      setPublicInfo(q.publicInfo);
+      setPrivateInfo(q.privateInfo);
+      setIsPublic(q.isPublic);
+      setImages(q.images);
+      setTags(q.tags);
+      setGiverKind(q.giver?.kind ?? 'character');
+      setGiverId(q.giver?.id ?? '');
+      setParentQuestId(q.parentQuestId ?? '');
+      setLinks(
+        q.links.map((l) => ({
+          kind: l.kind,
+          id: l.id,
+          role: l.role,
+          publicInfo: l.publicInfo,
+          privateInfo: l.privateInfo,
+        }))
+      );
+      setEvents(
+        q.events.map((ev) => ({
+          eventId: ev.eventId,
+          role: ev.role,
+          publicInfo: ev.publicInfo,
+          privateInfo: ev.privateInfo,
+        }))
+      );
+    },
+    validate,
+  });
+
+  const handleAddImage = useCallback(async (file: File) => {
+    setIsUploadingImage(true);
+    setError(null);
+    try {
+      const compressed = await compressImage(file);
+      const { publicUrl } = await uploadToR2(compressed, 'uploads/quests');
+      const newImage: QuestImage = { url: publicUrl, caption: '', crop: null };
+      setImages((prev) => [...prev, newImage]);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Image upload failed');
+    } finally {
+      setIsUploadingImage(false);
+    }
+  }, []);
+
+  const handleRemoveImage = useCallback((index: number) => {
+    setImages((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const handleImageFileChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      await handleAddImage(file);
+      // Reset input so same file can be re-selected
+      e.target.value = '';
+    },
+    [handleAddImage]
+  );
+
+  const handleGiverKindChange = (kind: QuestGiverKind) => {
+    setGiverKind(kind);
+    setGiverId('');
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (Object.keys(runValidation()).length > 0) return;
+    setError(null);
+
+    const payload = {
+      campaignId,
+      name,
+      type,
+      status,
+      publicInfo,
+      privateInfo,
+      isPublic,
+      giver: giverId ? { kind: giverKind, id: giverId } : null,
+      parentQuestId: parentQuestId || null,
+      links,
+      events,
+      images: images.map((img) => ({
+        url: img.url,
+        caption: img.caption,
+        crop: img.crop,
+      })),
+      tags,
+    };
+
+    const result =
+      isEdit && questId ? await update({ ...payload, id: questId }) : await create(payload);
+
+    if (result) onClose();
+    else setError(`Failed to ${isEdit ? 'update' : 'create'} quest. Please try again.`);
+  };
+
+  const handleDelete = async () => {
+    if (!questId) return;
+    setError(null);
+    const result = await remove({ id: questId, campaignId });
+    if (result) onClose();
+    else {
+      setError('Failed to delete quest. Please try again.');
+      setShowDeleteConfirm(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const isLoadingQuest = !!(isEdit && isFetching);
+  const isSaving = isCreating || isUpdating;
+  const isDisabled = isLoadingQuest || isSaving || isDeleting || isUploadingImage;
+
+  const selectClass =
+    'w-full bg-white/[0.04] border border-white/10 rounded-xl px-3 py-2.5 text-slate-200 text-sm focus:outline-none focus:border-blue-500/50 transition-all appearance-none cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed';
+
+  return createPortal(
+    <div
+      role="presentation"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-2 sm:p-4 backdrop-blur-sm"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <form
+        onSubmit={handleSubmit}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="quest-modal-title"
+        className="w-full h-full max-w-[90vw] max-h-[90vh] bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col"
+      >
+        <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
+          <h2
+            id="quest-modal-title"
+            className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest"
+          >
+            {isEdit ? 'Edit Quest' : 'Create Quest'}
+          </h2>
+          <div className="flex items-center gap-1 shrink-0">
+            {isEdit && questId && (
+              <ShowOnTabletopButton
+                campaignId={campaignId}
+                collection="quest"
+                documentId={questId}
+                isGM={isGM}
+              />
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close modal"
+              className="text-slate-500 hover:text-white transition-colors"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+        </header>
+
+        <div className="flex-1 overflow-y-auto p-4 sm:p-6 space-y-5 min-h-0">
+          {error && (
+            <div className="p-3 bg-rose-500/10 border border-rose-500/20 rounded-lg text-rose-400 text-xs font-semibold">
+              {error}
+            </div>
+          )}
+
+          {isLoadingQuest ? (
+            <div className="flex items-center justify-center py-12">
+              <p className="text-xs text-slate-500 animate-pulse">Loading quest...</p>
+            </div>
+          ) : (
+            <>
+              <FormInput
+                label="Name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                error={fieldErrors.name}
+                required
+                disabled={isDisabled}
+                placeholder="e.g. Goblin Arrows"
+              />
+
+              <FormInput
+                label="Type"
+                value={type}
+                onChange={(e) => setType(e.target.value)}
+                disabled={isDisabled}
+                placeholder="e.g. Main, Side, Personal"
+              />
+
+              {/* Status */}
+              <div>
+                <label
+                  htmlFor="quest-status"
+                  className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide"
+                >
+                  Status
+                </label>
+                <select
+                  id="quest-status"
+                  value={status}
+                  onChange={(e) => setStatus(e.target.value as QuestStatus)}
+                  disabled={isDisabled}
+                  className={selectClass}
+                >
+                  {STATUS_OPTIONS.map((s) => (
+                    <option key={s.value} value={s.value} className="bg-[#0D1117]">
+                      {s.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Giver */}
+              <div>
+                <span className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide">
+                  Quest giver
+                </span>
+                <div className="flex items-end gap-2">
+                  <div className="flex-shrink-0">
+                    <label
+                      htmlFor="quest-giver-kind"
+                      className="block text-[11px] text-slate-500 mb-1"
+                    >
+                      Type
+                    </label>
+                    <select
+                      id="quest-giver-kind"
+                      value={giverKind}
+                      onChange={(e) => handleGiverKindChange(e.target.value as QuestGiverKind)}
+                      disabled={isDisabled}
+                      className={selectClass}
+                    >
+                      {(Object.keys(GIVER_KIND_LABELS) as QuestGiverKind[]).map((k) => (
+                        <option key={k} value={k} className="bg-[#0D1117]">
+                          {GIVER_KIND_LABELS[k]}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <label
+                      htmlFor="quest-giver-entity"
+                      className="block text-[11px] text-slate-500 mb-1"
+                    >
+                      Giver
+                    </label>
+                    <select
+                      id="quest-giver-entity"
+                      aria-label="Quest giver"
+                      value={giverId}
+                      onChange={(e) => setGiverId(e.target.value)}
+                      disabled={isDisabled || giverCandidates.length === 0}
+                      className={selectClass}
+                    >
+                      <option value="" className="bg-[#0D1117]">
+                        {giverCandidates.length === 0
+                          ? `No ${GIVER_KIND_LABELS[giverKind].toLowerCase()}s`
+                          : `Select ${GIVER_KIND_LABELS[giverKind].toLowerCase()}…`}
+                      </option>
+                      {giverCandidates.map((c) => (
+                        <option key={c.id} value={c.id} className="bg-[#0D1117]">
+                          {c.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setGiverId('')}
+                    disabled={isDisabled || !giverId}
+                    className="flex-shrink-0 px-3 py-2.5 rounded-xl text-sm font-semibold bg-white/[0.06] hover:bg-white/[0.1] disabled:opacity-50 disabled:cursor-not-allowed text-slate-300 transition-colors"
+                  >
+                    Clear
+                  </button>
+                </div>
+              </div>
+
+              {/* Parent quest */}
+              <div>
+                <label
+                  htmlFor="quest-parent"
+                  className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide"
+                >
+                  Parent quest
+                </label>
+                <select
+                  id="quest-parent"
+                  value={parentQuestId}
+                  onChange={(e) => setParentQuestId(e.target.value)}
+                  disabled={isDisabled}
+                  className={selectClass}
+                >
+                  <option value="" className="bg-[#0D1117]">
+                    None
+                  </option>
+                  {parentQuestOptions.map((q) => (
+                    <option key={q.id} value={q.id} className="bg-[#0D1117]">
+                      {q.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Visibility toggle */}
+              <div className="flex items-center gap-4">
+                <label
+                  className={`flex items-center gap-2 ${isDisabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}
+                >
+                  <input
+                    type="radio"
+                    name="quest-visibility"
+                    checked={!isPublic}
+                    onChange={() => setIsPublic(false)}
+                    disabled={isDisabled}
+                    className="sr-only"
+                  />
+                  <div
+                    className={`h-8 px-3 rounded-lg border flex items-center gap-2 transition-all text-xs ${!isPublic ? 'bg-blue-600/10 border-blue-500/50 text-blue-300' : 'bg-white/[0.03] border-white/[0.07] text-slate-500 hover:border-white/20'}`}
+                  >
+                    <Lock className="h-3 w-3" />
+                    <span className="font-bold">Private (GM only)</span>
+                  </div>
+                </label>
+                <label
+                  className={`flex items-center gap-2 ${isDisabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}
+                >
+                  <input
+                    type="radio"
+                    name="quest-visibility"
+                    checked={isPublic}
+                    onChange={() => setIsPublic(true)}
+                    disabled={isDisabled}
+                    className="sr-only"
+                  />
+                  <div
+                    className={`h-8 px-3 rounded-lg border flex items-center gap-2 transition-all text-xs ${isPublic ? 'bg-emerald-600/10 border-emerald-500/50 text-emerald-300' : 'bg-white/[0.03] border-white/[0.07] text-slate-500 hover:border-white/20'}`}
+                  >
+                    <Globe className="h-3 w-3" />
+                    <span className="font-bold">Public</span>
+                  </div>
+                </label>
+              </div>
+
+              <MarkdownEditor
+                label="Public info"
+                value={publicInfo}
+                onChange={setPublicInfo}
+                placeholder="Public description of this quest..."
+                disabled={isDisabled}
+                minHeight="200px"
+              />
+
+              {isGM && (
+                <MarkdownEditor
+                  label="Private info (GM only)"
+                  value={privateInfo}
+                  onChange={setPrivateInfo}
+                  placeholder="GM-only notes about this quest..."
+                  disabled={isDisabled}
+                  minHeight="200px"
+                />
+              )}
+
+              {/* Images */}
+              <div>
+                <span className="block text-xs font-semibold text-slate-400 mb-2 tracking-wide">
+                  Images
+                </span>
+                {images.length > 0 && (
+                  <div className="flex flex-wrap gap-3 mb-3">
+                    {images.map((img, idx) => (
+                      <div key={idx} className="relative group">
+                        <img
+                          src={img.url}
+                          alt={img.caption || `Quest image ${idx + 1}`}
+                          className="w-20 h-20 object-cover rounded-lg border border-white/10"
+                        />
+                        {!isDisabled && (
+                          <button
+                            type="button"
+                            onClick={() => handleRemoveImage(idx)}
+                            className="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-rose-600 flex items-center justify-center hover:bg-rose-500 transition-colors"
+                            aria-label={`Remove image ${idx + 1}`}
+                          >
+                            <X className="h-3 w-3 text-white" />
+                          </button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <label
+                  className={`inline-flex items-center gap-2 px-3 py-2 rounded-xl text-xs font-semibold border transition-colors cursor-pointer ${isDisabled || isUploadingImage ? 'opacity-50 cursor-not-allowed border-white/10 text-slate-500' : 'border-white/10 text-slate-300 hover:border-blue-500/50 hover:text-blue-300'}`}
+                >
+                  <input
+                    type="file"
+                    accept=".jpg,.jpeg,.png,.webp"
+                    onChange={handleImageFileChange}
+                    disabled={isDisabled || isUploadingImage}
+                    className="hidden"
+                  />
+                  {isUploadingImage ? 'Uploading...' : 'Add image'}
+                </label>
+                <p className="text-xs text-slate-700 mt-1.5">JPG, PNG, or WebP. Max 5MB.</p>
+              </div>
+
+              <TagAutocompleteInput
+                campaignId={campaignId}
+                selectedTags={tags}
+                onTagsChange={setTags}
+                disabled={isDisabled}
+              />
+
+              <QuestLinksEditor
+                campaignId={campaignId}
+                links={links}
+                onChange={setLinks}
+                isGM={isGM}
+                disabled={isDisabled}
+              />
+
+              <QuestEventsEditor
+                campaignId={campaignId}
+                events={events}
+                onChange={setEvents}
+                isGM={isGM}
+                disabled={isDisabled}
+              />
+            </>
+          )}
+        </div>
+
+        <footer className="flex items-center justify-between px-4 sm:px-6 py-4 border-t border-white/[0.07] shrink-0 gap-3">
+          {isEdit && (
+            <div className="flex items-center gap-2">
+              {showDeleteConfirm ? (
+                <>
+                  <span className="text-xs text-rose-400 font-semibold">Delete this quest?</span>
+                  <PixelButton
+                    type="button"
+                    variant="danger"
+                    size="sm"
+                    onClick={handleDelete}
+                    disabled={isDisabled}
+                  >
+                    {isDeleting ? 'Deleting...' : 'Confirm'}
+                  </PixelButton>
+                  <PixelButton
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setShowDeleteConfirm(false)}
+                    disabled={isDisabled}
+                  >
+                    Cancel
+                  </PixelButton>
+                </>
+              ) : (
+                <PixelButton
+                  type="button"
+                  variant="danger"
+                  size="sm"
+                  onClick={() => setShowDeleteConfirm(true)}
+                  disabled={isDisabled}
+                >
+                  Delete
+                </PixelButton>
+              )}
+            </div>
+          )}
+          <div className="flex items-center gap-3 ml-auto">
+            <PixelButton type="button" variant="ghost" onClick={onClose} disabled={isDisabled}>
+              Cancel
+            </PixelButton>
+            <PixelButton type="submit" disabled={isDisabled}>
+              {isSaving ? 'Saving...' : isEdit ? 'Save Changes' : 'Create Quest'}
+            </PixelButton>
+          </div>
+        </footer>
+      </form>
+    </div>,
+    document.body
+  );
+}

--- a/app/components/wiki/quests/QuestViewModal.tsx
+++ b/app/components/wiki/quests/QuestViewModal.tsx
@@ -1,0 +1,83 @@
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { X } from 'lucide-react';
+import { QuestWindow } from './QuestWindow';
+import { useQuest } from '~/hooks/useQuests';
+import { useCampaign } from '~/hooks/useCampaigns';
+import { ShowOnTabletopButton } from '~/components/wiki/shared/ShowOnTabletopButton';
+
+interface QuestViewModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  questId: string;
+  campaignId: string;
+}
+
+export function QuestViewModal({ isOpen, onClose, questId, campaignId }: QuestViewModalProps) {
+  const { quest, isLoading } = useQuest(questId, campaignId);
+  const { campaign } = useCampaign(campaignId);
+  const isGM = campaign?.isGM ?? false;
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onEsc = (e: KeyboardEvent) => e.key === 'Escape' && onClose();
+    document.addEventListener('keydown', onEsc);
+    return () => document.removeEventListener('keydown', onEsc);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div
+      role="presentation"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-2 sm:p-4 backdrop-blur-sm"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="quest-view-modal-title"
+        className="w-full max-w-lg max-h-[90vh] bg-[#0D1117] border border-white/[0.07] rounded-2xl overflow-hidden shadow-2xl flex flex-col"
+      >
+        <header className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-white/[0.07] shrink-0">
+          <h2
+            id="quest-view-modal-title"
+            className="font-sans font-bold text-sm text-blue-400 uppercase tracking-widest truncate"
+          >
+            {quest?.name ?? 'Quest'}
+          </h2>
+          <div className="flex items-center gap-1 shrink-0">
+            <ShowOnTabletopButton
+              campaignId={campaignId}
+              collection="quest"
+              documentId={questId}
+              isGM={isGM}
+            />
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close modal"
+              className="text-slate-500 hover:text-white transition-colors"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+        </header>
+        <div className="flex-1 overflow-y-auto min-h-0">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <p className="text-xs text-slate-500 animate-pulse">Loading quest...</p>
+            </div>
+          ) : quest ? (
+            <QuestWindow quest={quest} />
+          ) : (
+            <div className="flex items-center justify-center py-12">
+              <p className="text-xs text-slate-500">Quest not found</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/app/components/wiki/quests/QuestWindow.tsx
+++ b/app/components/wiki/quests/QuestWindow.tsx
@@ -1,0 +1,252 @@
+import type React from 'react';
+import { Pencil } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { QuestData, QuestLink, QuestLinkKind, QuestStatus } from '~/types/quest';
+import type { PictureCrop } from '~/types/character';
+import { MARKDOWN_PROSE_CLASSES } from '~/utils/markdownProseClasses';
+
+const STATUS_LABELS: Record<QuestStatus, string> = {
+  not_started: 'Not started',
+  active: 'Active',
+  on_hold: 'On hold',
+  completed: 'Completed',
+  failed: 'Failed',
+};
+
+const LINK_KIND_LABELS: Record<QuestLinkKind, string> = {
+  character: 'Characters',
+  player: 'Players',
+  location: 'Locations',
+  organization: 'Organizations',
+};
+
+const LINK_KIND_ORDER: QuestLinkKind[] = ['character', 'player', 'location', 'organization'];
+
+function getCropStyle(crop: PictureCrop): React.CSSProperties {
+  const centerX = (crop.x + crop.width / 2) * 100;
+  const centerY = (crop.y + crop.height / 2) * 100;
+  const scale = 1 / crop.width;
+  return {
+    objectPosition: `${centerX}% ${centerY}%`,
+    transform: `scale(${scale})`,
+  };
+}
+
+interface QuestWindowProps {
+  quest: QuestData;
+  onEdit?: () => void;
+}
+
+export function QuestWindow({ quest, onEdit }: QuestWindowProps) {
+  const showMeta = quest.tags.length > 0 || (quest.canEdit && !!onEdit);
+
+  const linksByKind = LINK_KIND_ORDER.map((kind) => ({
+    kind,
+    items: quest.links.filter((l) => l.kind === kind),
+  })).filter((g) => g.items.length > 0);
+
+  return (
+    <div className="flex flex-col h-full" data-testid="quest-window">
+      {showMeta && (
+        <div className="flex items-center gap-2 px-3 py-1.5 border-b border-white/[0.05] shrink-0">
+          <div className="flex flex-wrap gap-1 flex-1 min-w-0">
+            {quest.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 font-sans font-bold text-[9px] tracking-tight"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+          {quest.canEdit && onEdit && (
+            <button
+              type="button"
+              onClick={onEdit}
+              className="shrink-0 p-1 rounded bg-white/[0.05] hover:bg-white/[0.1] text-slate-400 hover:text-white transition-colors"
+              aria-label="Edit quest"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+      )}
+
+      <div className="flex-1 overflow-y-auto p-3 min-h-0 space-y-5">
+        {/* Header: name, status, type, giver */}
+        <div className="space-y-2">
+          <h3 className="text-base font-bold text-slate-100">{quest.name}</h3>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-white/[0.05] border border-white/[0.08] text-slate-300 font-sans font-bold text-[10px] uppercase tracking-tight">
+              {STATUS_LABELS[quest.status]}
+            </span>
+            {quest.type && <span className="text-xs text-slate-400">{quest.type}</span>}
+          </div>
+          {quest.giver && quest.giver.label && (
+            <p className="text-xs text-slate-400">
+              Given by: <span className="text-slate-200 font-semibold">{quest.giver.label}</span>
+            </p>
+          )}
+        </div>
+
+        {/* Parent quest + sub-quests */}
+        {(quest.parentQuest || quest.subQuests.length > 0) && (
+          <div className="space-y-2">
+            {quest.parentQuest && (
+              <p className="text-xs text-slate-400">
+                Part of:{' '}
+                <span className="text-blue-400 font-semibold">{quest.parentQuest.name}</span>
+              </p>
+            )}
+            {quest.subQuests.length > 0 && (
+              <div>
+                <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">
+                  Sub-quests
+                </p>
+                <div className="flex flex-col gap-1">
+                  {quest.subQuests.map((sq) => (
+                    <div
+                      key={sq.id}
+                      className="flex items-center justify-between gap-2 rounded-md border border-white/[0.06] bg-white/[0.02] px-3 py-1.5"
+                    >
+                      <span className="text-xs font-semibold text-slate-200 truncate">
+                        {sq.name}
+                      </span>
+                      <span className="text-[10px] text-slate-500 shrink-0 uppercase tracking-tight">
+                        {STATUS_LABELS[sq.status]}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Images gallery */}
+        {quest.images.length > 0 && (
+          <div className="flex flex-col gap-3">
+            <p className="text-[10px] uppercase tracking-wider text-slate-500">Images</p>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+              {quest.images.map((image, idx) => (
+                <div key={idx} className="flex flex-col gap-1">
+                  <div className="w-full aspect-square overflow-hidden rounded-lg border border-white/[0.08]">
+                    <img
+                      src={image.url}
+                      alt={image.caption || `Quest image ${idx + 1}`}
+                      className="w-full h-full object-cover"
+                      style={image.crop ? getCropStyle(image.crop) : undefined}
+                    />
+                  </div>
+                  {image.caption && (
+                    <p className="text-[10px] text-slate-500 text-center leading-tight">
+                      {image.caption}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Public info */}
+        {quest.publicInfo && (
+          <div className={MARKDOWN_PROSE_CLASSES}>
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{quest.publicInfo}</ReactMarkdown>
+          </div>
+        )}
+
+        {/* GM-only private info */}
+        {quest.privateInfo && (
+          <div className="rounded-lg border border-amber-500/20 bg-amber-500/[0.04] p-3">
+            <p className="text-[10px] font-bold uppercase tracking-widest text-amber-400/80 mb-2">
+              GM Only
+            </p>
+            <div className={MARKDOWN_PROSE_CLASSES}>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{quest.privateInfo}</ReactMarkdown>
+            </div>
+          </div>
+        )}
+
+        {/* Linked entities, grouped by kind */}
+        {linksByKind.map((group) => (
+          <div key={group.kind}>
+            <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">
+              {LINK_KIND_LABELS[group.kind]}
+            </p>
+            <div className="flex flex-col gap-2">
+              {group.items.map((link: QuestLink) => (
+                <div
+                  key={`${link.kind}-${link.id}`}
+                  className="rounded-md border border-white/[0.06] bg-white/[0.02] px-3 py-2"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-xs font-bold text-slate-200 truncate">
+                      {link.label || 'Unknown'}
+                    </span>
+                    {link.role && (
+                      <span className="text-[11px] text-blue-400 shrink-0">{link.role}</span>
+                    )}
+                  </div>
+                  {link.publicInfo && (
+                    <div className={`${MARKDOWN_PROSE_CLASSES} mt-1`}>
+                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{link.publicInfo}</ReactMarkdown>
+                    </div>
+                  )}
+                  {link.privateInfo && (
+                    <div className="mt-1 rounded border border-amber-500/20 bg-amber-500/[0.04] px-2 py-1">
+                      <div className={MARKDOWN_PROSE_CLASSES}>
+                        <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                          {link.privateInfo}
+                        </ReactMarkdown>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+
+        {/* Linked events */}
+        {quest.events.length > 0 && (
+          <div>
+            <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">
+              Events
+            </p>
+            <div className="flex flex-col gap-2">
+              {quest.events.map((ev) => (
+                <div
+                  key={ev.eventId}
+                  className="rounded-md border border-white/[0.06] bg-white/[0.02] px-3 py-2"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-xs font-bold text-slate-200 truncate">
+                      {ev.label || 'Unknown event'}
+                    </span>
+                    {ev.role && (
+                      <span className="text-[11px] text-blue-400 shrink-0">{ev.role}</span>
+                    )}
+                  </div>
+                  {ev.publicInfo && (
+                    <div className={`${MARKDOWN_PROSE_CLASSES} mt-1`}>
+                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{ev.publicInfo}</ReactMarkdown>
+                    </div>
+                  )}
+                  {ev.privateInfo && (
+                    <div className="mt-1 rounded border border-amber-500/20 bg-amber-500/[0.04] px-2 py-1">
+                      <div className={MARKDOWN_PROSE_CLASSES}>
+                        <ReactMarkdown remarkPlugins={[remarkGfm]}>{ev.privateInfo}</ReactMarkdown>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/wiki/quests/QuestWindowWrapper.tsx
+++ b/app/components/wiki/quests/QuestWindowWrapper.tsx
@@ -1,0 +1,43 @@
+import { QuestWindow } from './QuestWindow';
+import { QuestModal } from './QuestModal';
+import { useQuest } from '~/hooks/useQuests';
+
+export function EditQuestModalWrapper({
+  campaignId,
+  questId,
+  onClose,
+}: {
+  campaignId: string;
+  questId: string;
+  onClose: () => void;
+}) {
+  return <QuestModal isOpen onClose={onClose} campaignId={campaignId} questId={questId} />;
+}
+
+export function QuestWindowWrapper({
+  questId,
+  campaignId,
+  onEdit,
+}: {
+  questId: string;
+  campaignId: string;
+  onEdit: () => void;
+}) {
+  const { quest, isLoading } = useQuest(questId, campaignId);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-xs text-slate-500 animate-pulse">Loading quest...</p>
+      </div>
+    );
+  }
+  if (!quest) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-xs text-slate-500">Quest not found</p>
+      </div>
+    );
+  }
+  return <QuestWindow quest={quest} onEdit={onEdit} />;
+}

--- a/app/components/wiki/quests/QuestsPanel.tsx
+++ b/app/components/wiki/quests/QuestsPanel.tsx
@@ -1,0 +1,137 @@
+import { useState } from 'react';
+import { useParams } from '@tanstack/react-router';
+import { Swords } from 'lucide-react';
+import { WikiCategoryHeader } from '~/components/wiki/shared/WikiCategoryHeader';
+import { WikiFilterBar } from '~/components/wiki/shared/WikiFilterBar';
+import { QuestCard } from './QuestCard';
+import { QuestModal } from './QuestModal';
+import { QuestViewModal } from './QuestViewModal';
+import { useQuests } from '~/hooks/useQuests';
+import type { QuestListItem, QuestStatus } from '~/types/quest';
+
+interface QuestsPanelProps {
+  onBack: () => void;
+}
+
+const STATUS_FILTERS: { value: QuestStatus | 'all'; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'not_started', label: 'Not started' },
+  { value: 'active', label: 'Active' },
+  { value: 'on_hold', label: 'On hold' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'failed', label: 'Failed' },
+];
+
+export function QuestsPanel({ onBack }: QuestsPanelProps) {
+  const { campaignId } = useParams({ from: '/campaigns/$campaignId/play' });
+
+  const [search, setSearch] = useState('');
+  const [filterTags, setFilterTags] = useState<string[]>([]);
+  const [statusFilter, setStatusFilter] = useState<QuestStatus | 'all'>('all');
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | undefined>();
+  const [viewId, setViewId] = useState<string | undefined>();
+
+  const { quests, isLoading, error } = useQuests(campaignId, {
+    search: search || undefined,
+    tags: filterTags.length > 0 ? filterTags : undefined,
+    status: statusFilter === 'all' ? undefined : statusFilter,
+  });
+
+  const handleCreateClick = () => {
+    setSelectedId(undefined);
+    setIsModalOpen(true);
+  };
+
+  const handleClick = (quest: QuestListItem) => {
+    if (quest.canEdit) {
+      setSelectedId(quest.id);
+      setIsModalOpen(true);
+    } else {
+      setViewId(quest.id);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full w-full bg-[#080A12]">
+      <WikiCategoryHeader title="Quests" onBack={onBack} />
+      <WikiFilterBar
+        search={search}
+        onSearchChange={setSearch}
+        onCreateClick={handleCreateClick}
+        campaignId={campaignId}
+        filterTags={filterTags}
+        onFilterTagsChange={setFilterTags}
+        searchPlaceholder="Search quests..."
+        showSessionFilter={false}
+        showVisibilityFilter={false}
+        visibility="all"
+        onVisibilityChange={() => {}}
+      />
+
+      <div className="flex flex-wrap gap-1.5 px-3 pb-3 border-b border-white/[0.07] bg-[#0D1117]">
+        {STATUS_FILTERS.map((s) => {
+          const active = statusFilter === s.value;
+          return (
+            <button
+              key={s.value}
+              type="button"
+              onClick={() => setStatusFilter(s.value)}
+              aria-pressed={active}
+              className={`px-2 py-0.5 rounded-full text-[10px] font-semibold border transition-colors ${active ? 'bg-amber-500/15 border-amber-500/40 text-amber-300' : 'bg-white/[0.03] border-white/[0.07] text-slate-500 hover:text-slate-300'}`}
+            >
+              {s.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {isLoading ? (
+        <div className="flex flex-1 items-center justify-center p-8">
+          <p className="font-sans font-semibold text-xs text-slate-500 animate-pulse">
+            Loading quests...
+          </p>
+        </div>
+      ) : error ? (
+        <div className="flex flex-1 items-center justify-center p-8 text-center">
+          <p className="font-sans font-semibold text-xs text-rose-400">{error}</p>
+        </div>
+      ) : quests.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center p-8 text-center">
+          <div className="h-12 w-12 rounded-full bg-white/[0.03] flex items-center justify-center mb-3">
+            <Swords className="h-6 w-6 text-slate-600" />
+          </div>
+          <p className="font-sans font-semibold text-xs text-slate-500">
+            No quests found matching your filters.
+          </p>
+        </div>
+      ) : (
+        <div className="flex-1 overflow-y-auto min-h-0">
+          <div className="flex flex-col">
+            {quests.map((quest) => (
+              <QuestCard key={quest.id} quest={quest} onClick={handleClick} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      <QuestModal
+        isOpen={isModalOpen}
+        onClose={() => {
+          setIsModalOpen(false);
+          setSelectedId(undefined);
+        }}
+        campaignId={campaignId}
+        questId={selectedId}
+      />
+      {viewId && (
+        <QuestViewModal
+          isOpen={!!viewId}
+          onClose={() => setViewId(undefined)}
+          questId={viewId}
+          campaignId={campaignId}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/hooks/useQuests.ts
+++ b/app/hooks/useQuests.ts
@@ -1,0 +1,207 @@
+import { createServerFn } from '@tanstack/react-start';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { QuestData, QuestListItem, QuestLinkKind, QuestStatus } from '~/types/quest';
+import { captureException } from '~/providers/TelemetryProvider';
+import { queryKeys } from '~/utils/queryKeys';
+import {
+  listQuestsSchema,
+  getQuestSchema,
+  createQuestSchema,
+  updateQuestSchema,
+  deleteQuestSchema,
+  listQuestsForEntitySchema,
+} from '~/types/schemas/quests';
+
+const listQuestsFn = createServerFn({ method: 'GET' })
+  .inputValidator(listQuestsSchema)
+  .handler(async ({ data }) => {
+    const { listQuests } = await import('~/server/functions/quests');
+    return listQuests({ data });
+  });
+
+const getQuestFn = createServerFn({ method: 'GET' })
+  .inputValidator(getQuestSchema)
+  .handler(async ({ data }) => {
+    const { getQuest } = await import('~/server/functions/quests');
+    return getQuest({ data });
+  });
+
+const createQuestFn = createServerFn({ method: 'POST' })
+  .inputValidator(createQuestSchema)
+  .handler(async ({ data }) => {
+    const { createQuest } = await import('~/server/functions/quests');
+    return createQuest({ data });
+  });
+
+const updateQuestFn = createServerFn({ method: 'POST' })
+  .inputValidator(updateQuestSchema)
+  .handler(async ({ data }) => {
+    const { updateQuest } = await import('~/server/functions/quests');
+    return updateQuest({ data });
+  });
+
+const deleteQuestFn = createServerFn({ method: 'POST' })
+  .inputValidator(deleteQuestSchema)
+  .handler(async ({ data }) => {
+    const { deleteQuest } = await import('~/server/functions/quests');
+    return deleteQuest({ data });
+  });
+
+const listQuestsForEntityFn = createServerFn({ method: 'GET' })
+  .inputValidator(listQuestsForEntitySchema)
+  .handler(async ({ data }) => {
+    const { listQuestsForEntity } = await import('~/server/functions/quests');
+    return listQuestsForEntity({ data });
+  });
+
+interface ListQuestsFilters {
+  search?: string;
+  tags?: string[];
+  status?: QuestStatus;
+  enabled?: boolean;
+}
+
+export function useQuests(campaignId: string, filters?: ListQuestsFilters) {
+  const { search, tags, status } = filters ?? {};
+  const {
+    data: quests = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.quests.list(campaignId, search, tags, status),
+    queryFn: () =>
+      listQuestsFn({
+        data: {
+          campaignId,
+          search,
+          tags,
+          status,
+        },
+      }),
+    enabled: (filters?.enabled ?? true) && !!campaignId,
+  });
+  return {
+    quests: quests as QuestListItem[],
+    isLoading,
+    error: error instanceof Error ? error.message : error ? String(error) : null,
+  };
+}
+
+export function useQuest(id: string, campaignId: string) {
+  const {
+    data: quest = null,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.quests.detail(id, campaignId),
+    queryFn: () => getQuestFn({ data: { id, campaignId } }),
+    enabled: !!id && !!campaignId,
+  });
+  return {
+    quest: quest as QuestData | null,
+    isLoading,
+    error: error instanceof Error ? error.message : error ? String(error) : null,
+  };
+}
+
+export function useQuestsForEntity(
+  campaignId: string,
+  kind: QuestLinkKind,
+  id: string,
+  enabled = true
+) {
+  const { data: quests = [], isLoading } = useQuery({
+    queryKey: queryKeys.quests.forEntity(campaignId, kind, id),
+    queryFn: () => listQuestsForEntityFn({ data: { campaignId, kind, id } }),
+    enabled: enabled && !!campaignId && !!id,
+  });
+  return { quests: quests as QuestListItem[], isLoading };
+}
+
+function errMsg(e: unknown): string | null {
+  return e instanceof Error ? e.message : e ? String(e) : null;
+}
+
+export function useCreateQuest() {
+  const qc = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: (input: Parameters<typeof createQuestFn>[0]['data']) =>
+      createQuestFn({ data: input }),
+    onSuccess: (_d, { campaignId }) => {
+      qc.invalidateQueries({ queryKey: ['quests', 'list', campaignId], exact: false });
+      qc.invalidateQueries({ queryKey: queryKeys.tags.list(campaignId) });
+    },
+    onError: (e) => captureException(e, { action: 'createQuest' }),
+  });
+  return {
+    create: async (input: Parameters<typeof createQuestFn>[0]['data']) => {
+      try {
+        return await mutation.mutateAsync(input);
+      } catch {
+        return null;
+      }
+    },
+    isLoading: mutation.isPending,
+    error: errMsg(mutation.error),
+  };
+}
+
+export function useUpdateQuest() {
+  const qc = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: (input: Parameters<typeof updateQuestFn>[0]['data']) =>
+      updateQuestFn({ data: input }),
+    onSuccess: (_d, variables) => {
+      qc.invalidateQueries({ queryKey: ['quests', 'list', variables.campaignId], exact: false });
+      qc.invalidateQueries({
+        queryKey: queryKeys.quests.detail(variables.id, variables.campaignId),
+      });
+      qc.invalidateQueries({ queryKey: queryKeys.tags.list(variables.campaignId) });
+      qc.invalidateQueries({
+        queryKey: ['quests', 'forEntity', variables.campaignId],
+        exact: false,
+      });
+      qc.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+    },
+    onError: (e) => captureException(e, { action: 'updateQuest' }),
+  });
+  return {
+    update: async (input: Parameters<typeof updateQuestFn>[0]['data']) => {
+      try {
+        return await mutation.mutateAsync(input);
+      } catch {
+        return null;
+      }
+    },
+    isLoading: mutation.isPending,
+    error: errMsg(mutation.error),
+  };
+}
+
+export function useDeleteQuest() {
+  const qc = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: (input: { id: string; campaignId: string }) => deleteQuestFn({ data: input }),
+    onSuccess: (_d, variables) => {
+      qc.invalidateQueries({ queryKey: ['quests', 'list', variables.campaignId], exact: false });
+      qc.removeQueries({ queryKey: queryKeys.quests.detail(variables.id, variables.campaignId) });
+      qc.invalidateQueries({
+        queryKey: ['quests', 'forEntity', variables.campaignId],
+        exact: false,
+      });
+      qc.invalidateQueries({ queryKey: queryKeys.gmscreens.all });
+    },
+    onError: (e) => captureException(e, { action: 'deleteQuest' }),
+  });
+  return {
+    remove: async (input: { id: string; campaignId: string }) => {
+      try {
+        return await mutation.mutateAsync(input);
+      } catch {
+        return null;
+      }
+    },
+    isLoading: mutation.isPending,
+    error: errMsg(mutation.error),
+  };
+}

--- a/app/server/db/models/Location.ts
+++ b/app/server/db/models/Location.ts
@@ -50,10 +50,13 @@ const locationSchema = new mongoose.Schema(
   { collection: 'location' }
 );
 
-locationSchema.index({ campaignId: 1, updatedAt: -1 });
-locationSchema.index({ campaignId: 1, locationType: 1 });
-locationSchema.index({ campaignId: 1, isPublic: 1 });
-locationSchema.index({ tags: 1 });
-locationSchema.index({ name: 'text', description: 'text' });
+// istanbul ignore next
+if (typeof (locationSchema as { index?: unknown }).index === 'function') {
+  locationSchema.index({ campaignId: 1, updatedAt: -1 });
+  locationSchema.index({ campaignId: 1, locationType: 1 });
+  locationSchema.index({ campaignId: 1, isPublic: 1 });
+  locationSchema.index({ tags: 1 });
+  locationSchema.index({ name: 'text', description: 'text' });
+}
 
 export const Location = mongoose.models.Location || mongoose.model('Location', locationSchema);

--- a/app/server/db/models/Quest.ts
+++ b/app/server/db/models/Quest.ts
@@ -1,0 +1,101 @@
+import mongoose from 'mongoose';
+import { normalizeTags } from '~/server/utils/helpers';
+
+const giverSchema = new mongoose.Schema(
+  {
+    kind: { type: String, enum: ['character', 'player', 'organization'], required: true },
+    id: { type: mongoose.Schema.Types.ObjectId, required: true },
+  },
+  { _id: false }
+);
+
+const questLinkSchema = new mongoose.Schema(
+  {
+    kind: {
+      type: String,
+      enum: ['character', 'player', 'location', 'organization'],
+      required: true,
+    },
+    id: { type: mongoose.Schema.Types.ObjectId, required: true },
+    role: { type: String, default: '' },
+    publicInfo: { type: String, default: '' },
+    privateInfo: { type: String, default: '' },
+  },
+  { _id: false }
+);
+
+const questEventLinkSchema = new mongoose.Schema(
+  {
+    eventId: { type: mongoose.Schema.Types.ObjectId, ref: 'Event', required: true },
+    role: { type: String, default: '' },
+    publicInfo: { type: String, default: '' },
+    privateInfo: { type: String, default: '' },
+  },
+  { _id: false }
+);
+
+const cropSchema = new mongoose.Schema(
+  {
+    x: { type: Number, required: true },
+    y: { type: Number, required: true },
+    width: { type: Number, required: true },
+    height: { type: Number, required: true },
+  },
+  { _id: false }
+);
+
+const imageSchema = new mongoose.Schema(
+  {
+    url: { type: String, required: true },
+    caption: { type: String, default: '' },
+    crop: { type: cropSchema, default: null },
+  },
+  { _id: false }
+);
+
+const questSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  type: { type: String, default: '' },
+  status: {
+    type: String,
+    enum: ['not_started', 'active', 'on_hold', 'completed', 'failed'],
+    default: 'not_started',
+  },
+  publicInfo: { type: String, default: '' },
+  privateInfo: { type: String, default: '' },
+  isPublic: { type: Boolean, default: false },
+  giver: { type: giverSchema, default: null },
+  parentQuestId: { type: mongoose.Schema.Types.ObjectId, ref: 'Quest', default: null },
+  links: { type: [questLinkSchema], default: [] },
+  events: { type: [questEventLinkSchema], default: [] },
+  images: { type: [imageSchema], default: [] },
+  tags: { type: [String], default: [] },
+  campaignId: { type: mongoose.Schema.Types.ObjectId, ref: 'Campaign', required: true },
+  createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+});
+
+questSchema.pre('save', function () {
+  if (this.isModified('tags')) {
+    this.tags = normalizeTags(this.tags as string[]);
+  }
+  this.updatedAt = new Date();
+});
+
+// istanbul ignore next
+if (typeof (questSchema as { index?: unknown }).index === 'function') {
+  questSchema.index({ campaignId: 1 });
+  questSchema.index({ campaignId: 1, updatedAt: -1 });
+  questSchema.index({ createdBy: 1 });
+  questSchema.index({ tags: 1 });
+  questSchema.index({ isPublic: 1 });
+  questSchema.index({ status: 1 });
+  questSchema.index({ parentQuestId: 1 });
+  questSchema.index({ 'giver.id': 1 });
+  questSchema.index({ 'links.id': 1 });
+  questSchema.index({ 'events.eventId': 1 });
+  questSchema.index({ name: 'text', publicInfo: 'text' });
+}
+
+export const Quest = mongoose.models.Quest || mongoose.model('Quest', questSchema);

--- a/app/server/functions/characters.ts
+++ b/app/server/functions/characters.ts
@@ -8,6 +8,7 @@ import { pruneLoreLinks } from '../utils/pruneLoreLinks';
 import { pruneEventLinks } from '../utils/pruneEventLinks';
 import { pruneMembershipsForMember } from './organizations';
 import { ensureTags as ensureTagsFn } from './tags';
+import { pruneQuestRefs } from './quests';
 import type { CharacterData, CharacterListItem, PictureCrop } from '~/types/character';
 import {
   createCharacterSchema,
@@ -323,6 +324,16 @@ export const deleteCharacter = async ({
     } catch (pruneError) {
       serverCaptureException(pruneError, sessionUserId, {
         action: 'deleteCharacter.pruneMemberships',
+        campaign_id: data.campaignId,
+        character_id: data.id,
+      });
+    }
+
+    try {
+      await pruneQuestRefs('character', data.id, data.campaignId);
+    } catch (pruneError) {
+      serverCaptureException(pruneError, sessionUserId, {
+        action: 'deleteCharacter.pruneQuests',
         campaign_id: data.campaignId,
         character_id: data.id,
       });

--- a/app/server/functions/events.ts
+++ b/app/server/functions/events.ts
@@ -9,6 +9,7 @@ import { Player } from '../db/models/Player';
 import { Location } from '../db/models/Location';
 import { Race } from '../db/models/Race';
 import { Lore } from '../db/models/Lore';
+import { pruneQuestRefs } from './quests';
 import {
   listEventsSchema,
   getEventSchema,
@@ -325,6 +326,17 @@ export const deleteEvent = async ({ data }: { data: z.infer<typeof deleteEventSc
     await Event.deleteOne({ _id: data.id, campaignId: data.campaignId });
     // Signature: removeDocumentRefsFromScreens(campaignId, collection, documentId)
     await removeDocumentRefsFromScreens(data.campaignId, 'events', data.id);
+
+    try {
+      await pruneQuestRefs('event', data.id, data.campaignId);
+    } catch (cleanupError) {
+      serverCaptureException(cleanupError, member.sessionUserId, {
+        action: 'deleteEvent.pruneQuests',
+        campaign_id: data.campaignId,
+        event_id: data.id,
+      });
+    }
+
     return { success: true };
   } catch (e) {
     serverCaptureException(e, undefined, { action: 'deleteEvent', eventId: data.id });

--- a/app/server/functions/gmscreens.ts
+++ b/app/server/functions/gmscreens.ts
@@ -303,6 +303,21 @@ const COLLECTION_REGISTRY: Record<string, CollectionFetcher> = {
         ) as Promise<Array<{ _id: unknown; title?: string; content?: string; isPublic?: boolean }>>;
     },
   },
+  quest: {
+    async fetch(ids: string[], campaignId: string) {
+      const { Quest } = await import('../db/models/Quest');
+      return Quest.find({ _id: { $in: ids }, campaignId }, '_id name publicInfo isPublic status')
+        .lean()
+        .then((docs) =>
+          docs.map((d) => ({
+            _id: d._id,
+            title: (d as { name?: string }).name,
+            content: (d as { publicInfo?: string }).publicInfo,
+            isPublic: (d as { isPublic?: boolean }).isPublic,
+          }))
+        ) as Promise<Array<{ _id: unknown; title?: string; content?: string; isPublic?: boolean }>>;
+    },
+  },
 };
 
 /**

--- a/app/server/functions/locations.ts
+++ b/app/server/functions/locations.ts
@@ -7,6 +7,7 @@ import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
 import { pruneLoreLinks } from '../utils/pruneLoreLinks';
 import { pruneEventLinks } from '../utils/pruneEventLinks';
 import { ensureTags as ensureTagsFn } from './tags';
+import { pruneQuestRefs } from './quests';
 import { S3Client, DeleteObjectCommand } from '@aws-sdk/client-s3';
 import type { LocationData, LocationListItem, LocationRef } from '~/types/location';
 import {
@@ -349,6 +350,16 @@ export const deleteLocation = async ({ data }: { data: z.infer<typeof deleteLoca
     } catch (cleanupError) {
       serverCaptureException(cleanupError, sessionUserId, {
         action: 'deleteLocation.cleanup',
+        campaignId: data.campaignId,
+        locationId: data.id,
+      });
+    }
+
+    try {
+      await pruneQuestRefs('location', data.id, data.campaignId);
+    } catch (cleanupError) {
+      serverCaptureException(cleanupError, sessionUserId, {
+        action: 'deleteLocation.pruneQuests',
         campaignId: data.campaignId,
         locationId: data.id,
       });

--- a/app/server/functions/organizations.ts
+++ b/app/server/functions/organizations.ts
@@ -4,6 +4,7 @@ import { serverCaptureException, serverCaptureEvent } from '../utils/telemetry';
 import { normalizeTags } from '../utils/helpers';
 import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
 import { ensureTags as ensureTagsFn } from './tags';
+import { pruneQuestRefs } from './quests';
 import { Organization } from '../db/models/Organization';
 import { OrganizationMembership } from '../db/models/OrganizationMembership';
 import { Location } from '../db/models/Location';
@@ -430,6 +431,16 @@ export const deleteOrganization = async ({
     } catch (cleanupError) {
       serverCaptureException(cleanupError, sessionUserId, {
         action: 'deleteOrganization.cleanup',
+        campaign_id: data.campaignId,
+        organization_id: data.id,
+      });
+    }
+
+    try {
+      await pruneQuestRefs('organization', data.id, data.campaignId);
+    } catch (cleanupError) {
+      serverCaptureException(cleanupError, sessionUserId, {
+        action: 'deleteOrganization.pruneQuests',
         campaign_id: data.campaignId,
         organization_id: data.id,
       });

--- a/app/server/functions/players.ts
+++ b/app/server/functions/players.ts
@@ -12,6 +12,7 @@ import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
 import { pruneLoreLinks } from '../utils/pruneLoreLinks';
 import { pruneEventLinks } from '../utils/pruneEventLinks';
 import { pruneMembershipsForMember } from './organizations';
+import { pruneQuestRefs } from './quests';
 import type { PlayerData, PlayerListItem } from '~/types/player';
 import type { PictureCrop } from '~/types/character';
 import {
@@ -344,6 +345,16 @@ export const deletePlayer = async ({ data }: { data: z.infer<typeof deletePlayer
     } catch (pruneError) {
       serverCaptureException(pruneError, sessionUserId, {
         action: 'deletePlayer.pruneMemberships',
+        campaign_id: data.campaignId,
+        player_id: data.id,
+      });
+    }
+
+    try {
+      await pruneQuestRefs('player', data.id, data.campaignId);
+    } catch (pruneError) {
+      serverCaptureException(pruneError, sessionUserId, {
+        action: 'deletePlayer.pruneQuests',
         campaign_id: data.campaignId,
         player_id: data.id,
       });

--- a/app/server/functions/quests.ts
+++ b/app/server/functions/quests.ts
@@ -83,13 +83,88 @@ async function resolveEntityLabel(
 
 async function resolveGiver(
   raw: Record<string, unknown> | null | undefined,
+  isGM: boolean,
   campaignId: string
 ): Promise<QuestGiver | null> {
   if (!raw || !raw.kind || !raw.id) return null;
   const kind = raw.kind as QuestGiverKind;
   const id = String(raw.id);
+  // An organization giver is GM-only when that org is private: hide the giver
+  // entirely from a non-GM (mirrors the link/event private-org/event gating)
+  // rather than leaking the org's name via the label.
+  if (kind === 'organization') {
+    const doc = (await Organization.findOne(
+      { _id: id, campaignId },
+      'name isPublic'
+    ).lean()) as AnyDoc | null;
+    if (!isGM && doc && doc.isPublic === false) return null;
+    return { kind, id, label: doc ? String(doc.name ?? '') : '' };
+  }
   const label = await resolveEntityLabel(kind, id, campaignId);
   return { kind, id, label };
+}
+
+// Batch-resolve display labels (and, for organizations, isPublic) for a set of
+// links grouped by kind — one query per collection instead of one per link.
+// Keyed by `${kind}:${id}`.
+async function resolveLinkEntities(
+  links: Array<{ kind: QuestLinkKind; id: string }>,
+  campaignId: string
+): Promise<Map<string, { label: string; isPublic?: boolean }>> {
+  const byKind: Record<QuestLinkKind, string[]> = {
+    character: [],
+    player: [],
+    location: [],
+    organization: [],
+  };
+  for (const l of links) byKind[l.kind]?.push(l.id);
+  const map = new Map<string, { label: string; isPublic?: boolean }>();
+  const tasks: Promise<void>[] = [];
+  if (byKind.character.length)
+    tasks.push(
+      Character.find({ _id: { $in: byKind.character }, campaignId }, 'firstName lastName')
+        .lean()
+        .then((docs) => {
+          for (const d of docs as AnyDoc[])
+            map.set(`character:${String(d._id)}`, { label: fullName(d) });
+        })
+    );
+  if (byKind.player.length)
+    tasks.push(
+      Player.find({ _id: { $in: byKind.player }, campaignId }, 'firstName lastName')
+        .lean()
+        .then((docs) => {
+          for (const d of docs as AnyDoc[])
+            map.set(`player:${String(d._id)}`, { label: fullName(d) });
+        })
+    );
+  if (byKind.location.length)
+    tasks.push(
+      Location.find({ _id: { $in: byKind.location }, campaignId }, 'name')
+        .lean()
+        .then((docs) => {
+          for (const d of docs as AnyDoc[])
+            map.set(`location:${String(d._id)}`, { label: String(d.name ?? '') });
+        })
+    );
+  if (byKind.organization.length)
+    tasks.push(
+      Organization.find({ _id: { $in: byKind.organization }, campaignId }, 'name isPublic')
+        .lean()
+        .then((docs) => {
+          for (const d of docs as AnyDoc[])
+            map.set(`organization:${String(d._id)}`, {
+              label: String(d.name ?? ''),
+              isPublic: Boolean(d.isPublic),
+            });
+        })
+    );
+  try {
+    await Promise.all(tasks);
+  } catch {
+    /* labels default to '' */
+  }
+  return map;
 }
 
 async function resolveLinks(
@@ -97,20 +172,31 @@ async function resolveLinks(
   isGM: boolean,
   campaignId: string
 ): Promise<QuestLink[]> {
-  return Promise.all(
-    (raw ?? []).map(async (l) => {
-      const kind = l.kind as QuestLinkKind;
-      const id = String(l.id);
-      return {
-        kind,
-        id,
-        label: await resolveEntityLabel(kind, id, campaignId),
-        role: (l.role as string) ?? '',
-        publicInfo: (l.publicInfo as string) ?? '',
-        privateInfo: isGM ? ((l.privateInfo as string) ?? '') : '',
-      };
-    })
+  const items = (raw ?? []).map((l) => ({
+    kind: l.kind as QuestLinkKind,
+    id: String(l.id),
+    raw: l,
+  }));
+  const entities = await resolveLinkEntities(
+    items.map(({ kind, id }) => ({ kind, id })),
+    campaignId
   );
+  const out: QuestLink[] = [];
+  for (const { kind, id, raw: l } of items) {
+    const ent = entities.get(`${kind}:${id}`);
+    // A private organization's name is GM-only (mirrors events + the tabletop
+    // hydration strip): never surface a private org as a link label to a non-GM.
+    if (!isGM && kind === 'organization' && ent && ent.isPublic === false) continue;
+    out.push({
+      kind,
+      id,
+      label: ent?.label ?? '',
+      role: (l.role as string) ?? '',
+      publicInfo: (l.publicInfo as string) ?? '',
+      privateInfo: isGM ? ((l.privateInfo as string) ?? '') : '',
+    });
+  }
+  return out;
 }
 
 async function resolveEvents(
@@ -118,37 +204,37 @@ async function resolveEvents(
   isGM: boolean,
   campaignId: string
 ): Promise<QuestEventLink[]> {
-  const resolved = await Promise.all(
-    (raw ?? []).map(async (e): Promise<QuestEventLink | null> => {
-      const eventId = String(e.eventId);
-      let label = '';
-      let dropForNonGM = false;
-      try {
-        const ev = (await Event.findOne(
-          { _id: eventId, campaignId },
-          'title isPublic'
-        ).lean()) as AnyDoc | null;
-        if (ev) {
-          label = String(ev.title ?? '');
-          // A private event's title/content is GM-only (mirrors
-          // tabletop-hydration's `!isGM && isPublic === false` gate) — never
-          // let a non-GM viewer see the title of an event they can't open.
-          if (!isGM && ev.isPublic === false) dropForNonGM = true;
-        }
-      } catch {
-        label = '';
-      }
-      if (dropForNonGM) return null;
-      return {
-        eventId,
-        label,
-        role: (e.role as string) ?? '',
-        publicInfo: (e.publicInfo as string) ?? '',
-        privateInfo: isGM ? ((e.privateInfo as string) ?? '') : '',
-      };
-    })
-  );
-  return resolved.filter((e): e is QuestEventLink => e !== null);
+  const items = (raw ?? []).map((e) => ({ eventId: String(e.eventId), raw: e }));
+  const ids = items.map((i) => i.eventId);
+  const evMap = new Map<string, { title: string; isPublic: boolean }>();
+  if (ids.length) {
+    try {
+      const docs = (await Event.find(
+        { _id: { $in: ids }, campaignId },
+        'title isPublic'
+      ).lean()) as AnyDoc[];
+      for (const d of docs)
+        evMap.set(String(d._id), { title: String(d.title ?? ''), isPublic: Boolean(d.isPublic) });
+    } catch {
+      /* labels default to '' */
+    }
+  }
+  const out: QuestEventLink[] = [];
+  for (const { eventId, raw: e } of items) {
+    const ev = evMap.get(eventId);
+    // A private event's title/content is GM-only (mirrors tabletop-hydration's
+    // `!isGM && isPublic === false` gate) — never let a non-GM viewer see the
+    // title of an event they can't open.
+    if (!isGM && ev && ev.isPublic === false) continue;
+    out.push({
+      eventId,
+      label: ev?.title ?? '',
+      role: (e.role as string) ?? '',
+      publicInfo: (e.publicInfo as string) ?? '',
+      privateInfo: isGM ? ((e.privateInfo as string) ?? '') : '',
+    });
+  }
+  return out;
 }
 
 function questVisibilityFilter(member: { isGM: boolean; userId: string }) {
@@ -213,7 +299,7 @@ async function serializeQuest(
   campaignId: string
 ): Promise<QuestData> {
   const [giver, links, events, parentQuest, subQuests] = await Promise.all([
-    resolveGiver(doc.giver as Record<string, unknown> | null, campaignId),
+    resolveGiver(doc.giver as Record<string, unknown> | null, member.isGM, campaignId),
     resolveLinks((doc.links as Array<Record<string, unknown>>) ?? [], member.isGM, campaignId),
     resolveEvents((doc.events as Array<Record<string, unknown>>) ?? [], member.isGM, campaignId),
     resolveParentSummary(doc.parentQuestId ? String(doc.parentQuestId) : null, campaignId, member),
@@ -245,7 +331,7 @@ async function serializeQuest(
 
 // Strip GM-only privateInfo out of an incoming links array for a non-GM writer,
 // preserving existing private values by matching on kind+id.
-function mergeLinkPrivate(
+async function mergeLinkPrivate(
   incoming: Array<{
     kind: string;
     id: string;
@@ -254,18 +340,54 @@ function mergeLinkPrivate(
     privateInfo: string;
   }>,
   existing: Array<Record<string, unknown>>,
-  isGM: boolean
-) {
+  isGM: boolean,
+  campaignId: string
+): Promise<
+  Array<{ kind: string; id: string; role: string; publicInfo: string; privateInfo: string }>
+> {
   const priv = new Map<string, string>();
   for (const l of existing ?? [])
     priv.set(`${l.kind}:${String(l.id)}`, (l.privateInfo as string) ?? '');
-  return incoming.map((l) => ({
+  const merged = incoming.map((l) => ({
     kind: l.kind,
     id: l.id,
     role: l.role,
     publicInfo: l.publicInfo,
     privateInfo: isGM ? l.privateInfo : (priv.get(`${l.kind}:${l.id}`) ?? ''),
   }));
+  if (isGM) return merged;
+
+  // resolveLinks drops private-organization links from what a non-GM viewer is
+  // shown, so a non-GM writer's submitted array never mentions them — their
+  // absence means "never seen", not "deliberately removed". Re-add any existing
+  // organization link omitted from the payload whose org is private (or no
+  // longer resolves — fail closed rather than deleting data they couldn't see).
+  const incomingKeys = new Set(incoming.map((l) => `${l.kind}:${l.id}`));
+  const omittedOrgs = (existing ?? []).filter(
+    (l) => l.kind === 'organization' && !incomingKeys.has(`organization:${String(l.id)}`)
+  );
+  if (omittedOrgs.length === 0) return merged;
+
+  const pubMap = new Map<string, boolean>();
+  try {
+    const docs = (await Organization.find(
+      { _id: { $in: omittedOrgs.map((l) => String(l.id)) }, campaignId },
+      '_id isPublic'
+    ).lean()) as AnyDoc[];
+    for (const d of docs) pubMap.set(String(d._id), Boolean(d.isPublic));
+  } catch {
+    /* fail closed: unresolved orgs stay private below */
+  }
+  const preserved = omittedOrgs
+    .filter((l) => pubMap.get(String(l.id)) !== true)
+    .map((l) => ({
+      kind: 'organization',
+      id: String(l.id),
+      role: (l.role as string) ?? '',
+      publicInfo: (l.publicInfo as string) ?? '',
+      privateInfo: (l.privateInfo as string) ?? '',
+    }));
+  return [...merged, ...preserved];
 }
 async function mergeEventPrivate(
   incoming: Array<{ eventId: string; role: string; publicInfo: string; privateInfo: string }>,
@@ -293,28 +415,24 @@ async function mergeEventPrivate(
   const omitted = (existing ?? []).filter((e) => !incomingIds.has(String(e.eventId)));
   if (omitted.length === 0) return merged;
 
-  const preserved: typeof merged = [];
-  for (const e of omitted) {
-    const eventId = String(e.eventId);
-    let isPublic = false;
-    try {
-      const ev = (await Event.findOne(
-        { _id: eventId, campaignId },
-        'isPublic'
-      ).lean()) as AnyDoc | null;
-      isPublic = ev ? Boolean(ev.isPublic) : false;
-    } catch {
-      isPublic = false;
-    }
-    if (!isPublic) {
-      preserved.push({
-        eventId,
-        role: (e.role as string) ?? '',
-        publicInfo: (e.publicInfo as string) ?? '',
-        privateInfo: (e.privateInfo as string) ?? '',
-      });
-    }
+  const pubMap = new Map<string, boolean>();
+  try {
+    const docs = (await Event.find(
+      { _id: { $in: omitted.map((e) => String(e.eventId)) }, campaignId },
+      '_id isPublic'
+    ).lean()) as AnyDoc[];
+    for (const d of docs) pubMap.set(String(d._id), Boolean(d.isPublic));
+  } catch {
+    /* fail closed: unresolved events stay private below */
   }
+  const preserved = omitted
+    .filter((e) => pubMap.get(String(e.eventId)) !== true)
+    .map((e) => ({
+      eventId: String(e.eventId),
+      role: (e.role as string) ?? '',
+      publicInfo: (e.publicInfo as string) ?? '',
+      privateInfo: (e.privateInfo as string) ?? '',
+    }));
   return [...merged, ...preserved];
 }
 
@@ -453,10 +571,11 @@ export const updateQuest = async ({
     if (!member.isGM && !isCreator) throw new Error('Forbidden');
 
     const finalTags = normalizeTags(data.tags ?? []);
-    const links = mergeLinkPrivate(
+    const links = await mergeLinkPrivate(
       data.links,
       (existing.links as Array<Record<string, unknown>>) ?? [],
-      member.isGM
+      member.isGM,
+      data.campaignId
     );
     const events = await mergeEventPrivate(
       data.events,

--- a/app/server/functions/quests.ts
+++ b/app/server/functions/quests.ts
@@ -118,19 +118,27 @@ async function resolveEvents(
   isGM: boolean,
   campaignId: string
 ): Promise<QuestEventLink[]> {
-  return Promise.all(
-    (raw ?? []).map(async (e) => {
+  const resolved = await Promise.all(
+    (raw ?? []).map(async (e): Promise<QuestEventLink | null> => {
       const eventId = String(e.eventId);
       let label = '';
+      let dropForNonGM = false;
       try {
         const ev = (await Event.findOne(
           { _id: eventId, campaignId },
-          'title'
+          'title isPublic'
         ).lean()) as AnyDoc | null;
-        if (ev) label = String(ev.title ?? '');
+        if (ev) {
+          label = String(ev.title ?? '');
+          // A private event's title/content is GM-only (mirrors
+          // tabletop-hydration's `!isGM && isPublic === false` gate) — never
+          // let a non-GM viewer see the title of an event they can't open.
+          if (!isGM && ev.isPublic === false) dropForNonGM = true;
+        }
       } catch {
         label = '';
       }
+      if (dropForNonGM) return null;
       return {
         eventId,
         label,
@@ -140,6 +148,7 @@ async function resolveEvents(
       };
     })
   );
+  return resolved.filter((e): e is QuestEventLink => e !== null);
 }
 
 function questVisibilityFilter(member: { isGM: boolean; userId: string }) {
@@ -258,19 +267,55 @@ function mergeLinkPrivate(
     privateInfo: isGM ? l.privateInfo : (priv.get(`${l.kind}:${l.id}`) ?? ''),
   }));
 }
-function mergeEventPrivate(
+async function mergeEventPrivate(
   incoming: Array<{ eventId: string; role: string; publicInfo: string; privateInfo: string }>,
   existing: Array<Record<string, unknown>>,
-  isGM: boolean
-) {
+  isGM: boolean,
+  campaignId: string
+): Promise<Array<{ eventId: string; role: string; publicInfo: string; privateInfo: string }>> {
   const priv = new Map<string, string>();
   for (const e of existing ?? []) priv.set(String(e.eventId), (e.privateInfo as string) ?? '');
-  return incoming.map((e) => ({
+  const merged = incoming.map((e) => ({
     eventId: e.eventId,
     role: e.role,
     publicInfo: e.publicInfo,
     privateInfo: isGM ? e.privateInfo : (priv.get(e.eventId) ?? ''),
   }));
+  if (isGM) return merged;
+
+  // resolveEvents drops links to private events from what a non-GM viewer is
+  // shown, so a non-GM writer's submitted `events` array never mentions them
+  // — their absence means "never seen", not "deliberately removed". Re-add
+  // any existing event link omitted from the payload whose event is private
+  // (or no longer resolves at all — fail closed rather than silently
+  // deleting data the writer couldn't have seen).
+  const incomingIds = new Set(incoming.map((e) => e.eventId));
+  const omitted = (existing ?? []).filter((e) => !incomingIds.has(String(e.eventId)));
+  if (omitted.length === 0) return merged;
+
+  const preserved: typeof merged = [];
+  for (const e of omitted) {
+    const eventId = String(e.eventId);
+    let isPublic = false;
+    try {
+      const ev = (await Event.findOne(
+        { _id: eventId, campaignId },
+        'isPublic'
+      ).lean()) as AnyDoc | null;
+      isPublic = ev ? Boolean(ev.isPublic) : false;
+    } catch {
+      isPublic = false;
+    }
+    if (!isPublic) {
+      preserved.push({
+        eventId,
+        role: (e.role as string) ?? '',
+        publicInfo: (e.publicInfo as string) ?? '',
+        privateInfo: (e.privateInfo as string) ?? '',
+      });
+    }
+  }
+  return [...merged, ...preserved];
 }
 
 export const listQuests = async ({
@@ -413,10 +458,11 @@ export const updateQuest = async ({
       (existing.links as Array<Record<string, unknown>>) ?? [],
       member.isGM
     );
-    const events = mergeEventPrivate(
+    const events = await mergeEventPrivate(
       data.events,
       (existing.events as Array<Record<string, unknown>>) ?? [],
-      member.isGM
+      member.isGM,
+      data.campaignId
     );
 
     const set: Record<string, unknown> = {

--- a/app/server/functions/quests.ts
+++ b/app/server/functions/quests.ts
@@ -97,7 +97,7 @@ async function resolveGiver(
       { _id: id, campaignId },
       'name isPublic'
     ).lean()) as AnyDoc | null;
-    if (!isGM && doc && doc.isPublic === false) return null;
+    if (!isGM && doc && Boolean(doc.isPublic) === false) return null;
     return { kind, id, label: doc ? String(doc.name ?? '') : '' };
   }
   const label = await resolveEntityLabel(kind, id, campaignId);
@@ -436,6 +436,43 @@ async function mergeEventPrivate(
   return [...merged, ...preserved];
 }
 
+// resolveGiver hides a private-organization giver from a non-GM read (returns
+// null), so a non-GM writer whose payload has no giver may simply never have
+// seen it. Preserve an existing private (or unresolvable) org giver rather than
+// silently wiping it — the giver analogue of mergeLinkPrivate/mergeEventPrivate.
+async function mergeGiverPrivate(
+  incoming: { kind: string; id: string } | null | undefined,
+  existing: Record<string, unknown> | null | undefined,
+  isGM: boolean,
+  campaignId: string
+): Promise<{ kind: string; id: string } | null> {
+  const inc =
+    incoming && incoming.kind && incoming.id
+      ? { kind: String(incoming.kind), id: String(incoming.id) }
+      : null;
+  // GM writes are authoritative; a non-GM who submitted a giver took an explicit
+  // action on the field, so honor it (even replacing an unseen private one).
+  if (isGM || inc) return inc;
+  // Non-GM submitted no giver. If the existing giver is one they could see
+  // (no giver, or a character/player/public-org giver), the empty payload is a
+  // genuine clear. Only preserve an org giver that was hidden from them.
+  if (!existing || !existing.kind || !existing.id) return null;
+  const kind = String(existing.kind);
+  const id = String(existing.id);
+  if (kind !== 'organization') return null;
+  let isPublic = false;
+  try {
+    const doc = (await Organization.findOne(
+      { _id: id, campaignId },
+      'isPublic'
+    ).lean()) as AnyDoc | null;
+    isPublic = doc ? Boolean(doc.isPublic) : false;
+  } catch {
+    isPublic = false; // fail closed: unresolvable org stays preserved
+  }
+  return isPublic ? null : { kind, id };
+}
+
 export const listQuests = async ({
   data,
 }: {
@@ -583,6 +620,12 @@ export const updateQuest = async ({
       member.isGM,
       data.campaignId
     );
+    const giver = await mergeGiverPrivate(
+      data.giver,
+      existing.giver as Record<string, unknown> | null,
+      member.isGM,
+      data.campaignId
+    );
 
     const set: Record<string, unknown> = {
       name: data.name.trim(),
@@ -590,7 +633,7 @@ export const updateQuest = async ({
       status: data.status,
       publicInfo: data.publicInfo,
       isPublic: data.isPublic,
-      giver: data.giver,
+      giver,
       parentQuestId: data.parentQuestId,
       links,
       events,

--- a/app/server/functions/quests.ts
+++ b/app/server/functions/quests.ts
@@ -1,0 +1,556 @@
+import { z } from 'zod';
+import { requireCampaignMember } from '../utils/requireCampaignMember';
+import { serverCaptureException, serverCaptureEvent } from '../utils/telemetry';
+import { normalizeTags } from '../utils/helpers';
+import { removeDocumentRefsFromScreens } from './gmscreens-helpers';
+import { ensureTags as ensureTagsFn } from './tags';
+import { Quest } from '../db/models/Quest';
+import { Character } from '../db/models/Character';
+import { Player } from '../db/models/Player';
+import { Location } from '../db/models/Location';
+import { Organization } from '../db/models/Organization';
+import { Event } from '../db/models/Event';
+import type {
+  QuestData,
+  QuestListItem,
+  QuestImage,
+  QuestGiver,
+  QuestLink,
+  QuestEventLink,
+  QuestSummary,
+  QuestStatus,
+  QuestGiverKind,
+  QuestLinkKind,
+} from '~/types/quest';
+import type { PictureCrop } from '~/types/character';
+import {
+  createQuestSchema,
+  updateQuestSchema,
+  deleteQuestSchema,
+  getQuestSchema,
+  listQuestsSchema,
+  listQuestsForEntitySchema,
+} from '~/types/schemas/quests';
+
+type AnyDoc = Record<string, unknown> & { _id: unknown };
+const LIST_LIMIT = 500;
+
+function iso(d: unknown): string {
+  return d instanceof Date ? d.toISOString() : '';
+}
+function fullName(doc: AnyDoc): string {
+  return `${doc.firstName ?? ''} ${doc.lastName ?? ''}`.trim();
+}
+
+function serializeImages(raw: unknown): QuestImage[] {
+  return ((raw as unknown[]) ?? []).map((i) => {
+    const img = i as Record<string, unknown>;
+    return {
+      url: String(img.url),
+      caption: (img.caption as string) ?? '',
+      crop: (img.crop as unknown as PictureCrop) ?? null,
+    };
+  });
+}
+
+// Resolve a display label for one polymorphic entity, scoped to the campaign.
+async function resolveEntityLabel(
+  kind: QuestGiverKind | QuestLinkKind,
+  id: string,
+  campaignId: string
+): Promise<string> {
+  try {
+    if (kind === 'character' || kind === 'player') {
+      const model = kind === 'character' ? Character : Player;
+      const doc = (await model
+        .findOne({ _id: id, campaignId }, 'firstName lastName')
+        .lean()) as AnyDoc | null;
+      return doc ? fullName(doc) : '';
+    }
+    if (kind === 'location') {
+      const doc = (await Location.findOne({ _id: id, campaignId }, 'name').lean()) as AnyDoc | null;
+      return doc ? String(doc.name ?? '') : '';
+    }
+    const doc = (await Organization.findOne(
+      { _id: id, campaignId },
+      'name'
+    ).lean()) as AnyDoc | null;
+    return doc ? String(doc.name ?? '') : '';
+  } catch {
+    return '';
+  }
+}
+
+async function resolveGiver(
+  raw: Record<string, unknown> | null | undefined,
+  campaignId: string
+): Promise<QuestGiver | null> {
+  if (!raw || !raw.kind || !raw.id) return null;
+  const kind = raw.kind as QuestGiverKind;
+  const id = String(raw.id);
+  const label = await resolveEntityLabel(kind, id, campaignId);
+  return { kind, id, label };
+}
+
+async function resolveLinks(
+  raw: Array<Record<string, unknown>>,
+  isGM: boolean,
+  campaignId: string
+): Promise<QuestLink[]> {
+  return Promise.all(
+    (raw ?? []).map(async (l) => {
+      const kind = l.kind as QuestLinkKind;
+      const id = String(l.id);
+      return {
+        kind,
+        id,
+        label: await resolveEntityLabel(kind, id, campaignId),
+        role: (l.role as string) ?? '',
+        publicInfo: (l.publicInfo as string) ?? '',
+        privateInfo: isGM ? ((l.privateInfo as string) ?? '') : '',
+      };
+    })
+  );
+}
+
+async function resolveEvents(
+  raw: Array<Record<string, unknown>>,
+  isGM: boolean,
+  campaignId: string
+): Promise<QuestEventLink[]> {
+  return Promise.all(
+    (raw ?? []).map(async (e) => {
+      const eventId = String(e.eventId);
+      let label = '';
+      try {
+        const ev = (await Event.findOne(
+          { _id: eventId, campaignId },
+          'title'
+        ).lean()) as AnyDoc | null;
+        if (ev) label = String(ev.title ?? '');
+      } catch {
+        label = '';
+      }
+      return {
+        eventId,
+        label,
+        role: (e.role as string) ?? '',
+        publicInfo: (e.publicInfo as string) ?? '',
+        privateInfo: isGM ? ((e.privateInfo as string) ?? '') : '',
+      };
+    })
+  );
+}
+
+function questVisibilityFilter(member: { isGM: boolean; userId: string }) {
+  return member.isGM ? {} : { $or: [{ isPublic: true }, { createdBy: member.userId }] };
+}
+
+async function resolveSubQuests(
+  parentId: string,
+  campaignId: string,
+  member: { isGM: boolean; userId: string }
+): Promise<QuestSummary[]> {
+  const docs = (await Quest.find(
+    { campaignId, parentQuestId: parentId, ...questVisibilityFilter(member) },
+    '_id name status'
+  )
+    .limit(LIST_LIMIT)
+    .lean()) as AnyDoc[];
+  return docs.map((d) => ({
+    id: String(d._id),
+    name: (d.name as string) ?? '',
+    status: (d.status as QuestStatus) ?? 'not_started',
+  }));
+}
+
+async function resolveParentSummary(
+  parentQuestId: string | null,
+  campaignId: string,
+  member: { isGM: boolean; userId: string }
+): Promise<QuestSummary | null> {
+  if (!parentQuestId) return null;
+  const d = (await Quest.findOne(
+    { _id: parentQuestId, campaignId, ...questVisibilityFilter(member) },
+    '_id name status'
+  ).lean()) as AnyDoc | null;
+  if (!d) return null;
+  return {
+    id: String(d._id),
+    name: (d.name as string) ?? '',
+    status: (d.status as QuestStatus) ?? 'not_started',
+  };
+}
+
+function serializeListItem(doc: AnyDoc, canEdit: boolean): QuestListItem {
+  return {
+    id: String(doc._id),
+    campaignId: String(doc.campaignId),
+    createdBy: String(doc.createdBy),
+    name: (doc.name as string) ?? '',
+    type: (doc.type as string) ?? '',
+    status: (doc.status as QuestStatus) ?? 'not_started',
+    isPublic: Boolean(doc.isPublic),
+    tags: (doc.tags as string[]) ?? [],
+    canEdit,
+    createdAt: iso(doc.createdAt),
+    updatedAt: iso(doc.updatedAt),
+  };
+}
+
+async function serializeQuest(
+  doc: AnyDoc,
+  member: { isGM: boolean; userId: string },
+  campaignId: string
+): Promise<QuestData> {
+  const [giver, links, events, parentQuest, subQuests] = await Promise.all([
+    resolveGiver(doc.giver as Record<string, unknown> | null, campaignId),
+    resolveLinks((doc.links as Array<Record<string, unknown>>) ?? [], member.isGM, campaignId),
+    resolveEvents((doc.events as Array<Record<string, unknown>>) ?? [], member.isGM, campaignId),
+    resolveParentSummary(doc.parentQuestId ? String(doc.parentQuestId) : null, campaignId, member),
+    resolveSubQuests(String(doc._id), campaignId, member),
+  ]);
+  return {
+    id: String(doc._id),
+    campaignId: String(doc.campaignId),
+    createdBy: String(doc.createdBy),
+    name: (doc.name as string) ?? '',
+    type: (doc.type as string) ?? '',
+    status: (doc.status as QuestStatus) ?? 'not_started',
+    publicInfo: (doc.publicInfo as string) ?? '',
+    privateInfo: member.isGM ? ((doc.privateInfo as string) ?? '') : '',
+    isPublic: Boolean(doc.isPublic),
+    giver,
+    parentQuestId: doc.parentQuestId ? String(doc.parentQuestId) : null,
+    parentQuest,
+    subQuests,
+    links,
+    events,
+    images: serializeImages(doc.images),
+    tags: (doc.tags as string[]) ?? [],
+    canEdit: member.isGM || String(doc.createdBy) === member.userId,
+    createdAt: iso(doc.createdAt),
+    updatedAt: iso(doc.updatedAt),
+  };
+}
+
+// Strip GM-only privateInfo out of an incoming links array for a non-GM writer,
+// preserving existing private values by matching on kind+id.
+function mergeLinkPrivate(
+  incoming: Array<{
+    kind: string;
+    id: string;
+    role: string;
+    publicInfo: string;
+    privateInfo: string;
+  }>,
+  existing: Array<Record<string, unknown>>,
+  isGM: boolean
+) {
+  const priv = new Map<string, string>();
+  for (const l of existing ?? [])
+    priv.set(`${l.kind}:${String(l.id)}`, (l.privateInfo as string) ?? '');
+  return incoming.map((l) => ({
+    kind: l.kind,
+    id: l.id,
+    role: l.role,
+    publicInfo: l.publicInfo,
+    privateInfo: isGM ? l.privateInfo : (priv.get(`${l.kind}:${l.id}`) ?? ''),
+  }));
+}
+function mergeEventPrivate(
+  incoming: Array<{ eventId: string; role: string; publicInfo: string; privateInfo: string }>,
+  existing: Array<Record<string, unknown>>,
+  isGM: boolean
+) {
+  const priv = new Map<string, string>();
+  for (const e of existing ?? []) priv.set(String(e.eventId), (e.privateInfo as string) ?? '');
+  return incoming.map((e) => ({
+    eventId: e.eventId,
+    role: e.role,
+    publicInfo: e.publicInfo,
+    privateInfo: isGM ? e.privateInfo : (priv.get(e.eventId) ?? ''),
+  }));
+}
+
+export const listQuests = async ({
+  data,
+}: {
+  data: z.infer<typeof listQuestsSchema>;
+}): Promise<QuestListItem[]> => {
+  let sessionUserId: string | undefined;
+  try {
+    const member = await requireCampaignMember(data.campaignId);
+    sessionUserId = member.sessionUserId;
+
+    const filter: Record<string, unknown> = { campaignId: data.campaignId };
+    if (!member.isGM) filter.$or = [{ isPublic: true }, { createdBy: member.userId }];
+    if (data.search) filter.$text = { $search: data.search };
+    if (data.status) filter.status = data.status;
+    if (data.tags && data.tags.length > 0) {
+      const normalized = [...new Set(normalizeTags(data.tags))];
+      if (normalized.length > 0) filter.tags = { $all: normalized };
+    }
+
+    const docs = (await Quest.find(filter)
+      .select('-publicInfo -privateInfo -images -links -events')
+      .sort({ updatedAt: -1 })
+      .limit(LIST_LIMIT)
+      .lean()) as AnyDoc[];
+
+    return docs.map((d) =>
+      serializeListItem(d, member.isGM || String(d.createdBy) === member.userId)
+    );
+  } catch (e) {
+    serverCaptureException(e, sessionUserId, { action: 'listQuests' });
+    throw e;
+  }
+};
+
+export const getQuest = async ({
+  data,
+}: {
+  data: z.infer<typeof getQuestSchema>;
+}): Promise<QuestData | null> => {
+  let sessionUserId: string | undefined;
+  try {
+    const member = await requireCampaignMember(data.campaignId);
+    sessionUserId = member.sessionUserId;
+
+    const doc = (await Quest.findById(data.id).lean()) as AnyDoc | null;
+    if (!doc || String(doc.campaignId) !== data.campaignId) return null;
+    const isCreator = String(doc.createdBy) === member.userId;
+    if (!member.isGM && !isCreator && !doc.isPublic) return null;
+
+    return serializeQuest(doc, member, data.campaignId);
+  } catch (e) {
+    serverCaptureException(e, sessionUserId, { action: 'getQuest' });
+    throw e;
+  }
+};
+
+export const createQuest = async ({
+  data,
+}: {
+  data: z.infer<typeof createQuestSchema>;
+}): Promise<QuestData> => {
+  let sessionUserId: string | undefined;
+  try {
+    const member = await requireCampaignMember(data.campaignId);
+    sessionUserId = member.sessionUserId;
+
+    const finalTags = normalizeTags(data.tags ?? []);
+    const links = data.links.map((l) => ({
+      kind: l.kind,
+      id: l.id,
+      role: l.role,
+      publicInfo: l.publicInfo,
+      privateInfo: member.isGM ? l.privateInfo : '',
+    }));
+    const events = data.events.map((e) => ({
+      eventId: e.eventId,
+      role: e.role,
+      publicInfo: e.publicInfo,
+      privateInfo: member.isGM ? e.privateInfo : '',
+    }));
+
+    const quest = new Quest({
+      campaignId: data.campaignId,
+      createdBy: member.userId,
+      name: data.name.trim(),
+      type: data.type,
+      status: data.status,
+      publicInfo: data.publicInfo,
+      privateInfo: member.isGM ? data.privateInfo : '',
+      isPublic: data.isPublic,
+      giver: data.giver,
+      parentQuestId: data.parentQuestId,
+      links,
+      events,
+      images: data.images,
+      tags: finalTags,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await quest.save();
+
+    if (finalTags.length > 0) {
+      await ensureTagsFn({ data: { campaignId: data.campaignId, tags: finalTags } });
+    }
+    serverCaptureEvent(sessionUserId!, 'quest_created', {
+      campaign_id: data.campaignId,
+      quest_id: String(quest._id),
+    });
+
+    return serializeQuest(quest.toObject() as AnyDoc, member, data.campaignId);
+  } catch (e) {
+    serverCaptureException(e, sessionUserId, { action: 'createQuest' });
+    throw e;
+  }
+};
+
+export const updateQuest = async ({
+  data,
+}: {
+  data: z.infer<typeof updateQuestSchema>;
+}): Promise<QuestData> => {
+  let sessionUserId: string | undefined;
+  try {
+    const member = await requireCampaignMember(data.campaignId);
+    sessionUserId = member.sessionUserId;
+
+    const existing = (await Quest.findOne({
+      _id: data.id,
+      campaignId: data.campaignId,
+    }).lean()) as AnyDoc | null;
+    if (!existing) throw new Error('Quest not found');
+    const isCreator = String(existing.createdBy) === member.userId;
+    if (!member.isGM && !isCreator) throw new Error('Forbidden');
+
+    const finalTags = normalizeTags(data.tags ?? []);
+    const links = mergeLinkPrivate(
+      data.links,
+      (existing.links as Array<Record<string, unknown>>) ?? [],
+      member.isGM
+    );
+    const events = mergeEventPrivate(
+      data.events,
+      (existing.events as Array<Record<string, unknown>>) ?? [],
+      member.isGM
+    );
+
+    const set: Record<string, unknown> = {
+      name: data.name.trim(),
+      type: data.type,
+      status: data.status,
+      publicInfo: data.publicInfo,
+      isPublic: data.isPublic,
+      giver: data.giver,
+      parentQuestId: data.parentQuestId,
+      links,
+      events,
+      images: data.images,
+      tags: finalTags,
+      updatedAt: new Date(),
+    };
+    if (member.isGM) set.privateInfo = data.privateInfo;
+
+    const quest = (await Quest.findOneAndUpdate(
+      { _id: data.id, campaignId: data.campaignId },
+      { $set: set },
+      { new: true }
+    ).lean()) as AnyDoc | null;
+    if (!quest) throw new Error('Quest not found');
+
+    if (finalTags.length > 0) {
+      await ensureTagsFn({ data: { campaignId: data.campaignId, tags: finalTags } });
+    }
+    serverCaptureEvent(sessionUserId!, 'quest_updated', {
+      campaign_id: data.campaignId,
+      quest_id: data.id,
+    });
+
+    return serializeQuest(quest, member, data.campaignId);
+  } catch (e) {
+    serverCaptureException(e, sessionUserId, { action: 'updateQuest' });
+    throw e;
+  }
+};
+
+export const deleteQuest = async ({ data }: { data: z.infer<typeof deleteQuestSchema> }) => {
+  let sessionUserId: string | undefined;
+  try {
+    const member = await requireCampaignMember(data.campaignId);
+    sessionUserId = member.sessionUserId;
+
+    const quest = (await Quest.findOne({
+      _id: data.id,
+      campaignId: data.campaignId,
+    }).lean()) as AnyDoc | null;
+    if (!quest) throw new Error('Quest not found');
+    if (!member.isGM && String(quest.createdBy) !== member.userId) throw new Error('Forbidden');
+
+    await Quest.deleteOne({ _id: data.id, campaignId: data.campaignId });
+    // Re-parent children to top-level rather than deleting them.
+    await Quest.updateMany(
+      { campaignId: data.campaignId, parentQuestId: data.id },
+      { $set: { parentQuestId: null } }
+    );
+
+    try {
+      await removeDocumentRefsFromScreens(data.campaignId, 'quest', data.id);
+    } catch (cleanupError) {
+      serverCaptureException(cleanupError, sessionUserId, {
+        action: 'deleteQuest.cleanup',
+        campaign_id: data.campaignId,
+        quest_id: data.id,
+      });
+    }
+
+    serverCaptureEvent(sessionUserId!, 'quest_deleted', {
+      campaign_id: data.campaignId,
+      quest_id: data.id,
+    });
+    return { success: true };
+  } catch (e) {
+    serverCaptureException(e, sessionUserId, { action: 'deleteQuest' });
+    throw e;
+  }
+};
+
+export const listQuestsForEntity = async ({
+  data,
+}: {
+  data: z.infer<typeof listQuestsForEntitySchema>;
+}): Promise<QuestListItem[]> => {
+  let sessionUserId: string | undefined;
+  try {
+    const member = await requireCampaignMember(data.campaignId);
+    sessionUserId = member.sessionUserId;
+
+    const matchRef: Record<string, unknown> = {
+      $or: [
+        { links: { $elemMatch: { kind: data.kind, id: data.id } } },
+        ...(data.kind === 'location' ? [] : [{ 'giver.kind': data.kind, 'giver.id': data.id }]),
+      ],
+    };
+    const filter: Record<string, unknown> = { campaignId: data.campaignId, ...matchRef };
+    if (!member.isGM) {
+      filter.$and = [{ $or: [{ isPublic: true }, { createdBy: member.userId }] }];
+    }
+
+    const docs = (await Quest.find(filter)
+      .select('-publicInfo -privateInfo -images -links -events')
+      .sort({ updatedAt: -1 })
+      .limit(LIST_LIMIT)
+      .lean()) as AnyDoc[];
+    return docs.map((d) =>
+      serializeListItem(d, member.isGM || String(d.createdBy) === member.userId)
+    );
+  } catch (e) {
+    serverCaptureException(e, sessionUserId, { action: 'listQuestsForEntity' });
+    throw e;
+  }
+};
+
+// Called from entity delete flows (Task 4) to drop dangling references.
+export async function pruneQuestRefs(
+  kind: 'character' | 'player' | 'location' | 'organization' | 'event',
+  id: string,
+  campaignId: string
+): Promise<void> {
+  if (kind === 'event') {
+    await Quest.updateMany(
+      { campaignId, 'events.eventId': id },
+      { $pull: { events: { eventId: id } } }
+    );
+    return;
+  }
+  await Quest.updateMany({ campaignId, 'links.id': id }, { $pull: { links: { kind, id } } });
+  if (kind === 'character' || kind === 'player' || kind === 'organization') {
+    await Quest.updateMany(
+      { campaignId, 'giver.kind': kind, 'giver.id': id },
+      { $set: { giver: null } }
+    );
+  }
+}

--- a/app/server/functions/tabletop-hydration.ts
+++ b/app/server/functions/tabletop-hydration.ts
@@ -192,6 +192,21 @@ const COLLECTION_REGISTRY: Record<string, CollectionFetcher> = {
         ) as Promise<Array<{ _id: unknown; title?: string; content?: string; isPublic?: boolean }>>;
     },
   },
+  quest: {
+    async fetch(ids: string[], campaignId: string) {
+      const { Quest } = await import('../db/models/Quest');
+      return Quest.find({ _id: { $in: ids }, campaignId }, '_id name publicInfo isPublic status')
+        .lean()
+        .then((docs) =>
+          docs.map((d) => ({
+            _id: d._id,
+            title: (d as { name?: string }).name,
+            content: (d as { publicInfo?: string }).publicInfo,
+            isPublic: (d as { isPublic?: boolean }).isPublic,
+          }))
+        ) as Promise<Array<{ _id: unknown; title?: string; content?: string; isPublic?: boolean }>>;
+    },
+  },
 };
 
 /**
@@ -229,6 +244,7 @@ export async function hydrateRefs(
         // for a non-GM viewer, or its title/content would leak on a shared screen.
         if (!isGM && collectionName === 'events' && doc.isPublic === false) continue;
         if (!isGM && collectionName === 'organization' && doc.isPublic === false) continue;
+        if (!isGM && collectionName === 'quest' && doc.isPublic === false) continue;
         const id = String(doc._id);
         hydrated[`${collectionName}:${id}`] = {
           id,

--- a/app/types/quest.ts
+++ b/app/types/quest.ts
@@ -1,0 +1,124 @@
+import type { PictureCrop } from './character';
+
+export type QuestStatus = 'not_started' | 'active' | 'on_hold' | 'completed' | 'failed';
+export type QuestGiverKind = 'character' | 'player' | 'organization';
+export type QuestLinkKind = 'character' | 'player' | 'location' | 'organization';
+
+export interface QuestImage {
+  url: string;
+  caption: string;
+  crop: PictureCrop | null;
+}
+
+export interface QuestGiver {
+  kind: QuestGiverKind;
+  id: string;
+  /** Resolved display name; '' if the referenced entity is gone. */
+  label: string;
+}
+
+export interface QuestLink {
+  kind: QuestLinkKind;
+  id: string;
+  /** Resolved display name. */
+  label: string;
+  role: string;
+  publicInfo: string;
+  /** GM-only; '' for non-GM viewers. */
+  privateInfo: string;
+}
+
+export interface QuestEventLink {
+  eventId: string;
+  /** Resolved event title. */
+  label: string;
+  role: string;
+  publicInfo: string;
+  /** GM-only; '' for non-GM viewers. */
+  privateInfo: string;
+}
+
+/** Lightweight parent/child reference used in the window header. */
+export interface QuestSummary {
+  id: string;
+  name: string;
+  status: QuestStatus;
+}
+
+export interface QuestData {
+  id: string;
+  campaignId: string;
+  createdBy: string;
+  name: string;
+  type: string;
+  status: QuestStatus;
+  publicInfo: string;
+  /** GM-only; '' for non-GM viewers. */
+  privateInfo: string;
+  isPublic: boolean;
+  giver: QuestGiver | null;
+  parentQuestId: string | null;
+  parentQuest: QuestSummary | null;
+  subQuests: QuestSummary[];
+  links: QuestLink[];
+  events: QuestEventLink[];
+  images: QuestImage[];
+  tags: string[];
+  canEdit: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface QuestListItem {
+  id: string;
+  campaignId: string;
+  createdBy: string;
+  name: string;
+  type: string;
+  status: QuestStatus;
+  isPublic: boolean;
+  tags: string[];
+  canEdit: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface QuestGiverInput {
+  kind: QuestGiverKind;
+  id: string;
+}
+
+export interface QuestLinkInput {
+  kind: QuestLinkKind;
+  id: string;
+  role: string;
+  publicInfo: string;
+  privateInfo: string;
+}
+
+export interface QuestEventLinkInput {
+  eventId: string;
+  role: string;
+  publicInfo: string;
+  privateInfo: string;
+}
+
+export interface CreateQuestInput {
+  campaignId: string;
+  name: string;
+  type: string;
+  status: QuestStatus;
+  publicInfo: string;
+  privateInfo: string;
+  isPublic: boolean;
+  giver: QuestGiverInput | null;
+  parentQuestId: string | null;
+  links: QuestLinkInput[];
+  events: QuestEventLinkInput[];
+  images: QuestImage[];
+  tags: string[];
+}
+
+export interface UpdateQuestInput extends CreateQuestInput {
+  id: string;
+}

--- a/app/types/schemas/gmscreens.ts
+++ b/app/types/schemas/gmscreens.ts
@@ -16,6 +16,7 @@ export const SUPPORTED_COLLECTIONS: [string, ...string[]] = [
   'lore',
   'events',
   'organization',
+  'quest',
 ];
 
 // ---------------------------------------------------------------------------

--- a/app/types/schemas/quests.ts
+++ b/app/types/schemas/quests.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+
+const questStatusEnum = z.enum(['not_started', 'active', 'on_hold', 'completed', 'failed']);
+const questGiverKindEnum = z.enum(['character', 'player', 'organization']);
+const questLinkKindEnum = z.enum(['character', 'player', 'location', 'organization']);
+
+const questGiverInputSchema = z
+  .object({
+    kind: questGiverKindEnum,
+    id: z.string().trim().min(1),
+  })
+  .nullable()
+  .default(null);
+
+const questLinkInputSchema = z.object({
+  kind: questLinkKindEnum,
+  id: z.string().trim().min(1),
+  role: z.string().optional().default(''),
+  publicInfo: z.string().optional().default(''),
+  privateInfo: z.string().optional().default(''),
+});
+
+const questEventLinkInputSchema = z.object({
+  eventId: z.string().trim().min(1),
+  role: z.string().optional().default(''),
+  publicInfo: z.string().optional().default(''),
+  privateInfo: z.string().optional().default(''),
+});
+
+const questImageSchema = z.object({
+  url: z.string().trim().min(1),
+  caption: z.string().trim().default(''),
+  crop: z
+    .object({
+      x: z.number().finite().min(0).max(1),
+      y: z.number().finite().min(0).max(1),
+      width: z.number().finite().gt(0).max(1),
+      height: z.number().finite().gt(0).max(1),
+    })
+    .nullable()
+    .default(null),
+});
+
+export const createQuestSchema = z.object({
+  campaignId: z.string().trim().min(1),
+  name: z.string().trim().min(1, 'Name is required'),
+  type: z.string().optional().default(''),
+  status: questStatusEnum.optional().default('not_started'),
+  publicInfo: z.string().optional().default(''),
+  privateInfo: z.string().optional().default(''),
+  isPublic: z.boolean().optional().default(false),
+  giver: questGiverInputSchema,
+  parentQuestId: z.string().trim().min(1).nullable().optional().default(null),
+  links: z.array(questLinkInputSchema).optional().default([]),
+  events: z.array(questEventLinkInputSchema).optional().default([]),
+  images: z.array(questImageSchema).optional().default([]),
+  tags: z.array(z.string()).optional().default([]),
+});
+
+export const updateQuestSchema = createQuestSchema.extend({
+  id: z.string().trim().min(1),
+});
+
+export const deleteQuestSchema = z.object({
+  id: z.string().trim().min(1),
+  campaignId: z.string().trim().min(1),
+});
+
+export const getQuestSchema = z.object({
+  id: z.string().trim().min(1),
+  campaignId: z.string().trim().min(1),
+});
+
+export const listQuestsSchema = z.object({
+  campaignId: z.string().trim().min(1),
+  search: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  status: questStatusEnum.optional(),
+});
+
+export const listQuestsForEntitySchema = z.object({
+  campaignId: z.string().trim().min(1),
+  kind: questLinkKindEnum,
+  id: z.string().trim().min(1),
+});

--- a/app/types/schemas/tabletop.ts
+++ b/app/types/schemas/tabletop.ts
@@ -55,6 +55,7 @@ const TABLETOP_COLLECTIONS: [string, ...string[]] = [
   'lore',
   'events',
   'organization',
+  'quest',
 ];
 
 export const openTabletopWindowSchema = z.object({

--- a/app/utils/queryKeys.ts
+++ b/app/utils/queryKeys.ts
@@ -195,6 +195,15 @@ export const queryKeys = {
     detail: (id: string, campaignId?: string) =>
       ['organizations', 'detail', campaignId ?? '', id] as const,
   },
+  quests: {
+    all: ['quests'] as const,
+    list: (campaignId: string, search?: string, tags?: string[], status?: string) =>
+      ['quests', 'list', campaignId, search ?? '', tags ?? [], status ?? ''] as const,
+    detail: (id: string, campaignId?: string) =>
+      ['quests', 'detail', campaignId ?? '', id] as const,
+    forEntity: (campaignId: string, kind: string, id: string) =>
+      ['quests', 'forEntity', campaignId, kind, id] as const,
+  },
   memberships: {
     all: ['memberships'] as const,
     forOrg: (campaignId: string, organizationId: string) =>

--- a/docs/specs/2026-07-14-quests-design.md
+++ b/docs/specs/2026-07-14-quests-design.md
@@ -1,0 +1,202 @@
+# Quests — Design
+
+**Date:** 2026-07-14 · **Status:** Planned (branch `new-orgs` → PR against `dev`)
+
+## Overview
+
+Quests are a wiki entity representing a story thread the party can take on —
+main quest, side job, personal arc — modeled after Kanka's Quests. A quest has
+public and GM-only (private) descriptive information, a **status**, an optional
+**quest giver** (a character, player, or organization), an optional **parent
+quest** (for sub-quest hierarchies), a freeform **type**, multiple images, tags,
+and rich links to other entities. It links to characters, players, locations,
+and organizations (each link carrying a role plus public + GM-private notes),
+and to calendar events (each event link also carrying a role plus public +
+private notes). Quests are managed in the same wiki UI as organizations, lore,
+races, and locations, and are viewed primarily as **GM-screen and tabletop
+windows**. Characters, players, locations, and organizations gain a **Quests**
+tab (in both the edit modal and the view window) listing every quest that links
+to them.
+
+This slice deliberately mirrors the Organizations vertical slice
+(`docs/specs/2026-07-13-organizations-design.md`) end to end — same stack
+(TanStack Start server functions, Mongoose, React Query, Zod validators, R2 CDN
+images, panel-based wiki UI in `play.tsx`), same privacy discipline, same
+tabletop/GM-screen registry pattern. Where a decision is unstated below, follow
+the Organizations precedent.
+
+## Data model
+
+One new mongoose collection (`quests`, the default pluralized name). Unlike
+Organizations, quest links and event links are **embedded** on the quest
+document rather than kept in a join collection — a quest owns its links and
+there is no independent membership lifecycle to manage.
+
+### `Quest` — `app/server/db/models/Quest.ts`
+
+| Field                     | Type                                                              | Notes                                                                                        |
+| ------------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `name`                    | String, required                                                  | Display name / window title                                                                  |
+| `type`                    | String                                                            | Freeform classification ("Main" / "Side" / "Personal"); autocomplete                         |
+| `status`                  | enum, default `not_started`                                       | `not_started` \| `active` \| `on_hold` \| `completed` \| `failed`                            |
+| `publicInfo`              | String (Markdown)                                                 | Rendered to everyone                                                                         |
+| `privateInfo`             | String (Markdown)                                                 | **GM-only**                                                                                  |
+| `isPublic`                | Boolean, default `false`                                          | Whole-entity visibility gate                                                                 |
+| `giver`                   | `{ kind: 'character' \| 'player' \| 'organization', id } \| null` | Polymorphic quest giver; optional (may be left blank)                                        |
+| `parentQuestId`           | ObjectId → Quest, nullable                                        | Sub-quest hierarchy                                                                          |
+| `links`                   | `[{ kind, id, role, publicInfo, privateInfo }]`                   | `kind`: `character`\|`player`\|`location`\|`organization`; per-link `privateInfo` is GM-only |
+| `events`                  | `[{ eventId → Event, role, publicInfo, privateInfo }]`            | Linked calendar events; per-link `privateInfo` is GM-only                                    |
+| `images`                  | `[{ url, caption, crop }]`                                        | Multiple images (reuses the shared `imageSchema`); **public** — not GM-gated                 |
+| `tags`                    | `[String]`                                                        | Normalized (lowercased/deduped) in `pre('save')`                                             |
+| `campaignId`, `createdBy` | ObjectId                                                          | Scoping / ownership                                                                          |
+| `createdAt`, `updatedAt`  | Date                                                              | Pre-save normalizes tags + bumps `updatedAt`                                                 |
+
+Indexes: `campaignId`, `{campaignId, updatedAt}`, `createdBy`, `tags`,
+`isPublic`, `status`, `parentQuestId`, `giver.id`, `links.id`, `events.eventId`,
+and a text index on `{name, publicInfo}`.
+
+The `links` and `events` entries reuse the same embedded-link shape (`role` +
+`publicInfo` + GM-only `privateInfo`), so the read-time stripping, the merge-on-
+non-GM-update logic, and the editor UI are shared between them. `links` uses a
+polymorphic `{kind, id}`; `events` references the `Event` collection directly by
+`eventId`.
+
+## Privacy model
+
+Identical discipline to Organizations. "Private" always means **GM-only**.
+
+1. **`isPublic` on the quest (whole-entity visibility).** A **private** quest
+   (`isPublic:false`) is entirely GM-only: absent from the wiki list for
+   non-GMs, dropped from the tabletop window list for non-GM viewers, and
+   excluded from every entity's **Quests** tab for non-GMs — a character's
+   involvement in a secret quest never leaks to players. A **public** quest is
+   visible to everyone.
+2. **GM-only fields within a public quest.** `privateInfo`, each link's
+   `privateInfo`, and each event link's `privateInfo` are always stripped from
+   server responses for non-GMs, and writable only by a GM. A non-GM update
+   **preserves** existing private values (merge links by `{kind,id}` and events
+   by `eventId`; omit the quest-level `privateInfo` from `$set`) rather than
+   wiping them.
+
+GM screens are a GM-only surface (nothing stripped). Tabletop is player-facing
+(stripping + the private-quest window drop apply). Quest **giver**, **status**,
+**type**, and **parentQuestId** are public metadata (not stripped) — a public
+quest shows them to everyone; a private quest is hidden wholesale anyway.
+
+## Server API — `app/server/functions/quests.ts`
+
+Quest CRUD (`list/get/create/update/deleteQuest`) + a reverse-lookup query
+(`listQuestsForEntity`, for the Quests tab). Every function authenticates via
+`requireCampaignMember`, gates edits on GM-or-creator
+(`canEdit = isGM || String(createdBy) === userId`), resolves display labels for
+giver/links/events/parent at read time, and strips GM-only fields for non-GMs.
+`LIST_LIMIT = 500` bounds list queries. Tags persist through `ensureTags`;
+telemetry via `serverCaptureException`/`serverCaptureEvent`. React Query hooks
+and the `createServerFn` wrappers live in `app/hooks/useQuests.ts`; query keys in
+`app/utils/queryKeys.ts` (`queryKeys.quests`).
+
+`listQuests` filters by search (`$text`), `tags` (`$all`), `status`, and
+`linkedKind`/`linkedId` (reverse lookup — "quests linked to this entity", via
+`links: { $elemMatch: { kind, id } }`, plus a `giver` match). The list
+projection drops the heavy fields (`publicInfo`, `privateInfo`, `images`,
+`links`, `events`).
+
+**Cleanup on delete:**
+
+- `deleteQuest` removes the quest from any GM screens
+  (`removeDocumentRefsFromScreens(campaignId, 'quest', id)`) and nulls
+  `parentQuestId` on any child quests (children become top-level, not deleted).
+- A new `pruneQuestRefs(kind, id, campaignId)` is called from
+  `deletePlayer` / `deleteCharacter` / `deleteLocation` / `deleteOrganization` /
+  `deleteEvent` to pull dangling `links`, clear a matching `giver`, and pull the
+  matching `events` entry — the same discipline as
+  `pruneMembershipsForMember`. Deleting an organization therefore also runs
+  `pruneQuestRefs('organization', …)` in addition to its existing membership
+  cleanup.
+
+## UI surfaces
+
+- **Wiki:** `app/components/wiki/quests/` — panel (`WikiFilterBar` search + tag
+  filters plus a **status** filter chip row), create/edit modal (name, type
+  autocomplete, status select, giver picker, parent-quest picker, public/private
+  Markdown, `isPublic` toggle, tags, image upload, a **links editor** with
+  per-link role + public/private info, and an **events editor** with the same
+  role + public/private fields), view modal, and the `QuestWindow` render
+  surface (`data-testid="quest-window"`: gallery, status/giver/type/parent +
+  sub-quests header, public/private Markdown, links grouped by kind, and the
+  events list). Registered in `WikiPanel.tsx` (`WikiCategoryId` union,
+  `WIKI_CATEGORIES` with a scroll icon, panel switch) — **not** `gmOnly`, so
+  players see public quests.
+  - `QuestLinksEditor` and `QuestEventsEditor` generalize the existing
+    `OrganizationLocationsEditor` / `EventLinksEditor` (kind dropdown + entity
+    dropdown + role + public/private notes). The giver and parent-quest pickers
+    are single-select entity dropdowns.
+- **Character/player/location/organization:** a **Quests** tab in each entity's
+  edit modal and view window, backed by a shared `EntityQuestsTab` (reverse
+  lookup via `listQuestsForEntity`; read-only list of linked quests with status
+  badges — quests are edited from the quest side, so this tab lists rather than
+  mutates).
+- **GM-screen + tabletop:** `'quest'` registered in `SUPPORTED_COLLECTIONS`
+  (gmscreens), `TABLETOP_COLLECTIONS`, and both `COLLECTION_REGISTRY` hydration
+  maps (fetcher selects `_id name publicInfo isPublic status`; non-GM private
+  quests stripped in `hydrateRefs`). `QuestWindowWrapper` /
+  `EditQuestModalWrapper` render the window in `GMScreensView.tsx` and
+  `TabletopView.tsx`; drag-to-tabletop and "Show on Tabletop" work via a
+  draggable `QuestCard` and the shared `ShowOnTabletopButton`
+  (`application/x-cartyx-document` payload `{ collection: 'quest', documentId,
+title }`).
+
+## Seed data
+
+`scripts/dev_seed.py` (`npm run dev:seed`) seeds the rich campaign ("The Lost
+Mines of Phandelver") with a handful of quests exercising the model:
+
+- Public quests with mixed statuses (e.g. an **active** main quest "Goblin
+  Arrows", a **completed** side quest, an **on-hold** personal arc), each with a
+  giver (character/player/organization), links to characters/locations/orgs
+  (with roles + notes), and one or two linked events with per-event notes.
+- At least one **GM-only private** quest (e.g. "The Black Spider's Plot") with
+  GM-only `privateInfo` and private link/event notes — exercising that a private
+  quest stays hidden from non-GM viewers, including on a linked character's
+  Quests tab.
+- At least one **sub-quest** (a child with `parentQuestId` set) to exercise the
+  hierarchy and the "null children on parent delete" path.
+
+Builder: `build_quest_docs`, inserted in the `rich_session_history` block. Quest
+images are uploaded to R2 with CDN URLs via a new
+`scripts/gen_seed_quest_images.mjs` (mirrors `gen_seed_org_images.mjs`).
+
+## Testing
+
+Unit (Vitest, `npm test`):
+
+- `quest-model.test.ts` — schema, defaults (status `not_started`), tag
+  normalization, embedded link/event shapes.
+- `quests.test.ts` — privacy stripping (quest `privateInfo`, per-link and
+  per-event `privateInfo`), private-quest list filtering, status filter,
+  reverse lookup (`listQuestsForEntity`), cascade delete (GM-screen ref removal
+  - child re-parenting), `pruneQuestRefs` on entity deletes, and GM-or-creator
+    permission gating.
+- Extend the **registry-sync guard** (`lore-window-collection.test.ts`) to
+  assert `'quest'` is present in `SUPPORTED_COLLECTIONS` /
+  `TABLETOP_COLLECTIONS` / both `COLLECTION_REGISTRY` maps.
+- `tabletop-hydration.test.ts` — quest hydration + non-GM private-quest strip.
+- Component tests: `QuestWindow.test.tsx`, `EntityQuestsTab.test.tsx`, and
+  `WikiPanel` quest registration.
+
+E2E (Playwright, `npm run e2e`): `e2e/gmscreens/gmscreens-quest-window.spec.ts`
+— provision a campaign + quest + GM screen directly in MongoDB, synthesize a
+drag of the `application/x-cartyx-document` payload onto the GM-screen tabpanel,
+and assert a `quest-window` appears and persists across reload (the same
+registry-sync guard class as the org e2e).
+
+## Out of scope (Kanka has these; cut for 1.0)
+
+- **Inventory / rewards** — Kanka attaches an inventory to a quest for completion
+  rewards. Not in 1.0.
+- **Calendar auto-event generation** — Kanka can add a quest to a calendar as an
+  event. Quests link to existing events only; they do not create calendar
+  entries. Not in 1.0.
+- **Two-way event links** — event links live on the quest only; the Event window
+  does not list the quests that reference it (no `quest` kind added to Event's
+  `linkSchema`).

--- a/e2e/gmscreens/gmscreens-quest-window.spec.ts
+++ b/e2e/gmscreens/gmscreens-quest-window.spec.ts
@@ -187,10 +187,26 @@ test('dragging a quest onto a GM screen opens a quest window', async ({ page }) 
 
   await expect(questWindow.first()).toBeVisible();
   await expect(page.getByText(QUEST_MARKER).first()).toBeVisible();
+
+  // Regression guard for the GM-screen hydration registry: without a `quest`
+  // fetcher in gmscreens.ts's COLLECTION_REGISTRY, the window TITLE BAR falls
+  // back to the raw `quest:<id>` key instead of the hydrated quest name. The
+  // title bar text is duplicated inside the window's own content (the quest
+  // heading), so assert via the title bar's minimize button, whose
+  // accessible name is built from the same `title` string FloatingWindow
+  // renders in its header — unambiguous, and only ever the header's title.
+  const questDialog = page.locator(`[role="dialog"]:has([data-testid="quest-window"])`).first();
+  await expect(questDialog.getByRole('button', { name: `Minimize ${QUEST_NAME}` })).toBeVisible();
+  await expect(
+    questDialog.getByRole('button', { name: `Minimize quest:${provisioned.questId}` })
+  ).toHaveCount(0);
 });
 
 test('the quest window persists across a reload (stored on the screen)', async ({ page }) => {
   await gotoGMScreens(page);
   await expect(page.getByTestId('quest-window').first()).toBeVisible({ timeout: 20000 });
   await expect(page.getByText(QUEST_MARKER).first()).toBeVisible();
+
+  const questDialog = page.locator(`[role="dialog"]:has([data-testid="quest-window"])`).first();
+  await expect(questDialog.getByRole('button', { name: `Minimize ${QUEST_NAME}` })).toBeVisible();
 });

--- a/e2e/gmscreens/gmscreens-quest-window.spec.ts
+++ b/e2e/gmscreens/gmscreens-quest-window.spec.ts
@@ -1,0 +1,196 @@
+/**
+ * E2E: quests can be dragged onto a GM screen and open a floating
+ * quest window, exactly like monsters/characters/organizations. Regression guard
+ * mirroring gmscreens-organization-window.spec.ts — the class of bug where a new
+ * collection is wired into the Tabletop system but not the parallel GM-screen
+ * SUPPORTED_COLLECTIONS / COLLECTION_REGISTRY / render branch.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { test, expect, type Page } from '@playwright/test';
+import { MongoClient, ObjectId, type Db } from 'mongodb';
+import { decodeJwt } from 'jose';
+
+test.describe.configure({ mode: 'serial', timeout: 90_000 });
+
+const CAMPAIGN_NAME = 'E2E GM Screen Quest';
+const QUEST_NAME = 'E2E Retrieve the Lost Amulet';
+const QUEST_MARKER = 'E2E-QUEST-PUBLIC-MARKER';
+
+interface Provisioned {
+  campaignId: string;
+  questId: string;
+}
+
+let client: MongoClient;
+let provisioned: Provisioned;
+
+function db(): Db {
+  return process.env.MONGODB_DB ? client.db(process.env.MONGODB_DB) : client.db();
+}
+
+async function provision(database: Db): Promise<Provisioned> {
+  const storage = JSON.parse(
+    readFileSync(join(process.cwd(), 'e2e', '.auth', 'storageState.json'), 'utf-8')
+  ) as { cookies: Array<{ name: string; value: string }> };
+  const cookie = storage.cookies.find((c) => c.name === 'cartyx_session');
+  if (!cookie) throw new Error('No cartyx_session cookie — globalSetup did not run?');
+  const providerId = (decodeJwt(cookie.value) as { user?: { id?: string } }).user?.id;
+  const gm = await database.collection('users').findOne({ providerId });
+  if (!gm?._id) throw new Error('Session GM user not found');
+
+  // Clear any leftovers from a previous run.
+  const stale = await database
+    .collection('campaigns')
+    .find({ name: CAMPAIGN_NAME }, { projection: { _id: 1 } })
+    .toArray();
+  if (stale.length) {
+    const ids = stale.map((c) => c._id);
+    await database.collection('gmscreen').deleteMany({ campaignId: { $in: ids } });
+    await database.collection('quests').deleteMany({ campaignId: { $in: ids } });
+    await database.collection('campaigns').deleteMany({ _id: { $in: ids } });
+  }
+
+  const now = new Date();
+  const campaignId = (
+    await database.collection('campaigns').insertOne({
+      gameMasterId: gm._id,
+      name: CAMPAIGN_NAME,
+      description: 'E2E GM-screen quest-window test.',
+      status: 'active',
+      inviteCode: 'e2e-' + Math.random().toString(36).slice(2, 12),
+      maxPlayers: 6,
+      members: [{ userId: gm._id, role: 'gm', joinedAt: now }],
+      links: [],
+      createdAt: now,
+      updatedAt: now,
+    })
+  ).insertedId;
+
+  const questId = (
+    await database.collection('quests').insertOne({
+      campaignId,
+      createdBy: gm._id,
+      name: QUEST_NAME,
+      publicInfo: `A quest to recover a lost artifact. ${QUEST_MARKER}`,
+      privateInfo: '',
+      isPublic: true,
+      status: 'not_started',
+      type: '',
+      giver: null,
+      parentQuestId: null,
+      images: [],
+      links: [],
+      events: [],
+      tags: ['e2e'],
+      createdAt: now,
+      updatedAt: now,
+    })
+  ).insertedId;
+
+  // A GM screen to drop the quest onto.
+  await database.collection('gmscreen').insertOne({
+    campaignId,
+    name: 'Quests',
+    tabOrder: 0,
+    createdBy: gm._id,
+    windows: [],
+    stacks: [],
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  return { campaignId: String(campaignId), questId: String(questId) };
+}
+
+/** Synthesize a document drop onto the GM-screen workspace. */
+async function dropOnScreen(page: Page, collection: string, documentId: string, title: string) {
+  await page.evaluate(
+    ({ collection, documentId, title }) => {
+      const ws = document.querySelector(
+        '[data-testid="gmscreens-view"] [role="tabpanel"]'
+      ) as HTMLElement | null;
+      if (!ws) return;
+      const rect = ws.getBoundingClientRect();
+      const dt = new DataTransfer();
+      dt.setData(
+        'application/x-cartyx-document',
+        JSON.stringify({ collection, documentId, title })
+      );
+      for (const type of ['dragenter', 'dragover', 'drop'] as const) {
+        const ev = new DragEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          clientX: rect.left + rect.width / 2,
+          clientY: rect.top + rect.height / 2,
+        });
+        Object.defineProperty(ev, 'dataTransfer', { value: dt });
+        ws.dispatchEvent(ev);
+      }
+    },
+    { collection, documentId, title }
+  );
+}
+
+async function gotoGMScreens(page: Page) {
+  await page.goto(`/campaigns/${provisioned.campaignId}/play?tab=gmscreens`);
+  const view = page.getByTestId('gmscreens-view');
+  try {
+    await expect(view).toBeVisible({ timeout: 20000 });
+  } catch {
+    await page.reload();
+    await expect(view).toBeVisible({ timeout: 20000 });
+  }
+  await expect(page.locator('[data-testid="gmscreens-view"] [role="tabpanel"]')).toBeVisible({
+    timeout: 15000,
+  });
+}
+
+test.beforeAll(async () => {
+  try {
+    process.loadEnvFile('.env');
+  } catch {
+    /* env may be set externally */
+  }
+  const uri = process.env.MONGODB_URI;
+  if (!uri) throw new Error('MONGODB_URI not set');
+  client = new MongoClient(uri);
+  await client.connect();
+  provisioned = await provision(db());
+});
+
+test.afterAll(async () => {
+  if (!client) return;
+  if (provisioned?.campaignId) {
+    const cid = new ObjectId(provisioned.campaignId);
+    await db().collection('gmscreen').deleteMany({ campaignId: cid });
+    await db().collection('quests').deleteMany({ campaignId: cid });
+    await db().collection('campaigns').deleteMany({ _id: cid });
+  }
+  await client.close();
+});
+
+test('dragging a quest onto a GM screen opens a quest window', async ({ page }) => {
+  await gotoGMScreens(page);
+
+  const questWindow = page.getByTestId('quest-window');
+
+  await expect
+    .poll(
+      async () => {
+        await dropOnScreen(page, 'quest', provisioned.questId, QUEST_NAME);
+        return questWindow.count();
+      },
+      { timeout: 25000, intervals: [250, 500, 750, 1000] }
+    )
+    .toBeGreaterThan(0);
+
+  await expect(questWindow.first()).toBeVisible();
+  await expect(page.getByText(QUEST_MARKER).first()).toBeVisible();
+});
+
+test('the quest window persists across a reload (stored on the screen)', async ({ page }) => {
+  await gotoGMScreens(page);
+  await expect(page.getByTestId('quest-window').first()).toBeVisible({ timeout: 20000 });
+  await expect(page.getByText(QUEST_MARKER).first()).toBeVisible();
+});

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "db:verify": "tsx scripts/mongo-admin.ts verify",
     "db:sync": "tsx scripts/mongo-admin.ts sync",
     "dev:clear": "node scripts/run-python.cjs dev_clear.py",
-    "dev:seed": "node scripts/run-python.cjs dev_seed.py && node scripts/gen_seed_avatars.mjs && node scripts/gen_seed_lore_images.mjs && node scripts/gen_seed_org_images.mjs",
+    "dev:seed": "node scripts/run-python.cjs dev_seed.py && node scripts/gen_seed_avatars.mjs && node scripts/gen_seed_lore_images.mjs && node scripts/gen_seed_org_images.mjs && node scripts/gen_seed_quest_images.mjs",
     "dev:repair-images": "node scripts/run-python.cjs repair_seed_images.py && node scripts/gen_seed_avatars.mjs",
     "dev:gen-avatars": "node scripts/gen_seed_avatars.mjs",
     "fixture": "tsx scripts/dev-fixtures/cli.ts",

--- a/scripts/dev_seed.py
+++ b/scripts/dev_seed.py
@@ -1272,13 +1272,13 @@ def build_quest_docs(*, campaign_id, gm_id, character_by_name, player_doc_ids,
     location_ids      : dict mapping location name → _id.
     event_ids         : dict mapping event title (build_event_docs) → _id.
 
-    NOTE ON PRIVACY: the quest→event join always exposes the linked Event's
-    *title* to every viewer regardless of the Event's own isPublic flag (see
-    resolveEvents in app/server/functions/quests.ts) — only its
-    content/gmContent stay GM-gated. To avoid leaking a GM-only event's title
-    through a PUBLIC quest, only public quests link to public Events here;
-    the private quest's event link points at a private Event, which is safe
-    because the whole quest doc — and therefore its events array — is
+    NOTE ON PRIVACY: resolveEvents (app/server/functions/quests.ts) drops a
+    quest's event link entirely for a non-GM viewer if the linked Event's own
+    isPublic flag is false — so a public quest must only link to public
+    Events, or a non-GM reader will simply see fewer event links than a GM
+    does. Here, only public quests link to public Events; the private
+    quest's event link points at a private Event, which is doubly safe
+    because the whole quest doc — and therefore its events array — is also
     filtered out for non-GM/non-creator viewers before that join ever runs.
     """
     def char(name):
@@ -1307,6 +1307,11 @@ def build_quest_docs(*, campaign_id, gm_id, character_by_name, player_doc_ids,
             return None
         return {"kind": kind, "id": entity_id, "role": role,
                 "publicInfo": public_info, "privateInfo": private_info}
+
+    def giver_ref(kind, entity_id):
+        if not entity_id:
+            return None
+        return {"kind": kind, "id": entity_id}
 
     def event_link(title, role, public_info, private_info=""):
         event_id = event_ids.get(title)
@@ -1363,7 +1368,7 @@ def build_quest_docs(*, campaign_id, gm_id, character_by_name, player_doc_ids,
                 "Wave Echo Cave."
             ),
             is_public=True,
-            giver={"kind": "character", "id": char("Sildar Hallwinter")},
+            giver=giver_ref("character", char("Sildar Hallwinter")),
             tags=["main"],
             links=[
                 link("location", phandalin, "Destination",
@@ -1395,7 +1400,7 @@ def build_quest_docs(*, campaign_id, gm_id, character_by_name, player_doc_ids,
                 "last seen with the reclusive druid Reidoth."
             ),
             is_public=True,
-            giver={"kind": "character", "id": char("Sister Garaele")},
+            giver=giver_ref("character", char("Sister Garaele")),
             tags=["side"],
             links=[
                 link("character", char("Reidoth the Druid"), "Contact",
@@ -1415,7 +1420,7 @@ def build_quest_docs(*, campaign_id, gm_id, character_by_name, player_doc_ids,
                 "the one they owe."
             ),
             is_public=True,
-            giver={"kind": "player", "id": player0},
+            giver=giver_ref("player", player0),
             tags=["personal"],
             links=[
                 link("player", player1, "Confidant",
@@ -1436,7 +1441,7 @@ def build_quest_docs(*, campaign_id, gm_id, character_by_name, player_doc_ids,
                 "Phandalin the party hasn't uncovered."
             ),
             is_public=False,
-            giver={"kind": "organization", "id": org_ids.get("black_spider")},
+            giver=giver_ref("organization", org_ids.get("black_spider")),
             tags=["villain", "secret"],
             links=[
                 link("character", char("Halia Thornton"), "Suspected Agent",

--- a/scripts/dev_seed.py
+++ b/scripts/dev_seed.py
@@ -1250,6 +1250,229 @@ def build_organization_membership_docs(*, org_ids, character_by_name,
     return [m for m in candidates if m is not None]
 
 
+def build_quest_docs(*, campaign_id, gm_id, character_by_name, player_doc_ids,
+                     org_ids, location_ids, event_ids, now):
+    """Return Quest docs for the rich campaign, matching Quest.ts exactly.
+
+    Exercises the full model: a public ACTIVE main quest with a character
+    giver, multi-kind links (character/location/organization), and linked
+    events; a public COMPLETED side quest; a public ON_HOLD personal quest
+    with a player giver and a player-kind link; a GM-only PRIVATE quest with
+    an organization giver, private link/event notes, and a private-info-only
+    linked event; and a SUB-QUEST whose parentQuestId points at the main
+    quest's _id (generated up front so it can be referenced before insertion).
+
+    Arguments
+    ---------
+    character_by_name : dict mapping "First Last" → Character _id (built by
+                        the caller from defn["characters"], same as the
+                        membership builder uses).
+    player_doc_ids    : list of Player document _ids.
+    org_ids           : dict mapping org key (build_organization_docs) → _id.
+    location_ids      : dict mapping location name → _id.
+    event_ids         : dict mapping event title (build_event_docs) → _id.
+
+    NOTE ON PRIVACY: the quest→event join always exposes the linked Event's
+    *title* to every viewer regardless of the Event's own isPublic flag (see
+    resolveEvents in app/server/functions/quests.ts) — only its
+    content/gmContent stay GM-gated. To avoid leaking a GM-only event's title
+    through a PUBLIC quest, only public quests link to public Events here;
+    the private quest's event link points at a private Event, which is safe
+    because the whole quest doc — and therefore its events array — is
+    filtered out for non-GM/non-creator viewers before that join ever runs.
+    """
+    def char(name):
+        return character_by_name.get(name)
+
+    phandalin = location_ids.get("Phandalin") or (
+        next(iter(location_ids.values())) if location_ids else None
+    )
+    player0 = player_doc_ids[0] if player_doc_ids else None
+    player1 = player_doc_ids[1] if len(player_doc_ids) > 1 else None
+
+    # Two generated images per quest — slugs MUST match the QUESTS list in
+    # scripts/gen_seed_quest_images.mjs, which renders the PNGs and (when the
+    # CDN is configured) uploads them to R2 under uploads/quests/ as part of
+    # `npm run dev:seed`.
+    def imgs(slug, name):
+        return [
+            {"url": public_url(f"/uploads/quests/{slug}-1.png"),
+             "caption": f"{name} — scene", "crop": None},
+            {"url": public_url(f"/uploads/quests/{slug}-2.png"),
+             "caption": f"{name} — detail", "crop": None},
+        ]
+
+    def link(kind, entity_id, role, public_info, private_info=""):
+        if not entity_id:
+            return None
+        return {"kind": kind, "id": entity_id, "role": role,
+                "publicInfo": public_info, "privateInfo": private_info}
+
+    def event_link(title, role, public_info, private_info=""):
+        event_id = event_ids.get(title)
+        if not event_id:
+            return None
+        return {"eventId": event_id, "role": role,
+                "publicInfo": public_info, "privateInfo": private_info}
+
+    def quest(name, *, type_, status, public_info, is_public, tags, slug,
+              private_info="", giver=None, parent_quest_id=None,
+              links=None, events=None, quest_id=None):
+        doc = {
+            "name": name,
+            "type": type_,
+            "status": status,
+            "publicInfo": public_info,
+            "privateInfo": private_info,
+            "isPublic": is_public,
+            "giver": giver,
+            "parentQuestId": parent_quest_id,
+            "links": [l for l in (links or []) if l is not None],
+            "events": [e for e in (events or []) if e is not None],
+            "images": imgs(slug, name),
+            "tags": tags,
+            "campaignId": campaign_id,
+            "createdBy": gm_id,
+            "createdAt": now,
+            "updatedAt": now,
+        }
+        if quest_id is not None:
+            doc["_id"] = quest_id
+        return doc
+
+    # Generated up front so the sub-quest can reference it as parentQuestId
+    # before the batch is inserted.
+    main_quest_id = ObjectId()
+
+    return [
+        quest(
+            "Goblin Arrows",
+            type_="Main",
+            status="active",
+            slug="goblin_arrows",
+            quest_id=main_quest_id,
+            public_info=(
+                "Gundren Rockseeker's supply wagon was ambushed on the Triboar "
+                "Trail by Cragmaw goblins. Gundren is missing; his associate "
+                "Sildar Hallwinter asks the party to track the goblins, learn "
+                "what happened to Gundren, and see the wagon safely to Phandalin."
+            ),
+            private_info=(
+                "GM: the goblins report to Cragmaw Castle, which answers in "
+                "turn to the Black Spider — this is the thread that leads to "
+                "Wave Echo Cave."
+            ),
+            is_public=True,
+            giver={"kind": "character", "id": char("Sildar Hallwinter")},
+            tags=["main"],
+            links=[
+                link("location", phandalin, "Destination",
+                     "The wagon and its escort must reach Phandalin."),
+                link("character", char("Gundren Rockseeker"), "Missing",
+                     "Taken captive somewhere along the trail.",
+                     "GM: held at Cragmaw Castle on the Black Spider's orders."),
+                link("organization", org_ids.get("lords_alliance"),
+                     "Interested Party",
+                     "The Lords' Alliance wants the trade road kept safe.",
+                     "GM: quietly hopes for a permanent garrison once the mine reopens."),
+            ],
+            events=[
+                event_link("The Siege of Phandalin", "Started at",
+                           "The ambush was the opening blow of the troubles "
+                           "that soon engulfed Phandalin."),
+                event_link("Wave Echo Cave Rediscovered", "Continues in",
+                           "The search for Gundren leads on toward the lost mine."),
+            ],
+        ),
+        quest(
+            "Old Owl Well",
+            type_="Side",
+            status="completed",
+            slug="old_owl_well",
+            public_info=(
+                "Sister Garaele of the Shrine of Luck asked the party to "
+                "recover a Harper spellbook from the ruins at Old Owl Well, "
+                "last seen with the reclusive druid Reidoth."
+            ),
+            is_public=True,
+            giver={"kind": "character", "id": char("Sister Garaele")},
+            tags=["side"],
+            links=[
+                link("character", char("Reidoth the Druid"), "Contact",
+                     "Guided the party to the ruins and the spellbook's location."),
+                link("location", phandalin, "Origin",
+                     "Sister Garaele gave the party this task at the Shrine of Luck."),
+            ],
+        ),
+        quest(
+            "An Old Debt",
+            type_="Personal",
+            status="on_hold",
+            slug="an_old_debt",
+            public_info=(
+                "Before the road to Phandalin, this adventurer swore to repay "
+                "an old debt of honor. The matter is on hold until they find "
+                "the one they owe."
+            ),
+            is_public=True,
+            giver={"kind": "player", "id": player0},
+            tags=["personal"],
+            links=[
+                link("player", player1, "Confidant",
+                     "The only other member of the party who knows the whole story."),
+            ],
+        ),
+        quest(
+            "The Black Spider's Plot",
+            type_="Villain",
+            status="active",
+            slug="black_spiders_plot",
+            public_info="",
+            private_info=(
+                "GM only: Nezznar the Black Spider, a drow mage, seeks sole "
+                "control of the Forge of Spells in Wave Echo Cave. He ordered "
+                "Gundren captured and Iarno 'Glasstaff' Albrek placed as his "
+                "agent among the Redbrands. His network still has agents in "
+                "Phandalin the party hasn't uncovered."
+            ),
+            is_public=False,
+            giver={"kind": "organization", "id": org_ids.get("black_spider")},
+            tags=["villain", "secret"],
+            links=[
+                link("character", char("Halia Thornton"), "Suspected Agent",
+                     "",
+                     "GM: her Zhentarim ties may overlap with the Black "
+                     "Spider's network — worth investigating."),
+                link("location", phandalin, "Base of Operations",
+                     "",
+                     "GM: the Spider's agents used the cellar beneath "
+                     "Tresendar Manor as a waypoint before the Redbrands fell."),
+            ],
+            events=[
+                event_link("Gundren's Disappearance", "Ordered by",
+                          "", "GM: carried out on the Black Spider's orders."),
+            ],
+        ),
+        quest(
+            "Clear the Cragmaw Hideout",
+            type_="Side",
+            status="completed",
+            slug="cragmaw_hideout",
+            public_info=(
+                "The goblins' trail led to a cave hideout by a stream — the "
+                "party stormed it to free Sildar and recover the wagon."
+            ),
+            is_public=True,
+            parent_quest_id=main_quest_id,
+            tags=["main", "sub-quest"],
+            links=[
+                link("location", phandalin, "Nearby",
+                     "The hideout lies a short march off the Triboar Trail."),
+            ],
+        ),
+    ]
+
+
 # Generic in-character banter the builder samples to pad transcripts to length.
 # Speaker is a player; lines are character-agnostic so any party fits.
 _BANTER_POOL = [
@@ -1858,10 +2081,17 @@ def main() -> None:
                 character_ids=character_ids, location_ids=location_ids, race_ids=race_ids,
                 player_ids=player_doc_ids, session_ids=list(session_ids.values()),
             )
+            # event_ids: title → inserted _id, so quests can link back to the
+            # events they reference (e.g. "Started at" the Siege of Phandalin).
+            event_ids: dict[str, object] = {}
             if event_docs:
                 # Mongoose pluralizes model('Event') to the `events` collection.
-                db.events.insert_many(event_docs)
-            print(f"    events     inserted {len(event_docs)}")
+                event_result = db.events.insert_many(event_docs)
+                event_ids = {
+                    doc["title"]: oid
+                    for doc, oid in zip(event_docs, event_result.inserted_ids)
+                }
+            print(f"    events     inserted {len(event_ids)}")
 
             # Organizations + memberships — link factions to the seeded
             # locations, characters, and players. Includes GM-only private orgs
@@ -1897,6 +2127,20 @@ def main() -> None:
                 # → `organizationmemberships`.
                 db.organizationmemberships.insert_many(membership_docs)
             print(f"    org members inserted {len(membership_docs)}")
+
+            # Quests — a public active main quest, a completed side quest, an
+            # on_hold personal quest, a GM-only private quest, and a sub-quest
+            # of the main quest, wired to the entities/orgs/events above.
+            quest_docs = build_quest_docs(
+                campaign_id=campaign_id, gm_id=gm_id,
+                character_by_name=character_by_name,
+                player_doc_ids=player_doc_ids, org_ids=org_ids,
+                location_ids=location_ids, event_ids=event_ids, now=now,
+            )
+            if quest_docs:
+                # Mongoose pluralizes model('Quest') to the `quests` collection.
+                db.quests.insert_many(quest_docs)
+            print(f"    quests     inserted {len(quest_docs)}")
 
         print()
 

--- a/scripts/gen_seed_quest_images.mjs
+++ b/scripts/gen_seed_quest_images.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+/**
+ * Generate local PNG scene/detail images for seeded quests.
+ *
+ * Each quest gets TWO deterministic images (`<slug>-1.png`, `<slug>-2.png`)
+ * so the wiki + tabletop image gallery has real content to render. The slugs
+ * MUST match the `imgs(...)` slugs in `build_quest_docs` in scripts/dev_seed.py
+ * (`/uploads/quests/<slug>-<n>.png`).
+ *
+ * Style mirrors gen_seed_org_images.mjs (deterministic hue from the slug), with
+ * a parchment/scroll glyph instead of a heraldic shield, and a per-variant hue
+ * shift so the two images for one quest look distinct.
+ *
+ * When the app's CDN is configured (CDN_URL + R2_* env vars) the PNGs are also
+ * uploaded to R2 — exactly like gen_seed_org_images.mjs — so the deployed dev
+ * app (which can't serve local public/uploads/ writes) resolves them via the
+ * CDN. The Python seed sets each image URL via `public_url(...)`, so the
+ * stored URL and the uploaded R2 key agree. Idempotent: local files are
+ * overwritten and R2 objects already present are skipped.
+ *
+ * Usage:
+ *   node scripts/gen_seed_quest_images.mjs
+ *   npm run dev:seed   (called automatically as part of the chain)
+ *
+ * Safety: r2Env() refuses a production-looking R2 bucket.
+ */
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Resvg } from '@resvg/resvg-js';
+import { S3Client, PutObjectCommand, ListObjectsV2Command } from '@aws-sdk/client-s3';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+// --- Minimal .env loader (mirrors gen_seed_org_images.mjs) -------------------
+function loadEnv() {
+  const envPath = join(REPO_ROOT, '.env');
+  if (!existsSync(envPath)) return;
+  for (const raw of readFileSync(envPath, 'utf8').split('\n')) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    let val = line.slice(eq + 1).trim();
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    if (!(key in process.env)) process.env[key] = val;
+  }
+}
+
+// --- CDN / R2 (mirrors gen_seed_org_images.mjs) ------------------------------
+function r2Env() {
+  const keys = [
+    'CDN_URL',
+    'R2_ACCOUNT_ID',
+    'R2_ACCESS_KEY_ID',
+    'R2_SECRET_ACCESS_KEY',
+    'R2_BUCKET',
+  ];
+  const env = Object.fromEntries(keys.map((k) => [k, process.env[k] ?? '']));
+  if (!keys.every((k) => env[k])) return null;
+  if (/prod/i.test(env.R2_BUCKET)) {
+    console.error('R2_BUCKET looks like a production bucket. Aborting.');
+    process.exit(1);
+  }
+  return env;
+}
+
+function r2ClientFor(env) {
+  return new S3Client({
+    region: 'auto',
+    endpoint: `https://${env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+    credentials: { accessKeyId: env.R2_ACCESS_KEY_ID, secretAccessKey: env.R2_SECRET_ACCESS_KEY },
+  });
+}
+
+async function listExistingKeys(s3, bucket, prefix) {
+  const keys = new Set();
+  let token;
+  do {
+    const page = await s3.send(
+      new ListObjectsV2Command({ Bucket: bucket, Prefix: prefix, ContinuationToken: token })
+    );
+    for (const obj of page.Contents ?? []) keys.add(obj.Key);
+    token = page.NextContinuationToken;
+  } while (token);
+  return keys;
+}
+
+// slug → display name. Slugs MUST match build_quest_docs in dev_seed.py.
+const QUESTS = [
+  { slug: 'goblin_arrows', name: 'Goblin Arrows' },
+  { slug: 'old_owl_well', name: 'Old Owl Well' },
+  { slug: 'an_old_debt', name: 'An Old Debt' },
+  { slug: 'black_spiders_plot', name: "The Black Spider's Plot" },
+  { slug: 'cragmaw_hideout', name: 'Clear the Cragmaw Hideout' },
+];
+
+// Two variants per quest — a subtitle + a hue nudge so the images differ.
+const VARIANTS = [
+  { suffix: '1', subtitle: 'Scene' },
+  { suffix: '2', subtitle: 'Detail' },
+];
+
+function hashToHues(slug) {
+  const bytes = createHash('sha1').update(slug).digest();
+  const hue1 = bytes[0] % 360;
+  const hue2 = (hue1 + 40 + (bytes[1] % 60)) % 360;
+  return { hue1, hue2 };
+}
+
+function escapeXml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function wrapTitle(title) {
+  if (title.length <= 22) return [title];
+  const mid = Math.floor(title.length / 2);
+  const before = title.lastIndexOf(' ', mid);
+  const after = title.indexOf(' ', mid);
+  let splitAt;
+  if (before === -1 && after === -1) return [title];
+  if (before === -1) splitAt = after;
+  else if (after === -1) splitAt = before;
+  else splitAt = mid - before <= after - mid ? before : after;
+  return [title.slice(0, splitAt).trim(), title.slice(splitAt + 1).trim()];
+}
+
+/**
+ * Build a deterministic 320×160 scroll banner for a quest variant.
+ * `variantIndex` nudges the hue so the quest's two images look distinct.
+ */
+function questBannerSvg(slug, name, subtitle, variantIndex) {
+  const { hue1, hue2 } = hashToHues(slug);
+  const h1 = (hue1 + variantIndex * 25) % 360;
+  const h2 = (hue2 + variantIndex * 25) % 360;
+  const W = 320;
+  const H = 160;
+
+  const bg1 = `hsl(${h1} 35% 14%)`;
+  const bg2 = `hsl(${h2} 28% 20%)`;
+  const accent = `hsl(${h1} 60% 65%)`;
+  const accentDim = `hsl(${h1} 35% 40%)`;
+  const gradId = `g${slug.replace(/[^a-z0-9]/g, '')}${variantIndex}`;
+
+  // Scroll glyph — left side (a rolled parchment rendered as two arcs + body).
+  const cx = 60;
+  const cy = H / 2;
+
+  const lines = wrapTitle(name);
+  const titleX = 116;
+  const titleAreaWidth = W - titleX - 16;
+
+  let titleSvg = '';
+  if (lines.length === 1) {
+    titleSvg = `<text x="${titleX}" y="${H / 2 - 2}" font-family="Georgia, 'Times New Roman', serif" font-size="20" font-weight="bold" fill="white">${escapeXml(lines[0])}</text>`;
+  } else {
+    titleSvg =
+      `<text x="${titleX}" y="${H / 2 - 16}" font-family="Georgia, 'Times New Roman', serif" font-size="18" font-weight="bold" fill="white">${escapeXml(lines[0])}</text>` +
+      `<text x="${titleX}" y="${H / 2 + 8}" font-family="Georgia, 'Times New Roman', serif" font-size="18" font-weight="bold" fill="white">${escapeXml(lines[1])}</text>`;
+  }
+  const subY = lines.length === 1 ? H / 2 + 22 : H / 2 + 34;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
+  <defs>
+    <linearGradient id="${gradId}" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="${bg1}"/>
+      <stop offset="100%" stop-color="${bg2}"/>
+    </linearGradient>
+  </defs>
+  <rect width="${W}" height="${H}" fill="url(#${gradId})"/>
+  <line x1="8" y1="8" x2="28" y2="8" stroke="${accentDim}" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="8" y1="8" x2="8" y2="28" stroke="${accentDim}" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="${W - 8}" y1="${H - 8}" x2="${W - 28}" y2="${H - 8}" stroke="${accentDim}" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="${W - 8}" y1="${H - 8}" x2="${W - 8}" y2="${H - 28}" stroke="${accentDim}" stroke-width="1.5" stroke-linecap="round"/>
+  <rect x="${cx - 24}" y="${cy - 32}" width="48" height="64" rx="6" fill="${accent}" fill-opacity="0.15" stroke="${accent}" stroke-width="2"/>
+  <ellipse cx="${cx}" cy="${cy - 32}" rx="24" ry="6" fill="${accent}" fill-opacity="0.25" stroke="${accent}" stroke-width="1.5"/>
+  <ellipse cx="${cx}" cy="${cy + 32}" rx="24" ry="6" fill="${accent}" fill-opacity="0.25" stroke="${accent}" stroke-width="1.5"/>
+  <line x1="${cx - 14}" y1="${cy - 12}" x2="${cx + 14}" y2="${cy - 12}" stroke="${accent}" stroke-width="1.5" stroke-opacity="0.7"/>
+  <line x1="${cx - 14}" y1="${cy}" x2="${cx + 14}" y2="${cy}" stroke="${accent}" stroke-width="1.5" stroke-opacity="0.7"/>
+  <line x1="${cx - 14}" y1="${cy + 12}" x2="${cx + 14}" y2="${cy + 12}" stroke="${accent}" stroke-width="1.5" stroke-opacity="0.7"/>
+  <line x1="108" y1="28" x2="108" y2="${H - 28}" stroke="${accentDim}" stroke-width="1" stroke-dasharray="3,3"/>
+  ${titleSvg}
+  <line x1="${titleX}" y1="${subY - 14}" x2="${titleX + titleAreaWidth}" y2="${subY - 14}" stroke="${accent}" stroke-width="1" stroke-opacity="0.5"/>
+  <text x="${titleX}" y="${subY}" font-family="sans-serif" font-size="11" fill="${accent}" fill-opacity="0.85" letter-spacing="1.5">${escapeXml(subtitle.toUpperCase())}</text>
+</svg>`;
+}
+
+function renderPng(svg) {
+  return new Resvg(svg, { fitTo: { mode: 'width', value: 320 } }).render().asPng();
+}
+
+async function main() {
+  loadEnv();
+  if (process.env.NODE_ENV === 'production' || /prod/i.test(process.env.MONGODB_URI ?? '')) {
+    console.error('Refusing to run against a production-looking environment.');
+    process.exit(1);
+  }
+
+  const outDir = join(REPO_ROOT, 'public', 'uploads', 'quests');
+  mkdirSync(outDir, { recursive: true });
+
+  // When the CDN is configured, mirror every image into R2 (the deployed dev
+  // app can't serve local public/uploads/ writes).
+  let cdn = null;
+  const env = r2Env();
+  if (env) {
+    const s3 = r2ClientFor(env);
+    cdn = {
+      s3,
+      bucket: env.R2_BUCKET,
+      existingKeys: await listExistingKeys(s3, env.R2_BUCKET, 'uploads/quests/'),
+    };
+    console.log(`CDN configured — uploading quest images to R2 bucket '${env.R2_BUCKET}'`);
+  }
+
+  let count = 0;
+  let uploaded = 0;
+  const uploads = [];
+  for (const { slug, name } of QUESTS) {
+    for (let i = 0; i < VARIANTS.length; i++) {
+      const v = VARIANTS[i];
+      const variantSlug = `${slug}-${v.suffix}`;
+      const png = renderPng(questBannerSvg(slug, name, v.subtitle, i));
+      writeFileSync(join(outDir, `${variantSlug}.png`), png);
+      count += 1;
+      if (cdn) {
+        const objKey = `uploads/quests/${variantSlug}.png`;
+        if (!cdn.existingKeys.has(objKey)) {
+          uploads.push(
+            cdn.s3
+              .send(
+                new PutObjectCommand({
+                  Bucket: cdn.bucket,
+                  Key: objKey,
+                  Body: png,
+                  ContentType: 'image/png',
+                })
+              )
+              .then(() => {
+                uploaded += 1;
+              })
+          );
+        }
+      }
+    }
+  }
+  await Promise.all(uploads);
+
+  console.log(
+    `\ngen_seed_quest_images: ${count} PNGs generated in public/uploads/quests/` +
+      (cdn ? `, ${uploaded} uploaded to R2` : '')
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/tests/components/mainview/WikiPanel.test.tsx
+++ b/tests/components/mainview/WikiPanel.test.tsx
@@ -73,6 +73,14 @@ vi.mock('~/components/wiki/organizations/OrganizationsPanel', () => ({
   ),
 }));
 
+vi.mock('~/components/wiki/quests/QuestsPanel', () => ({
+  QuestsPanel: ({ onBack }: { onBack: () => void }) => (
+    <div data-testid="quests-panel">
+      <button onClick={onBack}>Back</button>
+    </div>
+  ),
+}));
+
 vi.mock('~/components/wiki/maps/MapsPanel', () => ({
   MapsPanel: ({ onBack }: { onBack: () => void }) => (
     <div data-testid="maps-panel">
@@ -112,11 +120,11 @@ describe('WikiPanel', () => {
     expect(screen.getByRole('button', { name: 'Characters' })).toBeInTheDocument();
   });
 
-  it('shows only the nine player categories when not GM (no Maps, no Monsters, no Events)', () => {
+  it('shows only the ten player categories when not GM (no Maps, no Monsters, no Events)', () => {
     useCampaignMock.mockReturnValue({ campaign: { isGM: false } });
     render(<WikiPanel />);
 
-    expect(screen.getAllByRole('button')).toHaveLength(9);
+    expect(screen.getAllByRole('button')).toHaveLength(10);
     expect(screen.getByRole('button', { name: 'Characters' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Players' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Races' })).toBeInTheDocument();
@@ -128,6 +136,8 @@ describe('WikiPanel', () => {
     expect(screen.getByRole('button', { name: 'Lore' })).toBeInTheDocument();
     // Organizations is visible to all members.
     expect(screen.getByRole('button', { name: 'Organizations' })).toBeInTheDocument();
+    // Quests is visible to all members.
+    expect(screen.getByRole('button', { name: 'Quests' })).toBeInTheDocument();
     // Calendar is visible to all members.
     expect(screen.getByRole('button', { name: 'Calendar' })).toBeInTheDocument();
     // Maps + Monsters + Events are GM-only.
@@ -140,7 +150,7 @@ describe('WikiPanel', () => {
     useCampaignMock.mockReturnValue({ campaign: { isGM: true } });
     render(<WikiPanel />);
 
-    expect(screen.getAllByRole('button')).toHaveLength(12);
+    expect(screen.getAllByRole('button')).toHaveLength(13);
     expect(screen.getByRole('button', { name: 'Maps' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Monsters' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Events' })).toBeInTheDocument();
@@ -190,6 +200,16 @@ describe('WikiPanel', () => {
     await user.click(screen.getByRole('button', { name: 'Organizations' }));
 
     expect(screen.getByTestId('organizations-panel')).toBeInTheDocument();
+  });
+
+  it('clicking Quests shows QuestsPanel', async () => {
+    useCampaignMock.mockReturnValue({ campaign: { isGM: false } });
+    const user = userEvent.setup();
+    render(<WikiPanel />);
+
+    await user.click(screen.getByRole('button', { name: 'Quests' }));
+
+    expect(screen.getByTestId('quests-panel')).toBeInTheDocument();
   });
 
   it('clicking Characters shows CharactersPanel', async () => {

--- a/tests/components/shared/EntityQuestsTab.test.tsx
+++ b/tests/components/shared/EntityQuestsTab.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { EntityQuestsTab } from '~/components/shared/EntityQuestsTab';
+
+vi.mock('~/hooks/useQuests', () => ({
+  useQuestsForEntity: () => ({
+    quests: [
+      {
+        id: 'q1',
+        name: 'Goblin Arrows',
+        status: 'active',
+        type: 'Main',
+        isPublic: true,
+        tags: [],
+        canEdit: true,
+        campaignId: 'c1',
+        createdBy: 'u1',
+        createdAt: '',
+        updatedAt: '',
+      },
+    ],
+    isLoading: false,
+  }),
+}));
+
+describe('EntityQuestsTab', () => {
+  it('lists quests linked to the entity', () => {
+    render(<EntityQuestsTab campaignId="c1" kind="character" id="ch1" />);
+    expect(screen.getByText('Goblin Arrows')).toBeInTheDocument();
+  });
+});

--- a/tests/components/wiki/organizations/OrganizationWindow.test.tsx
+++ b/tests/components/wiki/organizations/OrganizationWindow.test.tsx
@@ -7,6 +7,10 @@ vi.mock('~/hooks/useOrganizations', () => ({
   useMembershipsForOrg: () => ({ memberships: [], isLoading: false }),
 }));
 
+vi.mock('~/hooks/useQuests', () => ({
+  useQuestsForEntity: () => ({ quests: [], isLoading: false }),
+}));
+
 const org: OrganizationData = {
   id: 'o1',
   campaignId: 'c1',

--- a/tests/components/wiki/quests/QuestWindow.test.tsx
+++ b/tests/components/wiki/quests/QuestWindow.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QuestWindow } from '~/components/wiki/quests/QuestWindow';
+import type { QuestData } from '~/types/quest';
+
+const base: QuestData = {
+  id: 'q1',
+  campaignId: 'c1',
+  createdBy: 'u1',
+  name: 'Goblin Arrows',
+  type: 'Main',
+  status: 'active',
+  publicInfo: 'Escort the wagon',
+  privateInfo: 'Ambush',
+  isPublic: true,
+  giver: { kind: 'character', id: 'ch1', label: 'Sildar Hallwinter' },
+  parentQuestId: null,
+  parentQuest: null,
+  subQuests: [],
+  links: [],
+  events: [],
+  images: [],
+  tags: [],
+  canEdit: true,
+  createdAt: '',
+  updatedAt: '',
+};
+
+describe('QuestWindow', () => {
+  it('renders name, status, giver, and public info', () => {
+    render(<QuestWindow quest={base} onEdit={vi.fn()} />);
+    expect(screen.getByTestId('quest-window')).toBeInTheDocument();
+    expect(screen.getByText('Goblin Arrows')).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.getByText(/Sildar Hallwinter/)).toBeInTheDocument();
+    expect(screen.getByText(/Escort the wagon/)).toBeInTheDocument();
+  });
+});

--- a/tests/server/db/quest-model.test.ts
+++ b/tests/server/db/quest-model.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+
+/*
+ * setup.ts mocks mongoose with a MockSchema that does not track paths. Schema
+ * tests need real mongoose, so unmock + resetModules and dynamically import.
+ */
+describe('Quest model', () => {
+  let RealQuest: any;
+
+  beforeAll(async () => {
+    vi.unmock('mongoose');
+    vi.resetModules();
+    const mod = await import('~/server/db/models/Quest');
+    RealQuest = mod.Quest;
+  });
+
+  afterAll(() => {
+    vi.doMock('mongoose', () => {
+      class MockSchema {
+        constructor(_def?: unknown) {}
+        static Types = { ObjectId: String };
+        pre(_hook: string, _fn: unknown) {}
+        index(_def?: unknown) {}
+      }
+      const mockModel = vi.fn(() => ({
+        findOne: vi.fn(),
+        findOneAndUpdate: vi.fn(),
+        findById: vi.fn(),
+        find: vi.fn(),
+        create: vi.fn(),
+        deleteOne: vi.fn(),
+        deleteMany: vi.fn(),
+      }));
+      return {
+        default: {
+          connect: vi.fn(),
+          connection: { readyState: 0 },
+          Schema: MockSchema,
+          model: mockModel,
+          models: {},
+        },
+        Schema: MockSchema,
+        model: mockModel,
+        models: {},
+        connection: { readyState: 0 },
+      };
+    });
+    vi.resetModules();
+  });
+
+  it('defaults status to not_started and normalizes tags on save shape', () => {
+    const q = new RealQuest({
+      name: 'Goblin Arrows',
+      campaignId: '507f1f77bcf86cd799439011',
+      createdBy: '507f1f77bcf86cd799439012',
+      tags: ['Main', 'main', ' Urgent '],
+    });
+    expect(q.status).toBe('not_started');
+    expect(q.isPublic).toBe(false);
+    expect(q.giver).toBeNull();
+    expect(q.parentQuestId).toBeNull();
+    expect(Array.isArray(q.links)).toBe(true);
+    expect(Array.isArray(q.events)).toBe(true);
+  });
+
+  it('rejects an unknown status', () => {
+    const q = new RealQuest({
+      name: 'X',
+      status: 'bogus',
+      campaignId: '507f1f77bcf86cd799439011',
+      createdBy: '507f1f77bcf86cd799439012',
+    });
+    const err = q.validateSync();
+    expect(err?.errors?.status).toBeTruthy();
+  });
+
+  it('accepts embedded links and events with role + notes', () => {
+    const q = new RealQuest({
+      name: 'X',
+      campaignId: '507f1f77bcf86cd799439011',
+      createdBy: '507f1f77bcf86cd799439012',
+      links: [
+        {
+          kind: 'character',
+          id: '507f1f77bcf86cd799439013',
+          role: 'Target',
+          publicInfo: 'pub',
+          privateInfo: 'gm',
+        },
+      ],
+      events: [
+        {
+          eventId: '507f1f77bcf86cd799439014',
+          role: 'Started at',
+          publicInfo: 'p',
+          privateInfo: 'g',
+        },
+      ],
+    });
+    expect(q.validateSync()).toBeUndefined();
+    expect(q.links[0].role).toBe('Target');
+    expect(q.events[0].role).toBe('Started at');
+  });
+});

--- a/tests/server/functions/quest-prune-wiring.test.ts
+++ b/tests/server/functions/quest-prune-wiring.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// This file proves the WIRING only: that each of the five entity delete
+// functions calls `pruneQuestRefs` with the right (kind, id, campaignId), and
+// that a rejection from it is swallowed (captured, not propagated). The
+// behavior of `pruneQuestRefs` itself is covered by quests.test.ts.
+
+vi.mock('~/server/utils/requireCampaignMember', () => ({ requireCampaignMember: vi.fn() }));
+vi.mock('~/server/functions/quests', () => ({ pruneQuestRefs: vi.fn() }));
+vi.mock('~/server/utils/telemetry', () => ({
+  serverCaptureException: vi.fn(),
+  serverCaptureEvent: vi.fn(),
+}));
+vi.mock('~/server/functions/gmscreens-helpers', () => ({ removeDocumentRefsFromScreens: vi.fn() }));
+vi.mock('~/server/functions/tags', () => ({ ensureTags: vi.fn() }));
+
+vi.mock('~/server/db/models/Organization', () => {
+  // deleteOrganization's earlier CRUD siblings `new Organization(doc).save()` —
+  // model the mock as a constructor, matching organizations.test.ts.
+  function OrganizationMock(this: Record<string, unknown>, doc: Record<string, unknown>) {
+    Object.assign(this, doc);
+    this.save = vi.fn().mockResolvedValue(this);
+  }
+  Object.assign(OrganizationMock, {
+    find: vi.fn(),
+    findOne: vi.fn(),
+    findById: vi.fn(),
+    findOneAndUpdate: vi.fn(),
+    deleteOne: vi.fn(),
+  });
+  return { Organization: OrganizationMock };
+});
+vi.mock('~/server/db/models/OrganizationMembership', () => ({
+  OrganizationMembership: {
+    find: vi.fn(),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+}));
+vi.mock('~/server/db/models/Player', () => ({
+  Player: {
+    findById: vi.fn(),
+    findOne: vi.fn(),
+    find: vi.fn(),
+    exists: vi.fn(),
+    updateMany: vi.fn(),
+  },
+}));
+vi.mock('~/server/db/models/Character', () => ({
+  Character: {
+    findById: vi.fn(),
+    findOne: vi.fn(),
+    find: vi.fn(),
+    exists: vi.fn(),
+    updateMany: vi.fn(),
+  },
+}));
+vi.mock('~/server/db/models/Location', () => ({
+  Location: { findById: vi.fn(), updateMany: vi.fn() },
+}));
+vi.mock('~/server/db/models/Event', () => ({
+  Event: { findById: vi.fn(), deleteOne: vi.fn(), updateMany: vi.fn() },
+}));
+vi.mock('~/server/db/models/Lore', () => ({
+  Lore: { updateMany: vi.fn(), create: vi.fn(), findById: vi.fn() },
+}));
+vi.mock('~/server/db/models/Calendar', () => ({ Calendar: { findOne: vi.fn() } }));
+vi.mock('~/server/db/models/Race', () => ({ Race: { findById: vi.fn() } }));
+
+import { requireCampaignMember } from '~/server/utils/requireCampaignMember';
+import { pruneQuestRefs } from '~/server/functions/quests';
+import { serverCaptureException } from '~/server/utils/telemetry';
+import { Organization } from '~/server/db/models/Organization';
+import { OrganizationMembership } from '~/server/db/models/OrganizationMembership';
+import { Player } from '~/server/db/models/Player';
+import { Character } from '~/server/db/models/Character';
+import { Location } from '~/server/db/models/Location';
+import { Event } from '~/server/db/models/Event';
+
+import { deleteOrganization } from '~/server/functions/organizations';
+import { deletePlayer } from '~/server/functions/players';
+import { deleteCharacter } from '~/server/functions/characters';
+import { deleteLocation } from '~/server/functions/locations';
+import { deleteEvent } from '~/server/functions/events';
+
+type DeleteFn = (a: { data: Record<string, unknown> }) => Promise<{ success: boolean }>;
+const call = (fn: unknown) => fn as DeleteFn;
+
+const gmMember = { userId: 'user-1', sessionUserId: 'sess-1', isGM: true };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(requireCampaignMember).mockResolvedValue(gmMember);
+  vi.mocked(pruneQuestRefs).mockResolvedValue(undefined);
+});
+
+// Per-entity setup of the minimal model mocks each delete function needs to
+// reach its post-delete cleanup section.
+const scenarios: Array<{
+  label: string;
+  kind: 'organization' | 'player' | 'character' | 'location' | 'event';
+  id: string;
+  campaignId: string;
+  fn: unknown;
+  setup: () => void;
+}> = [
+  {
+    label: 'deleteOrganization',
+    kind: 'organization',
+    id: 'o1',
+    campaignId: 'camp-1',
+    fn: deleteOrganization,
+    setup: () => {
+      vi.mocked(Organization.findOne).mockReturnValue({
+        lean: vi.fn().mockResolvedValue({ _id: 'o1', campaignId: 'camp-1', createdBy: 'user-1' }),
+      } as never);
+      vi.mocked(Organization.deleteOne).mockResolvedValue({} as never);
+      vi.mocked(OrganizationMembership.deleteMany).mockResolvedValue({} as never);
+    },
+  },
+  {
+    label: 'deletePlayer',
+    kind: 'player',
+    id: 'p1',
+    campaignId: 'camp-1',
+    fn: deletePlayer,
+    setup: () => {
+      vi.mocked(Player.findById).mockResolvedValue({
+        _id: 'p1',
+        campaignId: 'camp-1',
+        deleteOne: vi.fn().mockResolvedValue({}),
+      } as never);
+    },
+  },
+  {
+    label: 'deleteCharacter',
+    kind: 'character',
+    id: 'c1',
+    campaignId: 'camp-1',
+    fn: deleteCharacter,
+    setup: () => {
+      vi.mocked(Character.findById).mockResolvedValue({
+        _id: 'c1',
+        campaignId: 'camp-1',
+        createdBy: 'user-1',
+        deleteOne: vi.fn().mockResolvedValue({}),
+      } as never);
+      vi.mocked(Character.updateMany).mockResolvedValue({} as never);
+      vi.mocked(Player.updateMany).mockResolvedValue({} as never);
+    },
+  },
+  {
+    label: 'deleteLocation',
+    kind: 'location',
+    id: 'l1',
+    campaignId: 'camp-1',
+    fn: deleteLocation,
+    setup: () => {
+      vi.mocked(Location.findById).mockResolvedValue({
+        _id: 'l1',
+        campaignId: 'camp-1',
+        createdBy: 'user-1',
+        parentLocations: [],
+        childLocations: [],
+        images: [],
+        deleteOne: vi.fn().mockResolvedValue({}),
+      } as never);
+    },
+  },
+  {
+    label: 'deleteEvent',
+    kind: 'event',
+    id: 'e1',
+    campaignId: 'camp-1',
+    fn: deleteEvent,
+    setup: () => {
+      vi.mocked(Event.findById).mockReturnValue({
+        lean: vi.fn().mockResolvedValue({ _id: 'e1', campaignId: 'camp-1' }),
+      } as never);
+      vi.mocked(Event.deleteOne).mockResolvedValue({} as never);
+    },
+  },
+];
+
+describe('pruneQuestRefs wiring', () => {
+  for (const s of scenarios) {
+    it(`${s.label} calls pruneQuestRefs('${s.kind}', id, campaignId)`, async () => {
+      s.setup();
+
+      const result = await call(s.fn)({ data: { id: s.id, campaignId: s.campaignId } });
+
+      expect(pruneQuestRefs).toHaveBeenCalledWith(s.kind, s.id, s.campaignId);
+      expect(result.success).toBe(true);
+    });
+
+    it(`${s.label} still succeeds if pruneQuestRefs rejects (swallowed + captured)`, async () => {
+      s.setup();
+      vi.mocked(pruneQuestRefs).mockRejectedValueOnce(new Error('prune boom'));
+
+      const result = await call(s.fn)({ data: { id: s.id, campaignId: s.campaignId } });
+
+      expect(result.success).toBe(true);
+      expect(serverCaptureException).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.anything(),
+        expect.objectContaining({ action: expect.stringContaining('pruneQuests') })
+      );
+    });
+  }
+});

--- a/tests/server/functions/questTestDb.ts
+++ b/tests/server/functions/questTestDb.ts
@@ -184,9 +184,10 @@ export function createFakeModel(prefix: string) {
   };
 }
 
-// A read-only stub for models the quest functions only ever `findOne` for
+// A read-only stub for models the quest functions only ever read from for
 // label-resolution and never write to in these tests (Player, Location,
-// Organization, Event).
+// Organization, Event). `find` returns an empty batch (no matching entities),
+// `findOne` returns null — i.e. the entity never resolves.
 export function createNotFoundModel() {
-  return { findOne: () => chain(null) };
+  return { findOne: () => chain(null), find: () => chain([]) };
 }

--- a/tests/server/functions/questTestDb.ts
+++ b/tests/server/functions/questTestDb.ts
@@ -1,0 +1,192 @@
+import { vi } from 'vitest';
+
+/*
+ * This repo's vitest unit project never talks to a real (or in-memory) Mongo —
+ * tests/setup.ts globally mocks `mongoose` itself, and there is no
+ * mongodb-memory-server / real-Mongo harness anywhere in this codebase (see
+ * memory `reference_seed_ephemeral_mongo`: "the vitest unit suite does not
+ * use a real Mongo"). Server-function tests that need real create → read →
+ * update → delete round-trips therefore back their model mocks with a tiny
+ * in-memory, array-backed fake that emulates just the Mongoose query shapes
+ * those functions use (plain equality, dotted paths into embedded
+ * docs/arrays, $or/$and, $elemMatch, $all, $in, $set, $pull). This file
+ * factors that fake out of quests.test.ts so later suites (Task 4's
+ * Character/Player/Location/Organization/Event server-function tests) can
+ * reuse it instead of re-deriving the same operator semantics.
+ */
+
+function get(obj: unknown, key: string): unknown {
+  return (obj as Record<string, unknown> | null | undefined)?.[key];
+}
+
+export function matchDoc(doc: Record<string, unknown>, filter: Record<string, unknown>): boolean {
+  return Object.entries(filter).every(([key, val]) => {
+    if (key === '$or') return (val as Record<string, unknown>[]).some((f) => matchDoc(doc, f));
+    if (key === '$and') return (val as Record<string, unknown>[]).every((f) => matchDoc(doc, f));
+    if (key === '$text') return true;
+
+    if (key.includes('.')) {
+      const [head, ...rest] = key.split('.');
+      const restKey = rest.join('.');
+      const headVal = get(doc, head);
+      if (Array.isArray(headVal)) {
+        return headVal.some((el) => matchDoc(el as Record<string, unknown>, { [restKey]: val }));
+      }
+      return matchDoc((headVal as Record<string, unknown>) ?? {}, { [restKey]: val });
+    }
+
+    const actual = get(doc, key);
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+      const ops = val as Record<string, unknown>;
+      if ('$elemMatch' in ops) {
+        const arr = (actual as unknown[]) ?? [];
+        return arr.some((item) =>
+          matchDoc(item as Record<string, unknown>, ops.$elemMatch as Record<string, unknown>)
+        );
+      }
+      if ('$in' in ops) return (ops.$in as unknown[]).includes(actual);
+      if ('$all' in ops) {
+        const arr = (actual as unknown[]) ?? [];
+        return (ops.$all as unknown[]).every((v) => arr.includes(v));
+      }
+    }
+    return actual === val;
+  });
+}
+
+export function chain<T>(result: T) {
+  const q: Record<string, unknown> = {};
+  q.select = () => q;
+  q.sort = () => q;
+  q.limit = () => q;
+  q.lean = async () => result;
+  return q;
+}
+
+// Deep-clones a doc the way JSON.parse(JSON.stringify(...)) would (dropping
+// function-valued properties like the fake's own `.save`/`.toObject`), but —
+// unlike JSON round-tripping — preserves `Date` instances instead of turning
+// them into ISO strings, so production's `iso()` helper (`d instanceof
+// Date`) sees real Dates on round-trip instead of always falling back to ''.
+export function clone<T>(d: T): T {
+  return cloneValue(d) as T;
+}
+
+function cloneValue(v: unknown): unknown {
+  if (v instanceof Date) return new Date(v.getTime());
+  if (Array.isArray(v)) return v.map(cloneValue);
+  if (v && typeof v === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(v)) {
+      if (typeof val === 'function') continue;
+      out[k] = cloneValue(val);
+    }
+    return out;
+  }
+  return v;
+}
+
+/**
+ * Build a fake Mongoose-model-shaped object backed by an in-memory array.
+ * Supports both `new Model(doc)` (Quest-style, with `.save()`/`.toObject()`)
+ * and the static methods the quest (and future entity) server functions use:
+ * find/findById/findOne/findOneAndUpdate/create/updateMany/deleteOne/deleteMany.
+ *
+ * `prefix` seeds generated `_id`s (e.g. 'q' -> 'q1', 'q2', ...) so ids stay
+ * readable and collision-free across a test file's fakes.
+ */
+export function createFakeModel(prefix: string) {
+  const docs: Record<string, unknown>[] = [];
+  let seq = 1;
+  const nextId = () => `${prefix}${seq++}`;
+
+  function Model(this: Record<string, unknown>, doc: Record<string, unknown>) {
+    Object.assign(this, { _id: nextId(), ...doc });
+    this.save = vi.fn(async () => {
+      docs.push(clone(this));
+      return this;
+    });
+    this.toObject = () => clone(this);
+  }
+
+  Object.assign(Model, {
+    create: async (doc: Record<string, unknown>) => {
+      const rec = { _id: nextId(), ...doc };
+      docs.push(rec);
+      return rec;
+    },
+    deleteMany: async (filter: Record<string, unknown> = {}) => {
+      for (let i = docs.length - 1; i >= 0; i--) {
+        if (matchDoc(docs[i], filter)) docs.splice(i, 1);
+      }
+      return {};
+    },
+    find: (filter: Record<string, unknown> = {}) =>
+      chain(docs.filter((d) => matchDoc(d, filter)).map(clone)),
+    findOne: (filter: Record<string, unknown>) => {
+      const found = docs.find((d) => matchDoc(d, filter));
+      return chain(found ? clone(found) : null);
+    },
+    findById: (id: string) => {
+      const found = docs.find((d) => d._id === id);
+      return chain(found ? clone(found) : null);
+    },
+    findOneAndUpdate: (
+      filter: Record<string, unknown>,
+      update: { $set?: Record<string, unknown> }
+    ) => {
+      const idx = docs.findIndex((d) => matchDoc(d, filter));
+      if (idx === -1) return chain(null);
+      Object.assign(docs[idx], update.$set ?? {});
+      return chain(clone(docs[idx]));
+    },
+    deleteOne: async (filter: Record<string, unknown>) => {
+      const idx = docs.findIndex((d) => matchDoc(d, filter));
+      if (idx >= 0) docs.splice(idx, 1);
+      return { deletedCount: idx >= 0 ? 1 : 0 };
+    },
+    updateMany: async (
+      filter: Record<string, unknown>,
+      update: { $set?: Record<string, unknown>; $pull?: Record<string, unknown> }
+    ) => {
+      for (const d of docs) {
+        if (!matchDoc(d, filter)) continue;
+        if (update.$set) Object.assign(d, update.$set);
+        if (update.$pull) {
+          for (const [field, cond] of Object.entries(update.$pull)) {
+            const arr = (d[field] as unknown[]) ?? [];
+            d[field] = arr.filter(
+              (item) => !matchDoc(item as Record<string, unknown>, cond as Record<string, unknown>)
+            );
+          }
+        }
+      }
+      return {};
+    },
+  });
+
+  return Model as unknown as {
+    new (doc: Record<string, unknown>): Record<string, unknown>;
+    create: (doc: Record<string, unknown>) => Promise<Record<string, unknown>>;
+    deleteMany: (filter?: Record<string, unknown>) => Promise<Record<string, unknown>>;
+    find: (filter?: Record<string, unknown>) => ReturnType<typeof chain>;
+    findOne: (filter: Record<string, unknown>) => ReturnType<typeof chain>;
+    findById: (id: string) => ReturnType<typeof chain>;
+    findOneAndUpdate: (
+      filter: Record<string, unknown>,
+      update: { $set?: Record<string, unknown> }
+    ) => ReturnType<typeof chain>;
+    deleteOne: (filter: Record<string, unknown>) => Promise<Record<string, unknown>>;
+    updateMany: (
+      filter: Record<string, unknown>,
+      update: { $set?: Record<string, unknown>; $pull?: Record<string, unknown> }
+    ) => Promise<Record<string, unknown>>;
+  };
+}
+
+// A read-only stub for models the quest functions only ever `findOne` for
+// label-resolution and never write to in these tests (Player, Location,
+// Organization, Event).
+export function createNotFoundModel() {
+  return { findOne: () => chain(null) };
+}

--- a/tests/server/functions/quests.test.ts
+++ b/tests/server/functions/quests.test.ts
@@ -718,4 +718,111 @@ describe('quests server functions', () => {
     expect(preserved?.publicInfo).toBe('secret-pub');
     expect(preserved?.privateInfo).toBe('secret-priv');
   });
+
+  it('updateQuest (as non-GM) preserves a private-organization giver the writer never saw (submitted null)', async () => {
+    const privOrg = await Organization.create({
+      name: 'The Zhentarim',
+      campaignId: CAMPAIGN,
+      isPublic: false,
+    });
+    const q = await createQuest({
+      data: {
+        campaignId: CAMPAIGN,
+        name: 'Q',
+        type: '',
+        status: 'active',
+        publicInfo: '',
+        privateInfo: '',
+        isPublic: true,
+        giver: { kind: 'organization', id: String(privOrg._id) },
+        parentQuestId: null,
+        links: [],
+        events: [],
+        images: [],
+        tags: [],
+      },
+    });
+
+    // Non-GM creator never saw the private-org giver (resolveGiver returned null),
+    // so their payload submits giver: null — this must NOT wipe it.
+    member.isGM = false;
+    member.userId = 'u-gm';
+    await updateQuest({
+      data: {
+        id: q.id,
+        campaignId: CAMPAIGN,
+        name: 'Q renamed',
+        type: '',
+        status: 'active',
+        publicInfo: 'pub-updated',
+        privateInfo: '',
+        isPublic: true,
+        giver: null,
+        parentQuestId: null,
+        links: [],
+        events: [],
+        images: [],
+        tags: [],
+      },
+    });
+
+    member.isGM = true;
+    member.userId = 'u-gm';
+    const reloaded = await getQuest({ data: { id: q.id, campaignId: CAMPAIGN } });
+    expect(reloaded?.giver?.kind).toBe('organization');
+    expect(reloaded?.giver?.id).toBe(String(privOrg._id));
+    expect(reloaded?.giver?.label).toBe('The Zhentarim');
+  });
+
+  it('updateQuest (as non-GM) honors clearing a PUBLIC-org giver they could see', async () => {
+    const pubOrg = await Organization.create({
+      name: 'The Lords Alliance',
+      campaignId: CAMPAIGN,
+      isPublic: true,
+    });
+    const q = await createQuest({
+      data: {
+        campaignId: CAMPAIGN,
+        name: 'Q',
+        type: '',
+        status: 'active',
+        publicInfo: '',
+        privateInfo: '',
+        isPublic: true,
+        giver: { kind: 'organization', id: String(pubOrg._id) },
+        parentQuestId: null,
+        links: [],
+        events: [],
+        images: [],
+        tags: [],
+      },
+    });
+
+    // Non-GM COULD see the public-org giver, so submitting null is a genuine clear.
+    member.isGM = false;
+    member.userId = 'u-gm';
+    await updateQuest({
+      data: {
+        id: q.id,
+        campaignId: CAMPAIGN,
+        name: 'Q',
+        type: '',
+        status: 'active',
+        publicInfo: '',
+        privateInfo: '',
+        isPublic: true,
+        giver: null,
+        parentQuestId: null,
+        links: [],
+        events: [],
+        images: [],
+        tags: [],
+      },
+    });
+
+    member.isGM = true;
+    member.userId = 'u-gm';
+    const reloaded = await getQuest({ data: { id: q.id, campaignId: CAMPAIGN } });
+    expect(reloaded?.giver).toBeNull();
+  });
 });

--- a/tests/server/functions/quests.test.ts
+++ b/tests/server/functions/quests.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createFakeModel, createNotFoundModel } from './questTestDb';
 
 // Mirror the requireCampaignMember mock pattern from organizations.test.ts.
 const member = { sessionUserId: 'sess', userId: 'u-gm', isGM: true };
@@ -25,174 +26,19 @@ vi.mock('~/server/functions/gmscreens-helpers', () => ({
  *
  * The task brief's test body assumes real persistence (create → read,
  * create → delete → re-parent, prune-then-reload). To preserve that behavior
- * faithfully without inventing new test infrastructure, this file backs the
- * `Quest` and `Character` model mocks with tiny in-memory, array-backed fakes
- * that support exactly the Mongoose query shapes `app/server/functions/quests.ts`
- * uses (plain equality, dotted paths into embedded docs/arrays, $or/$and,
- * $elemMatch, $all, $in, $set, $pull). Player/Location/Organization/Event are
- * only ever read via a single `findOne`, so they get a simpler fake.
+ * faithfully without inventing new test infrastructure, `Quest` and
+ * `Character` are backed by the shared in-memory model fake in
+ * `./questTestDb` (see that file's header for why it exists and what
+ * Mongoose query shapes it supports). Player/Location/Organization/Event are
+ * only ever read via a single `findOne`, so they get a simpler not-found stub.
  */
 
-function get(obj: unknown, key: string): unknown {
-  return (obj as Record<string, unknown> | null | undefined)?.[key];
-}
-
-function matchDoc(doc: Record<string, unknown>, filter: Record<string, unknown>): boolean {
-  return Object.entries(filter).every(([key, val]) => {
-    if (key === '$or') return (val as Record<string, unknown>[]).some((f) => matchDoc(doc, f));
-    if (key === '$and') return (val as Record<string, unknown>[]).every((f) => matchDoc(doc, f));
-    if (key === '$text') return true;
-
-    if (key.includes('.')) {
-      const [head, ...rest] = key.split('.');
-      const restKey = rest.join('.');
-      const headVal = get(doc, head);
-      if (Array.isArray(headVal)) {
-        return headVal.some((el) => matchDoc(el as Record<string, unknown>, { [restKey]: val }));
-      }
-      return matchDoc((headVal as Record<string, unknown>) ?? {}, { [restKey]: val });
-    }
-
-    const actual = get(doc, key);
-    if (val && typeof val === 'object' && !Array.isArray(val)) {
-      const ops = val as Record<string, unknown>;
-      if ('$elemMatch' in ops) {
-        const arr = (actual as unknown[]) ?? [];
-        return arr.some((item) =>
-          matchDoc(item as Record<string, unknown>, ops.$elemMatch as Record<string, unknown>)
-        );
-      }
-      if ('$in' in ops) return (ops.$in as unknown[]).includes(actual);
-      if ('$all' in ops) {
-        const arr = (actual as unknown[]) ?? [];
-        return (ops.$all as unknown[]).every((v) => arr.includes(v));
-      }
-    }
-    return actual === val;
-  });
-}
-
-function chain<T>(result: T) {
-  const q: Record<string, unknown> = {};
-  q.select = () => q;
-  q.sort = () => q;
-  q.limit = () => q;
-  q.lean = async () => result;
-  return q;
-}
-
-function clone<T>(d: T): T {
-  return JSON.parse(JSON.stringify(d));
-}
-
-// --- Fake Quest collection (supports the exact query shapes quests.ts uses) ---
-const questHoisted = vi.hoisted(() => {
-  const docs: Record<string, unknown>[] = [];
-  let seq = 1;
-  return { docs, nextId: () => `q${seq++}` };
-});
-
-function FakeQuest(this: Record<string, unknown>, doc: Record<string, unknown>) {
-  Object.assign(this, { _id: questHoisted.nextId(), ...doc });
-  this.save = vi.fn(async () => {
-    questHoisted.docs.push(clone(this));
-    return this;
-  });
-  this.toObject = () => clone(this);
-}
-Object.assign(FakeQuest, {
-  deleteMany: async (filter: Record<string, unknown> = {}) => {
-    for (let i = questHoisted.docs.length - 1; i >= 0; i--) {
-      if (matchDoc(questHoisted.docs[i], filter)) questHoisted.docs.splice(i, 1);
-    }
-    return {};
-  },
-  find: (filter: Record<string, unknown> = {}) =>
-    chain(questHoisted.docs.filter((d) => matchDoc(d, filter)).map(clone)),
-  findOne: (filter: Record<string, unknown>) => {
-    const found = questHoisted.docs.find((d) => matchDoc(d, filter));
-    return chain(found ? clone(found) : null);
-  },
-  findById: (id: string) => {
-    const found = questHoisted.docs.find((d) => d._id === id);
-    return chain(found ? clone(found) : null);
-  },
-  findOneAndUpdate: (
-    filter: Record<string, unknown>,
-    update: { $set?: Record<string, unknown> }
-  ) => {
-    const idx = questHoisted.docs.findIndex((d) => matchDoc(d, filter));
-    if (idx === -1) return chain(null);
-    Object.assign(questHoisted.docs[idx], update.$set ?? {});
-    return chain(clone(questHoisted.docs[idx]));
-  },
-  deleteOne: async (filter: Record<string, unknown>) => {
-    const idx = questHoisted.docs.findIndex((d) => matchDoc(d, filter));
-    if (idx >= 0) questHoisted.docs.splice(idx, 1);
-    return { deletedCount: idx >= 0 ? 1 : 0 };
-  },
-  updateMany: async (
-    filter: Record<string, unknown>,
-    update: { $set?: Record<string, unknown>; $pull?: Record<string, unknown> }
-  ) => {
-    for (const d of questHoisted.docs) {
-      if (!matchDoc(d, filter)) continue;
-      if (update.$set) Object.assign(d, update.$set);
-      if (update.$pull) {
-        for (const [field, cond] of Object.entries(update.$pull)) {
-          const arr = (d[field] as unknown[]) ?? [];
-          d[field] = arr.filter(
-            (item) => !matchDoc(item as Record<string, unknown>, cond as Record<string, unknown>)
-          );
-        }
-      }
-    }
-    return {};
-  },
-});
-
-vi.mock('~/server/db/models/Quest', () => ({ Quest: FakeQuest }));
-
-// --- Fake Character collection (create/deleteMany used directly by the test; findOne used by quests.ts label resolution) ---
-const characterHoisted = vi.hoisted(() => {
-  const docs: Record<string, unknown>[] = [];
-  let seq = 1;
-  return { docs, nextId: () => `ch${seq++}` };
-});
-
-vi.mock('~/server/db/models/Character', () => ({
-  Character: {
-    create: async (doc: Record<string, unknown>) => {
-      const rec = { _id: characterHoisted.nextId(), ...doc };
-      characterHoisted.docs.push(rec);
-      return rec;
-    },
-    deleteMany: async () => {
-      characterHoisted.docs.length = 0;
-      return {};
-    },
-    findOne: (filter: Record<string, unknown>) => {
-      const found = characterHoisted.docs.find((d) => matchDoc(d, filter));
-      return chain(found ? clone(found) : null);
-    },
-  },
-}));
-
-// Player/Location/Organization/Event are only ever read via a single findOne
-// in quests.ts and are never referenced by id in this test suite, so a
-// not-found stub is sufficient.
-vi.mock('~/server/db/models/Player', () => ({
-  Player: { findOne: () => chain(null) },
-}));
-vi.mock('~/server/db/models/Location', () => ({
-  Location: { findOne: () => chain(null) },
-}));
-vi.mock('~/server/db/models/Organization', () => ({
-  Organization: { findOne: () => chain(null) },
-}));
-vi.mock('~/server/db/models/Event', () => ({
-  Event: { findOne: () => chain(null) },
-}));
+vi.mock('~/server/db/models/Quest', () => ({ Quest: createFakeModel('q') }));
+vi.mock('~/server/db/models/Character', () => ({ Character: createFakeModel('ch') }));
+vi.mock('~/server/db/models/Player', () => ({ Player: createNotFoundModel() }));
+vi.mock('~/server/db/models/Location', () => ({ Location: createNotFoundModel() }));
+vi.mock('~/server/db/models/Organization', () => ({ Organization: createNotFoundModel() }));
+vi.mock('~/server/db/models/Event', () => ({ Event: createNotFoundModel() }));
 
 import { Quest } from '~/server/db/models/Quest';
 import { Character } from '~/server/db/models/Character';
@@ -200,6 +46,7 @@ import {
   createQuest,
   getQuest,
   listQuests,
+  updateQuest,
   deleteQuest,
   listQuestsForEntity,
   pruneQuestRefs,
@@ -427,5 +274,174 @@ describe('quests server functions', () => {
     const reloaded = await getQuest({ data: { id: q.id, campaignId: CAMPAIGN } });
     expect(reloaded?.giver).toBeNull();
     expect(reloaded?.links).toHaveLength(0);
+  });
+
+  it('updateQuest (as GM) round-trips privateInfo on the quest, a link, and an event', async () => {
+    const ch = await Character.create({ firstName: 'A', lastName: 'B', campaignId: CAMPAIGN });
+    const q = await createQuest({
+      data: {
+        campaignId: CAMPAIGN,
+        name: 'Q',
+        type: '',
+        status: 'active',
+        publicInfo: '',
+        privateInfo: 'quest-secret-1',
+        isPublic: true,
+        giver: null,
+        parentQuestId: null,
+        links: [
+          {
+            kind: 'character',
+            id: String(ch._id),
+            role: 'r1',
+            publicInfo: 'pub1',
+            privateInfo: 'link-secret-1',
+          },
+        ],
+        events: [
+          { eventId: 'evt-1', role: 'er1', publicInfo: 'epub1', privateInfo: 'event-secret-1' },
+        ],
+        images: [],
+        tags: [],
+      },
+    });
+
+    const updated = await updateQuest({
+      data: {
+        id: q.id,
+        campaignId: CAMPAIGN,
+        name: 'Q',
+        type: '',
+        status: 'active',
+        publicInfo: '',
+        privateInfo: 'quest-secret-2',
+        isPublic: true,
+        giver: null,
+        parentQuestId: null,
+        links: [
+          {
+            kind: 'character',
+            id: String(ch._id),
+            role: 'r1',
+            publicInfo: 'pub1',
+            privateInfo: 'link-secret-2',
+          },
+        ],
+        events: [
+          { eventId: 'evt-1', role: 'er1', publicInfo: 'epub1', privateInfo: 'event-secret-2' },
+        ],
+        images: [],
+        tags: [],
+      },
+    });
+
+    expect(updated.privateInfo).toBe('quest-secret-2');
+    expect(updated.links[0].privateInfo).toBe('link-secret-2');
+    expect(updated.events[0].privateInfo).toBe('event-secret-2');
+  });
+
+  it('updateQuest (as non-GM) preserves existing GM-only privateInfo for matched links/events, blanks new ones, and leaves quest-level privateInfo untouched', async () => {
+    const ch = await Character.create({ firstName: 'A', lastName: 'B', campaignId: CAMPAIGN });
+    const q = await createQuest({
+      data: {
+        campaignId: CAMPAIGN,
+        name: 'Q',
+        type: '',
+        status: 'active',
+        publicInfo: '',
+        privateInfo: 'quest-secret',
+        isPublic: true,
+        giver: null,
+        parentQuestId: null,
+        links: [
+          {
+            kind: 'character',
+            id: String(ch._id),
+            role: 'r1',
+            publicInfo: 'pub1',
+            privateInfo: 'link-secret',
+          },
+        ],
+        events: [
+          { eventId: 'evt-1', role: 'er1', publicInfo: 'epub1', privateInfo: 'event-secret' },
+        ],
+        images: [],
+        tags: [],
+      },
+    });
+
+    // Non-GM creator updates the quest: submits an attempted privateInfo change
+    // on the existing (matched) link/event, plus a brand-new link/event.
+    member.isGM = false;
+    member.userId = 'u-gm'; // still the creator, so the update is allowed (not Forbidden)
+
+    await updateQuest({
+      data: {
+        id: q.id,
+        campaignId: CAMPAIGN,
+        name: 'Q renamed',
+        type: '',
+        status: 'active',
+        publicInfo: 'pub-updated',
+        privateInfo: 'attempted-wipe',
+        isPublic: true,
+        giver: null,
+        parentQuestId: null,
+        links: [
+          {
+            kind: 'character',
+            id: String(ch._id),
+            role: 'r1-updated',
+            publicInfo: 'pub1-updated',
+            privateInfo: 'non-gm-attempt-existing',
+          },
+          {
+            kind: 'character',
+            id: 'brand-new-id',
+            role: 'r2',
+            publicInfo: 'pub2',
+            privateInfo: 'non-gm-attempt-new',
+          },
+        ],
+        events: [
+          {
+            eventId: 'evt-1',
+            role: 'er1-updated',
+            publicInfo: 'epub1-updated',
+            privateInfo: 'non-gm-attempt-existing-event',
+          },
+          {
+            eventId: 'evt-2',
+            role: 'er2',
+            publicInfo: 'epub2',
+            privateInfo: 'non-gm-attempt-new-event',
+          },
+        ],
+        images: [],
+        tags: [],
+      },
+    });
+
+    // Read back as GM to see the true stored privateInfo values.
+    member.isGM = true;
+    member.userId = 'u-gm';
+    const reloaded = await getQuest({ data: { id: q.id, campaignId: CAMPAIGN } });
+    expect(reloaded?.name).toBe('Q renamed');
+    expect(reloaded?.publicInfo).toBe('pub-updated');
+    // Quest-level privateInfo is a non-GM writer's blind spot: left untouched, not wiped.
+    expect(reloaded?.privateInfo).toBe('quest-secret');
+
+    const existingLink = reloaded?.links.find((l) => l.id === String(ch._id));
+    expect(existingLink?.privateInfo).toBe('link-secret');
+    expect(existingLink?.role).toBe('r1-updated'); // non-private fields still apply
+
+    const newLink = reloaded?.links.find((l) => l.id === 'brand-new-id');
+    expect(newLink?.privateInfo).toBe('');
+
+    const existingEvent = reloaded?.events.find((e) => e.eventId === 'evt-1');
+    expect(existingEvent?.privateInfo).toBe('event-secret');
+
+    const newEvent = reloaded?.events.find((e) => e.eventId === 'evt-2');
+    expect(newEvent?.privateInfo).toBe('');
   });
 });

--- a/tests/server/functions/quests.test.ts
+++ b/tests/server/functions/quests.test.ts
@@ -1,0 +1,431 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mirror the requireCampaignMember mock pattern from organizations.test.ts.
+const member = { sessionUserId: 'sess', userId: 'u-gm', isGM: true };
+vi.mock('~/server/utils/requireCampaignMember', () => ({
+  requireCampaignMember: vi.fn(async () => member),
+}));
+vi.mock('~/server/utils/telemetry', () => ({
+  serverCaptureException: vi.fn(),
+  serverCaptureEvent: vi.fn(),
+}));
+vi.mock('~/server/functions/tags', () => ({ ensureTags: vi.fn(async () => {}) }));
+vi.mock('~/server/functions/gmscreens-helpers', () => ({
+  removeDocumentRefsFromScreens: vi.fn(async () => {}),
+}));
+
+/*
+ * This repo's vitest unit project never talks to a real (or in-memory) Mongo —
+ * tests/setup.ts globally mocks `mongoose` itself, and every sibling
+ * server-function test (organizations.test.ts, events.test.ts, ...) mocks the
+ * model imports directly with fixed return values. There is no
+ * mongodb-memory-server / real-Mongo harness anywhere in this codebase (see
+ * memory `reference_seed_ephemeral_mongo`: "the vitest unit suite does not
+ * use a real Mongo").
+ *
+ * The task brief's test body assumes real persistence (create → read,
+ * create → delete → re-parent, prune-then-reload). To preserve that behavior
+ * faithfully without inventing new test infrastructure, this file backs the
+ * `Quest` and `Character` model mocks with tiny in-memory, array-backed fakes
+ * that support exactly the Mongoose query shapes `app/server/functions/quests.ts`
+ * uses (plain equality, dotted paths into embedded docs/arrays, $or/$and,
+ * $elemMatch, $all, $in, $set, $pull). Player/Location/Organization/Event are
+ * only ever read via a single `findOne`, so they get a simpler fake.
+ */
+
+function get(obj: unknown, key: string): unknown {
+  return (obj as Record<string, unknown> | null | undefined)?.[key];
+}
+
+function matchDoc(doc: Record<string, unknown>, filter: Record<string, unknown>): boolean {
+  return Object.entries(filter).every(([key, val]) => {
+    if (key === '$or') return (val as Record<string, unknown>[]).some((f) => matchDoc(doc, f));
+    if (key === '$and') return (val as Record<string, unknown>[]).every((f) => matchDoc(doc, f));
+    if (key === '$text') return true;
+
+    if (key.includes('.')) {
+      const [head, ...rest] = key.split('.');
+      const restKey = rest.join('.');
+      const headVal = get(doc, head);
+      if (Array.isArray(headVal)) {
+        return headVal.some((el) => matchDoc(el as Record<string, unknown>, { [restKey]: val }));
+      }
+      return matchDoc((headVal as Record<string, unknown>) ?? {}, { [restKey]: val });
+    }
+
+    const actual = get(doc, key);
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+      const ops = val as Record<string, unknown>;
+      if ('$elemMatch' in ops) {
+        const arr = (actual as unknown[]) ?? [];
+        return arr.some((item) =>
+          matchDoc(item as Record<string, unknown>, ops.$elemMatch as Record<string, unknown>)
+        );
+      }
+      if ('$in' in ops) return (ops.$in as unknown[]).includes(actual);
+      if ('$all' in ops) {
+        const arr = (actual as unknown[]) ?? [];
+        return (ops.$all as unknown[]).every((v) => arr.includes(v));
+      }
+    }
+    return actual === val;
+  });
+}
+
+function chain<T>(result: T) {
+  const q: Record<string, unknown> = {};
+  q.select = () => q;
+  q.sort = () => q;
+  q.limit = () => q;
+  q.lean = async () => result;
+  return q;
+}
+
+function clone<T>(d: T): T {
+  return JSON.parse(JSON.stringify(d));
+}
+
+// --- Fake Quest collection (supports the exact query shapes quests.ts uses) ---
+const questHoisted = vi.hoisted(() => {
+  const docs: Record<string, unknown>[] = [];
+  let seq = 1;
+  return { docs, nextId: () => `q${seq++}` };
+});
+
+function FakeQuest(this: Record<string, unknown>, doc: Record<string, unknown>) {
+  Object.assign(this, { _id: questHoisted.nextId(), ...doc });
+  this.save = vi.fn(async () => {
+    questHoisted.docs.push(clone(this));
+    return this;
+  });
+  this.toObject = () => clone(this);
+}
+Object.assign(FakeQuest, {
+  deleteMany: async (filter: Record<string, unknown> = {}) => {
+    for (let i = questHoisted.docs.length - 1; i >= 0; i--) {
+      if (matchDoc(questHoisted.docs[i], filter)) questHoisted.docs.splice(i, 1);
+    }
+    return {};
+  },
+  find: (filter: Record<string, unknown> = {}) =>
+    chain(questHoisted.docs.filter((d) => matchDoc(d, filter)).map(clone)),
+  findOne: (filter: Record<string, unknown>) => {
+    const found = questHoisted.docs.find((d) => matchDoc(d, filter));
+    return chain(found ? clone(found) : null);
+  },
+  findById: (id: string) => {
+    const found = questHoisted.docs.find((d) => d._id === id);
+    return chain(found ? clone(found) : null);
+  },
+  findOneAndUpdate: (
+    filter: Record<string, unknown>,
+    update: { $set?: Record<string, unknown> }
+  ) => {
+    const idx = questHoisted.docs.findIndex((d) => matchDoc(d, filter));
+    if (idx === -1) return chain(null);
+    Object.assign(questHoisted.docs[idx], update.$set ?? {});
+    return chain(clone(questHoisted.docs[idx]));
+  },
+  deleteOne: async (filter: Record<string, unknown>) => {
+    const idx = questHoisted.docs.findIndex((d) => matchDoc(d, filter));
+    if (idx >= 0) questHoisted.docs.splice(idx, 1);
+    return { deletedCount: idx >= 0 ? 1 : 0 };
+  },
+  updateMany: async (
+    filter: Record<string, unknown>,
+    update: { $set?: Record<string, unknown>; $pull?: Record<string, unknown> }
+  ) => {
+    for (const d of questHoisted.docs) {
+      if (!matchDoc(d, filter)) continue;
+      if (update.$set) Object.assign(d, update.$set);
+      if (update.$pull) {
+        for (const [field, cond] of Object.entries(update.$pull)) {
+          const arr = (d[field] as unknown[]) ?? [];
+          d[field] = arr.filter(
+            (item) => !matchDoc(item as Record<string, unknown>, cond as Record<string, unknown>)
+          );
+        }
+      }
+    }
+    return {};
+  },
+});
+
+vi.mock('~/server/db/models/Quest', () => ({ Quest: FakeQuest }));
+
+// --- Fake Character collection (create/deleteMany used directly by the test; findOne used by quests.ts label resolution) ---
+const characterHoisted = vi.hoisted(() => {
+  const docs: Record<string, unknown>[] = [];
+  let seq = 1;
+  return { docs, nextId: () => `ch${seq++}` };
+});
+
+vi.mock('~/server/db/models/Character', () => ({
+  Character: {
+    create: async (doc: Record<string, unknown>) => {
+      const rec = { _id: characterHoisted.nextId(), ...doc };
+      characterHoisted.docs.push(rec);
+      return rec;
+    },
+    deleteMany: async () => {
+      characterHoisted.docs.length = 0;
+      return {};
+    },
+    findOne: (filter: Record<string, unknown>) => {
+      const found = characterHoisted.docs.find((d) => matchDoc(d, filter));
+      return chain(found ? clone(found) : null);
+    },
+  },
+}));
+
+// Player/Location/Organization/Event are only ever read via a single findOne
+// in quests.ts and are never referenced by id in this test suite, so a
+// not-found stub is sufficient.
+vi.mock('~/server/db/models/Player', () => ({
+  Player: { findOne: () => chain(null) },
+}));
+vi.mock('~/server/db/models/Location', () => ({
+  Location: { findOne: () => chain(null) },
+}));
+vi.mock('~/server/db/models/Organization', () => ({
+  Organization: { findOne: () => chain(null) },
+}));
+vi.mock('~/server/db/models/Event', () => ({
+  Event: { findOne: () => chain(null) },
+}));
+
+import { Quest } from '~/server/db/models/Quest';
+import { Character } from '~/server/db/models/Character';
+import {
+  createQuest,
+  getQuest,
+  listQuests,
+  deleteQuest,
+  listQuestsForEntity,
+  pruneQuestRefs,
+} from '~/server/functions/quests';
+
+const CAMPAIGN = '507f1f77bcf86cd799439011';
+
+beforeEach(async () => {
+  await Quest.deleteMany({});
+  await Character.deleteMany({});
+  member.isGM = true;
+  member.userId = 'u-gm';
+});
+
+describe('quests server functions', () => {
+  it('creates a quest and resolves its giver + link labels', async () => {
+    const ch = await Character.create({
+      firstName: 'Sildar',
+      lastName: 'Hallwinter',
+      campaignId: CAMPAIGN,
+    });
+    const q = await createQuest({
+      data: {
+        campaignId: CAMPAIGN,
+        name: 'Goblin Arrows',
+        type: 'Main',
+        status: 'active',
+        publicInfo: 'Escort the wagon',
+        privateInfo: 'Ambush at the bend',
+        isPublic: true,
+        giver: { kind: 'character', id: String(ch._id) },
+        parentQuestId: null,
+        links: [
+          {
+            kind: 'character',
+            id: String(ch._id),
+            role: 'Escort',
+            publicInfo: 'p',
+            privateInfo: 'g',
+          },
+        ],
+        events: [],
+        images: [],
+        tags: ['main'],
+      },
+    });
+    expect(q.status).toBe('active');
+    expect(q.giver?.label).toBe('Sildar Hallwinter');
+    expect(q.links[0].label).toBe('Sildar Hallwinter');
+    expect(q.links[0].privateInfo).toBe('g');
+  });
+
+  it('strips GM-only fields for a non-GM reader', async () => {
+    const q = await createQuest({
+      data: {
+        campaignId: CAMPAIGN,
+        name: 'Secret',
+        type: '',
+        status: 'active',
+        publicInfo: 'pub',
+        privateInfo: 'gm-secret',
+        isPublic: true,
+        giver: null,
+        parentQuestId: null,
+        links: [
+          {
+            kind: 'player',
+            id: '507f1f77bcf86cd799439099',
+            role: '',
+            publicInfo: 'p',
+            privateInfo: 'gm-link',
+          },
+        ],
+        events: [],
+        images: [],
+        tags: [],
+      },
+    });
+    member.isGM = false;
+    member.userId = 'someone-else';
+    const read = await getQuest({ data: { id: q.id, campaignId: CAMPAIGN } });
+    expect(read?.privateInfo).toBe('');
+    expect(read?.links[0].privateInfo).toBe('');
+    expect(read?.publicInfo).toBe('pub');
+  });
+
+  it('hides a private quest from a non-GM non-creator', async () => {
+    const q = await createQuest({
+      data: {
+        campaignId: CAMPAIGN,
+        name: 'Hidden',
+        type: '',
+        status: 'active',
+        publicInfo: '',
+        privateInfo: '',
+        isPublic: false,
+        giver: null,
+        parentQuestId: null,
+        links: [],
+        events: [],
+        images: [],
+        tags: [],
+      },
+    });
+    member.isGM = false;
+    member.userId = 'not-creator';
+    expect(await getQuest({ data: { id: q.id, campaignId: CAMPAIGN } })).toBeNull();
+    const list = await listQuests({ data: { campaignId: CAMPAIGN } });
+    expect(list.find((x) => x.id === q.id)).toBeUndefined();
+  });
+
+  it('filters the list by status', async () => {
+    for (const s of ['active', 'completed'] as const) {
+      await createQuest({
+        data: {
+          campaignId: CAMPAIGN,
+          name: s,
+          type: '',
+          status: s,
+          publicInfo: '',
+          privateInfo: '',
+          isPublic: true,
+          giver: null,
+          parentQuestId: null,
+          links: [],
+          events: [],
+          images: [],
+          tags: [],
+        },
+      });
+    }
+    const active = await listQuests({ data: { campaignId: CAMPAIGN, status: 'active' } });
+    expect(active).toHaveLength(1);
+    expect(active[0].status).toBe('active');
+  });
+
+  it('re-parents child quests on parent delete', async () => {
+    const parent = await createQuest({
+      data: {
+        campaignId: CAMPAIGN,
+        name: 'Parent',
+        type: '',
+        status: 'active',
+        publicInfo: '',
+        privateInfo: '',
+        isPublic: true,
+        giver: null,
+        parentQuestId: null,
+        links: [],
+        events: [],
+        images: [],
+        tags: [],
+      },
+    });
+    const child = await createQuest({
+      data: {
+        campaignId: CAMPAIGN,
+        name: 'Child',
+        type: '',
+        status: 'active',
+        publicInfo: '',
+        privateInfo: '',
+        isPublic: true,
+        giver: null,
+        parentQuestId: parent.id,
+        links: [],
+        events: [],
+        images: [],
+        tags: [],
+      },
+    });
+    await deleteQuest({ data: { id: parent.id, campaignId: CAMPAIGN } });
+    const reloaded = await getQuest({ data: { id: child.id, campaignId: CAMPAIGN } });
+    expect(reloaded?.parentQuestId).toBeNull();
+  });
+
+  it('listQuestsForEntity returns quests linking or given by an entity', async () => {
+    const ch = await Character.create({ firstName: 'A', lastName: 'B', campaignId: CAMPAIGN });
+    await createQuest({
+      data: {
+        campaignId: CAMPAIGN,
+        name: 'Linked',
+        type: '',
+        status: 'active',
+        publicInfo: '',
+        privateInfo: '',
+        isPublic: true,
+        giver: { kind: 'character', id: String(ch._id) },
+        parentQuestId: null,
+        links: [],
+        events: [],
+        images: [],
+        tags: [],
+      },
+    });
+    const found = await listQuestsForEntity({
+      data: { campaignId: CAMPAIGN, kind: 'character', id: String(ch._id) },
+    });
+    expect(found).toHaveLength(1);
+    expect(found[0].name).toBe('Linked');
+  });
+
+  it('pruneQuestRefs clears giver, links, and events for a deleted entity', async () => {
+    const ch = await Character.create({ firstName: 'A', lastName: 'B', campaignId: CAMPAIGN });
+    const q = await createQuest({
+      data: {
+        campaignId: CAMPAIGN,
+        name: 'Q',
+        type: '',
+        status: 'active',
+        publicInfo: '',
+        privateInfo: '',
+        isPublic: true,
+        giver: { kind: 'character', id: String(ch._id) },
+        parentQuestId: null,
+        links: [
+          { kind: 'character', id: String(ch._id), role: '', publicInfo: '', privateInfo: '' },
+        ],
+        events: [],
+        images: [],
+        tags: [],
+      },
+    });
+    await pruneQuestRefs('character', String(ch._id), CAMPAIGN);
+    const reloaded = await getQuest({ data: { id: q.id, campaignId: CAMPAIGN } });
+    expect(reloaded?.giver).toBeNull();
+    expect(reloaded?.links).toHaveLength(0);
+  });
+});

--- a/tests/server/functions/quests.test.ts
+++ b/tests/server/functions/quests.test.ts
@@ -40,11 +40,15 @@ vi.mock('~/server/db/models/Quest', () => ({ Quest: createFakeModel('q') }));
 vi.mock('~/server/db/models/Character', () => ({ Character: createFakeModel('ch') }));
 vi.mock('~/server/db/models/Player', () => ({ Player: createNotFoundModel() }));
 vi.mock('~/server/db/models/Location', () => ({ Location: createNotFoundModel() }));
-vi.mock('~/server/db/models/Organization', () => ({ Organization: createNotFoundModel() }));
+// Organization uses the fake model (not the not-found stub) so tests can create
+// orgs with an `isPublic` flag to exercise the private-org gating in
+// resolveLinks/resolveGiver/mergeLinkPrivate.
+vi.mock('~/server/db/models/Organization', () => ({ Organization: createFakeModel('org') }));
 vi.mock('~/server/db/models/Event', () => ({ Event: createFakeModel('ev') }));
 
 import { Quest } from '~/server/db/models/Quest';
 import { Character } from '~/server/db/models/Character';
+import { Organization } from '~/server/db/models/Organization';
 import { Event } from '~/server/db/models/Event';
 import {
   createQuest,
@@ -62,6 +66,7 @@ beforeEach(async () => {
   await Quest.deleteMany({});
   await Character.deleteMany({});
   await Event.deleteMany({});
+  await Organization.deleteMany({});
   member.isGM = true;
   member.userId = 'u-gm';
 });
@@ -553,6 +558,161 @@ describe('quests server functions', () => {
     member.userId = 'u-gm';
     const reloaded = await getQuest({ data: { id: q.id, campaignId: CAMPAIGN } });
     const preserved = reloaded?.events.find((e) => e.eventId === String(privEvent._id));
+    expect(preserved).toBeDefined();
+    expect(preserved?.role).toBe('secret-role');
+    expect(preserved?.publicInfo).toBe('secret-pub');
+    expect(preserved?.privateInfo).toBe('secret-priv');
+  });
+
+  it('drops a private-organization link for a non-GM but keeps a public one; a GM sees both', async () => {
+    const pubOrg = await Organization.create({
+      name: 'The Harpers',
+      campaignId: CAMPAIGN,
+      isPublic: true,
+    });
+    const privOrg = await Organization.create({
+      name: 'The Black Spider Network',
+      campaignId: CAMPAIGN,
+      isPublic: false,
+    });
+    const q = await createQuest({
+      data: {
+        campaignId: CAMPAIGN,
+        name: 'Faction quest',
+        type: '',
+        status: 'active',
+        publicInfo: '',
+        privateInfo: '',
+        isPublic: true,
+        giver: null,
+        parentQuestId: null,
+        links: [
+          {
+            kind: 'organization',
+            id: String(pubOrg._id),
+            role: 'ally',
+            publicInfo: 'p1',
+            privateInfo: 'gm1',
+          },
+          {
+            kind: 'organization',
+            id: String(privOrg._id),
+            role: 'enemy',
+            publicInfo: 'p2',
+            privateInfo: 'gm2',
+          },
+        ],
+        events: [],
+        images: [],
+        tags: [],
+      },
+    });
+
+    const asGM = await getQuest({ data: { id: q.id, campaignId: CAMPAIGN } });
+    expect(asGM?.links.map((l) => l.id).sort()).toEqual(
+      [String(pubOrg._id), String(privOrg._id)].sort()
+    );
+
+    member.isGM = false;
+    member.userId = 'someone-else';
+    const asNonGM = await getQuest({ data: { id: q.id, campaignId: CAMPAIGN } });
+    expect(asNonGM?.links).toHaveLength(1);
+    expect(asNonGM?.links[0].id).toBe(String(pubOrg._id));
+    expect(asNonGM?.links[0].label).toBe('The Harpers');
+  });
+
+  it('hides a private-organization giver from a non-GM but shows it to a GM', async () => {
+    const privOrg = await Organization.create({
+      name: 'The Black Spider Network',
+      campaignId: CAMPAIGN,
+      isPublic: false,
+    });
+    const q = await createQuest({
+      data: {
+        campaignId: CAMPAIGN,
+        name: 'Given by a secret org',
+        type: '',
+        status: 'active',
+        publicInfo: '',
+        privateInfo: '',
+        isPublic: true,
+        giver: { kind: 'organization', id: String(privOrg._id) },
+        parentQuestId: null,
+        links: [],
+        events: [],
+        images: [],
+        tags: [],
+      },
+    });
+
+    const asGM = await getQuest({ data: { id: q.id, campaignId: CAMPAIGN } });
+    expect(asGM?.giver?.label).toBe('The Black Spider Network');
+
+    member.isGM = false;
+    member.userId = 'someone-else';
+    const asNonGM = await getQuest({ data: { id: q.id, campaignId: CAMPAIGN } });
+    expect(asNonGM?.giver).toBeNull();
+  });
+
+  it('updateQuest (as non-GM) preserves a private-organization link the writer never saw, even when omitted from their payload', async () => {
+    const privOrg = await Organization.create({
+      name: 'The Cult of the Dragon',
+      campaignId: CAMPAIGN,
+      isPublic: false,
+    });
+    const q = await createQuest({
+      data: {
+        campaignId: CAMPAIGN,
+        name: 'Q',
+        type: '',
+        status: 'active',
+        publicInfo: '',
+        privateInfo: '',
+        isPublic: true,
+        giver: null,
+        parentQuestId: null,
+        links: [
+          {
+            kind: 'organization',
+            id: String(privOrg._id),
+            role: 'secret-role',
+            publicInfo: 'secret-pub',
+            privateInfo: 'secret-priv',
+          },
+        ],
+        events: [],
+        images: [],
+        tags: [],
+      },
+    });
+
+    // Non-GM creator: resolveLinks never showed them the private-org link,
+    // so their submitted `links` payload legitimately omits it entirely.
+    member.isGM = false;
+    member.userId = 'u-gm';
+    await updateQuest({
+      data: {
+        id: q.id,
+        campaignId: CAMPAIGN,
+        name: 'Q renamed',
+        type: '',
+        status: 'active',
+        publicInfo: 'pub-updated',
+        privateInfo: '',
+        isPublic: true,
+        giver: null,
+        parentQuestId: null,
+        links: [],
+        events: [],
+        images: [],
+        tags: [],
+      },
+    });
+
+    member.isGM = true;
+    member.userId = 'u-gm';
+    const reloaded = await getQuest({ data: { id: q.id, campaignId: CAMPAIGN } });
+    const preserved = reloaded?.links.find((l) => l.id === String(privOrg._id));
     expect(preserved).toBeDefined();
     expect(preserved?.role).toBe('secret-role');
     expect(preserved?.publicInfo).toBe('secret-pub');

--- a/tests/server/functions/quests.test.ts
+++ b/tests/server/functions/quests.test.ts
@@ -29,8 +29,11 @@ vi.mock('~/server/functions/gmscreens-helpers', () => ({
  * faithfully without inventing new test infrastructure, `Quest` and
  * `Character` are backed by the shared in-memory model fake in
  * `./questTestDb` (see that file's header for why it exists and what
- * Mongoose query shapes it supports). Player/Location/Organization/Event are
+ * Mongoose query shapes it supports). Player/Location/Organization are
  * only ever read via a single `findOne`, so they get a simpler not-found stub.
+ * `Event` also uses the fake model (not the not-found stub) so tests can
+ * create events with an `isPublic` flag to exercise the private-event-link
+ * gating in resolveEvents/mergeEventPrivate.
  */
 
 vi.mock('~/server/db/models/Quest', () => ({ Quest: createFakeModel('q') }));
@@ -38,10 +41,11 @@ vi.mock('~/server/db/models/Character', () => ({ Character: createFakeModel('ch'
 vi.mock('~/server/db/models/Player', () => ({ Player: createNotFoundModel() }));
 vi.mock('~/server/db/models/Location', () => ({ Location: createNotFoundModel() }));
 vi.mock('~/server/db/models/Organization', () => ({ Organization: createNotFoundModel() }));
-vi.mock('~/server/db/models/Event', () => ({ Event: createNotFoundModel() }));
+vi.mock('~/server/db/models/Event', () => ({ Event: createFakeModel('ev') }));
 
 import { Quest } from '~/server/db/models/Quest';
 import { Character } from '~/server/db/models/Character';
+import { Event } from '~/server/db/models/Event';
 import {
   createQuest,
   getQuest,
@@ -57,6 +61,7 @@ const CAMPAIGN = '507f1f77bcf86cd799439011';
 beforeEach(async () => {
   await Quest.deleteMany({});
   await Character.deleteMany({});
+  await Event.deleteMany({});
   member.isGM = true;
   member.userId = 'u-gm';
 });
@@ -443,5 +448,114 @@ describe('quests server functions', () => {
 
     const newEvent = reloaded?.events.find((e) => e.eventId === 'evt-2');
     expect(newEvent?.privateInfo).toBe('');
+  });
+
+  it('drops a private-event link for a non-GM viewer but keeps a public one; a GM sees both', async () => {
+    const pubEvent = await Event.create({
+      title: 'Public Ambush',
+      campaignId: CAMPAIGN,
+      isPublic: true,
+    });
+    const privEvent = await Event.create({
+      title: 'Secret Meeting',
+      campaignId: CAMPAIGN,
+      isPublic: false,
+    });
+    const q = await createQuest({
+      data: {
+        campaignId: CAMPAIGN,
+        name: 'Multi-event quest',
+        type: '',
+        status: 'active',
+        publicInfo: '',
+        privateInfo: '',
+        isPublic: true,
+        giver: null,
+        parentQuestId: null,
+        links: [],
+        events: [
+          { eventId: String(pubEvent._id), role: 'r1', publicInfo: 'p1', privateInfo: 'gm1' },
+          { eventId: String(privEvent._id), role: 'r2', publicInfo: 'p2', privateInfo: 'gm2' },
+        ],
+        images: [],
+        tags: [],
+      },
+    });
+
+    const asGM = await getQuest({ data: { id: q.id, campaignId: CAMPAIGN } });
+    expect(asGM?.events.map((e) => e.eventId).sort()).toEqual(
+      [String(pubEvent._id), String(privEvent._id)].sort()
+    );
+
+    member.isGM = false;
+    member.userId = 'someone-else';
+    const asNonGM = await getQuest({ data: { id: q.id, campaignId: CAMPAIGN } });
+    expect(asNonGM?.events).toHaveLength(1);
+    expect(asNonGM?.events[0].eventId).toBe(String(pubEvent._id));
+    expect(asNonGM?.events[0].label).toBe('Public Ambush');
+  });
+
+  it('updateQuest (as non-GM) preserves a private-event link the writer never saw, even when omitted from their payload', async () => {
+    const privEvent = await Event.create({
+      title: 'Hidden Rendezvous',
+      campaignId: CAMPAIGN,
+      isPublic: false,
+    });
+    const q = await createQuest({
+      data: {
+        campaignId: CAMPAIGN,
+        name: 'Q',
+        type: '',
+        status: 'active',
+        publicInfo: '',
+        privateInfo: '',
+        isPublic: true,
+        giver: null,
+        parentQuestId: null,
+        links: [],
+        events: [
+          {
+            eventId: String(privEvent._id),
+            role: 'secret-role',
+            publicInfo: 'secret-pub',
+            privateInfo: 'secret-priv',
+          },
+        ],
+        images: [],
+        tags: [],
+      },
+    });
+
+    // Non-GM creator: resolveEvents never showed them the private-event link,
+    // so their submitted `events` payload legitimately omits it entirely.
+    member.isGM = false;
+    member.userId = 'u-gm';
+    await updateQuest({
+      data: {
+        id: q.id,
+        campaignId: CAMPAIGN,
+        name: 'Q renamed',
+        type: '',
+        status: 'active',
+        publicInfo: 'pub-updated',
+        privateInfo: 'attempted-wipe',
+        isPublic: true,
+        giver: null,
+        parentQuestId: null,
+        links: [],
+        events: [],
+        images: [],
+        tags: [],
+      },
+    });
+
+    member.isGM = true;
+    member.userId = 'u-gm';
+    const reloaded = await getQuest({ data: { id: q.id, campaignId: CAMPAIGN } });
+    const preserved = reloaded?.events.find((e) => e.eventId === String(privEvent._id));
+    expect(preserved).toBeDefined();
+    expect(preserved?.role).toBe('secret-role');
+    expect(preserved?.publicInfo).toBe('secret-pub');
+    expect(preserved?.privateInfo).toBe('secret-priv');
   });
 });

--- a/tests/server/functions/tabletop-hydration.test.ts
+++ b/tests/server/functions/tabletop-hydration.test.ts
@@ -7,9 +7,11 @@ vi.mock('~/server/db/models/Race', () => ({ Race: { find: vi.fn() } }));
 vi.mock('~/server/db/models/Rule', () => ({ Rule: { find: vi.fn() } }));
 vi.mock('~/server/db/models/Event', () => ({ Event: { find: vi.fn() } }));
 vi.mock('~/server/db/models/Organization', () => ({ Organization: { find: vi.fn() } }));
+vi.mock('~/server/db/models/Quest', () => ({ Quest: { find: vi.fn() } }));
 
 import { Event } from '~/server/db/models/Event';
 import { Organization } from '~/server/db/models/Organization';
+import { Quest } from '~/server/db/models/Quest';
 import { hydrateRefs } from '~/server/functions/tabletop-hydration';
 
 const eventDocs = [
@@ -28,6 +30,17 @@ const organizationDocs = [{ _id: 'orgPriv', name: 'Secret', publicInfo: '', isPu
 function mockOrganizationFind() {
   vi.mocked(Organization.find).mockReturnValue({
     lean: vi.fn().mockResolvedValue(organizationDocs),
+  } as never);
+}
+
+const questDocs = [
+  { _id: 'qPub', name: 'Public Quest', publicInfo: 'go', isPublic: true, status: 'active' },
+  { _id: 'qPriv', name: 'Secret Quest', publicInfo: 's', isPublic: false, status: 'active' },
+];
+
+function mockQuestFind() {
+  vi.mocked(Quest.find).mockReturnValue({
+    lean: vi.fn().mockResolvedValue(questDocs),
   } as never);
 }
 
@@ -75,5 +88,28 @@ describe('hydrateRefs — organization privacy on shared screens', () => {
       { isGM: false }
     );
     expect(result['organization:orgPriv']).toBeUndefined();
+  });
+});
+
+describe('hydrateRefs — quest privacy on shared screens', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuestFind();
+  });
+
+  const refs = [
+    { collection: 'quest', documentId: 'qPub' },
+    { collection: 'quest', documentId: 'qPriv' },
+  ];
+
+  it('hydrates a public quest and strips a private quest for non-GM viewers', async () => {
+    const asPlayer = await hydrateRefs(refs, 'camp-1', { isGM: false });
+    expect(asPlayer['quest:qPub']?.title).toBe('Public Quest');
+    expect(asPlayer['quest:qPriv']).toBeUndefined();
+  });
+
+  it('hydrates private quests for a GM viewer', async () => {
+    const asGM = await hydrateRefs(refs, 'camp-1', { isGM: true });
+    expect(asGM['quest:qPriv']?.title).toBe('Secret Quest');
   });
 });

--- a/tests/types/schemas/lore-window-collection.test.ts
+++ b/tests/types/schemas/lore-window-collection.test.ts
@@ -88,3 +88,31 @@ describe('organization is an accepted tabletop/GM-screen window collection', () 
     expect(result.success).toBe(true);
   });
 });
+
+/**
+ * Regression guard: `'quest'` must be an accepted window collection so that
+ * dragging a quest card onto the tabletop / GM screens opens a window.
+ */
+describe('quest is an accepted tabletop/GM-screen window collection', () => {
+  it('openTabletopWindowSchema accepts collection "quest"', () => {
+    const result = openTabletopWindowSchema.safeParse({
+      screenId: 's1',
+      campaignId: 'c1',
+      collection: 'quest',
+      documentId: 'q1',
+      x: 0,
+      y: 0,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('gmscreens openWindowSchema accepts collection "quest"', () => {
+    const result = openWindowSchema.safeParse({
+      screenId: 's1',
+      campaignId: 'c1',
+      collection: 'quest',
+      documentId: 'q1',
+    });
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a **Quests** wiki entity so campaigns can move quest tracking off Kanka. Quests mirror the Organizations vertical slice end-to-end (same stack: TanStack Start server functions, Mongoose, React Query, Zod, R2 images, panel-based wiki UI, GM-screen/tabletop windows).

A quest has:
- **Status** (`not_started` / `active` / `on_hold` / `completed` / `failed`), a freeform **type**, and public + GM-private markdown.
- A polymorphic **quest giver** (character / player / organization, or none) and a **parent quest** (sub-quest hierarchies).
- Rich **links** to characters, players, locations, and organizations — each with a role + public/GM-private notes.
- **Event links** — each with a role + public/GM-private notes.
- Multiple **images**, **tags**, and whole-entity `isPublic` visibility.

Surfaces: wiki panel (search + tag + status filters), create/edit modal, view modal, and windows on **GM screens + tabletop** (drag-to-place). Characters/players/locations/organizations gain a read-only **Linked Quests** section (reverse lookup).

Design spec: `docs/specs/2026-07-14-quests-design.md`.

## Privacy invariant
"Private" always means GM-only. Quest/link/event `privateInfo` is stripped for non-GM readers and preserved (not wiped) on non-GM updates; `isPublic:false` hides the quest everywhere for non-GM (list, reverse-lookup, tabletop hydration). A public quest linking a **private event** no longer leaks that event's title to non-GM viewers, and a non-GM update preserves private-event links they can't see.

## Testing
- Full unit suite green (**1669 tests**), typecheck clean, lint 0 errors / 24 baseline warnings.
- New e2e `gmscreens-quest-window` passes (drag a quest onto a GM screen; window renders + persists; title-bar hydration guarded).
- Seed: 5 quests (active main, completed side, on-hold personal, GM-private, sub-quest) validated against ephemeral mongodb-memory-server.

## Notes
- Registers `'quest'` across both hydration registries, both window allowlists, and both view render branches (registry-sync guard extended).
- Deferred (non-blocking, per review): consistent gating of private-org link/giver labels; batch the N+1 event lookups; component tests for Location/Organization edit modals (pre-existing gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)