### PR TITLE
feat(audio): hardening — rate limits, storage quota, queue fairness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,15 @@ jobs:
           NODE_ENV: production
           BASE_URL: https://cartyx.io
 
+      # Reads what the build actually emitted: no server env names, no
+      # `process.env`, no mongoose under `.output/public`. Nothing else in CI
+      # can catch a server-only module reaching the browser — it is a runtime
+      # ReferenceError, so typecheck, lint, the unit suite and `npm run build`
+      # itself all stay green. Must run in THIS job: it is the only one that
+      # produces `.output/`. See scripts/check-client-bundle.mjs.
+      - name: Client-bundle guard
+        run: npm run check:client-bundle
+
   storybook:
     name: Storybook & browser tests
     runs-on: ubuntu-latest

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -53,6 +53,16 @@ const config: StorybookConfig = {
         find: /^~\/server\/.*$/,
         replacement: path.resolve(__dirname, './mocks/serverFunctions.ts'),
       },
+      // Server-only despite living under `app/lib/`, so the `~/server/**`
+      // pattern above misses it: it reads `process.env` at module scope and is
+      // statically reachable from AudioUploadDropzone's story through
+      // ~/utils/uploadAudio -> ~/utils/audio-server-fns. The real client build
+      // strips the handler bodies that reference it and drops the module; the
+      // Storybook build does not. See ./mocks/audioRateLimits.ts.
+      {
+        find: /^~\/lib\/audio-rate-limits$/,
+        replacement: path.resolve(__dirname, './mocks/audioRateLimits.ts'),
+      },
       // Reaches node:async_hooks via @tanstack/start-storage-context, which a
       // browser bundle cannot resolve. See ./mocks/react-start.ts.
       {

--- a/.storybook/mocks/audioRateLimits.ts
+++ b/.storybook/mocks/audioRateLimits.ts
@@ -1,0 +1,67 @@
+/**
+ * Stand-in for `~/lib/audio-rate-limits` in Storybook.
+ *
+ * WHY THIS EXISTS. That module lives under `app/lib/`, not `app/server/`, so
+ * the `~/server/**` alias in `main.ts` does not catch it — but it is
+ * server-only all the same: every reference to its exports, in both server-fn
+ * wrapper modules, sits inside a `.handler()` body that the TanStack Start
+ * plugin strips before the client build runs, after which Rollup drops the
+ * module entirely (verified after `npm run build`: zero occurrences of
+ * `AUDIO_INGEST_RATE_LIMIT_CAPACITY` or `rateLimitMessage`'s message fragment
+ * anywhere under `.output/public`).
+ *
+ * Storybook deliberately does NOT run that plugin (see
+ * ../vite.config.ts), so handler bodies survive, the module is reachable from
+ * `AudioUploadDropzone` -> `~/utils/uploadAudio` -> `~/utils/audio-server-fns`,
+ * and it really is evaluated in a browser. It reads `process.env[...]` at
+ * module scope — a COMPUTED member access, which Vite's `define` cannot
+ * rewrite — so evaluating it in the preview throws `ReferenceError: process is
+ * not defined` at import time and takes the whole story file down with it.
+ * That is the exact failure `~/lib/audio-rate-limits`' own module comment
+ * predicts for a browser; the app bundle is safe from it, the Storybook bundle
+ * is not.
+ *
+ * Aliasing here rather than guarding the source keeps that prediction true:
+ * a `typeof process` check in the real module would make an accidental
+ * client-bundling of it silent instead of loud.
+ *
+ * Every export of the real module is reproduced, whether or not a story can
+ * reach it today — a missing name fails the preview build with `"<name>" is
+ * not exported by …`, which is loud and self-describing, but only after
+ * someone hits it. Limiters here are objects with a throwing `check`, not
+ * no-ops that return `{ allowed: true }`: nothing in a story should ever
+ * consult a rate limiter (handler bodies never execute — `createServerFn` is
+ * itself mocked, see ./react-start.ts), so reaching one means a story is doing
+ * something Storybook cannot honestly answer.
+ */
+
+function unavailable(name: string) {
+  return () => {
+    throw new Error(
+      `Storybook: rate limiter "${name}" was consulted. Limiters are server-only ` +
+        `state — stories never execute a server-fn handler, so reaching one means ` +
+        `the component is calling server code directly. Pass the data in as a prop.`
+    );
+  };
+}
+
+/** `RateLimiter` (`~/lib/rate-limit`) has exactly one method: `check`. */
+function limiter(name: string) {
+  return { check: unavailable(name) };
+}
+
+export const audioIngestLimiter = limiter('audioIngestLimiter');
+export const packageWriteLimiter = limiter('packageWriteLimiter');
+export const boardStateLimiter = limiter('boardStateLimiter');
+export const libraryMutationLimiter = limiter('libraryMutationLimiter');
+export const orphanCleanupLimiter = limiter('orphanCleanupLimiter');
+
+/**
+ * Pure string formatting with no environment dependency — reproduced verbatim
+ * rather than stubbed, so a story that ever renders a rate-limit message shows
+ * the real copy instead of a throw.
+ */
+export function rateLimitMessage(action: string, retryAfterMs: number): string {
+  const seconds = Math.max(1, Math.ceil(retryAfterMs / 1000));
+  return `Too many ${action} requests. Try again in ${seconds}s.`;
+}

--- a/.storybook/mocks/audioRateLimits.ts
+++ b/.storybook/mocks/audioRateLimits.ts
@@ -55,6 +55,8 @@ export const packageWriteLimiter = limiter('packageWriteLimiter');
 export const boardStateLimiter = limiter('boardStateLimiter');
 export const libraryMutationLimiter = limiter('libraryMutationLimiter');
 export const orphanCleanupLimiter = limiter('orphanCleanupLimiter');
+export const packageEditLimiter = limiter('packageEditLimiter');
+export const storageUsageReadLimiter = limiter('storageUsageReadLimiter');
 
 /**
  * Pure string formatting with no environment dependency — reproduced verbatim

--- a/app/components/audio/AudioOrphanCleanup.stories.tsx
+++ b/app/components/audio/AudioOrphanCleanup.stories.tsx
@@ -79,6 +79,36 @@ export const TruncatedScan: Story = {
   },
 };
 
+/**
+ * B2: the shared `~/utils/format-bytes` this component now uses adds a GB
+ * tier (previously it had its own copy that stopped at MB). A single asset
+ * can never reach it (`AUDIO_MAX_BYTES` caps one at 50 MB), but the delete
+ * button's total sums every orphan found, and that can cross 1 GiB on an
+ * account with enough of them — see `AudioOrphanCleanup.test.tsx` for the
+ * assertion this renders `1.50 GB`, not `1536.0 MB`.
+ */
+export const LargeOrphanTotal: Story = {
+  args: {
+    result: {
+      orphans: [
+        {
+          key: 'uploads/audio/renditions/507f1f77bcf86cd799439011.opus',
+          sizeBytes: 0.75 * 1024 * 1024 * 1024,
+          lastModified: '2026-07-01T10:00:00.000Z',
+        },
+        {
+          key: 'uploads/audio/renditions/507f1f77bcf86cd799439012.opus',
+          sizeBytes: 0.75 * 1024 * 1024 * 1024,
+          lastModified: '2026-07-01T10:00:01.000Z',
+        },
+      ],
+      scannedObjectCount: 12,
+      truncated: false,
+      r2Disabled: false,
+    },
+  },
+};
+
 export const StorageDisabled: Story = {
   args: {
     result: { orphans: [], scannedObjectCount: 0, truncated: false, r2Disabled: true },

--- a/app/components/audio/AudioOrphanCleanup.tsx
+++ b/app/components/audio/AudioOrphanCleanup.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { AlertTriangle, RefreshCw, Search, Trash2 } from 'lucide-react';
 import type { ScanOrphanAudioResult } from '~/types/schemas/audio';
+import { formatBytes } from '~/utils/format-bytes';
 
 export interface AudioOrphanCleanupProps {
   /** Latest scan result, or null before the first scan has returned. */
@@ -13,12 +14,6 @@ export interface AudioOrphanCleanupProps {
   lastDelete: { deleted: number; failed: number } | null;
   onScan: () => void;
   onDelete: (keys: string[]) => void;
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
 }
 
 /**

--- a/app/components/audio/AudioQuotaBar.stories.tsx
+++ b/app/components/audio/AudioQuotaBar.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { AudioQuotaBar } from './AudioQuotaBar';
+
+const GIB = 1024 * 1024 * 1024;
+
+const meta: Meta<typeof AudioQuotaBar> = {
+  title: 'Audio/AudioQuotaBar',
+  component: AudioQuotaBar,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="max-w-lg bg-[#0D1117] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  // Every arg required by AudioQuotaBarProps gets a default here — Task 5's
+  // brief calls out (citing phase 2a's tasks 14/15/16) that a story relying
+  // on `component`'s own defaultProps rather than explicit `args` can throw
+  // on render the moment a required prop is missing. There are none of those
+  // here, but the args below are still explicit for every story rather than
+  // partial overrides of an implicit "loaded" baseline.
+  args: {
+    usageBytes: 512 * 1024 * 1024,
+    assetCount: 12,
+    limitBytes: 2 * GIB,
+    error: null,
+  },
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Healthy: Story = {};
+
+/**
+ * `NEAR_LIMIT_RATIO` is 0.9 — this sits just past it (91%), one MB shy of
+ * `Over`, so the two stories stay visually distinguishable from each other in
+ * the Storybook grid rather than looking identical.
+ */
+export const NearLimit: Story = {
+  args: {
+    usageBytes: Math.round(2 * GIB * 0.91),
+    assetCount: 40,
+  },
+};
+
+/**
+ * Exactly AT the limit, not past it — `quotaStatus`'s `>=` boundary mirrors
+ * `assertUnderStorageQuota`'s server-side refusal (`usage.bytes >=
+ * limitBytes`), so this is the smallest usage value the server would already
+ * be refusing new uploads for.
+ */
+export const OverLimit: Story = {
+  args: {
+    usageBytes: 2 * GIB,
+    assetCount: 57,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    usageBytes: null,
+    limitBytes: null,
+  },
+};
+
+export const QueryFailed: Story = {
+  args: {
+    usageBytes: null,
+    limitBytes: null,
+    error: 'Failed to load storage usage.',
+  },
+};
+
+export const EmptyLibrary: Story = {
+  args: {
+    usageBytes: 0,
+    assetCount: 0,
+  },
+};

--- a/app/components/audio/AudioQuotaBar.tsx
+++ b/app/components/audio/AudioQuotaBar.tsx
@@ -1,0 +1,148 @@
+import { AlertTriangle, XCircle } from 'lucide-react';
+
+/** Props for the AudioQuotaBar component. */
+export interface AudioQuotaBarProps {
+  /**
+   * Bytes used across every asset the signed-in user owns, aggregated by
+   * `getUserStorageUsage` (`~/server/functions/audio-quota.ts`). `null` while
+   * the usage query hasn't resolved yet — distinct from `0`, which is a real
+   * "empty library" answer.
+   */
+  usageBytes: number | null;
+  /** Asset rows contributing to `usageBytes`. Ignored while `usageBytes` is `null`. */
+  assetCount: number;
+  /**
+   * The server's per-user cap, in bytes — `AUDIO_USER_QUOTA_BYTES`, read via
+   * `getAudioUserQuotaBytes()` (`~/server/functions/audio.ts`) and returned
+   * by the SAME server call that produced `usageBytes`. This must always
+   * come from that response, never a client-side constant: the write-side
+   * enforcement in `assertUnderStorageQuota` reads the env var fresh on
+   * every request, and a hand-copied "2 GiB" here would silently diverge the
+   * moment an operator changes it (Task 11 wires that env var into the Helm
+   * chart specifically so it can change without an image rebuild). `null`
+   * while loading, same as `usageBytes`.
+   */
+  limitBytes: number | null;
+  /** Message from a failed usage query, already stringified. */
+  error?: string | null;
+}
+
+/** Fraction of the limit at which usage is called out as "near" rather than "healthy". */
+const NEAR_LIMIT_RATIO = 0.9;
+
+type QuotaStatus = 'healthy' | 'near' | 'over';
+
+/**
+ * `usageBytes >= limitBytes` here matches `assertUnderStorageQuota`'s own
+ * boundary (`~/server/functions/audio.ts`) exactly: the server refuses a new
+ * upload once the caller's usage is AT the limit, not only once it's past
+ * it. If this bar called that state merely "near", a user reading "healthy"
+ * or "getting close" would be surprised by a refusal their own numbers
+ * already crossed.
+ */
+function quotaStatus(usageBytes: number, limitBytes: number): QuotaStatus {
+  if (usageBytes >= limitBytes) return 'over';
+  if (limitBytes > 0 && usageBytes / limitBytes >= NEAR_LIMIT_RATIO) return 'near';
+  return 'healthy';
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+  return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}
+
+/**
+ * "X of Y used" against the per-user storage quota, shown on `/audio` near
+ * the dropzone — a quota a user discovers only by hitting it is a support
+ * ticket (see the phase 1.5 design doc).
+ *
+ * Presentational: the route owns the query. `usageBytes`/`assetCount`/
+ * `limitBytes` all come from one `getAudioStorageUsageFn` response — see
+ * that prop's doc comment for why `limitBytes` in particular must never be
+ * a client-side constant.
+ *
+ * The near/over distinction is never colour-only: each state pairs a
+ * distinct icon (none for healthy, a warning triangle for near, a filled
+ * X for over) with its own sentence, so the difference survives grayscale
+ * and reads correctly to a screen reader that ignores CSS entirely. The
+ * progress track itself carries `role="progressbar"` with a numeric value
+ * AND `aria-valuetext`, so assistive tech gets the same "X of Y used"
+ * phrasing sighted users see rather than a bare percentage.
+ */
+export function AudioQuotaBar({ usageBytes, assetCount, limitBytes, error }: AudioQuotaBarProps) {
+  if (error) {
+    return (
+      <p role="alert" className="mt-3 font-sans text-xs text-red-400">
+        {error}
+      </p>
+    );
+  }
+
+  if (usageBytes === null || limitBytes === null) {
+    return (
+      <div aria-live="polite" className="mt-3 font-sans text-xs text-slate-500">
+        Checking storage usage…
+      </div>
+    );
+  }
+
+  const status = quotaStatus(usageBytes, limitBytes);
+  const percent = limitBytes > 0 ? Math.min(100, (usageBytes / limitBytes) * 100) : 100;
+  const usedLabel = formatBytes(usageBytes);
+  const limitLabel = formatBytes(limitBytes);
+  const valueText = `${usedLabel} of ${limitLabel} used`;
+
+  const trackFillClass =
+    status === 'over' ? 'bg-red-500' : status === 'near' ? 'bg-amber-400' : 'bg-blue-500';
+  const summaryTextClass =
+    status === 'over' ? 'text-red-400' : status === 'near' ? 'text-amber-300' : 'text-slate-400';
+
+  return (
+    <div className="mt-3 rounded border border-white/[0.07] bg-white/[0.02] p-3">
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-sans text-[10px] font-bold uppercase tracking-widest text-slate-500">
+          Storage
+        </span>
+        <span className={`flex items-center gap-1.5 font-sans text-xs ${summaryTextClass}`}>
+          {status === 'near' && (
+            <AlertTriangle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          )}
+          {status === 'over' && <XCircle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />}
+          {valueText}
+        </span>
+      </div>
+
+      <div
+        role="progressbar"
+        aria-label="Storage used"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(percent)}
+        aria-valuetext={valueText}
+        className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-white/[0.06]"
+      >
+        <div
+          className={`h-full rounded-full transition-[width] ${trackFillClass}`}
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+
+      {status === 'near' && (
+        <p className="mt-1.5 font-sans text-[11px] text-amber-300">
+          Approaching your storage limit — delete an asset to make room.
+        </p>
+      )}
+      {status === 'over' && (
+        <p className="mt-1.5 font-sans text-[11px] text-red-400">
+          Storage limit reached. New uploads will be refused until you delete an asset.
+        </p>
+      )}
+
+      <p className="mt-1 font-sans text-[11px] text-slate-500">
+        {assetCount} asset{assetCount === 1 ? '' : 's'}
+      </p>
+    </div>
+  );
+}

--- a/app/components/audio/AudioQuotaBar.tsx
+++ b/app/components/audio/AudioQuotaBar.tsx
@@ -1,4 +1,5 @@
 import { AlertTriangle, XCircle } from 'lucide-react';
+import { formatBytes } from '~/utils/format-bytes';
 
 /** Props for the AudioQuotaBar component. */
 export interface AudioQuotaBarProps {
@@ -44,13 +45,6 @@ function quotaStatus(usageBytes: number, limitBytes: number): QuotaStatus {
   if (usageBytes >= limitBytes) return 'over';
   if (limitBytes > 0 && usageBytes / limitBytes >= NEAR_LIMIT_RATIO) return 'near';
   return 'healthy';
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
-  return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
 }
 
 /**

--- a/app/components/soundboard/PackageConflictNotice.stories.tsx
+++ b/app/components/soundboard/PackageConflictNotice.stories.tsx
@@ -1,3 +1,4 @@
+import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { PackageConflictNotice } from './PackageConflictNotice';
 
@@ -20,10 +21,50 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 /**
+ * Same `Controlled` shape `MasterBar.stories.tsx` and `MoodEditor.stories.tsx`
+ * use, and here it is doing real work rather than ceremony: `onOverwrite` and
+ * `onDiscard` are REQUIRED props with no defaults, so a story that supplied
+ * only `savedAt` would render two enabled buttons wired to
+ * `onClick={undefined}` — a canvas that looks interactive and silently does
+ * nothing. That would still typecheck (`const meta: Meta<typeof …>` is an
+ * explicit annotation rather than `satisfies`, which erases the required-args
+ * narrowing) and `test:storybook` would still pass, because no story here has
+ * a `play` that clicks. Wiring both handlers to state also makes the canvas
+ * behave the way the editor does: overwriting goes busy, discarding dismisses.
+ */
+function Controlled(args: React.ComponentProps<typeof PackageConflictNotice>) {
+  const [busy, setBusy] = useState(args.busy ?? false);
+  const [chose, setChose] = useState<'overwrite' | 'discard' | null>(null);
+
+  if (chose === 'discard') {
+    return <p className="text-sm text-slate-400">Discarded — reloading the saved version…</p>;
+  }
+
+  return (
+    <>
+      <PackageConflictNotice
+        {...args}
+        busy={busy}
+        onOverwrite={() => {
+          setChose('overwrite');
+          setBusy(true);
+        }}
+        onDiscard={() => setChose('discard')}
+      />
+      {chose === 'overwrite' && (
+        <p className="mt-2 text-sm text-slate-400">Keeping your edits and overwriting…</p>
+      )}
+    </>
+  );
+}
+
+/**
  * The normal case: `updatePackage` refused the save because the stored
  * package moved on. Both ways out are offered, both say what they cost.
  */
-export const Conflict: Story = {};
+export const Conflict: Story = {
+  render: (args) => <Controlled {...args} />,
+};
 
 /**
  * The overwrite is in flight. Both buttons are disabled — a second click
@@ -31,6 +72,7 @@ export const Conflict: Story = {};
  * path would race the save it is sitting next to.
  */
 export const Overwriting: Story = {
+  render: (args) => <Controlled {...args} />,
   args: { busy: true },
 };
 
@@ -43,5 +85,6 @@ export const Overwriting: Story = {
  * value.
  */
 export const WithoutATimestamp: Story = {
+  render: (args) => <Controlled {...args} />,
   args: { savedAt: '' },
 };

--- a/app/components/soundboard/PackageConflictNotice.stories.tsx
+++ b/app/components/soundboard/PackageConflictNotice.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { PackageConflictNotice } from './PackageConflictNotice';
+
+const meta: Meta<typeof PackageConflictNotice> = {
+  title: 'Soundboard/PackageConflictNotice',
+  component: PackageConflictNotice,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="max-w-2xl bg-[#080A12] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    savedAt: '2026-07-31T14:32:07.000Z',
+  },
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The normal case: `updatePackage` refused the save because the stored
+ * package moved on. Both ways out are offered, both say what they cost.
+ */
+export const Conflict: Story = {};
+
+/**
+ * The overwrite is in flight. Both buttons are disabled — a second click
+ * would fire a second write against the same precondition, and the "discard"
+ * path would race the save it is sitting next to.
+ */
+export const Overwriting: Story = {
+  args: { busy: true },
+};
+
+/**
+ * `savedAt` absent — the refusal crossed a wire that dropped the extra
+ * property (see `~/lib/soundboard/stale-write.ts` on why callers must treat
+ * it as optional). The notice still explains itself and still offers both
+ * choices; it just says no "when", rather than rendering "Invalid Date". The
+ * discard path is unaffected — it re-reads the package rather than using this
+ * value.
+ */
+export const WithoutATimestamp: Story = {
+  args: { savedAt: '' },
+};

--- a/app/components/soundboard/PackageConflictNotice.tsx
+++ b/app/components/soundboard/PackageConflictNotice.tsx
@@ -1,0 +1,102 @@
+import { AlertTriangle } from 'lucide-react';
+
+export interface PackageConflictNoticeProps {
+  /**
+   * The `updatedAt` the SERVER currently holds, ISO-encoded — carried on the
+   * refusal itself (`PackageStaleWriteError.currentUpdatedAt`). Shown so the
+   * conflict has a "when", and passed back as the overwrite's precondition by
+   * the caller. Rendered as nothing at all if it is empty or unparseable
+   * rather than as "Invalid Date".
+   */
+  savedAt: string;
+  /**
+   * Keep the local draft and write it over the stored version. Still fenced
+   * on the caller's side — this replays the same edit against `savedAt`, so a
+   * THIRD write landing in between is refused again rather than clobbered.
+   */
+  onOverwrite: () => void;
+  /** Throw the local draft away and load what is stored. */
+  onDiscard: () => void;
+  /** A save is in flight (usually the overwrite this notice just triggered). */
+  busy?: boolean;
+}
+
+function formatSavedAt(savedAt: string): string | null {
+  const d = new Date(savedAt);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleString();
+}
+
+/**
+ * What the editor shows when `updatePackage` refuses a save because the
+ * package changed underneath it.
+ *
+ * THE POINT OF THIS COMPONENT IS THAT IT DOES NOT DECIDE. The refusal it
+ * reports is non-destructive on both sides — the caller's unsaved draft is
+ * still in the editor behind this notice, and the newer stored version is
+ * still in Mongo — and the whole reason the server refuses instead of merging
+ * is that a merge over `items`/`moods` cannot be done correctly without
+ * knowing which side ADDED and which side REMOVED each element. Unioning them
+ * would resurrect exactly the items an asset delete pruned, which is the bug
+ * the precondition exists to stop.
+ *
+ * So both outcomes are offered, both are labelled with what they cost, and
+ * neither happens without a click. A single "Reload" button would be the
+ * discard-with-a-confirmation-button this deliberately is not: it would give
+ * the user one way forward and that way would throw their work away.
+ */
+export function PackageConflictNotice({
+  savedAt,
+  onOverwrite,
+  onDiscard,
+  busy = false,
+}: PackageConflictNoticeProps) {
+  const when = formatSavedAt(savedAt);
+
+  return (
+    <div
+      role="alert"
+      data-testid="package-conflict-notice"
+      className="mb-6 rounded-lg border border-amber-500/40 bg-amber-500/[0.06] p-4"
+    >
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" aria-hidden="true" />
+        <div className="min-w-0">
+          <p className="font-sans text-sm font-semibold text-amber-300">
+            This package changed somewhere else
+          </p>
+          <p className="mt-1 text-sm text-slate-300">
+            It was saved{' '}
+            {when ? (
+              <>
+                at <time dateTime={savedAt}>{when}</time>,{' '}
+              </>
+            ) : null}
+            after you opened it — from another tab, or by an asset you deleted from your library.
+            Nothing has been lost: your unsaved edits are still on this page, and the saved version
+            is still stored. Pick which one to keep.
+          </p>
+
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={onOverwrite}
+              disabled={busy}
+              className="rounded bg-amber-600 px-3 py-1.5 font-sans text-xs font-semibold text-white transition-colors hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {busy ? 'Saving…' : 'Keep my edits and overwrite'}
+            </button>
+            <button
+              type="button"
+              onClick={onDiscard}
+              disabled={busy}
+              className="rounded border border-white/15 px-3 py-1.5 font-sans text-xs font-semibold text-slate-200 transition-colors hover:bg-white/5 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Discard my edits and load the saved version
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/hooks/useSoundboard.ts
+++ b/app/hooks/useSoundboard.ts
@@ -502,50 +502,57 @@ export function useSoundboard(
   // Audio
   // ---------------------------------------------------------------------
 
-  const loadAsset = useCallback(async (assetId: string): Promise<EngineAsset | null> => {
-    const ctx = ctxRef.current;
-    if (!ctx) throw new Error('Soundboard: loadAsset ran with no AudioContext');
+  const loadAsset = useCallback(
+    async (assetId: string, signal: AbortSignal): Promise<EngineAsset | null> => {
+      const ctx = ctxRef.current;
+      if (!ctx) throw new Error('Soundboard: loadAsset ran with no AudioContext');
 
-    const assets = optionsRef.current.assets;
-    // `enableAudio` refuses to build an engine while this is undefined, so
-    // reaching here means the invariant broke. THROW rather than return null:
-    // both end up in the engine's permanent `unplayable` set, but only a throw
-    // reaches `onLoadError` -> `captureException` instead of vanishing.
-    if (!assets) throw new Error('Soundboard: loadAsset ran before the asset list settled');
+      const assets = optionsRef.current.assets;
+      // `enableAudio` refuses to build an engine while this is undefined, so
+      // reaching here means the invariant broke. THROW rather than return null:
+      // both end up in the engine's permanent `unplayable` set, but only a throw
+      // reaches `onLoadError` -> `captureException` instead of vanishing.
+      if (!assets) throw new Error('Soundboard: loadAsset ran before the asset list settled');
 
-    const asset = assets.find((candidate) => candidate.id === assetId);
-    // Absent from a SETTLED list is not "nothing to play" — it is the list
-    // being wrong. Today that happens two ways: `listAudioAssetsFn` is
-    // cursor-paginated (default 50) while a package holds up to 64 items, and
-    // it filters `{ ownerId: userId }` so no system package's assets are ever
-    // in it (Task 21 adds `listPackageAssetsFn` to fix the source). Either way
-    // the pad dies permanently, so it must not die quietly.
-    if (!asset) throw new Error(`Soundboard: asset ${assetId} is not in the board's asset list`);
-    // Still transcoding: temporary in the world, permanent for this engine.
-    // Loud, for the same reason.
-    if (
-      asset.status === 'pending' ||
-      asset.status === 'processing' ||
-      asset.status === 'uploading'
-    ) {
-      throw new Error(`Soundboard: asset ${assetId} is not ready (status: ${asset.status})`);
-    }
+      const asset = assets.find((candidate) => candidate.id === assetId);
+      // Absent from a SETTLED list is not "nothing to play" — it is the list
+      // being wrong. Today that happens two ways: `listAudioAssetsFn` is
+      // cursor-paginated (default 50) while a package holds up to 64 items, and
+      // it filters `{ ownerId: userId }` so no system package's assets are ever
+      // in it (Task 21 adds `listPackageAssetsFn` to fix the source). Either way
+      // the pad dies permanently, so it must not die quietly.
+      if (!asset) throw new Error(`Soundboard: asset ${assetId} is not in the board's asset list`);
+      // Still transcoding: temporary in the world, permanent for this engine.
+      // Loud, for the same reason.
+      if (
+        asset.status === 'pending' ||
+        asset.status === 'processing' ||
+        asset.status === 'uploading'
+      ) {
+        throw new Error(`Soundboard: asset ${assetId} is not ready (status: ${asset.status})`);
+      }
 
-    // `failed`/no rendition are the only genuine "there is nothing to play,
-    // ever" answers, and the only ones that may return null silently.
-    if (asset.status !== 'ready') return null;
-    const rendition = pickRendition(asset.renditions);
-    if (!rendition) return null;
+      // `failed`/no rendition are the only genuine "there is nothing to play,
+      // ever" answers, and the only ones that may return null silently.
+      if (asset.status !== 'ready') return null;
+      const rendition = pickRendition(asset.renditions);
+      if (!rendition) return null;
 
-    const response = await fetch(rendition.url);
-    if (!response.ok) throw new Error(`Audio rendition fetch failed (${response.status})`);
-    const bytes = await response.arrayBuffer();
-    const buffer = await ctx.decodeAudioData(bytes);
-    // `durationSamples` passes through UNMODIFIED: the engine divides it by
-    // `AUDIO_RENDITION_SAMPLE_RATE` to compute `loopEnd`, and rounding it
-    // anywhere on the way makes Safari loops tick on every repeat.
-    return { buffer, durationSamples: asset.durationSamples };
-  }, []);
+      // `signal` aborts the instant the engine's `dispose()` runs — teardown,
+      // a board clear, or the retry path rebuilding a desynced engine (see
+      // `teardownAudio`). Passing it through actually cancels the network
+      // request rather than merely leaving its result unread.
+      const response = await fetch(rendition.url, { signal });
+      if (!response.ok) throw new Error(`Audio rendition fetch failed (${response.status})`);
+      const bytes = await response.arrayBuffer();
+      const buffer = await ctx.decodeAudioData(bytes);
+      // `durationSamples` passes through UNMODIFIED: the engine divides it by
+      // `AUDIO_RENDITION_SAMPLE_RATE` to compute `loopEnd`, and rounding it
+      // anywhere on the way makes Safari loops tick on every repeat.
+      return { buffer, durationSamples: asset.durationSamples };
+    },
+    []
+  );
 
   const teardownAudio = useCallback((): void => {
     schedulerRef.current?.dispose();
@@ -641,11 +648,22 @@ export function useSoundboard(
       // Without this the pad stays lit forever.
       onItemEnded: (itemId) => dispatch({ type: 'stop', itemId }),
       onLoadError: (assetId, error) => {
+        // Guard FIRST. `dispose()` aborts every in-flight load and the
+        // engine itself already stops calling this once it is disposed (see
+        // `ensureAsset`'s `disposed` guard in `engine.ts`) — but the cleanup
+        // effect below flips `mountedRef` to `false` and THEN calls
+        // `teardownAudio()`, so a rejection that was already mid-flight when
+        // this callback starts running can still land here in the same tick
+        // dispose fires. Capturing it would be exactly the "one GlitchTip
+        // event per asset on every board clear" this task exists to stop —
+        // a teardown is not a genuine failure, so it must never reach
+        // `captureException`. A real failure while the board is still
+        // mounted falls through untouched.
+        if (!mountedRef.current) return;
         captureException(error, { area: 'soundboard', campaignId: campaignIdRef.current, assetId });
         // Surface it too. A GlitchTip event tells ME; `loadErrors` tells the
         // GM mid-session, which is the only audience that can react to a pad
         // that will now be silent for the rest of the engine's life.
-        if (!mountedRef.current) return;
         setLoadErrors((previous) => {
           if (previous.has(assetId)) return previous;
           const next = new Set(previous);

--- a/app/lib/audio-rate-limits.ts
+++ b/app/lib/audio-rate-limits.ts
@@ -101,6 +101,39 @@ export const packageWriteLimiter = createRateLimiter({ capacity: 15, refillPerSe
 export const boardStateLimiter = createRateLimiter({ capacity: 40, refillPerSec: 2 });
 
 /**
+ * Library mutations: `deleteAudioAsset` and `updateAudioAsset`. Not in the
+ * design's table; added after review found the original in-code justification
+ * for leaving them ungated was factually wrong on both counts.
+ *
+ * `deleteAudioAsset` **does** spend R2 — up to six `DeleteObjectCommand`
+ * calls per request (source, both renditions, and the three once-variant
+ * objects). And both it and `updateAudioAsset` throw on a caller-supplied id
+ * that misses `findOne({ _id, ownerId })`, which any authenticated user can
+ * trigger by generating well-formed ObjectIds against a schema of
+ * `z.object({ id: objectId })`. That throw is now an `AudioClientError` (see
+ * `~/server/functions/audio.ts`), which closes the GlitchTip-amplification
+ * half at its source; this bucket bounds the R2 spend and the write volume
+ * that the type change does not touch.
+ *
+ * Capacity 60 — generous on purpose, because clearing out or re-tagging a
+ * library is a genuine session-length activity. The UI drives both one asset
+ * at a time (a confirm dialog per delete, a modal save per edit — there is no
+ * bulk-delete endpoint), so 60 covers a user disposing of or editing sixty
+ * assets in one sitting without ever meeting the limiter.
+ *
+ * Refill 0.5/s — one every two seconds, deliberately slower than the ingest
+ * bucket's. A human clicking through a confirm dialog per asset cannot
+ * sustain much more than that, while a scripted loop drops from thousands per
+ * second to one per two seconds.
+ *
+ * `bulkTagAudioAssets` is NOT on this bucket, and that reason is real rather
+ * than assumed: it is an `updateMany` that returns `{ modified: 0 }` when
+ * nothing matches, so it has no not-found throw and no capture path at all,
+ * and its `ids` array is already bounded by `.max(200)` in the schema.
+ */
+export const libraryMutationLimiter = createRateLimiter({ capacity: 60, refillPerSec: 0.5 });
+
+/**
  * Orphan cleanup: `scanOrphanAudio` and `deleteOrphanAudio`. Not in the
  * design's table; added on the same reasoning that put `retryAudioAsset` on
  * the ingest bucket — the table names endpoint GROUPS, and the placement

--- a/app/lib/audio-rate-limits.ts
+++ b/app/lib/audio-rate-limits.ts
@@ -27,13 +27,39 @@ import { createRateLimiter } from '~/lib/rate-limit';
  * note). The web pod runs `replicaCount: 1`, so per-process is the whole
  * picture today; at N>1 replicas every number below becomes per-replica.
  *
- * THE NUMBERS ARE HARDCODED ON PURPOSE. Task 11 of this phase wires the
- * limits that need operational tuning (quota, job cap) into the Helm chart as
- * server env. If a rate-limit value ever needs the same treatment it must be
- * a plain `process.env` read with the default below retained, and never a
+ * `audioIngestLimiter`'s two numbers are env-overridable (below); the other
+ * three buckets stay hardcoded — see that limiter's own comment for why it
+ * alone gets this treatment, and Task 11's report
+ * (`.superpowers/sdd/2026-07-31-audio-hardening-plan/task-11-report.md`) for
+ * the build-bundle evidence that a plain `process.env` read here is safe.
+ * Follow the identical pattern if another bucket ever needs it: never a
  * `VITE_PUBLIC_*` name — this module is client-bundled, so a `VITE_PUBLIC_*`
  * read here would bake the limit into the browser image.
  */
+
+/**
+ * Guards a `process.env` read the same way
+ * `~/server/functions/audio.ts`'s `getAudioUserQuotaBytes` /
+ * `getMaxPendingJobsPerUser` do: `Number(undefined)` and `Number('')` (what
+ * Helm renders for a `values.yaml` key nobody set) are both non-positive
+ * under this check, so an absent or empty env var falls through to
+ * `fallback` rather than producing `NaN` or `0` — a configured `0` would
+ * make the bucket refuse every request instantly, which is a
+ * misconfiguration, not a deliberate zero-capacity limiter.
+ *
+ * Read once, at module load (this module's constants are built at import
+ * time, same as the hardcoded buckets below) — not re-read per request like
+ * the two functions above, because a token bucket's state must persist
+ * across requests and there is nothing to re-read INTO once constructed.
+ * Changing the env value therefore takes effect on the next pod restart, the
+ * same restart-required idiom `audioWorker.env.LOG_LEVEL` already uses (a
+ * `helm upgrade` that changes a plain Deployment env value triggers that
+ * restart on its own — no checksum annotation needed, unlike a Secret).
+ */
+function envPositiveNumber(name: string, fallback: number): number {
+  const raw = Number(process.env[name]);
+  return Number.isFinite(raw) && raw > 0 ? raw : fallback;
+}
 
 /**
  * Ingest: `createAudioUpload`, `confirmAudioUpload`, both once-variant
@@ -58,8 +84,26 @@ import { createRateLimiter } from '~/lib/rate-limit';
  * tight loop would otherwise manage — and the storage quota (task 4) and
  * per-user pending-job cap (task 5) bound what those calls can actually
  * consume.
+ *
+ * `AUDIO_INGEST_RATE_LIMIT_CAPACITY` / `AUDIO_INGEST_RATE_LIMIT_REFILL_PER_SEC`,
+ * both env-overridable with the 60 / 1 above retained as defaults — this is
+ * the ONE bucket of the five in this file wired to the Helm chart (Task 11),
+ * because it is the one this module's own comments already single out as
+ * "the queue-starvation lever" and the design doc's open-questions table
+ * flags default rate-limit values generally as something to "tune after real
+ * usage." The other four buckets stay hardcoded: nothing has called out
+ * `packageWriteLimiter`/`boardStateLimiter`/`libraryMutationLimiter`/
+ * `orphanCleanupLimiter` as needing operational tuning, and wiring five
+ * buckets' worth of env plumbing on spec would be scope beyond what Task 11
+ * asked for. The mechanism below (a plain `process.env` read, module-scope,
+ * verified absent from the client bundle — see `envPositiveNumber`'s comment
+ * and the Task 11 report) extends to any of them identically if that need
+ * ever arises.
  */
-export const audioIngestLimiter = createRateLimiter({ capacity: 60, refillPerSec: 1 });
+export const audioIngestLimiter = createRateLimiter({
+  capacity: envPositiveNumber('AUDIO_INGEST_RATE_LIMIT_CAPACITY', 60),
+  refillPerSec: envPositiveNumber('AUDIO_INGEST_RATE_LIMIT_REFILL_PER_SEC', 1),
+});
 
 /**
  * Package writes: `createPackage` and `clonePackage`. The design's other

--- a/app/lib/audio-rate-limits.ts
+++ b/app/lib/audio-rate-limits.ts
@@ -17,18 +17,43 @@ import { createRateLimiter } from '~/lib/rate-limit';
  * for the exact mechanism.
  *
  * WHERE THEY ARE APPLIED: in the wrapper layer, immediately after
- * `requireActor()`, keyed on the caller's Mongo `_id`. That placement is
- * deliberate — the key is an ACCOUNT rather than an IP (so rotating IPs buys
- * an abuser nothing, and a household behind one NAT is not one bucket), and
- * it sits one layer above every server function, so a function added later
- * cannot silently skip the gate.
+ * `requireActor()`, keyed on the caller's Mongo `_id`. The key is an ACCOUNT
+ * rather than an IP, which is the deliberate part — rotating IPs buys an
+ * abuser nothing, and a household behind one NAT is not one bucket.
+ *
+ * WHAT THAT PLACEMENT DOES NOT BUY, corrected in the final whole-branch
+ * review: it does NOT mean "a function added later cannot silently skip the
+ * gate", which is what this comment (and `~/utils/audio-server-fns.ts`'s)
+ * used to claim. A gate in the wrapper layer only covers callers that come
+ * through the wrapper layer, and a SECOND ingest adapter already does not:
+ * the phase-3 REST routes (`app/routes/api/audio/uploads.ts` and
+ * `uploads.$id.confirm.ts`) call `createAudioUpload`/`confirmAudioUpload` in
+ * `~/server/functions/audio.ts` directly. The storage quota and the
+ * pending-job cap DO cover them, because those checks live inside `audio.ts`
+ * itself; only these buckets are bypassed. That is unreachable today —
+ * `resolveApiUser` 401s every request — but phase 3 is precisely the phase
+ * that turns that adapter on, and it will need its own key for these buckets
+ * (the bearer token's resolved user id) rather than inheriting one. The rule
+ * that follows: anything that must be bounded for BOTH adapters belongs
+ * beside the quota/cap checks inside `audio.ts`, not here.
  *
  * SCOPE: these buckets are in-process (see `~/lib/rate-limit`'s own scope
  * note). The web pod runs `replicaCount: 1`, so per-process is the whole
  * picture today; at N>1 replicas every number below becomes per-replica.
  *
+ * NO BUCKET ON READS — `listPackages`, `getPackage`, `listPackageAssets`,
+ * `listAudioAssets`, `loadBoardState`. Per the design: they are bounded by
+ * their projections and by the `$in` over a package's <=64 items, and a read
+ * bound risks breaking a legitimate board reload (opening a campaign fires
+ * several of these at once, and a refused one leaves a half-loaded board).
+ * `getAudioStorageUsage` is the one deliberate exception — see
+ * `storageUsageReadLimiter` below for why the argument above does not cover
+ * it. (This paragraph used to sit on `rateLimitMessage`'s JSDoc at the
+ * bottom of the file, where it rendered as the hover tooltip for a string
+ * formatter; it is module policy, so it lives with the module.)
+ *
  * `audioIngestLimiter`'s two numbers are env-overridable (below); the other
- * four buckets stay hardcoded — see that limiter's own comment for why it
+ * six buckets stay hardcoded — see that limiter's own comment for why it
  * alone gets this treatment.
  *
  * WHY A PLAIN `process.env` READ BELOW DOES NOT CONTRADICT "THIS MODULE IS
@@ -123,11 +148,11 @@ function envPositiveNumber(name: string, fallback: number): number {
  * because it is the one this module's own comments already single out as
  * "the queue-starvation lever" and the design doc's open-questions table
  * flags default rate-limit values generally as something to "tune after real
- * usage." The other four buckets stay hardcoded: nothing has called out
+ * usage." The other six buckets stay hardcoded: nothing has called out
  * `packageWriteLimiter`/`boardStateLimiter`/`libraryMutationLimiter`/
- * `orphanCleanupLimiter` as needing operational tuning, and wiring five
- * buckets' worth of env plumbing on spec would be scope beyond what Task 11
- * asked for. The mechanism below (a plain `process.env` read, module-scope)
+ * `orphanCleanupLimiter`/`packageEditLimiter`/`storageUsageReadLimiter` as
+ * needing operational tuning, and wiring seven buckets' worth of env
+ * plumbing on spec would be scope beyond what Task 11 asked for. The mechanism below (a plain `process.env` read, module-scope)
  * extends to any of them identically if that need ever arises — see the
  * module comment above (`envPositiveNumber`'s guard, and the invariant that
  * keeps this safe) before doing so.
@@ -241,12 +266,91 @@ export const libraryMutationLimiter = createRateLimiter({ capacity: 60, refillPe
 export const orphanCleanupLimiter = createRateLimiter({ capacity: 10, refillPerSec: 1 / 30 });
 
 /**
- * NO BUCKET ON READS — `listPackages`, `getPackage`, `listPackageAssets`,
- * `listAudioAssets`, `loadBoardState`. Per the design: they are bounded by
- * their projections and by the `$in` over a package's <=64 items, and a read
- * bound risks breaking a legitimate board reload (opening a campaign fires
- * several of these at once, and a refused one leaves a half-loaded board).
+ * Package edits: `updatePackageFn` only. Added in the final whole-branch
+ * review, which superseded Task 2's ruling to leave it ungated. That ruling
+ * was made on footprint alone — true as far as it goes (an update cannot
+ * grow the user's footprint; the schema's `.max()`ed arrays bound the
+ * document) — but footprint is not the only cost this surface bounds:
  *
+ *  - EVERY call is a whole-document `$set` of `items` AND `moods`, up to
+ *    ~410 KiB. That is the largest single write anywhere on this surface,
+ *    several hundred times a `saveBoardState` — and `saveBoardState` IS
+ *    gated (`boardStateLimiter`, 40/2), specifically because the design
+ *    names "amplify Atlas writes" as a threat. The bigger write cannot be
+ *    the one left open.
+ *  - Every success fires an un-awaited `serverCaptureEvent('package_updated')`
+ *    — one Umami event per call, at caller-controlled volume. That is the
+ *    exact telemetry-amplification class that got `scanOrphanAudio`/
+ *    `deleteOrphanAudio` gated mid-phase.
+ *
+ * And Task 7's optimistic-concurrency fence does NOT bound either of those:
+ * `PackageStaleWriteError` carries `currentUpdatedAt`, so a script simply
+ * replays with the value the refusal handed it and every iteration succeeds.
+ *
+ * Capacity 30 — this is a human-click endpoint: one explicit "Save changes"
+ * press per call, each preceded by an edit and followed by a round trip.
+ * Thirty back-to-back saves is far past any real editing session. It must
+ * also clear the two-saves-in-a-row case comfortably (the editor re-seeds
+ * its draft from the save's own response, so a second Save immediately
+ * after the first is a legitimate, and now token-costing, action), and 30
+ * does that with 28 to spare.
+ *
+ * Refill 0.5/s — one every two seconds, deliberately the same rate as
+ * `libraryMutationLimiter` and for the same reason: a human editing and
+ * saving cannot sustain more, while a scripted replay loop drops from
+ * thousands per second to one per two seconds.
+ *
+ * NOT shared with `libraryMutationLimiter` despite the matching refill: that
+ * bucket bounds asset deletes/edits, and sharing would let a library-cleanup
+ * session consume a package-editing session's budget for no gain — they are
+ * different resources reached from different pages.
+ *
+ * `deletePackageFn` stays UNGATED, and unlike the old blanket sentence about
+ * "update and delete" this reason is actually true of delete: it is a single
+ * `deleteOne` by `{_id, ownerId}` (no document body at all, so nothing to
+ * amplify by size), and its `package_deleted` event fires only when a row
+ * really was removed — a replay against the same id hits `deletedCount: 0`
+ * and throws `PackageClientError`, which files nothing. Its event volume is
+ * therefore bounded by how many packages the caller owns, and the only ways
+ * to get more are `createPackage`/`clonePackage`, both on
+ * `packageWriteLimiter` behind a 100-package cap.
+ */
+export const packageEditLimiter = createRateLimiter({ capacity: 30, refillPerSec: 0.5 });
+
+/**
+ * Storage-usage read: `getAudioStorageUsageFn`. The one exception to the
+ * NO-BUCKET-ON-READS policy in the module comment above, added in the final
+ * whole-branch review.
+ *
+ * The justification it replaces said this read was safe because "its cost
+ * scales with the caller's own asset count, not with how often they call
+ * it." That is the wrong axis: total Atlas CPU is count TIMES frequency, and
+ * frequency is exactly the parameter a caller controls. It also happens to
+ * be the only read on this surface that is an `$group` AGGREGATION rather
+ * than a projected `find` over an indexed filter, so it is the one where
+ * frequency buys the most work per call.
+ *
+ * Why a bucket here does not run into the reason the other reads have none:
+ * that reason is "a refused read leaves a half-loaded board." This read
+ * feeds ONE indicator — `AudioQuotaBar` on `/audio`, which takes an explicit
+ * `error` prop and renders a message in place of the bar. Nothing else on
+ * the page depends on it, and no board reload involves it at all.
+ *
+ * Capacity 90 — `/audio` fetches this once on mount and refetches on every
+ * `invalidateAudio()`, which fires once per upload BATCH (the dropzone calls
+ * `onUploaded` after the whole drop, not per file) and once per library
+ * mutation. Those mutations are themselves capped at 60 by
+ * `libraryMutationLimiter`, so 90 covers a full library-cleanup session's
+ * worth of refetches with 30 left over for page loads and react-query's
+ * refetch-on-window-focus.
+ *
+ * Refill 1/s — far above any human-driven refetch cadence (the number only
+ * moves on ingest or delete), and it caps a scripted aggregation loop at
+ * ~3,600/hour instead of thousands per second.
+ */
+export const storageUsageReadLimiter = createRateLimiter({ capacity: 90, refillPerSec: 1 });
+
+/**
  * Formats the refusal message a rejected caller sees. Rounds UP to whole
  * seconds and never says "0s" — a message that tells the user to retry
  * immediately is worse than no message, because retrying immediately fails.

--- a/app/lib/audio-rate-limits.ts
+++ b/app/lib/audio-rate-limits.ts
@@ -101,6 +101,37 @@ export const packageWriteLimiter = createRateLimiter({ capacity: 15, refillPerSe
 export const boardStateLimiter = createRateLimiter({ capacity: 40, refillPerSec: 2 });
 
 /**
+ * Orphan cleanup: `scanOrphanAudio` and `deleteOrphanAudio`. Not in the
+ * design's table; added on the same reasoning that put `retryAudioAsset` on
+ * the ingest bucket — the table names endpoint GROUPS, and the placement
+ * rationale it states ("no server function added later can silently skip it")
+ * argues for covering the surface rather than the list.
+ *
+ * This is the tightest bucket of the four, because these two are the only
+ * endpoints on the surface where a single call has an unbounded EXTERNAL
+ * cost. Both run `findOrphans`, which pages an R2 `ListObjectsV2` over the
+ * caller's prefix up to `AUDIO_ORPHAN_SCAN_MAX_KEYS` (10,000) — up to ten
+ * Class-A operations per call — and both fire an un-awaited
+ * `serverCaptureEvent` (`audio_orphan_scan` / `audio_orphan_delete`) on every
+ * success. Ungated, a loop makes both R2 spend and Umami event volume an
+ * attacker-controlled parameter; the second is the same telemetry-
+ * amplification shape 2a's review found twice.
+ *
+ * Capacity 10 — orphan cleanup is an operator-cadence action, not a user-loop
+ * one. `/audio` drives it from two explicit buttons: one scan, then one
+ * batched delete for the whole selection (the key list is a single
+ * `.max()`ed array, not a call per key). A whole session is
+ * scan -> delete -> re-scan to verify, i.e. three calls; 10 covers three such
+ * cycles back to back.
+ *
+ * Refill 1/30s — one call every thirty seconds sustained. That is far above
+ * any human's cleanup cadence (nothing about the result changes within thirty
+ * seconds) and caps the sustained cost at ~120 scans/hour rather than
+ * thousands.
+ */
+export const orphanCleanupLimiter = createRateLimiter({ capacity: 10, refillPerSec: 1 / 30 });
+
+/**
  * NO BUCKET ON READS — `listPackages`, `getPackage`, `listPackageAssets`,
  * `listAudioAssets`, `loadBoardState`. Per the design: they are bounded by
  * their projections and by the `$in` over a package's <=64 items, and a read

--- a/app/lib/audio-rate-limits.ts
+++ b/app/lib/audio-rate-limits.ts
@@ -28,13 +28,45 @@ import { createRateLimiter } from '~/lib/rate-limit';
  * picture today; at N>1 replicas every number below becomes per-replica.
  *
  * `audioIngestLimiter`'s two numbers are env-overridable (below); the other
- * three buckets stay hardcoded — see that limiter's own comment for why it
- * alone gets this treatment, and Task 11's report
- * (`.superpowers/sdd/2026-07-31-audio-hardening-plan/task-11-report.md`) for
- * the build-bundle evidence that a plain `process.env` read here is safe.
- * Follow the identical pattern if another bucket ever needs it: never a
- * `VITE_PUBLIC_*` name — this module is client-bundled, so a `VITE_PUBLIC_*`
- * read here would bake the limit into the browser image.
+ * four buckets stay hardcoded — see that limiter's own comment for why it
+ * alone gets this treatment.
+ *
+ * WHY A PLAIN `process.env` READ BELOW DOES NOT CONTRADICT "THIS MODULE IS
+ * CLIENT-BUNDLED" ABOVE: this module IS in the client's static import graph
+ * — both wrapper files import it at the top level — but every reference to
+ * its exports, in both wrappers, lives inside a `.handler()` body, which
+ * TanStack Start strips before the client build runs. Once every reference
+ * is gone, Rollup drops the now-unused import, and with no other consumer
+ * anywhere in `app/` (checked: `grep -rl "audio-rate-limits" app` returns
+ * only these two files), the whole module — including any `process.env`
+ * read inside it — never reaches the browser. Verified empirically for
+ * `AUDIO_INGEST_RATE_LIMIT_CAPACITY`: after `npm run build`, zero
+ * occurrences anywhere under `.output/public`, with `mongoose` (163 hits
+ * under `.output/server`, 0 under `.output/public`) and `rateLimitMessage`'s
+ * unmangled `requests. Try again in ` template-literal fragment as controls
+ * proving the search was meaningful rather than searching an empty place.
+ *
+ * THE INVARIANT THIS DEPENDS ON, STATED PLAINLY, because nothing mechanical
+ * enforces it: every reference to anything exported from this file — in
+ * EVERY consumer, not just the two that exist today — must stay inside a
+ * `.handler()` body. Break that once (a route or component statically
+ * imports `audioIngestLimiter`, say, to show a caller their remaining
+ * budget) and this module ships to the browser. It would not fail loudly:
+ * `process.env[name]` is a COMPUTED member access, which Vite's `define`
+ * text-replacement cannot match (it only rewrites literal
+ * `process.env.SOME_NAME` property reads), so the failure mode is not a
+ * baked-in value — it's `process` being undefined at module-evaluation time,
+ * i.e. a `ReferenceError` thrown the instant that chunk loads in every
+ * browser. `typecheck`/`lint`/`test` all stay green, and `npm run build`
+ * would SUCCEED too, because this is a runtime crash, not a build error —
+ * the same "nothing mechanically enforces that" gap
+ * `~/utils/require-actor.ts`'s doc comment already names for the identical
+ * hazard on the dynamic-import side of this codebase. Keep every future
+ * usage of this module's exports inside a handler.
+ *
+ * And never a `VITE_PUBLIC_*` name regardless of where it's referenced from
+ * — that bakes the limit into the browser image on purpose, which defeats
+ * the entire point of making it operator-tunable.
  */
 
 /**
@@ -95,10 +127,10 @@ function envPositiveNumber(name: string, fallback: number): number {
  * `packageWriteLimiter`/`boardStateLimiter`/`libraryMutationLimiter`/
  * `orphanCleanupLimiter` as needing operational tuning, and wiring five
  * buckets' worth of env plumbing on spec would be scope beyond what Task 11
- * asked for. The mechanism below (a plain `process.env` read, module-scope,
- * verified absent from the client bundle — see `envPositiveNumber`'s comment
- * and the Task 11 report) extends to any of them identically if that need
- * ever arises.
+ * asked for. The mechanism below (a plain `process.env` read, module-scope)
+ * extends to any of them identically if that need ever arises — see the
+ * module comment above (`envPositiveNumber`'s guard, and the invariant that
+ * keeps this safe) before doing so.
  */
 export const audioIngestLimiter = createRateLimiter({
   capacity: envPositiveNumber('AUDIO_INGEST_RATE_LIMIT_CAPACITY', 60),

--- a/app/lib/audio-rate-limits.ts
+++ b/app/lib/audio-rate-limits.ts
@@ -1,0 +1,117 @@
+import { createRateLimiter } from '~/lib/rate-limit';
+
+/**
+ * The per-account request budgets for the audio ingest and soundboard-package
+ * surface, plus the one message helper the wrappers format their refusals
+ * with.
+ *
+ * WHY THIS MODULE EXISTS SEPARATELY: the buckets are consumed from BOTH
+ * `~/utils/audio-server-fns.ts` and `~/utils/soundboard-server-fns.ts`, and a
+ * limiter is only a limiter if both wrappers share ONE instance of it — a
+ * bucket created per-module would silently double every budget the day a
+ * third wrapper appears. It lives under `app/lib/` because both of those
+ * wrapper modules are client-bundled: this file may therefore import nothing
+ * but `~/lib/rate-limit` (itself import-free). Adding any dependency here
+ * that reaches mongoose or `@sentry/node` breaks `npm run build`, not
+ * `typecheck`/`lint`/`test` — see `~/utils/require-actor.ts`'s doc comment
+ * for the exact mechanism.
+ *
+ * WHERE THEY ARE APPLIED: in the wrapper layer, immediately after
+ * `requireActor()`, keyed on the caller's Mongo `_id`. That placement is
+ * deliberate — the key is an ACCOUNT rather than an IP (so rotating IPs buys
+ * an abuser nothing, and a household behind one NAT is not one bucket), and
+ * it sits one layer above every server function, so a function added later
+ * cannot silently skip the gate.
+ *
+ * SCOPE: these buckets are in-process (see `~/lib/rate-limit`'s own scope
+ * note). The web pod runs `replicaCount: 1`, so per-process is the whole
+ * picture today; at N>1 replicas every number below becomes per-replica.
+ *
+ * THE NUMBERS ARE HARDCODED ON PURPOSE. Task 11 of this phase wires the
+ * limits that need operational tuning (quota, job cap) into the Helm chart as
+ * server env. If a rate-limit value ever needs the same treatment it must be
+ * a plain `process.env` read with the default below retained, and never a
+ * `VITE_PUBLIC_*` name — this module is client-bundled, so a `VITE_PUBLIC_*`
+ * read here would bake the limit into the browser image.
+ */
+
+/**
+ * Ingest: `createAudioUpload`, `confirmAudioUpload`, both once-variant
+ * halves, and `retryAudioAsset`. The design's "tight" row, and the one that
+ * matters most — every confirm enqueues transcode work on a single-replica
+ * worker with a global FIFO claim, so this is the queue-starvation lever.
+ * `retryAudioAsset` is on this bucket too: it makes a `failed` row claimable
+ * again, which is the same act as a confirm under a different verb.
+ *
+ * Capacity 60 — the legitimate burst is a multi-file dropzone drop, which
+ * costs TWO calls per file (presign + confirm; `AudioUploadDropzone` runs
+ * them sequentially, one file at a time). 60 tokens absorbs a 30-file drop
+ * with the bucket starting full, comfortably over the 20-file drop the plan
+ * names as legitimate, and still cuts a scripted flood of 200 confirms in a
+ * second down to 60.
+ *
+ * Refill 1/s — one call every second sustained, i.e. one FILE every two
+ * seconds once the burst budget is spent. A GM importing a 100-file SFX
+ * library gets the first 30 files at full speed and the rest at ~2 s each
+ * (~3 minutes), which is slower than the upload itself only for tiny files.
+ * An abuser gets 3,600 calls an hour instead of the tens of thousands a
+ * tight loop would otherwise manage — and the storage quota (task 4) and
+ * per-user pending-job cap (task 5) bound what those calls can actually
+ * consume.
+ */
+export const audioIngestLimiter = createRateLimiter({ capacity: 60, refillPerSec: 1 });
+
+/**
+ * Package writes: `createPackage` and `clonePackage`. The design's other
+ * "tight" row — cheap per call, but `MAX_PACKAGES_PER_USER` is 100, so a
+ * hundred calls is the entire cap, and nothing in the UI creates packages in
+ * bulk (each one is a form submit or a single clone-button click).
+ *
+ * Capacity 15 — an impatient GM reorganising a library might create or clone
+ * a dozen packages back to back; 15 covers that with headroom and is still
+ * well short of the 100 cap.
+ *
+ * Refill 0.25/s — one every four seconds sustained. That is far above any
+ * human's package-authoring rate and turns "fill the 100-package cap
+ * instantly" into a ~6-minute grind, which is long enough that the cap's own
+ * refusal is what the abuser actually meets.
+ */
+export const packageWriteLimiter = createRateLimiter({ capacity: 15, refillPerSec: 0.25 });
+
+/**
+ * Board state: `saveBoardState`. The design's "moderate" row.
+ *
+ * Legitimately this is debounced client-side — `SAVE_FLUSH_MS` (200 ms) for
+ * discrete play/stop/mood changes and a trailing `SAVE_SETTLE_MS` (800 ms)
+ * for slider drags (see `~/hooks/useSoundboard.ts`), so the theoretical
+ * ceiling for one window is 5 writes/second and the realistic rate is far
+ * below 1.
+ *
+ * Capacity 40 — eight seconds at that theoretical 5/s ceiling, which also
+ * covers a GM driving the board from the tabletop window and the GM screen
+ * at once (same account, one bucket) during a frantic combat round.
+ *
+ * Refill 2/s — roughly double the worst realistic sustained rate, so the
+ * bound only ever catches a scripted caller. Note this is looser per-second
+ * than the ingest bucket by design: a save is one small document write with
+ * no queue and no R2 object behind it, and `saveBoardState` is additionally
+ * GM-gated, so a brand-new signup (`role: 'unknown'`) cannot reach it at
+ * all.
+ */
+export const boardStateLimiter = createRateLimiter({ capacity: 40, refillPerSec: 2 });
+
+/**
+ * NO BUCKET ON READS — `listPackages`, `getPackage`, `listPackageAssets`,
+ * `listAudioAssets`, `loadBoardState`. Per the design: they are bounded by
+ * their projections and by the `$in` over a package's <=64 items, and a read
+ * bound risks breaking a legitimate board reload (opening a campaign fires
+ * several of these at once, and a refused one leaves a half-loaded board).
+ *
+ * Formats the refusal message a rejected caller sees. Rounds UP to whole
+ * seconds and never says "0s" — a message that tells the user to retry
+ * immediately is worse than no message, because retrying immediately fails.
+ */
+export function rateLimitMessage(action: string, retryAfterMs: number): string {
+  const seconds = Math.max(1, Math.ceil(retryAfterMs / 1000));
+  return `Too many ${action} requests. Try again in ${seconds}s.`;
+}

--- a/app/lib/rate-limit.ts
+++ b/app/lib/rate-limit.ts
@@ -25,7 +25,11 @@ export interface RateLimiterOptions {
   refillPerSec: number;
   /** Injected clock in milliseconds. Defaults to `Date.now` so callers need not pass one. */
   now?: () => number;
-  /** Bound on tracked keys; the oldest key (by first-seen order) is evicted past this. */
+  /**
+   * Bound on tracked keys; the oldest key (by first-seen order) is evicted
+   * past this. That is a MEMORY BOUND, not a fairness guarantee — see the
+   * eviction site in `check` for what "oldest" does and does not mean here.
+   */
   maxKeys?: number;
 }
 
@@ -48,6 +52,21 @@ export interface RateLimiter {
 export function createRateLimiter(options: RateLimiterOptions): RateLimiter {
   const { capacity, refillPerSec, now = Date.now, maxKeys = 500 } = options;
 
+  // The invariant lives here rather than at each call site. Both values are
+  // divisors or ceilings of the whole mechanism: `refillPerSec <= 0` makes
+  // `retryAfterMs` `Infinity` or negative and a bucket that never refills,
+  // and `capacity <= 0` makes every bucket start empty, so either one turns
+  // a limiter into a permanent refusal for every key — silently, at runtime,
+  // long after construction. `~/lib/audio-rate-limits.ts`'s
+  // `envPositiveNumber` already guards the two env-configured numbers; this
+  // guards the other buckets and any future caller that forgets to.
+  if (!Number.isFinite(refillPerSec) || refillPerSec <= 0) {
+    throw new Error(`createRateLimiter: refillPerSec must be > 0, got ${refillPerSec}`);
+  }
+  if (!Number.isFinite(capacity) || capacity <= 0) {
+    throw new Error(`createRateLimiter: capacity must be > 0, got ${capacity}`);
+  }
+
   const buckets = new Map<string, Bucket>();
 
   return {
@@ -59,6 +78,15 @@ export function createRateLimiter(options: RateLimiterOptions): RateLimiter {
         if (buckets.size >= maxKeys) {
           // Map iteration order is insertion order, so the first key is the
           // oldest — same eviction strategy as exception-throttle.ts.
+          //
+          // "Oldest" means FIRST SEEN, not least recently used: a key found
+          // via `get` below never re-enters insertion order, so an actively
+          // throttled key can be evicted and its bucket then re-created at
+          // full capacity by its next call. This is a memory bound, not a
+          // fairness guarantee, and it is deliberately left that way (it
+          // matches `exception-throttle.ts`, and defeating it costs an
+          // attacker `maxKeys` distinct authenticated accounts, since the key
+          // is a Mongo `_id`). Do not read LRU into the word "oldest".
           const oldest = buckets.keys().next().value;
           if (oldest !== undefined) buckets.delete(oldest);
         }

--- a/app/lib/rate-limit.ts
+++ b/app/lib/rate-limit.ts
@@ -1,0 +1,85 @@
+/**
+ * Pure, framework-free token-bucket rate limiter.
+ *
+ * Each key gets its own bucket that starts full (`capacity` tokens) and
+ * refills continuously at `refillPerSec` tokens per second. A `check(key)`
+ * call consumes one token if available (`allowed: true`) or, if the bucket
+ * is empty, reports how long until one token will exist (`retryAfterMs`).
+ * Time is injected via `now` (defaulting to `Date.now`) so callers can drive
+ * it deterministically in tests, mirroring `app/utils/exception-throttle.ts`
+ * — the shape this module follows.
+ *
+ * Scope: this is an in-process, in-memory limiter. The web pod currently
+ * runs `replicaCount: 1`, so a single process's bucket state is the whole
+ * picture and this is honest as a global (or per-key) limit. If the
+ * deployment is ever scaled to multiple replicas, each replica gets its own
+ * independent buckets — the effective limit becomes per-replica, not
+ * cluster-wide. Re-derive this module (e.g. onto a shared store) before
+ * relying on it at N>1 replicas.
+ */
+
+export interface RateLimiterOptions {
+  /** Maximum tokens a bucket can hold — the largest burst a key may pass in one go. */
+  capacity: number;
+  /** Tokens restored per second, applied continuously based on elapsed time. */
+  refillPerSec: number;
+  /** Injected clock in milliseconds. Defaults to `Date.now` so callers need not pass one. */
+  now?: () => number;
+  /** Bound on tracked keys; the oldest key (by first-seen order) is evicted past this. */
+  maxKeys?: number;
+}
+
+export interface RateLimitDecision {
+  /** Whether this call may proceed. */
+  allowed: boolean;
+  /** Milliseconds until this key would next have a token available. Always `0` when `allowed` is `true`. */
+  retryAfterMs: number;
+}
+
+interface Bucket {
+  tokens: number;
+  lastRefillMs: number;
+}
+
+export interface RateLimiter {
+  check(key: string): RateLimitDecision;
+}
+
+export function createRateLimiter(options: RateLimiterOptions): RateLimiter {
+  const { capacity, refillPerSec, now = Date.now, maxKeys = 500 } = options;
+
+  const buckets = new Map<string, Bucket>();
+
+  return {
+    check(key) {
+      const nowMs = now();
+      let bucket = buckets.get(key);
+
+      if (!bucket) {
+        if (buckets.size >= maxKeys) {
+          // Map iteration order is insertion order, so the first key is the
+          // oldest — same eviction strategy as exception-throttle.ts.
+          const oldest = buckets.keys().next().value;
+          if (oldest !== undefined) buckets.delete(oldest);
+        }
+        bucket = { tokens: capacity, lastRefillMs: nowMs };
+        buckets.set(key, bucket);
+      } else {
+        const elapsedMs = nowMs - bucket.lastRefillMs;
+        if (elapsedMs > 0) {
+          bucket.tokens = Math.min(capacity, bucket.tokens + (elapsedMs / 1000) * refillPerSec);
+          bucket.lastRefillMs = nowMs;
+        }
+      }
+
+      if (bucket.tokens >= 1) {
+        bucket.tokens -= 1;
+        return { allowed: true, retryAfterMs: 0 };
+      }
+
+      const deficit = 1 - bucket.tokens;
+      const retryAfterMs = Math.ceil((deficit / refillPerSec) * 1000);
+      return { allowed: false, retryAfterMs };
+    },
+  };
+}

--- a/app/lib/soundboard/engine.browser.test.ts
+++ b/app/lib/soundboard/engine.browser.test.ts
@@ -108,6 +108,24 @@ function loaderFor(assets: Record<string, EngineAsset>) {
   return (assetId: string) => Promise.resolve(assets[assetId] ?? null);
 }
 
+/**
+ * Same as `loaderFor`, plus a call count per `assetId`. The asset cache is
+ * private engine state — the number of times `loadAsset` gets asked for a
+ * given id is the only black-box signal of whether that id's buffer is still
+ * cached (1 call) or was evicted and had to be re-decoded (2+ calls).
+ */
+function countingLoader(assets: Record<string, EngineAsset>): {
+  loadAsset: (assetId: string) => Promise<EngineAsset | null>;
+  calls: Record<string, number>;
+} {
+  const calls: Record<string, number> = {};
+  const loadAsset = (assetId: string) => {
+    calls[assetId] = (calls[assetId] ?? 0) + 1;
+    return Promise.resolve(assets[assetId] ?? null);
+  };
+  return { loadAsset, calls };
+}
+
 describe('createEngine — fades', () => {
   it('fades in on a clean linear ramp that reaches the target at exactly t = fade', async () => {
     const ctx = new OfflineAudioContext(1, 3 * SR, SR);
@@ -730,5 +748,115 @@ describe('createEngine — volume and teardown', () => {
 
     expect(at(rendered, 0.9)).toBeCloseTo(1, 5);
     expect(peakBetween(rendered, 1.01, 2)).toBeCloseTo(0, 5);
+  });
+});
+
+describe('createEngine — decoded-buffer cache cap', () => {
+  // Real fixtures, real bytes: three 0.01 s mono buffers, 480 samples each.
+  // `assetCacheCapBytes` is overridden per test so the cap is genuinely
+  // crossed by a few KB of fixture instead of requiring gigabytes of real
+  // decoded audio to prove the same thing.
+  const BYTES_PER_ASSET = 480 * 1 * 4; // mono, float32 — 1920 bytes.
+
+  function tinyAsset(ctx: BaseAudioContext): EngineAsset {
+    return { buffer: dcBuffer(ctx, 0.01), durationSamples: 480 };
+  }
+
+  it('evicts an idle asset past the cap, and never the one still playing', async () => {
+    const ctx = new OfflineAudioContext(1, SR, SR);
+    const fixtures: Record<string, EngineAsset> = {
+      a: tinyAsset(ctx),
+      b: tinyAsset(ctx),
+      c: tinyAsset(ctx),
+    };
+    const { loadAsset, calls } = countingLoader(fixtures);
+    // Room for two assets, not three — the fixture only has teeth if loading
+    // the third genuinely crosses the cap rather than approaching it.
+    const assetCacheCapBytes = BYTES_PER_ASSET * 2 + 1;
+    const engine = createEngine(ctx, { loadAsset, assetCacheCapBytes });
+
+    const itemA = boardItem({ itemId: 'a', assetId: 'a', playing: true, volume: 1, loop: true });
+    const itemB = boardItem({ itemId: 'b', assetId: 'b', playing: true, volume: 1, loop: true });
+    const itemC = boardItem({ itemId: 'c', assetId: 'c', playing: true, volume: 1, loop: true });
+
+    // a loads and is left playing for the rest of the test — the
+    // "currently playing" asset. It is also the OLDEST cache entry once b
+    // and c have loaded, which matters below: a plain LRU-by-age policy
+    // would reach for it first and get this exactly backwards.
+    engine.apply(board([itemA]));
+    await engine.ready();
+
+    // b loads, plays briefly, then stops — idle, but still resident.
+    engine.apply(board([itemA, itemB]));
+    await engine.ready();
+    engine.apply(board([itemA, { ...itemB, playing: false }]));
+    await engine.ready();
+    expect(calls.a).toBe(1);
+    expect(calls.b).toBe(1);
+
+    // c loads. a + b + c is three assets' worth of bytes — over cap. a is
+    // playing and idle-b is not; eviction must take b.
+    engine.apply(board([itemA, { ...itemB, playing: false }, itemC]));
+    await engine.ready();
+
+    // Retrigger a: stop it, then immediately restart it. If a survived
+    // eviction this is a synchronous restart — its buffer is still in the
+    // cache, so no new decode is needed. If a was wrongly evicted instead of
+    // b, `start` finds no buffer and reconcile has to re-request it.
+    engine.apply(board([{ ...itemA, playing: false }, { ...itemB, playing: false }, itemC]));
+    engine.apply(board([itemA, { ...itemB, playing: false }, itemC]));
+    await engine.ready();
+    expect(calls.a).toBe(1);
+
+    // b, in contrast, must have been evicted — playing it again needs a
+    // fresh decode.
+    engine.apply(board([itemA, itemB, itemC]));
+    await engine.ready();
+    expect(calls.b).toBe(2);
+
+    // Nothing here should have thrown or left the graph in a bad state.
+    await expect(ctx.startRendering()).resolves.toBeTruthy();
+  });
+
+  it('re-decodes an evicted asset on next play, and it actually plays — not a silent no-op', async () => {
+    const ctx = new OfflineAudioContext(1, SR, SR);
+    const fixtures: Record<string, EngineAsset> = { x: tinyAsset(ctx), y: tinyAsset(ctx) };
+    const { loadAsset, calls } = countingLoader(fixtures);
+    const errors: Array<{ assetId: string; error: unknown }> = [];
+    // Room for exactly one of these assets at a time.
+    const assetCacheCapBytes = BYTES_PER_ASSET + 1;
+    const engine = createEngine(ctx, {
+      loadAsset,
+      assetCacheCapBytes,
+      onLoadError: (assetId, error) => errors.push({ assetId, error }),
+    });
+
+    const itemX = boardItem({ itemId: 'x', assetId: 'x', playing: true, volume: 1, loop: true });
+    const itemY = boardItem({ itemId: 'y', assetId: 'y', playing: true, volume: 1, loop: true });
+
+    // x loads and plays, then stops — idle, but still cached.
+    engine.apply(board([itemX]));
+    await engine.ready();
+    engine.apply(board([{ ...itemX, playing: false }]));
+    await engine.ready();
+
+    // y loads and plays. x + y is two assets' worth of bytes against a
+    // one-asset cap — over cap. x is idle and y is playing, so eviction must
+    // take x, not y.
+    engine.apply(board([{ ...itemX, playing: false }, itemY]));
+    await engine.ready();
+    expect(calls.x).toBe(1);
+
+    // Stop y, then play x again. x's buffer is gone — this must re-decode
+    // rather than leaving the pad silently unlit.
+    engine.apply(board([itemX, { ...itemY, playing: false }]));
+    await engine.ready();
+
+    expect(calls.x).toBe(2);
+    expect(errors).toEqual([]);
+
+    const rendered = await ctx.startRendering();
+    // Not just "no error" — actually sounding, at the volume x was given.
+    expect(at(rendered, 0.005)).toBeCloseTo(1, 4);
   });
 });

--- a/app/lib/soundboard/engine.browser.test.ts
+++ b/app/lib/soundboard/engine.browser.test.ts
@@ -751,6 +751,89 @@ describe('createEngine — volume and teardown', () => {
   });
 });
 
+describe('createEngine — teardown aborts in-flight loads (Task 9)', () => {
+  it('does not throw into the graph or file a capture when dispose() runs on a load still in flight', async () => {
+    const ctx = new OfflineAudioContext(1, SR, SR);
+    const errors: Array<{ assetId: string; error: unknown }> = [];
+    let calls = 0;
+    // Settles ONLY in response to the AbortSignal `dispose()` fires — never
+    // on its own. A loader that resolved by itself would let `dispose()` win
+    // a race against an already-settled load and prove nothing; this shape
+    // guarantees the load is genuinely still pending when dispose runs, which
+    // is the one condition the guard under test actually has to hold up
+    // under.
+    const loadAsset = (_assetId: string, signal: AbortSignal): Promise<EngineAsset | null> => {
+      calls += 1;
+      return new Promise((_resolve, reject) => {
+        signal.addEventListener('abort', () => {
+          reject(new DOMException('The operation was aborted.', 'AbortError'));
+        });
+      });
+    };
+    const engine = createEngine(ctx, {
+      loadAsset,
+      onLoadError: (assetId, error) => errors.push({ assetId, error }),
+    });
+
+    engine.apply(
+      board([boardItem({ itemId: 'storm', assetId: 'a1', playing: true, volume: 1, loop: true })])
+    );
+    // The load is genuinely in flight — `loadAsset` above never resolves on
+    // its own, so if this were 0 the rest of the test would be vacuous.
+    expect(calls).toBe(1);
+
+    expect(() => engine.dispose()).not.toThrow();
+    // Let the abort's rejection reach `ensureAsset`'s `.catch` — a microtask,
+    // not a real delay.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(errors).toEqual([]);
+    // Not just "no capture" — the graph itself must still be renderable, i.e.
+    // nothing threw into a callback Web Audio was driving.
+    await expect(ctx.startRendering()).resolves.toBeTruthy();
+  });
+
+  it('still reports a genuine load failure while the engine is live — the disposed guard does not swallow everything', async () => {
+    const ctx = new OfflineAudioContext(1, SR, SR);
+    const errors: Array<{ assetId: string; error: unknown }> = [];
+    const boom = new Error('decode failed');
+    const engine = createEngine(ctx, {
+      loadAsset: () => Promise.reject(boom),
+      onLoadError: (assetId, error) => errors.push({ assetId, error }),
+    });
+
+    engine.apply(
+      board([boardItem({ itemId: 'storm', assetId: 'a1', playing: true, volume: 1, loop: true })])
+    );
+    await engine.ready();
+
+    // The engine was never disposed, so this is the ordinary case: a real
+    // failure must still reach telemetry. Proves the `disposed` gate added
+    // for teardown does not accidentally silence everything.
+    expect(errors).toEqual([{ assetId: 'a1', error: boom }]);
+  });
+
+  it('dispose() drains `pending` — ready() resolves promptly even for a load that never settles on its own (Handoff 1)', async () => {
+    const ctx = new OfflineAudioContext(1, SR, SR);
+    // Ignores the abort signal entirely — standing in for a caller whose
+    // network layer cannot be cancelled (or simply did not wire the signal
+    // through). If `dispose()` left this entry in `pending`, `ready()`'s
+    // `while (pending.size > 0) await Promise.all(...)` would await a
+    // promise that never settles and this test would hang until vitest's
+    // timeout, not resolve.
+    const loadAsset = (): Promise<EngineAsset | null> => new Promise(() => {});
+    const engine = createEngine(ctx, { loadAsset });
+
+    engine.apply(
+      board([boardItem({ itemId: 'storm', assetId: 'a1', playing: true, volume: 1, loop: true })])
+    );
+
+    engine.dispose();
+
+    await expect(engine.ready()).resolves.toBeUndefined();
+  });
+});
+
 describe('createEngine — decoded-buffer cache cap', () => {
   // Real fixtures, real bytes: three 0.01 s mono buffers, 480 samples each.
   // `assetCacheCapBytes` is overridden per test so the cap is genuinely

--- a/app/lib/soundboard/engine.browser.test.ts
+++ b/app/lib/soundboard/engine.browser.test.ts
@@ -859,4 +859,66 @@ describe('createEngine — decoded-buffer cache cap', () => {
     // Not just "no error" — actually sounding, at the volume x was given.
     expect(at(rendered, 0.005)).toBeCloseTo(1, 4);
   });
+
+  it('fires a cold one-shot correctly even when the cache is fully saturated with playing assets', async () => {
+    // Stereo, and the two beds vs. the one-shot are put on separate channels
+    // (the same isolation trick the fades tests use) — on a single shared
+    // channel, "the beds are playing" and "the one-shot also played" sum
+    // together and become indistinguishable in the rendered output.
+    const ctx = new OfflineAudioContext(2, SR, SR);
+    const bedBuffer = () => dcBuffer(ctx, 0.01, { channels: 2, activeChannel: 0 });
+    const oneShotBuffer = () => dcBuffer(ctx, 0.01, { channels: 2, activeChannel: 1 });
+    const bytesPerStereoAsset = 480 * 2 * 4; // 3840 bytes.
+    const fixtures: Record<string, EngineAsset> = {
+      p1: { buffer: bedBuffer(), durationSamples: 480 },
+      p2: { buffer: bedBuffer(), durationSamples: 480 },
+      c: { buffer: oneShotBuffer(), durationSamples: 480 },
+    };
+    const { loadAsset, calls } = countingLoader(fixtures);
+    const errors: Array<{ assetId: string; error: unknown }> = [];
+    // Room for exactly the two beds below — zero idle headroom once both are
+    // playing. This is not a contrived corner: the cap's own derivation notes
+    // that two long ambience beds playing together already consume the whole
+    // 1 GiB production cap, so "nothing evictable" is the normal state of a
+    // busy board, not an edge case.
+    const assetCacheCapBytes = bytesPerStereoAsset * 2;
+    const engine = createEngine(ctx, {
+      loadAsset,
+      assetCacheCapBytes,
+      onLoadError: (assetId, error) => errors.push({ assetId, error }),
+    });
+
+    const p1 = boardItem({ itemId: 'p1', assetId: 'p1', playing: true, volume: 1, loop: true });
+    const p2 = boardItem({ itemId: 'p2', assetId: 'p2', playing: true, volume: 1, loop: true });
+    // Never played as a pad (`playing: false`) — only ever reached through
+    // `fireOneShot`, so its asset is genuinely cold when fired below.
+    const cItem = boardItem({ itemId: 'c', assetId: 'c', playing: false, volume: 1, loop: false });
+
+    // Both beds load and are left playing. The cache is now exactly at cap,
+    // nothing idle to reclaim.
+    engine.apply(board([p1, p2]));
+    await engine.ready();
+    expect(calls.p1).toBe(1);
+    expect(calls.p2).toBe(1);
+
+    // Fire a one-shot on the third, never-loaded asset. Decoding it pushes
+    // the cache over cap with both beds still playing — the only thing
+    // `evictAssets` could otherwise reach for is the one-shot's own
+    // just-landed buffer, before `fireOneShot`'s own continuation ever gets a
+    // turn to call `start` and mark it playing. That race is exactly what
+    // `firingOneShots` exists to close.
+    engine.apply(board([p1, p2, cItem]));
+    engine.fireOneShot('c');
+    await engine.ready();
+
+    expect(calls.c).toBe(1);
+    expect(errors).toEqual([]);
+
+    const rendered = await ctx.startRendering();
+    // c's own channel: silence here would mean the fire was dropped — the
+    // assertion that actually rules that out, not just "no thrown error".
+    expect(at(rendered, 0.005, 1)).toBeCloseTo(1, 4);
+    // Sanity: the beds are still there too, undisturbed by the one-shot.
+    expect(at(rendered, 0.005, 0)).toBeCloseTo(2, 4);
+  });
 });

--- a/app/lib/soundboard/engine.ts
+++ b/app/lib/soundboard/engine.ts
@@ -43,7 +43,33 @@ export type SoundboardEngineOptions = {
   onItemEnded?: (itemId: string) => void;
   /** Fired when `loadAsset` rejects. The engine keeps running, silent for that asset. */
   onLoadError?: (assetId: string, error: unknown) => void;
+  /**
+   * Overrides `DEFAULT_ASSET_CACHE_CAP_BYTES`. Not needed in production — the
+   * default is sized against the documented worst case. Exists so tests can
+   * cross the cap with small fixture buffers instead of allocating gigabytes
+   * of real decoded audio.
+   */
+  assetCacheCapBytes?: number;
 };
+
+/**
+ * Default cap, in bytes, on the sum of decoded `AudioBuffer` sizes held in
+ * the engine's asset cache (`assets`).
+ *
+ * Sized against the documented worst case rather than picked round: at the
+ * current caps (64 items, 30-minute assets, 48 kHz stereo float32) ONE fully
+ * decoded asset already costs `48_000 × 1800 × 2 channels × 4 bytes` ≈
+ * 691 MB — see `docs/specs/2026-07-31-audio-hardening-design.md`. 1 GiB
+ * leaves room for that single worst-case asset plus a handful of shorter
+ * loops and one-shots resident at once (a storm bed, a rain bed, and a few
+ * one-shots layered over them is the realistic ceiling for one board), while
+ * still bounding a board that plays through all 64 documented-max assets —
+ * ~44 GB unbounded — down to about 1/44th of that. It is a per-engine cap:
+ * a page holding several boards' engines multiplies it, which is a
+ * lifecycle question for whoever owns how many engines exist at once, not
+ * something one engine's cache can bound from the inside.
+ */
+export const DEFAULT_ASSET_CACHE_CAP_BYTES = 1024 * 1024 * 1024;
 
 export type SoundboardEngine = {
   /**
@@ -85,6 +111,13 @@ export type SoundboardEngine = {
 type Track = {
   gain: GainNode | null;
   source: AudioBufferSourceNode | null;
+  /**
+   * The asset this track's current (or most recent) source plays from. Set by
+   * `start`; read by `isAssetPlaying` to decide what the cache cap may evict.
+   * Stale while `source` is `null` — harmless, since every read of this field
+   * is gated on `source` being non-null first.
+   */
+  assetId: string | null;
   /** `ctx.currentTime` at which `source` started — needed to find the playhead
    * when loop is flipped off mid-play. */
   startedAt: number;
@@ -151,7 +184,19 @@ export function createEngine(
    * that one-shot, because it is the same key within this map.
    */
   const oneShots = new Map<string, Track>();
+  /**
+   * The decoded-buffer cache, keyed by `assetId`. Bounded by
+   * `assetCacheCapBytes` (see `evictAssets`) rather than left to grow for the
+   * engine's whole life — see `DEFAULT_ASSET_CACHE_CAP_BYTES`.
+   *
+   * Iteration order doubles as recency order: `touchAsset` moves an entry to
+   * the end on every access, so `evictAssets` walking front-to-back visits
+   * least-recently-used entries first. `Map` preserves insertion order and
+   * does NOT reorder on a plain `set` of an existing key, which is why
+   * `touchAsset` has to delete-then-set rather than just `set`.
+   */
   const assets = new Map<string, EngineAsset>();
+  const assetCacheCapBytes = options.assetCacheCapBytes ?? DEFAULT_ASSET_CACHE_CAP_BYTES;
   const pending = new Map<string, Promise<void>>();
   /** Assets whose load returned `null` or threw — never retried. */
   const unplayable = new Set<string>();
@@ -196,6 +241,72 @@ export function createEngine(
     return Math.min(asset.durationSamples / AUDIO_RENDITION_SAMPLE_RATE, asset.buffer.duration);
   }
 
+  /** Decoded size of one asset's buffer: float32 PCM, 4 bytes per sample per channel. */
+  function assetBytes(asset: EngineAsset): number {
+    return asset.buffer.length * asset.buffer.numberOfChannels * 4;
+  }
+
+  /**
+   * True if `assetId`'s buffer is behind a source that is actually sounding
+   * right now — a pad in `tracks` or a transient fire in `oneShots`.
+   *
+   * This is the one rule `evictAssets` may never break: a `Track`'s `source`
+   * doubles as "is this pad sounding" throughout the engine (see the `Track`
+   * doc comment), so checking it here is the same test every other read of
+   * play state uses, not a separate notion of "playing" invented for the
+   * cache.
+   */
+  function isAssetPlaying(assetId: string): boolean {
+    for (const track of tracks.values()) {
+      if (track.source && track.assetId === assetId) return true;
+    }
+    for (const track of oneShots.values()) {
+      if (track.source && track.assetId === assetId) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Moves `assetId` to the most-recently-used end of `assets`'s iteration
+   * order. See the `assets` doc comment for why a delete + re-set is needed.
+   * A no-op if the asset is not cached (nothing to touch).
+   */
+  function touchAsset(assetId: string): void {
+    const asset = assets.get(assetId);
+    if (!asset) return;
+    assets.delete(assetId);
+    assets.set(assetId, asset);
+  }
+
+  /**
+   * Evict least-recently-used, not-currently-playing assets until the cache
+   * is back at or under `assetCacheCapBytes` — or until nothing left is
+   * evictable.
+   *
+   * Called only after `reconcile` has had a chance to start whatever should
+   * be playing (see the call site in `ensureAsset`): a `finally` ordered the
+   * other way round would let a just-decoded asset that is about to be
+   * played get evicted before `start` ever marks it playing, since at the
+   * moment its bytes land in `assets` its track has no source yet.
+   *
+   * Leaving the cache over cap when everything resident is playing is
+   * correct, not a bug: that memory is sound the GM is actually hearing, and
+   * the only rule that is not negotiable is that eviction never touches it.
+   * An evicted asset is not lost — the next `ensureAsset` for it re-decodes
+   * through the exact same path a cold engine uses for a first play.
+   */
+  function evictAssets(): void {
+    let total = 0;
+    for (const asset of assets.values()) total += assetBytes(asset);
+    if (total <= assetCacheCapBytes) return;
+    for (const [assetId, asset] of assets) {
+      if (total <= assetCacheCapBytes) break;
+      if (isAssetPlaying(assetId)) continue;
+      assets.delete(assetId);
+      total -= assetBytes(asset);
+    }
+  }
+
   function trackFor(itemId: string, transient: boolean): Track {
     const map = transient ? oneShots : tracks;
     const existing = map.get(itemId);
@@ -203,6 +314,7 @@ export function createEngine(
     const created: Track = {
       gain: null,
       source: null,
+      assetId: null,
       startedAt: 0,
       volume: 1,
       fadeSeconds: 0,
@@ -268,6 +380,9 @@ export function createEngine(
   function start(item: BoardItemState, transient: boolean): void {
     const asset = assets.get(item.assetId);
     if (!asset) return;
+    // Mark this asset as freshly used before anything below can be evicted
+    // out from under it.
+    touchAsset(item.assetId);
     const track = trackFor(item.itemId, transient);
     if (track.source) stopTrack(item.itemId, track, true);
 
@@ -316,6 +431,7 @@ export function createEngine(
 
     track.gain = gain;
     track.source = source;
+    track.assetId = item.assetId;
     track.startedAt = now;
     track.volume = item.volume;
     track.fadeSeconds = fade;
@@ -400,6 +516,10 @@ export function createEngine(
         // the state that triggered the load — the GM may have changed mood
         // three times while a 6 MB ambience downloaded.
         if (!disposed && latest) reconcile(latest);
+        // AFTER reconcile, not before: reconcile is what starts this asset
+        // playing if it should be, and `evictAssets` must see that before it
+        // decides what is safe to evict. See `evictAssets`'s doc comment.
+        if (!disposed) evictAssets();
       });
     pending.set(assetId, load);
   }

--- a/app/lib/soundboard/engine.ts
+++ b/app/lib/soundboard/engine.ts
@@ -30,8 +30,17 @@ export type SoundboardEngineOptions = {
    * Fetch + `decodeAudioData` for one asset id. Returning `null` means "this
    * asset cannot be played" (not ready, no rendition, deleted) and the engine
    * will not ask again for the lifetime of the engine.
+   *
+   * `signal` aborts the instant `dispose()` runs (see there). A caller whose
+   * implementation makes a network request SHOULD pass it straight through
+   * (`fetch(url, { signal })`) so a torn-down board actually cancels its
+   * in-flight downloads rather than merely discarding a result nobody will
+   * use. The engine does not depend on this for correctness — any
+   * settlement that lands after `dispose()`, aborted or not, is dropped
+   * unconditionally (see `ensureAsset`) — so an implementation that ignores
+   * `signal` degrades to wasted bandwidth, not wrong behaviour.
    */
-  loadAsset: (assetId: string) => Promise<EngineAsset | null>;
+  loadAsset: (assetId: string, signal: AbortSignal) => Promise<EngineAsset | null>;
   /**
    * Fired when a pad releases itself — a one-shot reaching the end of its
    * buffer, or a loop that was flipped to `1×` finishing its current pass.
@@ -236,6 +245,16 @@ export function createEngine(
    * lifetime of engines that come and go.
    */
   const live = new Set<AudioBufferSourceNode>();
+  /**
+   * Aborted in `dispose()`. Threaded through to `options.loadAsset` on every
+   * call so a caller whose implementation is a `fetch` can actually cancel
+   * the request on teardown rather than just having its result ignored — see
+   * that option's doc comment. `ensureAsset`'s `disposed` guards are what
+   * make capture-suppression correct even for an implementation that ignores
+   * this signal entirely; aborting is resource hygiene on top of that, not a
+   * second source of truth.
+   */
+  const abortController = new AbortController();
 
   let latest: BoardState | null = null;
   let masterVolume = 1;
@@ -529,12 +548,28 @@ export function createEngine(
   function ensureAsset(assetId: string): void {
     if (assets.has(assetId) || pending.has(assetId) || unplayable.has(assetId)) return;
     const load = options
-      .loadAsset(assetId)
+      .loadAsset(assetId, abortController.signal)
       .then((asset) => {
+        // A disposed engine's `assets`/`unplayable` are deliberately cleared
+        // by `dispose()` (Handoff 1) and MUST stay empty afterward — a load
+        // that happened to be mid-flight at teardown and settles successfully
+        // later must not silently repopulate the cache of an engine nobody
+        // can ever play through again.
+        if (disposed) return;
         if (asset) assets.set(assetId, asset);
         else unplayable.add(assetId);
       })
       .catch((error: unknown) => {
+        // THE TEARDOWN-TELEMETRY FIX. Once `dispose()` has run, every load
+        // still in flight is expected to reject — that is the point of
+        // aborting them — and is not a genuine failure anyone needs to hear
+        // about. Gating on `disposed` here (rather than sniffing the error
+        // for an "AbortError" name) also silences a load that fails for an
+        // unrelated reason after teardown, which is correct: nobody is
+        // listening to this engine anymore either way. A failure that lands
+        // while the engine is still live — the ordinary case — is untouched
+        // and still reports exactly as before.
+        if (disposed) return;
         unplayable.add(assetId);
         options.onLoadError?.(assetId, error);
       })
@@ -715,6 +750,15 @@ export function createEngine(
     dispose(): void {
       if (disposed) return;
       disposed = true;
+      // Cancels every fetch/decode chain still in flight (up to 64 of them,
+      // one per asset a board can reference). This is network hygiene, not
+      // what makes teardown silent — `ensureAsset`'s `disposed` guards do
+      // that regardless of whether `options.loadAsset` honours the signal at
+      // all. Ordering matters only in that `disposed` is already `true`
+      // before this fires: `abort()`'s listeners run synchronously, but the
+      // promise rejection they cause is always a later microtask, so
+      // `ensureAsset`'s guards see the flag correctly either way.
+      abortController.abort();
       const now = ctx.currentTime;
       for (const source of live) {
         source.onended = null;
@@ -727,6 +771,30 @@ export function createEngine(
       live.clear();
       tracks.clear();
       oneShots.clear();
+      // Handoff from Task 8's review: without this, a disposed engine held
+      // onto its whole decoded-buffer cache — up to the full byte cap (1 GiB
+      // by default) — reachable until the entire engine object was garbage
+      // collected. Nothing SOUNDS different for clearing these: every source
+      // is already stopped above, and `master.disconnect()` below is what
+      // makes dispose silent. This is releasing memory a dead engine has no
+      // further use for, nothing more.
+      assets.clear();
+      pending.clear();
+      unplayable.clear();
+      // `firingOneShots` is deliberately left alone. Unlike the collections
+      // above it is not dead weight to reclaim: every entry is a reservation
+      // tied to a `pending` promise whose `.then()` continuation
+      // (`fireOneShot`'s cold path) is ALREADY attached and will still run
+      // when that promise settles — dispose cannot detach it, only make its
+      // body a no-op via the `!disposed` check it already has. That
+      // continuation's own `finally` removes the entry regardless of
+      // `disposed` (see the set's doc comment: "self-clears … including
+      // engine disposal"), so it is never permanently retained. And nothing
+      // reads this set once `disposed` is true — `evictAssets`, its only
+      // reader, is gated on `!disposed` at both call sites — so a stale
+      // entry in the window between now and that `finally` is inert. Clearing
+      // it here would just be a second writer racing the one that already
+      // owns cleanup correctly.
       // This, not the loop above, is what makes dispose silent.
       master.disconnect();
     },

--- a/app/lib/soundboard/engine.ts
+++ b/app/lib/soundboard/engine.ts
@@ -59,15 +59,22 @@ export type SoundboardEngineOptions = {
  * Sized against the documented worst case rather than picked round: at the
  * current caps (64 items, 30-minute assets, 48 kHz stereo float32) ONE fully
  * decoded asset already costs `48_000 × 1800 × 2 channels × 4 bytes` ≈
- * 691 MB — see `docs/specs/2026-07-31-audio-hardening-design.md`. 1 GiB
- * leaves room for that single worst-case asset plus a handful of shorter
- * loops and one-shots resident at once (a storm bed, a rain bed, and a few
- * one-shots layered over them is the realistic ceiling for one board), while
- * still bounding a board that plays through all 64 documented-max assets —
- * ~44 GB unbounded — down to about 1/44th of that. It is a per-engine cap:
- * a page holding several boards' engines multiplies it, which is a
- * lifecycle question for whoever owns how many engines exist at once, not
- * something one engine's cache can bound from the inside.
+ * 691 MB (≈ 659 MiB) — see `docs/specs/2026-07-31-audio-hardening-design.md`.
+ * 1 GiB leaves only ≈ 365 MiB of headroom past that one asset — enough for a
+ * realistic handful of SHORT residents alongside it (one-shots, stingers, a
+ * minute-or-two loop), NOT a second near-worst-case 30-minute bed: two long
+ * ambience beds playing together (a storm plus rain, both looping — an
+ * entirely normal soundboard pattern) already sum past the cap on their own.
+ * That is an accepted, not a hidden, consequence: when the cache is over cap
+ * and everything resident is playing, `evictAssets` leaves it over cap (see
+ * its doc comment) rather than cutting audio — the cap bounds the RUNAWAY
+ * case, it does not guarantee everything simultaneously playing always fits.
+ * Against that runaway case — a board that plays through all 64
+ * documented-max assets, ~44 GB unbounded — 1 GiB is still roughly a 41×
+ * reduction. It is a per-engine cap: a page holding several boards' engines
+ * multiplies it, which is a lifecycle question for whoever owns how many
+ * engines exist at once, not something one engine's cache can bound from the
+ * inside.
  */
 export const DEFAULT_ASSET_CACHE_CAP_BYTES = 1024 * 1024 * 1024;
 
@@ -201,6 +208,23 @@ export function createEngine(
   /** Assets whose load returned `null` or threw — never retried. */
   const unplayable = new Set<string>();
   /**
+   * `assetId`s with a `fireOneShot` cold load in flight that has not yet had
+   * its chance to `start()` the resulting source.
+   *
+   * `fireOneShot`'s cold path (see its implementation) chains its own
+   * `.then()` onto the SAME promise `ensureAsset` already attached its
+   * `.finally()` to — and that `.finally()` is what calls `evictAssets`.
+   * Promise semantics guarantee `fireOneShot`'s continuation always runs
+   * strictly AFTER that `.finally()` completes, so by the time it would call
+   * `start()` and mark the asset playing via `isAssetPlaying`, eviction has
+   * already run once. Without this set, a one-shot's own just-decoded buffer
+   * could be evicted before it ever plays, whenever nothing else resident is
+   * evictable — dropping the fire silently, no error. This bridges exactly
+   * that gap: added before `ensureAsset` is asked to load, removed once
+   * `start()` has had its attempt (successful or not).
+   */
+  const firingOneShots = new Set<string>();
+  /**
    * Every source that has been started and not yet ended — INCLUDING sources
    * that are stopping but still fading out, which is why `stopTrack` replaces
    * the auto-release handler with a bookkeeping one rather than nulling it.
@@ -294,6 +318,10 @@ export function createEngine(
    * the only rule that is not negotiable is that eviction never touches it.
    * An evicted asset is not lost — the next `ensureAsset` for it re-decodes
    * through the exact same path a cold engine uses for a first play.
+   *
+   * `firingOneShots` extends that same rule to an asset that ISN'T playing
+   * yet but is about to be, for the one caller where "about to be" cannot
+   * wait for a later reconcile to make it so — see that set's doc comment.
    */
   function evictAssets(): void {
     let total = 0;
@@ -301,7 +329,7 @@ export function createEngine(
     if (total <= assetCacheCapBytes) return;
     for (const [assetId, asset] of assets) {
       if (total <= assetCacheCapBytes) break;
-      if (isAssetPlaying(assetId)) continue;
+      if (isAssetPlaying(assetId) || firingOneShots.has(assetId)) continue;
       assets.delete(assetId);
       total -= assetBytes(asset);
     }
@@ -655,12 +683,24 @@ export function createEngine(
         return;
       }
       if (unplayable.has(item.assetId)) return;
+      // Reserved BEFORE `ensureAsset` so it is visible to `evictAssets` for
+      // the whole window this cold load is in flight — including the
+      // instant `ensureAsset`'s own `.finally()` runs eviction, which is
+      // always before the `.then()` below gets a turn. See `firingOneShots`.
+      firingOneShots.add(item.assetId);
       ensureAsset(item.assetId);
       // Fire as soon as the buffer lands. A random ambient crack that arrives
       // late is still a crack; the alternative is silence until the scheduler's
       // next tick, which for a 5-minute interval is a long wait.
       void pending.get(item.assetId)?.then(() => {
-        if (!disposed && assets.has(item.assetId)) start(item, true);
+        try {
+          if (!disposed && assets.has(item.assetId)) start(item, true);
+        } finally {
+          // Whether or not this ended up sounding — evicted while cold-loading
+          // fails closed (`assets.has` is false, `start` is skipped) rather
+          // than throwing — the reservation's job is done either way.
+          firingOneShots.delete(item.assetId);
+        }
       });
     },
 

--- a/app/lib/soundboard/stale-write.ts
+++ b/app/lib/soundboard/stale-write.ts
@@ -1,0 +1,59 @@
+/**
+ * The one identity a stale-package-write refusal is recognised by, shared by
+ * the server that throws it and the browser that has to react to it.
+ *
+ * WHY A NAME AND NOT `instanceof`. `updatePackage` throws a real
+ * `PackageStaleWriteError` (`~/server/functions/packages`), but that class
+ * only exists on the server — `~/server/functions/packages` is reached solely
+ * through `await import(...)` inside a `.handler()` body and never enters the
+ * client bundle, which is exactly the constraint that keeps mongoose out of
+ * the browser. So the browser cannot `instanceof` it.
+ *
+ * What it CAN do is read `.name`. A server-fn rejection is serialized with
+ * seroval (`@tanstack/start-server-core`'s `handleServerAction` calls
+ * `toCrossJSONAsync` on the thrown value) and seroval's error encoder keeps
+ * `message`, keeps `name` whenever it differs from the base constructor's,
+ * and copies every own property across; the client then rethrows the
+ * reconstructed value (`serverFnFetcher`'s `if (result instanceof Error)
+ * throw result`). What arrives in the browser is therefore a plain `Error`
+ * carrying OUR `name` and OUR `currentUpdatedAt` — not our class. Under SSR,
+ * where the handler is invoked directly with no serialization at all, the
+ * genuine instance arrives instead; `.name` is the one discriminator true of
+ * both.
+ *
+ * This is a NAME check, not a message check. The message is user-facing copy
+ * and will be reworded; the name is the contract. `~/utils/error-
+ * classification.ts` already keys on `error.name === 'TimeoutError'` for the
+ * same reason.
+ */
+export const PACKAGE_STALE_WRITE_ERROR_NAME = 'PackageStaleWriteError';
+
+/**
+ * A stale-write refusal as the BROWSER sees it: an `Error` whose `name` is
+ * the sentinel above, plus the server's current `updatedAt` for the document
+ * the caller tried to overwrite.
+ *
+ * `currentUpdatedAt` is optional here and not on the server class, because
+ * this type describes a value that crossed a wire — a client built against an
+ * older server, or a future serializer that drops extra properties, would
+ * still produce a recognisable refusal with the field missing. Callers must
+ * treat it as "may be absent", never assert it.
+ */
+export type StalePackageWriteError = Error & { currentUpdatedAt?: string };
+
+/**
+ * True when a rejection from `updatePackageFn` is the optimistic-concurrency
+ * refusal — the caller's `expectedUpdatedAt` did not match the stored
+ * document, so the write was refused rather than applied over somebody
+ * else's.
+ *
+ * Deliberately distinguishable from the sibling refusal it would otherwise be
+ * confused with: `updatePackage` throws a plain `PackageClientError('Package
+ * not found')` when the id does not resolve for this owner, and that one
+ * returns `false` here. The two mean opposite things to a user — "this is
+ * gone / not yours" versus "this is here and newer than you think" — and the
+ * editor offers completely different affordances for each.
+ */
+export function isStalePackageWriteError(error: unknown): error is StalePackageWriteError {
+  return error instanceof Error && error.name === PACKAGE_STALE_WRITE_ERROR_NAME;
+}

--- a/app/routes/audio.tsx
+++ b/app/routes/audio.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { createFileRoute, redirect } from '@tanstack/react-router';
-import { useMutation, useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useInfiniteQuery, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { InfiniteData, QueryKey } from '@tanstack/react-query';
 import { X } from 'lucide-react';
 import { getMe } from '~/server/functions/rpc';
 import { Topbar } from '~/components/Topbar';
 import { AudioLibraryBrowser } from '~/components/audio/AudioLibraryBrowser';
 import { AudioUploadDropzone } from '~/components/audio/AudioUploadDropzone';
+import { AudioQuotaBar } from '~/components/audio/AudioQuotaBar';
 import { AudioBulkTagBar } from '~/components/audio/AudioBulkTagBar';
 import type { BulkTagPayload } from '~/components/audio/AudioBulkTagBar';
 import { AudioAssetDetail } from '~/components/audio/AudioAssetDetail';
@@ -23,6 +24,7 @@ import {
   retryAudioAssetFn,
   scanOrphanAudioFn,
   deleteOrphanAudioFn,
+  getAudioStorageUsageFn,
 } from '~/utils/audio-server-fns';
 import { uploadOnceVariantFile } from '~/utils/uploadAudio';
 import { queryKeys } from '~/utils/queryKeys';
@@ -152,6 +154,15 @@ export function AudioLibraryPage() {
     // user has paged down to must keep the poll alive, and a settled library
     // must still go quiet.
     refetchInterval: (q) => (shouldPoll(flattenAudioPages(q.state.data)) ? POLL_MS : false),
+  });
+
+  // Task 5: usage against the storage quota, shown near the dropzone. Not
+  // part of the poll above — the quota only moves on ingest/delete, not on
+  // transcode progress, so it doesn't need the 4s refetch. `invalidateAudio`
+  // covers it below alongside every other audio-branch query.
+  const usageQuery = useQuery({
+    queryKey: queryKeys.audio.usage(),
+    queryFn: () => getAudioStorageUsageFn(),
   });
 
   const assets = useMemo(() => flattenAudioPages(query.data), [query.data]);
@@ -330,6 +341,17 @@ export function AudioLibraryPage() {
           </h1>
 
           <AudioUploadDropzone onUploaded={invalidateAudio} />
+
+          <AudioQuotaBar
+            usageBytes={usageQuery.data?.bytes ?? null}
+            assetCount={usageQuery.data?.assetCount ?? 0}
+            limitBytes={usageQuery.data?.limitBytes ?? null}
+            error={
+              usageQuery.error
+                ? errorMessage(usageQuery.error, 'Failed to load storage usage.')
+                : null
+            }
+          />
 
           {nowPlaying && playbackSources.length > 0 && (
             <div className="mt-4 flex items-center gap-3 rounded border border-white/[0.07] bg-white/[0.02] p-3">

--- a/app/routes/audio_.packages_.$packageId.tsx
+++ b/app/routes/audio_.packages_.$packageId.tsx
@@ -295,6 +295,16 @@ export function PackageEditorPage() {
         setConflict({ savedAt: e.currentUpdatedAt ?? '' });
         return;
       }
+      // Any OTHER failure clears the conflict, and clearing it is load-bearing
+      // rather than tidiness. The notice suppresses the generic error line
+      // (`!conflict &&`, below), so a "Keep my edits and overwrite" click that
+      // fails with anything that is not a stale write — a 500, a dropped
+      // connection, a validator rejection — would otherwise render NOTHING:
+      // the button flips back from "Saving…" and the user's only signal that
+      // their click did nothing is the absence of change. Dropping the
+      // conflict state hands the failure back to the error line, which is the
+      // one surface that can describe it.
+      setConflict(null);
       captureException(e, { action: 'PackageEditorPage.save' });
     },
   });

--- a/app/routes/audio_.packages_.$packageId.tsx
+++ b/app/routes/audio_.packages_.$packageId.tsx
@@ -277,6 +277,18 @@ export function PackageEditorPage() {
         },
       }),
     onSuccess: (updated) => {
+      // SEEDED, not merely invalidated, and that is load-bearing rather than
+      // an optimisation. `updatePackage` returns the fresh document
+      // (`{ new: true }`), and `dirty` below is a REFERENCE comparison against
+      // `pkg`. Invalidating alone would leave `pkg` as the pre-save object
+      // until the refetch's round trip landed — so the button would still
+      // read "Save changes" on an already-saved package, and a second Save in
+      // that window would send the `updatedAt` this save just superseded,
+      // which Task 7's fence refuses. The user would then be shown a conflict
+      // notice about their OWN save; a conflict dialog that fires on the
+      // happy path is how users learn to click through conflict dialogs.
+      // `tests/routes/audio-packages-package-id-route.test.tsx` pins this by
+      // saving twice with the refetch held open.
       qc.setQueryData(queryKeys.packages.detail(packageId), updated);
       setItems(updated.items);
       setMoods(updated.moods);

--- a/app/routes/audio_.packages_.$packageId.tsx
+++ b/app/routes/audio_.packages_.$packageId.tsx
@@ -6,6 +6,7 @@ import { getMe } from '~/server/functions/rpc';
 import { Topbar } from '~/components/Topbar';
 import { PackageEditor } from '~/components/soundboard/PackageEditor';
 import { MoodEditor } from '~/components/soundboard/MoodEditor';
+import { PackageConflictNotice } from '~/components/soundboard/PackageConflictNotice';
 import { getPackageFn, updatePackageFn } from '~/utils/soundboard-server-fns';
 import { listAudioAssetsFn } from '~/utils/audio-server-fns';
 import { queryKeys } from '~/utils/queryKeys';
@@ -14,6 +15,7 @@ import type { AudioFilters } from '~/components/audio/AudioFilterBar';
 import type { AudioAssetData, AudioEnvironment, AudioMood } from '~/types/audio';
 import type { MoodData, PackageItemData } from '~/types/soundboard';
 import { pruneOrphanedMoodStates } from '~/lib/soundboard/prune';
+import { isStalePackageWriteError } from '~/lib/soundboard/stale-write';
 
 /** Server-side page size for the asset picker — same value `/audio` uses. */
 const PAGE_SIZE = 50;
@@ -159,6 +161,22 @@ export function PackageEditorPage() {
     }
   }, [pkg]);
 
+  /**
+   * Set when the server REFUSED a save because the package moved on under us
+   * (`PackageStaleWriteError` — see `updatePackage`'s doc comment for why the
+   * write is fenced at all). Holds the `updatedAt` the server actually has,
+   * which is both what the notice displays and the precondition an
+   * "overwrite" retry must carry.
+   *
+   * Note what this state deliberately does NOT do: it does not touch
+   * `items`/`moods`/`name`. The refusal costs the user nothing — their draft
+   * is still in those three pieces of state and still on screen behind the
+   * notice — and it costs the other write nothing either, because it never
+   * landed. Which side wins is then a decision the user makes explicitly, via
+   * one of `PackageConflictNotice`'s two buttons.
+   */
+  const [conflict, setConflict] = useState<{ savedAt: string } | null>(null);
+
   const isSystemPackage = pkg?.ownerId === null;
   // `updatePackageSchema.name` is `min(1)` — an empty/whitespace-only draft
   // must not reach the server as a doomed round trip.
@@ -225,14 +243,27 @@ export function PackageEditorPage() {
       items: nextItems,
       moods: nextMoods,
       name: nextName,
+      expectedUpdatedAt,
     }: {
       items: PackageItemData[];
       moods: MoodData[];
       name: string;
+      /**
+       * The revision this save is built on. A mutation VARIABLE rather than
+       * something the mutationFn reads out of `pkg` itself, because the two
+       * entry points supply different ones: an ordinary Save sends the
+       * `updatedAt` of the package as loaded, while the conflict notice's
+       * "keep my edits" sends the newer one the refusal reported. Both are
+       * still compare-and-swap — the retry is not a force flag, it is the
+       * same fence against a fresher expectation, so a third write landing in
+       * between is refused again rather than clobbered.
+       */
+      expectedUpdatedAt: string;
     }) =>
       updatePackageFn({
         data: {
           id: packageId,
+          expectedUpdatedAt,
           name: nextName,
           items: nextItems,
           // Always sent alongside `items`, not only when an item was
@@ -250,9 +281,22 @@ export function PackageEditorPage() {
       setItems(updated.items);
       setMoods(updated.moods);
       setName(updated.name);
+      setConflict(null);
       void qc.invalidateQueries({ queryKey: queryKeys.packages.all });
     },
-    onError: (e) => captureException(e, { action: 'PackageEditorPage.save' }),
+    onError: (e) => {
+      // A stale-write refusal is NOT reported. It is the caller's own doing
+      // in the same sense the server treats it (`PackageStaleWriteError`
+      // extends `PackageClientError`, so `reportPackageError` files no
+      // GlitchTip event for it either) — two tabs open on one package is
+      // expected, not a fault, and capturing here would file one client error
+      // per Save click for a condition the UI already handles completely.
+      if (isStalePackageWriteError(e)) {
+        setConflict({ savedAt: e.currentUpdatedAt ?? '' });
+        return;
+      }
+      captureException(e, { action: 'PackageEditorPage.save' });
+    },
   });
 
   const handleItemsChange = useCallback((next: PackageItemData[]) => {
@@ -264,7 +308,33 @@ export function PackageEditorPage() {
   }, []);
 
   const handleSave = () => {
-    if (items && moods && name !== null && nameValid) saveMutation.mutate({ items, moods, name });
+    if (items && moods && name !== null && nameValid && pkg)
+      saveMutation.mutate({ items, moods, name, expectedUpdatedAt: pkg.updatedAt });
+  };
+
+  /**
+   * "Keep my edits and overwrite": the SAME draft, replayed against the
+   * revision the refusal reported. Nothing about the draft is rebuilt or
+   * re-derived here — that would be a second chance to lose an edit — and
+   * nothing bypasses the fence.
+   */
+  const handleOverwrite = () => {
+    if (items && moods && name !== null && nameValid && conflict)
+      saveMutation.mutate({ items, moods, name, expectedUpdatedAt: conflict.savedAt });
+  };
+
+  /**
+   * "Discard my edits and load the saved version". Invalidating the detail
+   * query refetches the package, which re-seeds `items`/`moods`/`name` through
+   * the effect above — that is the discard, and it happens only here, on this
+   * explicitly-labelled button. `saveMutation.reset()` clears the refusal
+   * itself so the generic error paragraph does not survive the notice it
+   * replaced.
+   */
+  const handleDiscard = () => {
+    setConflict(null);
+    saveMutation.reset();
+    void qc.invalidateQueries({ queryKey: queryKeys.packages.detail(packageId) });
   };
 
   return (
@@ -330,6 +400,26 @@ export function PackageEditorPage() {
               )}
             </div>
 
+            {/*
+              Directly under the Save button that produced it, not at the foot
+              of the page with the generic error line: this is a decision the
+              user has to make before anything else they do here means
+              anything, and the editor below is long enough that a notice
+              under the mood section would be off-screen from where they
+              clicked. It also REPLACES the generic error line (see the
+              `!conflict` guard on it below) — the same refusal rendered twice,
+              once as a red "failed" and once as the notice explaining what to
+              do about it, reads as two problems.
+            */}
+            {conflict && (
+              <PackageConflictNotice
+                savedAt={conflict.savedAt}
+                onOverwrite={handleOverwrite}
+                onDiscard={handleDiscard}
+                busy={saveMutation.isPending}
+              />
+            )}
+
             <PackageEditor
               items={items}
               onItemsChange={handleItemsChange}
@@ -352,7 +442,7 @@ export function PackageEditorPage() {
               />
             </div>
 
-            {saveMutation.error && (
+            {!conflict && saveMutation.error && (
               <p role="alert" className="mt-4 text-sm text-red-400">
                 {errorMessage(saveMutation.error, 'Failed to save changes. Please try again.')}
               </p>

--- a/app/server/db/models/AudioAsset.ts
+++ b/app/server/db/models/AudioAsset.ts
@@ -67,6 +67,23 @@ const audioAssetSchema = new mongoose.Schema({
   // successful attach, which is why this field exists: without it those
   // bytes were measured once for the `AUDIO_MAX_BYTES` gate and then never
   // recorded anywhere the storage quota could see.
+  //
+  // INVARIANT, load-bearing: this field must be reset to `null` at EVERY
+  // site that clears or replaces `onceSourceKey` above, not only where it
+  // is set. It describes the object the key points at, so once the key
+  // stops pointing at that object, a standing byte count is a lie the
+  // storage quota can't detect — it just silently over-counts, forever,
+  // until (if ever) a future successful attach happens to overwrite it.
+  // Task 3b's review caught exactly this: the field was added and wired
+  // into the quota and the one write that SETS it, but not into the
+  // sites that clear/replace the key. Every current site that writes
+  // `onceSourceKey` also writes this field in the same `$set`:
+  // `createOnceVariantUpload` (replace, -> null) and
+  // `confirmOnceVariantUpload`'s reject path (clear, -> null) in
+  // `app/server/functions/audio.ts`; `markOnceFailed` in
+  // `audio-worker/src/process.ts` and `reapAbandonedOnceUploads` in
+  // `audio-worker/src/claim.ts` (both clear, -> null). If `onceSourceKey`
+  // ever grows a new writer, that writer owns this field too.
   onceSourceBytes: { type: Number, default: null },
   // Which pipeline pass the row's CURRENT status/attempts/claim state
   // describes: 'main' for the ordinary source -> renditions pipeline (every

--- a/app/server/db/models/AudioAsset.ts
+++ b/app/server/db/models/AudioAsset.ts
@@ -54,6 +54,20 @@ const audioAssetSchema = new mongoose.Schema({
   // (see `variant` below and `renditionKeyBase`'s callers in
   // audio-worker/src/process.ts).
   onceSourceKey: { type: String, default: null },
+  // The once-source object's REAL size, measured by
+  // `confirmOnceVariantUpload`'s HeadObject — mirrors `sourceBytes` above,
+  // same shape and same nullability, for the same reason: null until
+  // confirm, never seeded from anything client-declared. Set by
+  // `confirmOnceVariantUpload`'s success path and by nothing else. Rows
+  // written before this field existed simply lack it; `getUserStorageUsage`
+  // treats absent the same as null (see `audio-quota.ts`'s `$ifNull`
+  // guard). The worker's terminal write for a successful once-attach
+  // (`audio-worker/src/process.ts`) does not clear this alongside
+  // `onceSourceKey` — the once-source object stays live and billed after a
+  // successful attach, which is why this field exists: without it those
+  // bytes were measured once for the `AUDIO_MAX_BYTES` gate and then never
+  // recorded anywhere the storage quota could see.
+  onceSourceBytes: { type: Number, default: null },
   // Which pipeline pass the row's CURRENT status/attempts/claim state
   // describes: 'main' for the ordinary source -> renditions pipeline (every
   // asset, including every one that predates this field), 'once' while a

--- a/app/server/db/models/AudioAsset.ts
+++ b/app/server/db/models/AudioAsset.ts
@@ -85,6 +85,42 @@ const audioAssetSchema = new mongoose.Schema({
   // `audio-worker/src/claim.ts` (both clear, -> null). If `onceSourceKey`
   // ever grows a new writer, that writer owns this field too.
   onceSourceBytes: { type: Number, default: null },
+  // When the CURRENT once-variant attach presigned its upload — the clock
+  // `reapAbandonedOnceUploads` (audio-worker/src/claim.ts) measures a stuck
+  // attach against. Cross-service contract field: written here, read only by
+  // the worker.
+  //
+  // It exists because that reaper used to gate on `updatedAt`, and
+  // `updatedAt` cannot answer the question it was being asked. "How long has
+  // this attach been stuck?" is a JOB-LIVENESS question; `updatedAt` answers
+  // "when was this document last modified at all", and unrelated writers
+  // legitimately bump it. `updateAudioAsset` and `bulkTagAudioAssets` are
+  // both unfenced facet edits — retitle the track, add a tag — so a GM who
+  // edits an asset whose once-attach died mid-PUT pushes the reap out by the
+  // full timeout, every time, and there is no self-service recovery:
+  // `createOnceVariantUpload` requires `status: 'ready'` and the row is
+  // stuck in `uploading`. Editing it again (or a bulk retag that happens to
+  // include it) postpones it again, indefinitely. A dedicated field is
+  // immune by construction. (The mirror-image case is `AudioPackage`'s
+  // optimistic-concurrency precondition, which is CORRECTLY `updatedAt`:
+  // there the question really is "has this document been modified since I
+  // read it", so any writer bumping it should be a conflict.)
+  //
+  // INVARIANT, and it is what keeps this field cheap: it has EXACTLY ONE
+  // writer, `createOnceVariantUpload` in `app/server/functions/audio.ts`,
+  // which is also the only write in either package that can put a row into
+  // `status: 'uploading', variant: 'once'` — the only state the reaper reads
+  // it in. Nothing else may stamp it, and nothing needs to clear it: a value
+  // left over from a finished attach is unreachable, because getting back
+  // into the state that reads it necessarily runs the one writer again. If a
+  // second path into `uploading`/`once` is ever added, that path owns this
+  // field too.
+  //
+  // Rows written before this field existed lack it, and the reaper falls
+  // back to `updatedAt` for exactly those (see its `$or`) — old rows keep
+  // today's behaviour rather than being treated as infinitely stale, which
+  // would reap every in-flight attach at deploy time.
+  onceUploadStartedAt: { type: Date, default: null },
   // Which pipeline pass the row's CURRENT status/attempts/claim state
   // describes: 'main' for the ordinary source -> renditions pipeline (every
   // asset, including every one that predates this field), 'once' while a

--- a/app/server/db/models/AudioPackage.ts
+++ b/app/server/db/models/AudioPackage.ts
@@ -67,6 +67,15 @@ const audioPackageSchema = new mongoose.Schema({
   moods: { type: [moodSchema], default: [] },
 
   createdAt: { type: Date, default: Date.now },
+  // `updatedAt` is not only a display value here: `updatePackage`
+  // (`~/server/functions/packages`) uses it as its optimistic-concurrency
+  // precondition, ANDing the caller's last-seen value into the update filter
+  // so a save built on a stale read is refused rather than replacing
+  // `items`/`moods` wholesale over a newer write. EVERY writer of this
+  // collection must therefore stamp it — `deleteAudioAsset`'s package prune
+  // (`~/server/functions/audio`) does, and any new one must too. A write that
+  // changes the document without advancing this field is invisible to that
+  // fence and silently reopens the clobber.
   updatedAt: { type: Date, default: Date.now },
 });
 

--- a/app/server/functions/audio-quota.ts
+++ b/app/server/functions/audio-quota.ts
@@ -1,0 +1,112 @@
+import mongoose from 'mongoose';
+import { connectDB, isDBConnected } from '../db/connection';
+import { AudioAsset } from '../db/models/AudioAsset';
+
+/**
+ * Per-user R2 storage usage, aggregated on demand rather than kept as a
+ * denormalised counter on `User`.
+ *
+ * WHY ON DEMAND, NOT A COUNTER
+ * -----------------------------
+ * A counter needs a writer at every place bytes are added or removed:
+ * `confirmAudioUpload` (source lands), `processAsset`'s success path
+ * (renditions land), `deleteAudioAsset` (asset removed), and both the
+ * worker's and the upload-side reapers (abandoned rows removed). Phase 2a's
+ * adversarial review found correctness bugs in three of those exact
+ * functions. A drifted quota either blocks a user who is actually under it
+ * or admits one who is actually over — both are worse than the cost of this
+ * query. One `$group` over one user's own assets, served by the existing
+ * `{ownerId, createdAt}` index (an `ownerId`-only `$match` uses it as a
+ * prefix), runs in the tens of milliseconds. That trade is deliberate: see
+ * the phase 1.5 design doc.
+ */
+export interface AudioStorageUsage {
+  bytes: number;
+  assetCount: number;
+}
+
+/**
+ * The byte-bearing fields on one `AudioAsset` row.
+ *
+ * This mirrors `audio-cleanup.ts`'s `referencedKeys`, one level down
+ * (`.bytes` instead of `.key`), over the same five rendition slots — but it
+ * is NOT the same list, and is not imported from there:
+ *
+ * - `referencedKeys` enumerates SIX key fields because it also tracks
+ *   `onceSourceKey` — the once-variant's own uploaded source object, needed
+ *   so the orphan scanner doesn't report a live in-flight once-attach as
+ *   unreferenced. That object's size is never persisted anywhere on the
+ *   row (`onceSourceBytes` does not exist in `AudioAsset`'s schema — see
+ *   `../db/models/AudioAsset.ts`); only its two RENDITIONS, once produced,
+ *   record `bytes`. So the byte-bearing enumeration below has five entries,
+ *   not six, and the discrepancy is a property of the schema, not an
+ *   oversight here.
+ * - Because the two lists name different leaf fields (`.key` vs `.bytes`)
+ *   and differ in count for the reason above, a single shared array can't
+ *   drive both without either fabricating an unused `onceSourceBytes`
+ *   placeholder or adding structure whose only real consumer is a five-line
+ *   list. Copied instead, deliberately, with this comment as the
+ *   cross-reference: if `AudioAsset` ever grows a new rendition slot (or an
+ *   `onceSourceBytes` field), add its `.key` path to `referencedKeys` in
+ *   `audio-cleanup.ts` AND its `.bytes` path here.
+ */
+const BYTES_FIELD_PATHS = [
+  'sourceBytes',
+  'renditions.opus.bytes',
+  'renditions.aac.bytes',
+  'onceRenditions.opus.bytes',
+  'onceRenditions.aac.bytes',
+] as const;
+
+async function ensureDb() {
+  if (!isDBConnected()) await connectDB();
+}
+
+/**
+ * Sum of every byte-bearing field across every asset a user owns, plus how
+ * many asset rows contributed.
+ *
+ * Counts EVERY status, not just `ready` — an asset sitting in `pending` or
+ * `processing` already occupies real R2 bytes (its source object, confirmed
+ * by `confirmAudioUpload`'s `HeadObject` before the row ever reaches
+ * `pending`), and counting only `ready` would let a user park unbounded
+ * bytes there indefinitely.
+ *
+ * `$ifNull` guards every addend: a field that is `null` (never confirmed, or
+ * a rendition slot never produced) or entirely absent (a rendition
+ * sub-document that was never set — the schema's `default: undefined`) would
+ * otherwise make Mongo's `$add` evaluate the WHOLE sum to `null` for that
+ * document, not just that one term. Falling back to `0` per-field is what
+ * makes an unconfirmed asset contribute `0` rather than poisoning the total.
+ *
+ * `userId` — the Mongo `_id`, and the ONLY value that may scope this query —
+ * is cast to a real `ObjectId` before the pipeline runs. Unlike `.find()`,
+ * `.aggregate()` sends its pipeline straight to MongoDB without Mongoose's
+ * query-time casting, so a bare string here would silently match nothing
+ * (see `tabletop.ts`'s `$expr` comment for the same rule applied to a
+ * different aggregation-context query).
+ */
+export async function getUserStorageUsage(userId: string): Promise<AudioStorageUsage> {
+  await ensureDb();
+
+  const [result] = (await AudioAsset.aggregate([
+    { $match: { ownerId: new mongoose.Types.ObjectId(userId) } },
+    {
+      $group: {
+        _id: null,
+        assetCount: { $sum: 1 },
+        bytes: {
+          $sum: {
+            $add: BYTES_FIELD_PATHS.map((path) => ({ $ifNull: [`$${path}`, 0] })),
+          },
+        },
+      },
+    },
+  ])) as Array<{ assetCount: number; bytes: number }>;
+
+  // No matching group means the user owns no asset rows at all.
+  return {
+    bytes: result?.bytes ?? 0,
+    assetCount: result?.assetCount ?? 0,
+  };
+}

--- a/app/server/functions/audio-quota.ts
+++ b/app/server/functions/audio-quota.ts
@@ -29,29 +29,27 @@ export interface AudioStorageUsage {
  * The byte-bearing fields on one `AudioAsset` row.
  *
  * This mirrors `audio-cleanup.ts`'s `referencedKeys`, one level down
- * (`.bytes` instead of `.key`), over the same five rendition slots — but it
- * is NOT the same list, and is not imported from there:
+ * (`.bytes` instead of `.key`), over the same six object slots — and, as of
+ * `onceSourceBytes` landing on the schema, the same COUNT too:
  *
- * - `referencedKeys` enumerates SIX key fields because it also tracks
- *   `onceSourceKey` — the once-variant's own uploaded source object, needed
- *   so the orphan scanner doesn't report a live in-flight once-attach as
- *   unreferenced. That object's size is never persisted anywhere on the
- *   row (`onceSourceBytes` does not exist in `AudioAsset`'s schema — see
- *   `../db/models/AudioAsset.ts`); only its two RENDITIONS, once produced,
- *   record `bytes`. So the byte-bearing enumeration below has five entries,
- *   not six, and the discrepancy is a property of the schema, not an
- *   oversight here.
- * - Because the two lists name different leaf fields (`.key` vs `.bytes`)
- *   and differ in count for the reason above, a single shared array can't
- *   drive both without either fabricating an unused `onceSourceBytes`
- *   placeholder or adding structure whose only real consumer is a five-line
- *   list. Copied instead, deliberately, with this comment as the
- *   cross-reference: if `AudioAsset` ever grows a new rendition slot (or an
- *   `onceSourceBytes` field), add its `.key` path to `referencedKeys` in
- *   `audio-cleanup.ts` AND its `.bytes` path here.
+ * - `referencedKeys` enumerates six key fields: `sourceKey`, `onceSourceKey`,
+ *   and the four rendition `.key` slots. This list enumerates their `.bytes`
+ *   counterparts — `onceSourceKey`'s is `onceSourceBytes`, set by
+ *   `confirmOnceVariantUpload`'s success write, the once-variant analogue of
+ *   `sourceBytes`/`confirmAudioUpload`.
+ * - Rows written before `onceSourceBytes` existed simply lack the field; the
+ *   `$ifNull` guard below treats that the same as any other unconfirmed slot
+ *   and contributes 0, not `null`/`NaN`. No migration needed.
+ * - The two lists still name different leaf fields (`.key` vs `.bytes`), so a
+ *   single shared array can't drive both without adding structure whose only
+ *   real consumer is a six-line list. Copied instead, deliberately, with this
+ *   comment as the cross-reference: if `AudioAsset` ever grows a new
+ *   rendition slot or source field, add its `.key` path to `referencedKeys`
+ *   in `audio-cleanup.ts` AND its `.bytes` path here.
  */
 const BYTES_FIELD_PATHS = [
   'sourceBytes',
+  'onceSourceBytes',
   'renditions.opus.bytes',
   'renditions.aac.bytes',
   'onceRenditions.opus.bytes',

--- a/app/server/functions/audio.ts
+++ b/app/server/functions/audio.ts
@@ -233,6 +233,60 @@ export function getMaxPendingJobsPerUser(): number {
 }
 
 /**
+ * The per-user queue-depth check, shared by every path that can move a row
+ * into `pending`/`processing`: `confirmAudioUpload` (a new source),
+ * `confirmOnceVariantUpload` (a once-variant source, Task 18), and
+ * `retryAudioAsset` (requeueing a `failed` row). All three are doors into
+ * the SAME bounded resource `getMaxPendingJobsPerUser` describes, so the
+ * counting/threshold logic has exactly one definition. The cap originally
+ * shipped on `confirmAudioUpload` alone — the entry point new uploads
+ * enqueue through — but `confirmOnceVariantUpload` enqueues a fresh
+ * transcode job the identical way, and `retryAudioAsset` pushes an
+ * already-existing row back into `pending` one click at a time with no
+ * depth check of its own (it IS rate-limited, by Task 2's
+ * `audioIngestLimiter`, but a rate limit bounds how FAST a caller can act,
+ * not how DEEP the queue they build gets — a caller patient enough to stay
+ * under the rate limit could otherwise requeue every failed row they own,
+ * unbounded). Left open, either door defeats the whole point of this cap:
+ * one stranger putting unbounded work in front of everyone else on a
+ * single-replica FIFO worker.
+ *
+ * Returns `null` when the caller has room to enqueue one more job.
+ * Otherwise returns the numbers each call site needs to build ITS OWN
+ * refusal — deliberately just numbers, not a thrown error and not a
+ * side-effecting action: what happens next differs across the three
+ * callers (an R2 object to delete or not, a row to revert to `failed` vs.
+ * back to `ready` vs. left untouched entirely), so this function does
+ * exactly one thing and each call site owns its own cleanup. See each call
+ * site's comment for why its cleanup is shaped the way it is.
+ *
+ * Scoped `{ ownerId: userId, ... }` — never a bare status filter — for the
+ * same reason every cap in this codebase is: an unscoped count would refuse
+ * EVERY user once the GLOBAL queue reached the limit, a different (and
+ * wrong) control than "one account cannot occupy more than N slots of it".
+ *
+ * `>=`, matching `assertUnderStorageQuota`/`assertPackageBudget`'s
+ * deliberate boundary below: the count is read before the row that would
+ * consume a slot actually lands, so a caller already AT the cap is refused
+ * rather than landing exactly on it. Like those checks, this is a resource
+ * bound, not an exact invariant, and the same slack `assertUnderStorageQuota`
+ * documents applies here unmodified: two concurrent requests from the same
+ * user can both read `count == max - 1` and both proceed, landing the user
+ * one job over the cap — closing that with a transaction would cost more
+ * than the one extra queued job it prevents.
+ */
+async function checkPendingJobCap(
+  userId: string
+): Promise<{ pendingCount: number; maxPendingJobs: number } | null> {
+  const maxPendingJobs = getMaxPendingJobsPerUser();
+  const pendingCount = await AudioAsset.countDocuments({
+    ownerId: userId,
+    status: { $in: ['pending', 'processing'] },
+  });
+  return pendingCount >= maxPendingJobs ? { pendingCount, maxPendingJobs } : null;
+}
+
+/**
  * The storage-quota gate, shared by every entry point that presigns an
  * upload via `getAudioUploadUrl`: `createAudioUpload` (a new asset's
  * source) and `createOnceVariantUpload` (Task 18's once-variant source,
@@ -420,26 +474,17 @@ export async function confirmAudioUpload({
 
     const { client, bucket } = createR2();
 
-    // The per-user queue-depth bound (see `getMaxPendingJobsPerUser`'s doc
-    // comment) — checked HERE, before `HeadObject`, because this is "the
-    // point where a row becomes claimable": nothing before this line can
-    // put a row into `pending`/`processing`, and everything after it is
+    // The per-user queue-depth bound (see `checkPendingJobCap`'s doc
+    // comment for the shared counting logic and `getMaxPendingJobsPerUser`
+    // for the default) — checked HERE, before `HeadObject`, because this is
+    // "the point where a row becomes claimable": nothing before this line
+    // can put a row into `pending`/`processing`, and everything after it is
     // building toward exactly that. Checking before `HeadObject` also means
     // a caller already at the cap is refused without spending an R2 round
     // trip on an object that is about to be rejected regardless of what it
     // turns out to be.
-    //
-    // Scoped `{ ownerId: userId, ... }` — never a bare status filter — for
-    // the same reason every cap in this codebase is: an unscoped count
-    // would refuse EVERY user once the GLOBAL queue reached the limit,
-    // which is a different (and wrong) control than "one account cannot
-    // occupy more than N slots of it".
-    const maxPendingJobs = getMaxPendingJobsPerUser();
-    const pendingCount = await AudioAsset.countDocuments({
-      ownerId: userId,
-      status: { $in: ['pending', 'processing'] },
-    });
-    if (pendingCount >= maxPendingJobs) {
+    const cap = await checkPendingJobCap(userId);
+    if (cap) {
       // The object already exists in R2 by the time confirm runs (the
       // browser's PUT to the presigned URL already landed) — refusing here
       // does not avoid creating an object the way the storage-quota check
@@ -448,7 +493,7 @@ export async function confirmAudioUpload({
       // reference it, and the orphan scanner is the only other path back,
       // on a later manual sweep instead of immediately.
       await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: asset.sourceKey }));
-      const reason = `Too many pending transcode jobs (${pendingCount} of ${maxPendingJobs} already queued). Wait for one to finish before uploading more.`;
+      const reason = `Too many pending transcode jobs (${cap.pendingCount} of ${cap.maxPendingJobs} already queued). Wait for one to finish before uploading more.`;
       // FENCED on `status: 'uploading', variant: { $ne: 'once' }` — the
       // identical ordering trap the tooLarge/badType write below closes,
       // and the identical fix: this request can be suspended inside the
@@ -756,6 +801,62 @@ export async function confirmOnceVariantUpload({
     }
 
     const { client, bucket } = createR2();
+
+    // The same per-user queue-depth bound `confirmAudioUpload` checks, and
+    // for the identical reason: this is the point where a once-variant job
+    // becomes claimable (the success write below flips `status` to
+    // `pending`), so it is checked before `HeadObject` for the same
+    // "don't pay for a round trip you're about to refuse anyway" reason.
+    // See `checkPendingJobCap`'s doc comment for why this function is one
+    // of three doors into the same bounded resource and cannot be left
+    // uncapped just because the brief that introduced this control named
+    // `confirmAudioUpload` specifically.
+    //
+    // The refusal below is NOT a copy of `confirmAudioUpload`'s: THIS
+    // row is an existing, previously-`ready` `music` asset borrowing its
+    // `status` field for the once-attach's own state machine — see the
+    // `tooLarge`/`badType` branch immediately below for why writing
+    // `status: 'failed'` here would brick that asset rather than merely
+    // failing a fresh row. A cap refusal reverts the SAME way that branch
+    // does: back to `ready`/`main`, with the once-source object gone and
+    // the reason recorded on `onceLastError`, not `lastError`.
+    const cap = await checkPendingJobCap(userId);
+    if (cap) {
+      // The once-source object already exists in R2 (the browser's PUT
+      // already landed) — must be deleted explicitly or it is stranded,
+      // same reasoning as every other reject branch in this function.
+      await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: asset.onceSourceKey }));
+      const reason = `Too many pending transcode jobs (${cap.pendingCount} of ${cap.maxPendingJobs} already queued). Wait for one to finish before uploading more.`;
+      // FENCED identically to the tooLarge/badType write below, and for the
+      // identical ordering-trap reason documented there: this request can
+      // be suspended inside the `DeleteObjectCommand` await above, and a
+      // concurrent confirm for the SAME once-attach could complete in that
+      // window. An identity-only write would then revert a row a different,
+      // later request had already legitimately queued, after this
+      // request's own delete had destroyed the object that later request's
+      // success depended on.
+      await AudioAsset.findOneAndUpdate(
+        { _id: data.assetId, ownerId: userId, status: 'uploading', variant: 'once' },
+        {
+          $set: {
+            status: 'ready',
+            variant: 'main',
+            onceSourceKey: null,
+            // Paired with `onceSourceKey` above — see `createOnceVariantUpload`'s
+            // identical reset for why a cleared key must never leave a stale
+            // byte count standing.
+            onceSourceBytes: null,
+            onceLastError: reason,
+            updatedAt: new Date(),
+          },
+        }
+      );
+      // AudioClientError: the caller's own doing, reachable at will, must
+      // not file a GlitchTip event — same shape as every other cap/quota
+      // refusal in this file.
+      throw new AudioClientError(reason);
+    }
+
     const head = await client.send(
       new HeadObjectCommand({ Bucket: bucket, Key: asset.onceSourceKey })
     );
@@ -1215,6 +1316,46 @@ export async function retryAudioAsset({
 } & Actor): Promise<AudioAssetData> {
   try {
     await ensureDb();
+
+    // The same per-user queue-depth bound `confirmAudioUpload` and
+    // `confirmOnceVariantUpload` check, and for the same underlying reason
+    // — see `checkPendingJobCap`'s doc comment: this is the third of three
+    // doors into `pending`/`processing`, and Task 2's `audioIngestLimiter`
+    // rate-limits how FAST a caller can click Retry but not how DEEP the
+    // queue they build gets, so it does not substitute for this.
+    //
+    // Checked BEFORE the eligibility write below, so a caller at the cap is
+    // refused without even attempting a write the fenced filter would very
+    // likely have granted.
+    //
+    // Unlike the other two doors, refusal here touches NEITHER R2 nor the
+    // row. `confirmAudioUpload`/`confirmOnceVariantUpload` each just
+    // finished a fresh upload's PUT — there is a brand-new R2 object that
+    // will never be confirmed and must be reclaimed, and a row mid-transition
+    // that needs to land somewhere definite. Retry starts from a different
+    // place: `sourceKey` already exists, was already measured by the
+    // original confirm, and is untouched by a retry either way — there is
+    // no new object to strand. And the row is already `failed`; refusing
+    // to requeue it doesn't put it in a new state, it just leaves it in the
+    // one it was already in, still eligible the moment the caller's queue
+    // has room. So the correct action is the cheapest one: throw, and
+    // change nothing.
+    const cap = await checkPendingJobCap(userId);
+    if (cap) {
+      // AudioClientError: the caller's own doing, reachable at will by
+      // clicking Retry repeatedly, must not file a GlitchTip event — same
+      // shape as every other cap/quota refusal in this file. Deliberately
+      // NOT the plain `Error` the "cannot be retried" throw below uses:
+      // that one requires the caller to already own a real `failed` row in
+      // a specific state (see the class doc comment at the top of this
+      // file), but this refusal fires purely from the caller's OWN queue
+      // depth and is reachable on any retry attempt regardless of which
+      // row it names.
+      throw new AudioClientError(
+        `Too many pending transcode jobs (${cap.pendingCount} of ${cap.maxPendingJobs} already queued). Wait for one to finish before retrying.`
+      );
+    }
+
     const doc = await AudioAsset.findOneAndUpdate(
       {
         _id: data.id,

--- a/app/server/functions/audio.ts
+++ b/app/server/functions/audio.ts
@@ -50,11 +50,23 @@ async function ensureDb() {
  * uploads.$id.confirm.ts` classifies these by `e instanceof Error` plus a
  * message regex, and `AudioClientError` satisfies both.
  *
+ * `retryAudioAsset`'s "cannot be retried" throw is the sixth site of the same
+ * class, worded differently because its miss is a single compound
+ * `findOneAndUpdate({ _id, ownerId, status: 'failed', confirmedAt: { $ne:
+ * null }, permanentFailure: { $ne: true } })` rather than a bare `{ _id,
+ * ownerId }` lookup — but nothing gates it on ownership FIRST the way
+ * `confirmAudioUpload`'s precondition throw does, so a caller who does not
+ * own the guessed id gets this exact throw regardless of the row's state.
+ * It is reachable purely by guessing ids, same as the other five, just with
+ * extra clauses folded into the one query. `retryAudioAsset` has no phase-3
+ * bearer route, so there is no message-regex classifier to keep in sync.
+ *
  * NOT converted: the sibling precondition throws on the same functions
  * ('Audio asset is not awaiting confirmation', 'Only music assets can have a
  * once-variant attached', ...). Those require the caller to already OWN a real
- * asset in a specific state, so they are not reachable by guessing ids and
- * their volume is bounded by the caller's own library. Leaving them as plain
+ * asset in a specific state — reached only AFTER a separate ownership check
+ * has already passed — so they are not reachable by guessing ids and their
+ * volume is bounded by the caller's own library. Leaving them as plain
  * `Error`s keeps a genuine state-machine surprise visible in GlitchTip.
  */
 export class AudioClientError extends Error {
@@ -1344,13 +1356,10 @@ export async function retryAudioAsset({
     if (cap) {
       // AudioClientError: the caller's own doing, reachable at will by
       // clicking Retry repeatedly, must not file a GlitchTip event — same
-      // shape as every other cap/quota refusal in this file. Deliberately
-      // NOT the plain `Error` the "cannot be retried" throw below uses:
-      // that one requires the caller to already own a real `failed` row in
-      // a specific state (see the class doc comment at the top of this
-      // file), but this refusal fires purely from the caller's OWN queue
-      // depth and is reachable on any retry attempt regardless of which
-      // row it names.
+      // shape as every other cap/quota refusal in this file, and now the
+      // same class as the "cannot be retried" throw below: this refusal
+      // fires purely from the caller's OWN queue depth and is reachable on
+      // any retry attempt regardless of which row it names.
       throw new AudioClientError(
         `Too many pending transcode jobs (${cap.pendingCount} of ${cap.maxPendingJobs} already queued). Wait for one to finish before retrying.`
       );
@@ -1379,7 +1388,10 @@ export async function retryAudioAsset({
       // `.lean()` for the same reason as updateAudioAsset — see that comment.
     ).lean();
     if (!doc) {
-      throw new Error(
+      // AudioClientError, not a plain `Error`: this compound filter's miss
+      // is reachable by guessing ids the same way the five `'Audio asset
+      // not found'` sites are — see the class doc comment above for why.
+      throw new AudioClientError(
         'Audio asset cannot be retried (not found, not failed, its upload never completed, or the file itself was rejected)'
       );
     }

--- a/app/server/functions/audio.ts
+++ b/app/server/functions/audio.ts
@@ -36,6 +36,25 @@ async function ensureDb() {
  *
  * `~/types/schemas/audio.ts` rejects these shapes at the request boundary, so
  * this class covers the fail-closed paths behind it rather than the common case.
+ *
+ * IT ALSO COVERS EVERY `'Audio asset not found'` THROW IN THIS FILE, and that
+ * is deliberate. Each one fires when `findOne({ _id: <caller-supplied id>,
+ * ownerId: userId })` misses — which for a schema of `z.object({ id: objectId
+ * })` any authenticated user can trigger at will by generating well-formed
+ * ObjectIds. As a plain `Error` those reached `reportAudioError` and filed one
+ * GlitchTip event per request, making the report volume the caller's
+ * parameter — the same shape `packages.ts` documents on `getPackage` and the
+ * reason `PackageClientError` exists. The message is unchanged, so nothing the
+ * user or the phase-3 bearer adapter sees changes: `~/routes/api/audio/
+ * uploads.$id.confirm.ts` classifies these by `e instanceof Error` plus a
+ * message regex, and `AudioClientError` satisfies both.
+ *
+ * NOT converted: the sibling precondition throws on the same functions
+ * ('Audio asset is not awaiting confirmation', 'Only music assets can have a
+ * once-variant attached', ...). Those require the caller to already OWN a real
+ * asset in a specific state, so they are not reachable by guessing ids and
+ * their volume is bounded by the caller's own library. Leaving them as plain
+ * `Error`s keeps a genuine state-machine surprise visible in GlitchTip.
  */
 export class AudioClientError extends Error {
   /**
@@ -179,7 +198,7 @@ export async function confirmAudioUpload({
   try {
     await ensureDb();
     const asset = await AudioAsset.findOne({ _id: data.assetId, ownerId: userId });
-    if (!asset) throw new Error('Audio asset not found');
+    if (!asset) throw new AudioClientError('Audio asset not found');
     // Confirm is only meaningful for a row still awaiting its upload. Without
     // this precondition a logged-in user could replay confirm against an
     // already-`ready` asset to flip it back to `pending` and make the worker
@@ -350,7 +369,7 @@ export async function createOnceVariantUpload({
   try {
     await ensureDb();
     const asset = await AudioAsset.findOne({ _id: data.assetId, ownerId: userId });
-    if (!asset) throw new Error('Audio asset not found');
+    if (!asset) throw new AudioClientError('Audio asset not found');
     if (asset.kind !== 'music') {
       throw new Error('Only music assets can have a once-variant attached');
     }
@@ -459,7 +478,7 @@ export async function confirmOnceVariantUpload({
   try {
     await ensureDb();
     const asset = await AudioAsset.findOne({ _id: data.assetId, ownerId: userId });
-    if (!asset) throw new Error('Audio asset not found');
+    if (!asset) throw new AudioClientError('Audio asset not found');
     if (asset.status !== 'uploading' || asset.variant !== 'once' || !asset.onceSourceKey) {
       throw new Error('Once-variant asset is not awaiting confirmation');
     }
@@ -792,7 +811,7 @@ export async function updateAudioAsset({
       { $set: set },
       { new: true }
     ).lean();
-    if (!doc) throw new Error('Audio asset not found');
+    if (!doc) throw new AudioClientError('Audio asset not found');
     return serializeAudioAsset(doc as unknown as AudioDoc);
   } catch (e) {
     reportAudioError(e, { userId, sessionUserId }, { action: 'updateAudioAsset' });
@@ -957,7 +976,7 @@ export async function deleteAudioAsset({
   try {
     await ensureDb();
     const asset = await AudioAsset.findOne({ _id: data.id, ownerId: userId });
-    if (!asset) throw new Error('Audio asset not found');
+    if (!asset) throw new AudioClientError('Audio asset not found');
 
     const { client, bucket } = createR2();
     // Task 18 made onceRenditions/onceSourceKey real: an asset with a once-

--- a/app/server/functions/audio.ts
+++ b/app/server/functions/audio.ts
@@ -192,6 +192,96 @@ export function getAudioUserQuotaBytes(): number {
   return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_AUDIO_USER_QUOTA_BYTES;
 }
 
+/**
+ * The storage-quota gate, shared by every entry point that presigns an
+ * upload via `getAudioUploadUrl`: `createAudioUpload` (a new asset's
+ * source) and `createOnceVariantUpload` (Task 18's once-variant source,
+ * attached to an existing `music` asset). Both must run this BEFORE that
+ * presign — the only R2-touching step either function takes — for two
+ * reasons: refusing first means no R2 object exists yet for anything to
+ * reclaim, and the E2E suite (deliberately fake R2 credentials) can only
+ * tell a quota refusal apart from a credentials failure if the refusal
+ * never reaches the presign step at all.
+ *
+ * BOTH callers, not just `createAudioUpload`, because Task 3b deliberately
+ * made `onceSourceBytes` the sixth term in `getUserStorageUsage`'s
+ * aggregation specifically so once-variant bytes COUNT toward this quota
+ * (`app/server/functions/audio-quota.ts`). Gating only the path that
+ * creates the FIRST five terms' bytes while leaving the once-variant path
+ * ungated would mean the quota counts bytes it never enforced against —
+ * the exact hole Task 3b closed on the read side, reopened on the write
+ * side: a user sitting exactly at the limit could still attach a
+ * once-variant (its own source plus opus/aac renditions, ~126 MB at the
+ * design doc's figure) to every `music` asset they own, roughly doubling
+ * the effective ceiling for a music-heavy library.
+ *
+ * Throws `AudioClientError` on refusal (both the fail-closed and the
+ * over-quota shape); returns normally when the caller is under quota.
+ * `action` distinguishes which caller is asking, purely for the telemetry
+ * tag on a fail-closed capture (see below) — `createAudioUpload` passes
+ * `'createAudioUpload'`, `createOnceVariantUpload` passes
+ * `'createOnceVariantUpload'`, each producing the same
+ * `'<name>.quotaCheck'` action string this check has always used.
+ *
+ * Not exported: this module's two upload-presigning functions are its only
+ * callers, and this module is reached only via `await import(...)` from
+ * server-fn handlers and two server-only API routes (see the module
+ * comment in `~/utils/audio-server-fns.ts`), so there is no reason to widen
+ * this file's public surface for it.
+ */
+async function assertUnderStorageQuota(actor: Actor, action: string): Promise<void> {
+  const limitBytes = getAudioUserQuotaBytes();
+  let usage: AudioStorageUsage;
+  try {
+    usage = await getUserStorageUsage(actor.userId);
+  } catch (e) {
+    // FAIL CLOSED. An aggregation that cannot be measured is refused, not
+    // admitted — the easy bug here is a `catch` that logs and continues,
+    // which quietly turns the quota into a suggestion.
+    //
+    // This failure IS reported to GlitchTip, unlike the `AudioClientError`
+    // thrown right below — deliberately, and for a different reason than
+    // every other capture this file skips. Every other `AudioClientError`
+    // here refuses something the CALLER did (a guessable not-found, a rate
+    // limit, a resource cap) and is reachable by that caller at will, so
+    // reporting it would make report volume an attacker's parameter. An
+    // aggregation failure is the opposite: no request shape triggers it on
+    // demand, it is a genuine Mongo/index/connection fault, and it
+    // silently blocks every upload for this user — for every user, if
+    // systemic — until someone notices. Swallowing it here would make
+    // quota enforcement's own failure mode invisible. So the UNDERLYING
+    // fault is captured once, right here, while the REFUSAL that reaches
+    // the caller stays an `AudioClientError` — whether the fault deserves a
+    // report and whether the outward rejection may amplify are separate
+    // questions, and this answers them differently on purpose.
+    serverCaptureException(e, telemetryId(actor), { action: `${action}.quotaCheck` });
+    throw new AudioClientError(
+      'Unable to verify your storage usage right now. Please try again shortly.'
+    );
+  }
+
+  // `>=`, matching `assertPackageBudget`'s deliberate choice for
+  // `MAX_PACKAGES_PER_USER` (`~/server/functions/packages.ts`): usage is
+  // measured BEFORE this upload lands, so a caller already AT the limit is
+  // refused rather than allowed to land exactly on it. Same "resource
+  // bound, not exact invariant" reasoning too — this cannot be made
+  // airtight with a transaction because the incoming file's declared
+  // `data.bytes` is client-controlled and unverified until confirm's own
+  // `HeadObject` measures it (see the comment on `sourceBytes` in
+  // `createAudioUpload` below), so it is not part of this boundary check.
+  // The worst-case overshoot this admits is bounded by ONE accepted
+  // request's eventual total footprint — not just `AUDIO_MAX_BYTES`'s 50
+  // MiB source cap, but the source PLUS the opus/aac renditions the worker
+  // produces from it, ~126 MB per the design doc's own measurement — the
+  // same shape of slack two concurrent package creates can produce there.
+  if (usage.bytes >= limitBytes) {
+    throw new AudioClientError(
+      `Storage quota exceeded: ${usage.bytes} of ${limitBytes} bytes used. Delete an asset to make room.`,
+      { usageBytes: usage.bytes, limitBytes }
+    );
+  }
+}
+
 export async function createAudioUpload({
   data,
   userId,
@@ -202,64 +292,10 @@ export async function createAudioUpload({
   try {
     await ensureDb();
 
-    // Enforced FIRST, before `resolveAudioStoragePrefix` and before
-    // `getAudioUploadUrl` (the presign, the only R2-touching step in this
-    // function): refusing here means no R2 object exists yet for anything to
-    // reclaim, and no needless Mongo write mints a storage prefix for a
-    // request about to be refused anyway. It also means the E2E suite —
-    // which runs against deliberately fake R2 credentials — can tell a quota
-    // refusal apart from a credentials failure, because this refusal never
-    // reaches the presign step at all. See the design doc's "Quota
-    // enforcement point".
-    const limitBytes = getAudioUserQuotaBytes();
-    let usage: AudioStorageUsage;
-    try {
-      usage = await getUserStorageUsage(userId);
-    } catch (e) {
-      // FAIL CLOSED. An aggregation that cannot be measured is refused, not
-      // admitted — the easy bug here is a `catch` that logs and continues,
-      // which quietly turns the quota into a suggestion.
-      //
-      // This failure IS reported to GlitchTip, unlike the `AudioClientError`
-      // thrown right below — deliberately, and for a different reason than
-      // every other capture this file skips. Every other `AudioClientError`
-      // here refuses something the CALLER did (a guessable not-found, a rate
-      // limit, a resource cap) and is reachable by that caller at will, so
-      // reporting it would make report volume an attacker's parameter. An
-      // aggregation failure is the opposite: no request shape triggers it on
-      // demand, it is a genuine Mongo/index/connection fault, and it
-      // silently blocks every upload for this user — for every user, if
-      // systemic — until someone notices. Swallowing it here would make
-      // quota enforcement's own failure mode invisible. So the UNDERLYING
-      // fault is captured once, right here, while the REFUSAL that reaches
-      // the caller stays an `AudioClientError` — whether the fault deserves a
-      // report and whether the outward rejection may amplify are separate
-      // questions, and this answers them differently on purpose.
-      serverCaptureException(e, telemetryId({ userId, sessionUserId }), {
-        action: 'createAudioUpload.quotaCheck',
-      });
-      throw new AudioClientError(
-        'Unable to verify your storage usage right now. Please try again shortly.'
-      );
-    }
-
-    // `>=`, matching `assertPackageBudget`'s deliberate choice for
-    // `MAX_PACKAGES_PER_USER` (`~/server/functions/packages.ts`): usage is
-    // measured BEFORE this upload lands, so a caller already AT the limit is
-    // refused rather than allowed to land exactly on it. Same "resource
-    // bound, not exact invariant" reasoning too — this cannot be made
-    // airtight with a transaction because the incoming file's declared
-    // `data.bytes` is client-controlled and unverified until confirm's own
-    // `HeadObject` measures it (see the comment on `sourceBytes` below), so
-    // it is not part of this boundary check; the worst-case overshoot this
-    // admits is bounded by `AUDIO_MAX_BYTES` per accepted request, the same
-    // shape of slack two concurrent package creates can produce there.
-    if (usage.bytes >= limitBytes) {
-      throw new AudioClientError(
-        `Storage quota exceeded: ${usage.bytes} of ${limitBytes} bytes used. Delete an asset to make room.`,
-        { usageBytes: usage.bytes, limitBytes }
-      );
-    }
+    // Enforced FIRST, before `resolveAudioStoragePrefix` and before the
+    // presign — see `assertUnderStorageQuota`'s own doc comment for the
+    // full reasoning, shared verbatim with `createOnceVariantUpload` below.
+    await assertUnderStorageQuota({ userId, sessionUserId }, 'createAudioUpload');
 
     // Mints the user's R2 namespace if this is their first upload, and returns
     // the existing one otherwise — see `./audio-storage.ts`. It runs before the
@@ -482,6 +518,14 @@ export async function createOnceVariantUpload({
 } & Actor) {
   try {
     await ensureDb();
+
+    // Enforced FIRST, same as `createAudioUpload` and for the same reason —
+    // see `assertUnderStorageQuota`'s doc comment. This is the path Task 3b's
+    // `onceSourceBytes` aggregation term exists to gate: without this call, a
+    // caller already at the quota could still attach a once-variant (its own
+    // source plus renditions) to every `music` asset they own.
+    await assertUnderStorageQuota({ userId, sessionUserId }, 'createOnceVariantUpload');
+
     const asset = await AudioAsset.findOne({ _id: data.assetId, ownerId: userId });
     if (!asset) throw new AudioClientError('Audio asset not found');
     if (asset.kind !== 'music') {

--- a/app/server/functions/audio.ts
+++ b/app/server/functions/audio.ts
@@ -391,6 +391,16 @@ export async function createOnceVariantUpload({
       {
         $set: {
           onceSourceKey: key,
+          // Paired with `onceSourceKey` above: the bytes field describes the
+          // object the key points at, and the key just moved to a brand-new,
+          // not-yet-confirmed object. Leaving the OLD measurement standing
+          // would misattribute it to a key that no longer exists — the exact
+          // "stale field describes destroyed bytes" bug the `onceRenditions:
+          // {}` clear below exists to prevent, applied to this field's own
+          // sibling. `confirmOnceVariantUpload`'s success write is the only
+          // place this is ever set to a real number again, once THIS attach's
+          // object is actually measured.
+          onceSourceBytes: null,
           // CLEARED, not left standing. The once rendition keys are
           // DETERMINISTIC per asset (`${base}.once.${ext}` —
           // `renditionKeyBase`'s callers in audio-worker/src/process.ts), and
@@ -542,6 +552,15 @@ export async function confirmOnceVariantUpload({
             status: 'ready',
             variant: 'main',
             onceSourceKey: null,
+            // Paired with `onceSourceKey` above, same as `createOnceVariantUpload`'s
+            // reset: the rejected object is deleted (above) and the row no
+            // longer has a once-source at all, so nothing may describe its
+            // size. In the normal case this attach's own `onceSourceBytes`
+            // was already `null` (set by `createOnceVariantUpload` when THIS
+            // attach started) — explicit here anyway so this write's own
+            // invariant does not depend on a different function having run
+            // first.
+            onceSourceBytes: null,
             onceLastError: reason,
             updatedAt: new Date(),
           },

--- a/app/server/functions/audio.ts
+++ b/app/server/functions/audio.ts
@@ -79,12 +79,14 @@ export class AudioClientError extends Error {
   readonly retryAfterMs?: number;
 
   /**
-   * Set only by the storage-quota refusal in `createAudioUpload`: the
-   * caller's measured usage and the limit it was checked against, at the
-   * moment of refusal. The message already embeds both as text, but a
-   * structured pair is what lets the UI (Task 5) render "X of Y used"
-   * without re-parsing prose or making a second round trip. Absent on every
-   * other client error, which is not quota-based.
+   * Set only by a storage-quota refusal — all four of them
+   * (`createAudioUpload`, `createOnceVariantUpload`, `confirmAudioUpload`,
+   * `confirmOnceVariantUpload`; see `checkStorageQuota`): the caller's
+   * measured usage and the limit it was checked against, at the moment of
+   * refusal. The message already embeds both as text, but a structured pair
+   * is what lets the UI (Task 5) render "X of Y used" without re-parsing
+   * prose or making a second round trip. Absent on every other client error,
+   * which is not quota-based.
    */
   readonly usageBytes?: number;
   readonly limitBytes?: number;
@@ -180,6 +182,18 @@ function titleFromFilename(filename: string): string {
  * whole point — not a measured figure; the design doc's own open-questions
  * table defers tuning to real usage, and Task 11 wires this env var name
  * into the Helm chart so raising it needs no image rebuild.
+ *
+ * WHAT THIS NUMBER DOES NOT BOUND, for whoever tunes it: bytes that have
+ * been presigned and PUT but not yet CONFIRMED are invisible to it.
+ * `sourceBytes`/`onceSourceBytes` are written by the confirm success writes
+ * and nowhere else, so an in-flight upload is real R2 storage the
+ * aggregation cannot count until it lands — for at most the worker's
+ * `UPLOAD_TIMEOUT_MS` (15 min by default), after which the reaper deletes
+ * the abandoned object. Transient rather than accumulating, but it means the
+ * real per-user ceiling is this quota PLUS whatever one account can hold in
+ * flight, which the ingest rate limiter and the pending-job cap are what
+ * actually bound. Same note lives in `deploy/charts/cartyx/values.yaml`,
+ * where an operator meets the knob.
  */
 const DEFAULT_AUDIO_USER_QUOTA_BYTES = 2 * 1024 * 1024 * 1024;
 
@@ -301,44 +315,90 @@ async function checkPendingJobCap(
   return pendingCount >= maxPendingJobs ? { pendingCount, maxPendingJobs } : null;
 }
 
+/** The one wording every quota refusal on this surface uses, presign or confirm. */
+function storageQuotaMessage(usageBytes: number, limitBytes: number): string {
+  return `Storage quota exceeded: ${usageBytes} of ${limitBytes} bytes used. Delete an asset to make room.`;
+}
+
 /**
- * The storage-quota gate, shared by every entry point that presigns an
- * upload via `getAudioUploadUrl`: `createAudioUpload` (a new asset's
- * source) and `createOnceVariantUpload` (Task 18's once-variant source,
- * attached to an existing `music` asset). Both must run this BEFORE that
- * presign — the only R2-touching step either function takes — for two
- * reasons: refusing first means no R2 object exists yet for anything to
- * reclaim, and the E2E suite (deliberately fake R2 credentials) can only
- * tell a quota refusal apart from a credentials failure if the refusal
- * never reaches the presign step at all.
+ * The storage-quota measurement, shared by all FOUR entry points that can
+ * add bytes to a user's footprint: the two that presign an upload via
+ * `getAudioUploadUrl` (`createAudioUpload`, `createOnceVariantUpload`) and
+ * the two that make those bytes countable (`confirmAudioUpload`,
+ * `confirmOnceVariantUpload`).
  *
- * BOTH callers, not just `createAudioUpload`, because Task 3b deliberately
- * made `onceSourceBytes` the sixth term in `getUserStorageUsage`'s
- * aggregation specifically so once-variant bytes COUNT toward this quota
- * (`app/server/functions/audio-quota.ts`). Gating only the path that
- * creates the FIRST five terms' bytes while leaving the once-variant path
- * ungated would mean the quota counts bytes it never enforced against —
- * the exact hole Task 3b closed on the read side, reopened on the write
- * side: a user sitting exactly at the limit could still attach a
- * once-variant (its own source plus opus/aac renditions, ~126 MB at the
- * design doc's figure) to every `music` asset they own, roughly doubling
- * the effective ceiling for a music-heavy library.
+ * Returns `null` when the caller is under quota. Otherwise returns the two
+ * numbers each call site needs to build ITS OWN refusal — deliberately just
+ * numbers, exactly like `checkPendingJobCap` above and for the identical
+ * reason: what a refusal has to clean up differs per caller (nothing at all
+ * at presign time, since no object exists yet; an R2 object plus a fenced
+ * row write at confirm time — and the two confirms revert to DIFFERENT
+ * states). So this function measures, and each call site owns its cleanup.
  *
- * Throws `AudioClientError` on refusal (both the fail-closed and the
- * over-quota shape); returns normally when the caller is under quota.
+ * WHY THE CONFIRMS TOO, when a presign-time check reads as sufficient.
+ * Bytes only become COUNTABLE at confirm: `sourceBytes` and
+ * `onceSourceBytes` are written by the success writes below and nowhere
+ * else, so a presign-time check reads a number that cannot include anything
+ * the caller has already presigned and PUT. The check and the byte-landing
+ * are in DIFFERENT requests separated by a client-controlled delay, so with
+ * a presign-only gate the overshoot is bounded by how many presigns a caller
+ * can hold open, not by concurrency. Concretely, with the shipped defaults
+ * and no concurrency at all: spend 30 `audioIngestLimiter` tokens on
+ * `createAudioUpload`, PUT 50 MiB to each (every check sees usage unchanged,
+ * because nothing has confirmed), then spend the other 30 on
+ * `confirmAudioUpload` — usage goes from 0 to ~30 x 126 MB, roughly 3.8 GB
+ * against a 2 GiB quota, before the next presign is refused. Checking again
+ * at confirm reduces that to one accepted request's footprint (see the
+ * boundary comment below).
+ *
+ * The presign check still earns its place: it is the only one that can
+ * refuse BEFORE an object exists in R2, so a user already over quota never
+ * spends bandwidth on an upload that is going to be deleted anyway, and the
+ * E2E suite (deliberately fake R2 credentials) can only tell a quota refusal
+ * apart from a credentials failure because that refusal never reaches the
+ * presign step.
+ *
+ * WHERE EACH CALLER MUST PUT IT. The presign pair: before
+ * `getAudioUploadUrl`, the only R2-touching step either takes, so a refusal
+ * leaves nothing to reclaim. The confirm pair: before `HeadObject`, for the
+ * mirror-image reason `checkPendingJobCap` is checked there — a refusal then
+ * costs no outbound R2 call beyond the delete it has to perform anyway.
+ *
+ * BOTH once-variant halves are on this check, not just the main pair,
+ * because Task 3b deliberately made `onceSourceBytes` the sixth term in
+ * `getUserStorageUsage`'s aggregation specifically so once-variant bytes
+ * COUNT toward this quota (`app/server/functions/audio-quota.ts`). Gating
+ * only the paths that create the FIRST five terms' bytes would mean the
+ * quota counts bytes it never enforced against — the exact hole Task 3b
+ * closed on the read side, reopened on the write side: a user sitting
+ * exactly at the limit could still attach a once-variant (its own source
+ * plus opus/aac renditions, ~126 MB at the design doc's figure) to every
+ * `music` asset they own, roughly doubling the effective ceiling for a
+ * music-heavy library.
+ *
+ * THROWS on exactly one path — when the aggregation itself fails (fail
+ * closed, see below). Every other outcome is a return value. At the two
+ * confirms that throw deliberately performs NO cleanup: the row stays
+ * `uploading` and the object stays in R2, because a Mongo/index fault is
+ * transient and a retried confirm succeeds once it clears, whereas deleting
+ * a good object over a blip would destroy an upload the user could still
+ * have completed. If they never retry, the worker's reaper reclaims both,
+ * which is the same path an abandoned upload already takes.
+ *
  * `action` distinguishes which caller is asking, purely for the telemetry
- * tag on a fail-closed capture (see below) — `createAudioUpload` passes
- * `'createAudioUpload'`, `createOnceVariantUpload` passes
- * `'createOnceVariantUpload'`, each producing the same
- * `'<name>.quotaCheck'` action string this check has always used.
+ * tag on a fail-closed capture — each caller passes its own name, producing
+ * the `'<name>.quotaCheck'` action string this check has always used.
  *
- * Not exported: this module's two upload-presigning functions are its only
- * callers, and this module is reached only via `await import(...)` from
- * server-fn handlers and two server-only API routes (see the module
- * comment in `~/utils/audio-server-fns.ts`), so there is no reason to widen
- * this file's public surface for it.
+ * Not exported: this module's four ingest functions are its only callers,
+ * and this module is reached only via `await import(...)` from server-fn
+ * handlers and two server-only API routes (see the module comment in
+ * `~/utils/audio-server-fns.ts`), so there is no reason to widen this
+ * file's public surface for it.
  */
-async function assertUnderStorageQuota(actor: Actor, action: string): Promise<void> {
+async function checkStorageQuota(
+  actor: Actor,
+  action: string
+): Promise<{ usageBytes: number; limitBytes: number } | null> {
   const limitBytes = getAudioUserQuotaBytes();
   let usage: AudioStorageUsage;
   try {
@@ -371,23 +431,59 @@ async function assertUnderStorageQuota(actor: Actor, action: string): Promise<vo
 
   // `>=`, matching `assertPackageBudget`'s deliberate choice for
   // `MAX_PACKAGES_PER_USER` (`~/server/functions/packages.ts`): usage is
-  // measured BEFORE this upload lands, so a caller already AT the limit is
-  // refused rather than allowed to land exactly on it. Same "resource
-  // bound, not exact invariant" reasoning too — this cannot be made
-  // airtight with a transaction because the incoming file's declared
-  // `data.bytes` is client-controlled and unverified until confirm's own
-  // `HeadObject` measures it (see the comment on `sourceBytes` in
-  // `createAudioUpload` below), so it is not part of this boundary check.
-  // The worst-case overshoot this admits is bounded by ONE accepted
-  // request's eventual total footprint — not just `AUDIO_MAX_BYTES`'s 50
-  // MiB source cap, but the source PLUS the opus/aac renditions the worker
-  // produces from it, ~126 MB per the design doc's own measurement — the
-  // same shape of slack two concurrent package creates can produce there.
+  // measured BEFORE this request's bytes land, so a caller already AT the
+  // limit is refused rather than allowed to land exactly on it.
+  //
+  // THE RESIDUAL, stated honestly. With the confirm-side check in place the
+  // worst-case overshoot is ONE accepted request's eventual total footprint:
+  // the confirm that passes this check is measuring a source that is ALREADY
+  // in R2 (up to `AUDIO_MAX_BYTES`, 50 MiB), and the worker will then produce
+  // the opus/aac renditions from it — ~126 MB per the design doc's own
+  // measurement. It cannot be made airtight with a transaction either: at
+  // presign time the incoming file's declared `data.bytes` is
+  // client-controlled and unverified until confirm's own `HeadObject`
+  // measures it (see the comment on `sourceBytes` in `createAudioUpload`
+  // below), so it is not part of this boundary check.
+  //
+  // The earlier version of this comment likened that slack to "the same shape
+  // two concurrent package creates can produce" in `assertPackageBudget`.
+  // That analogy was wrong and is gone: `assertPackageBudget` counts and
+  // inserts inside ONE request, so concurrency there buys `+1`, whereas here
+  // the check and the byte-landing sat in DIFFERENT requests separated by a
+  // client-controlled delay — a residual bounded by open presigns rather than
+  // by concurrency, and orders of magnitude larger. Gating the confirms is
+  // what makes the "one request's footprint" claim true; see this function's
+  // doc comment for the arithmetic it used to admit.
+  //
+  // What remains INVISIBLE to this number, deliberately: bytes a caller has
+  // presigned and PUT but not yet confirmed. Nothing writes `sourceBytes`/
+  // `onceSourceBytes` until confirm, so those objects are real R2 storage the
+  // quota cannot see for up to the worker's `UPLOAD_TIMEOUT_MS` (15 min by
+  // default), after which `reapAbandonedUploads`/`reapAbandonedOnceUploads`
+  // delete them. Transient, not accumulating — but it means the true storage
+  // ceiling per user is the quota PLUS whatever they can hold in flight, and
+  // an operator tuning `AUDIO_USER_QUOTA_BYTES` should read it that way (the
+  // Helm values file says so where the knob actually lives).
   if (usage.bytes >= limitBytes) {
-    throw new AudioClientError(
-      `Storage quota exceeded: ${usage.bytes} of ${limitBytes} bytes used. Delete an asset to make room.`,
-      { usageBytes: usage.bytes, limitBytes }
-    );
+    return { usageBytes: usage.bytes, limitBytes };
+  }
+  return null;
+}
+
+/**
+ * The presign-side wrapper: `checkStorageQuota` plus the throw, because
+ * neither presigning caller has anything to clean up before refusing — no
+ * R2 object exists yet, and no row has been created or claimed. The two
+ * CONFIRM callers deliberately do not use this: each has an object to delete
+ * and a fenced row write to perform first, and those differ per path.
+ */
+async function assertUnderStorageQuota(actor: Actor, action: string): Promise<void> {
+  const over = await checkStorageQuota(actor, action);
+  if (over) {
+    throw new AudioClientError(storageQuotaMessage(over.usageBytes, over.limitBytes), {
+      usageBytes: over.usageBytes,
+      limitBytes: over.limitBytes,
+    });
   }
 }
 
@@ -541,6 +637,55 @@ export async function confirmAudioUpload({
       // in the message so the caller knows to wait rather than retry
       // immediately.
       throw new AudioClientError(reason);
+    }
+
+    // The storage quota, checked HERE as well as at presign — see
+    // `checkStorageQuota`'s doc comment for why a presign-only gate reads a
+    // number that cannot include anything the caller has already presigned
+    // and PUT, and for the overshoot that admits. Placed before
+    // `HeadObject` for the same reason the cap check above is: a refusal
+    // then costs no outbound R2 call beyond the delete it must perform
+    // anyway.
+    const quota = await checkStorageQuota({ userId, sessionUserId }, 'confirmAudioUpload');
+    if (quota) {
+      // The cleanup is the cap refusal's, because the situation directly
+      // above is the same one: the object already exists in R2 (the
+      // browser's PUT landed), nothing will ever reference it again, so it
+      // has to be deleted explicitly or it is stranded until the orphan
+      // scanner's next manual sweep.
+      await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: asset.sourceKey }));
+      const reason = storageQuotaMessage(quota.usageBytes, quota.limitBytes);
+      // FENCED exactly as the cap refusal above is, and for the identical
+      // ordering trap documented there: this request can be suspended inside
+      // the `DeleteObjectCommand` await while a concurrent confirm for the
+      // SAME asset legitimately queues the row (or the worker finishes it),
+      // and an identity-only write would then stamp `failed` over it after
+      // this request's delete already destroyed the object it points at.
+      //
+      // `status: 'failed'` and NOT `permanentFailure`: this row is a fresh
+      // upload with nothing else at stake (unlike `confirmOnceVariantUpload`,
+      // whose row is an existing playable asset — see its own refusal), so
+      // failing it is right; but unlike the tooLarge/badType branch below,
+      // re-uploading the same file AFTER deleting something else succeeds,
+      // which is the opposite of what `permanentFailure` means.
+      await AudioAsset.findOneAndUpdate(
+        { _id: data.assetId, ownerId: userId, status: 'uploading', variant: { $ne: 'once' } },
+        {
+          $set: {
+            status: 'failed',
+            lastError: reason,
+            updatedAt: new Date(),
+          },
+        }
+      );
+      // AudioClientError carrying both figures, exactly like the presign
+      // refusal: the caller's own doing, reachable at will, so it must file
+      // no GlitchTip event, and the UI can render "X of Y used" from the
+      // structured pair rather than re-parsing the message.
+      throw new AudioClientError(reason, {
+        usageBytes: quota.usageBytes,
+        limitBytes: quota.limitBytes,
+      });
     }
 
     const head = await client.send(new HeadObjectCommand({ Bucket: bucket, Key: asset.sourceKey }));
@@ -880,6 +1025,55 @@ export async function confirmOnceVariantUpload({
       // not file a GlitchTip event — same shape as every other cap/quota
       // refusal in this file.
       throw new AudioClientError(reason);
+    }
+
+    // The storage quota, checked here for the same reason `confirmAudioUpload`
+    // checks it — see `checkStorageQuota`'s doc comment — and before
+    // `HeadObject` for the same reason the cap check above is.
+    //
+    // This path matters as much as the main one rather than less: Task 3b put
+    // `onceSourceBytes` into the usage aggregation precisely so a once-source
+    // counts, and this is the write that first makes it countable.
+    const quota = await checkStorageQuota({ userId, sessionUserId }, 'confirmOnceVariantUpload');
+    if (quota) {
+      // The once-source object already exists in R2 (the browser's PUT
+      // landed) — deleted explicitly or it is stranded, same as every other
+      // reject branch in this function.
+      await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: asset.onceSourceKey }));
+      const reason = storageQuotaMessage(quota.usageBytes, quota.limitBytes);
+      // REVERTS, it does not fail — the difference from `confirmAudioUpload`'s
+      // quota refusal, and the same difference the cap refusal above and the
+      // tooLarge/badType branch below both carry. This row is the MAIN
+      // asset's own document, a fully-transcoded `music` asset that was
+      // `ready` before the attach started; writing `status: 'failed'` here
+      // would brick it (`retryAudioAsset` refuses `permanentFailure`,
+      // `createOnceVariantUpload` refuses a non-`ready` row). So: back to
+      // `ready`/`main`, once-source key and bytes cleared together, reason on
+      // `onceLastError` rather than `lastError`.
+      //
+      // Fenced on `variant: 'once'` EXACT (not `$ne`), matching the two
+      // writes around it: only a row still mid-attach may be reverted, so a
+      // stale refusal that resumes after the user started a second attach is
+      // a no-op instead of silently cancelling that fresh attach.
+      await AudioAsset.findOneAndUpdate(
+        { _id: data.assetId, ownerId: userId, status: 'uploading', variant: 'once' },
+        {
+          $set: {
+            status: 'ready',
+            variant: 'main',
+            onceSourceKey: null,
+            onceSourceBytes: null,
+            onceLastError: reason,
+            updatedAt: new Date(),
+          },
+        }
+      );
+      // AudioClientError carrying both figures — same reasoning as the main
+      // confirm's quota refusal.
+      throw new AudioClientError(reason, {
+        usageBytes: quota.usageBytes,
+        limitBytes: quota.limitBytes,
+      });
     }
 
     const head = await client.send(

--- a/app/server/functions/audio.ts
+++ b/app/server/functions/audio.ts
@@ -38,9 +38,18 @@ async function ensureDb() {
  * this class covers the fail-closed paths behind it rather than the common case.
  */
 export class AudioClientError extends Error {
-  constructor(message: string) {
+  /**
+   * Set only when the refusal is a rate-limit rejection thrown by
+   * `~/utils/audio-server-fns.ts`'s wrapper gate: how long until the caller's
+   * bucket has a token again, so the UI can say WHEN to retry rather than
+   * just "no". Absent on every other client error, which is not time-based.
+   */
+  readonly retryAfterMs?: number;
+
+  constructor(message: string, options?: { retryAfterMs?: number }) {
     super(message);
     this.name = 'AudioClientError';
+    this.retryAfterMs = options?.retryAfterMs;
   }
 }
 

--- a/app/server/functions/audio.ts
+++ b/app/server/functions/audio.ts
@@ -6,6 +6,7 @@ import { AudioPackage } from '../db/models/AudioPackage';
 import { escapeRegExp, normalizeTags } from '../utils/helpers';
 import { serverCaptureException, serverCaptureEvent } from '../utils/telemetry';
 import { resolveAudioStoragePrefix } from './audio-storage';
+import { getUserStorageUsage, type AudioStorageUsage } from './audio-quota';
 import { createR2, getAudioUploadUrl } from './uploads';
 import { pruneOrphanedMoodStates } from '~/lib/soundboard/prune';
 import { AUDIO_MAX_BYTES, AUDIO_SOURCE_TYPES } from '~/types/audio';
@@ -65,10 +66,26 @@ export class AudioClientError extends Error {
    */
   readonly retryAfterMs?: number;
 
-  constructor(message: string, options?: { retryAfterMs?: number }) {
+  /**
+   * Set only by the storage-quota refusal in `createAudioUpload`: the
+   * caller's measured usage and the limit it was checked against, at the
+   * moment of refusal. The message already embeds both as text, but a
+   * structured pair is what lets the UI (Task 5) render "X of Y used"
+   * without re-parsing prose or making a second round trip. Absent on every
+   * other client error, which is not quota-based.
+   */
+  readonly usageBytes?: number;
+  readonly limitBytes?: number;
+
+  constructor(
+    message: string,
+    options?: { retryAfterMs?: number; usageBytes?: number; limitBytes?: number }
+  ) {
     super(message);
     this.name = 'AudioClientError';
     this.retryAfterMs = options?.retryAfterMs;
+    this.usageBytes = options?.usageBytes;
+    this.limitBytes = options?.limitBytes;
   }
 }
 
@@ -138,6 +155,43 @@ function titleFromFilename(filename: string): string {
   return filename.replace(/\.[^.]+$/, '').slice(0, 200) || 'Untitled';
 }
 
+/**
+ * 2 GiB. The design doc measures ~126 MB per asset at the ingest caps (50
+ * MiB source + ~47 MB opus + ~29 MB aac renditions) — this admits 16 assets
+ * at that worst case, and considerably more at realistic file sizes, since
+ * most uploads are well under the 50 MiB source cap. This is a conservative
+ * starting point for a self-hosted, single-node app with OPEN REGISTRATION —
+ * bounding what an unknown stranger can cost in R2 storage is this task's
+ * whole point — not a measured figure; the design doc's own open-questions
+ * table defers tuning to real usage, and Task 11 wires this env var name
+ * into the Helm chart so raising it needs no image rebuild.
+ */
+const DEFAULT_AUDIO_USER_QUOTA_BYTES = 2 * 1024 * 1024 * 1024;
+
+/**
+ * `AUDIO_USER_QUOTA_BYTES`, read fresh on every call rather than baked into a
+ * module-level constant at import time — same idiom `~/server/session.ts`'s
+ * `setSession` uses for `APP_ENV`/`NODE_ENV`, and it means a value change
+ * takes effect on the next request with no need to re-import this module.
+ *
+ * Server env only, never `VITE_PUBLIC_*` — a `VITE_PUBLIC_*` name gets
+ * INLINED by Vite into the client bundle wherever it is referenced, module
+ * boundary or not, and changing a limit must not require an image rebuild
+ * (see the `deploying` skill's client-baked env rules).
+ *
+ * Guarded the same way the audio worker's `envPositive` is
+ * (`audio-worker/src/config.ts` — a separate npm package, so its helper
+ * cannot be imported here): `Number(process.env.X)` on an unset OR EMPTY
+ * string is `NaN`, and Helm renders an empty string for a `values.yaml` key
+ * nobody set, so a bare `?? DEFAULT` would not catch that case. A configured
+ * `0` or negative value is caught too — it would refuse every upload for
+ * every user, which is a misconfiguration, not a deliberate zero-byte quota.
+ */
+export function getAudioUserQuotaBytes(): number {
+  const raw = Number(process.env.AUDIO_USER_QUOTA_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_AUDIO_USER_QUOTA_BYTES;
+}
+
 export async function createAudioUpload({
   data,
   userId,
@@ -147,6 +201,66 @@ export async function createAudioUpload({
 } & Actor) {
   try {
     await ensureDb();
+
+    // Enforced FIRST, before `resolveAudioStoragePrefix` and before
+    // `getAudioUploadUrl` (the presign, the only R2-touching step in this
+    // function): refusing here means no R2 object exists yet for anything to
+    // reclaim, and no needless Mongo write mints a storage prefix for a
+    // request about to be refused anyway. It also means the E2E suite —
+    // which runs against deliberately fake R2 credentials — can tell a quota
+    // refusal apart from a credentials failure, because this refusal never
+    // reaches the presign step at all. See the design doc's "Quota
+    // enforcement point".
+    const limitBytes = getAudioUserQuotaBytes();
+    let usage: AudioStorageUsage;
+    try {
+      usage = await getUserStorageUsage(userId);
+    } catch (e) {
+      // FAIL CLOSED. An aggregation that cannot be measured is refused, not
+      // admitted — the easy bug here is a `catch` that logs and continues,
+      // which quietly turns the quota into a suggestion.
+      //
+      // This failure IS reported to GlitchTip, unlike the `AudioClientError`
+      // thrown right below — deliberately, and for a different reason than
+      // every other capture this file skips. Every other `AudioClientError`
+      // here refuses something the CALLER did (a guessable not-found, a rate
+      // limit, a resource cap) and is reachable by that caller at will, so
+      // reporting it would make report volume an attacker's parameter. An
+      // aggregation failure is the opposite: no request shape triggers it on
+      // demand, it is a genuine Mongo/index/connection fault, and it
+      // silently blocks every upload for this user — for every user, if
+      // systemic — until someone notices. Swallowing it here would make
+      // quota enforcement's own failure mode invisible. So the UNDERLYING
+      // fault is captured once, right here, while the REFUSAL that reaches
+      // the caller stays an `AudioClientError` — whether the fault deserves a
+      // report and whether the outward rejection may amplify are separate
+      // questions, and this answers them differently on purpose.
+      serverCaptureException(e, telemetryId({ userId, sessionUserId }), {
+        action: 'createAudioUpload.quotaCheck',
+      });
+      throw new AudioClientError(
+        'Unable to verify your storage usage right now. Please try again shortly.'
+      );
+    }
+
+    // `>=`, matching `assertPackageBudget`'s deliberate choice for
+    // `MAX_PACKAGES_PER_USER` (`~/server/functions/packages.ts`): usage is
+    // measured BEFORE this upload lands, so a caller already AT the limit is
+    // refused rather than allowed to land exactly on it. Same "resource
+    // bound, not exact invariant" reasoning too — this cannot be made
+    // airtight with a transaction because the incoming file's declared
+    // `data.bytes` is client-controlled and unverified until confirm's own
+    // `HeadObject` measures it (see the comment on `sourceBytes` below), so
+    // it is not part of this boundary check; the worst-case overshoot this
+    // admits is bounded by `AUDIO_MAX_BYTES` per accepted request, the same
+    // shape of slack two concurrent package creates can produce there.
+    if (usage.bytes >= limitBytes) {
+      throw new AudioClientError(
+        `Storage quota exceeded: ${usage.bytes} of ${limitBytes} bytes used. Delete an asset to make room.`,
+        { usageBytes: usage.bytes, limitBytes }
+      );
+    }
+
     // Mints the user's R2 namespace if this is their first upload, and returns
     // the existing one otherwise — see `./audio-storage.ts`. It runs before the
     // presign because the key cannot be built without it, and before the row is

--- a/app/server/functions/audio.ts
+++ b/app/server/functions/audio.ts
@@ -555,6 +555,11 @@ export async function confirmOnceVariantUpload({
       {
         $set: {
           status: 'pending',
+          // The HeadObject-measured size of the once-source object, recorded
+          // so the storage quota (`getUserStorageUsage`) can see it — this is
+          // the same `bytes` already computed above for the AUDIO_MAX_BYTES
+          // gate, not a new measurement or a new outbound R2 call.
+          onceSourceBytes: bytes,
           confirmedAt: new Date(),
           updatedAt: new Date(),
         },

--- a/app/server/functions/audio.ts
+++ b/app/server/functions/audio.ts
@@ -755,6 +755,16 @@ export async function createOnceVariantUpload({
           // now }` filter would silently delay this attach's first claim
           // by up to the backoff cap (5 minutes by default).
           nextAttemptAt: null,
+          // The once reaper's clock, and the ONLY write in either package
+          // that sets it — see `onceUploadStartedAt` on the model for the
+          // full argument. In short: this write is the only way a row can
+          // enter `status: 'uploading', variant: 'once'`, so it is the only
+          // write that starts an attach, so it is the only one entitled to
+          // say when the current attach began. `updatedAt` below cannot
+          // stand in for it, because `updateAudioAsset` and
+          // `bulkTagAudioAssets` bump `updatedAt` on any row their owner
+          // edits, which pushed the reap of a dead attach out indefinitely.
+          onceUploadStartedAt: new Date(),
           updatedAt: new Date(),
         },
       },

--- a/app/server/functions/audio.ts
+++ b/app/server/functions/audio.ts
@@ -133,7 +133,10 @@ function telemetryId(actor: Actor): string {
 /** Report to GlitchTip unless the failure was the caller's own doing. */
 function reportAudioError(e: unknown, actor: Actor, context: Record<string, unknown>) {
   if (e instanceof AudioClientError) return;
-  serverCaptureException(e, telemetryId(actor), context);
+  // `void`: deliberately not awaited (CLAUDE.md — capture calls must never
+  // block a request-critical path), and explicit now that this file lints
+  // `no-floating-promises` (see the config's B3 comment for why).
+  void serverCaptureException(e, telemetryId(actor), context);
 }
 
 /**
@@ -360,7 +363,7 @@ async function assertUnderStorageQuota(actor: Actor, action: string): Promise<vo
     // the caller stays an `AudioClientError` — whether the fault deserves a
     // report and whether the outward rejection may amplify are separate
     // questions, and this answers them differently on purpose.
-    serverCaptureException(e, telemetryId(actor), { action: `${action}.quotaCheck` });
+    void serverCaptureException(e, telemetryId(actor), { action: `${action}.quotaCheck` });
     throw new AudioClientError(
       'Unable to verify your storage usage right now. Please try again shortly.'
     );
@@ -622,7 +625,7 @@ export async function confirmAudioUpload({
     );
     if (!updated) throw new Error('Audio asset is not awaiting confirmation');
 
-    serverCaptureEvent(telemetryId({ userId, sessionUserId }), 'audio_upload_confirmed', {
+    void serverCaptureEvent(telemetryId({ userId, sessionUserId }), 'audio_upload_confirmed', {
       assetId: data.assetId,
     });
     return { assetId: data.assetId, status: updated.status ?? 'pending' };
@@ -962,9 +965,13 @@ export async function confirmOnceVariantUpload({
     );
     if (!updated) throw new Error('Once-variant asset is not awaiting confirmation');
 
-    serverCaptureEvent(telemetryId({ userId, sessionUserId }), 'audio_once_variant_confirmed', {
-      assetId: data.assetId,
-    });
+    void serverCaptureEvent(
+      telemetryId({ userId, sessionUserId }),
+      'audio_once_variant_confirmed',
+      {
+        assetId: data.assetId,
+      }
+    );
     return { assetId: data.assetId, status: updated.status ?? 'pending' };
   } catch (e) {
     reportAudioError(e, { userId, sessionUserId }, { action: 'confirmOnceVariantUpload' });
@@ -1395,7 +1402,7 @@ export async function retryAudioAsset({
         'Audio asset cannot be retried (not found, not failed, its upload never completed, or the file itself was rejected)'
       );
     }
-    serverCaptureEvent(telemetryId({ userId, sessionUserId }), 'audio_asset_retried', {
+    void serverCaptureEvent(telemetryId({ userId, sessionUserId }), 'audio_asset_retried', {
       assetId: data.id,
     });
     return serializeAudioAsset(doc as unknown as AudioDoc);

--- a/app/server/functions/audio.ts
+++ b/app/server/functions/audio.ts
@@ -193,6 +193,46 @@ export function getAudioUserQuotaBytes(): number {
 }
 
 /**
+ * How many transcode jobs (`status: 'pending' | 'processing'`) one user may
+ * occupy at once. This is the fairness control the design doc calls for:
+ * "cap pending jobs per user, not round-robin claim" — `claimNext`
+ * (audio-worker/src/claim.ts) is a single atomic `findOneAndUpdate` sorted
+ * `createdAt` ascending across ALL users with no per-owner term, and nothing
+ * across three phases has broken it, so bounding what one user can put INTO
+ * that queue is the cheaper correct move over adding a fairness term to it.
+ *
+ * 20. The design's dropzone is per-file (each file is its own
+ * `createAudioUpload` -> PUT -> `confirmAudioUpload` round trip), but
+ * `AudioUploadDropzone`'s own doc comment states the realistic legitimate
+ * burst this has to admit: uploads within one drop run SEQUENTIALLY, only
+ * one batch runs at a time, and "GM upload sessions are 'drop a folder, wait,
+ * drop the next,' not a firehose." A folder of ambience/SFX for a session is
+ * the shape of burst this cap exists to let through — tens of files, not
+ * hundreds. 20 admits that folder-sized drop with room to spare while still
+ * meaningfully bounding the other side of the trade: with one worker
+ * replica and a global FIFO claim, every job a flood occupies is a job every
+ * OTHER user's asset waits behind, so the cap has to be small enough that a
+ * single account's worst-case backlog is minutes, not hours, of head-of-line
+ * blocking for everyone else.
+ */
+const DEFAULT_MAX_PENDING_JOBS_PER_USER = 20;
+
+/**
+ * `MAX_PENDING_JOBS_PER_USER`, read fresh on every call — same idiom as
+ * `getAudioUserQuotaBytes` immediately above, for the identical reasons: a
+ * value change takes effect on the next request with no re-import, and it is
+ * guarded against the empty-string case Helm renders for an unset
+ * `values.yaml` key (`Number('')` is `0`, not `NaN`, so `raw > 0` still has
+ * to be the gate — a bare `Number.isFinite` check alone would admit it and
+ * refuse every confirm for every user). Server env only, never
+ * `VITE_PUBLIC_*` — see that function's comment for why.
+ */
+export function getMaxPendingJobsPerUser(): number {
+  const raw = Number(process.env.MAX_PENDING_JOBS_PER_USER);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_MAX_PENDING_JOBS_PER_USER;
+}
+
+/**
  * The storage-quota gate, shared by every entry point that presigns an
  * upload via `getAudioUploadUrl`: `createAudioUpload` (a new asset's
  * source) and `createOnceVariantUpload` (Task 18's once-variant source,
@@ -379,6 +419,70 @@ export async function confirmAudioUpload({
     }
 
     const { client, bucket } = createR2();
+
+    // The per-user queue-depth bound (see `getMaxPendingJobsPerUser`'s doc
+    // comment) — checked HERE, before `HeadObject`, because this is "the
+    // point where a row becomes claimable": nothing before this line can
+    // put a row into `pending`/`processing`, and everything after it is
+    // building toward exactly that. Checking before `HeadObject` also means
+    // a caller already at the cap is refused without spending an R2 round
+    // trip on an object that is about to be rejected regardless of what it
+    // turns out to be.
+    //
+    // Scoped `{ ownerId: userId, ... }` — never a bare status filter — for
+    // the same reason every cap in this codebase is: an unscoped count
+    // would refuse EVERY user once the GLOBAL queue reached the limit,
+    // which is a different (and wrong) control than "one account cannot
+    // occupy more than N slots of it".
+    const maxPendingJobs = getMaxPendingJobsPerUser();
+    const pendingCount = await AudioAsset.countDocuments({
+      ownerId: userId,
+      status: { $in: ['pending', 'processing'] },
+    });
+    if (pendingCount >= maxPendingJobs) {
+      // The object already exists in R2 by the time confirm runs (the
+      // browser's PUT to the presigned URL already landed) — refusing here
+      // does not avoid creating an object the way the storage-quota check
+      // in `createAudioUpload` does by refusing before the presign. It has
+      // to be deleted explicitly or it is stranded: nothing else will ever
+      // reference it, and the orphan scanner is the only other path back,
+      // on a later manual sweep instead of immediately.
+      await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: asset.sourceKey }));
+      const reason = `Too many pending transcode jobs (${pendingCount} of ${maxPendingJobs} already queued). Wait for one to finish before uploading more.`;
+      // FENCED on `status: 'uploading', variant: { $ne: 'once' }` — the
+      // identical ordering trap the tooLarge/badType write below closes,
+      // and the identical fix: this request can be suspended inside the
+      // `DeleteObjectCommand` await above for the length of one R2 round
+      // trip, and a concurrent confirm for the SAME asset (a client retry
+      // racing this request) could complete in that window and move the
+      // row to `pending` — or the worker could claim and finish it, moving
+      // it to `ready` — before this write runs. An identity-only write
+      // would then stamp `status: 'failed'` over a row that is now
+      // legitimately queued or already done, after this request's own
+      // delete has already destroyed the (still-referenced, still-good)
+      // object that row pointed at. The fence makes the stale write a
+      // no-op instead: the row this path means to fail is by definition
+      // still `uploading` and still not the once pipeline's, so a narrower
+      // filter cannot cost this path anything it should have done.
+      await AudioAsset.findOneAndUpdate(
+        { _id: data.assetId, ownerId: userId, status: 'uploading', variant: { $ne: 'once' } },
+        {
+          $set: {
+            status: 'failed',
+            lastError: reason,
+            updatedAt: new Date(),
+          },
+        }
+      );
+      // AudioClientError: this is the caller's own doing (they queued more
+      // than their share) and is reachable at will by uploading and
+      // confirming repeatedly, so it must not file a GlitchTip event — same
+      // shape as `assertUnderStorageQuota`'s refusal. The count is embedded
+      // in the message so the caller knows to wait rather than retry
+      // immediately.
+      throw new AudioClientError(reason);
+    }
+
     const head = await client.send(new HeadObjectCommand({ Bucket: bucket, Key: asset.sourceKey }));
 
     const bytes = head.ContentLength ?? 0;

--- a/app/server/functions/packages.ts
+++ b/app/server/functions/packages.ts
@@ -42,9 +42,17 @@ async function ensureDb() {
  * GlitchTip volume path if left unguarded.
  */
 export class PackageClientError extends Error {
-  constructor(message: string) {
+  /**
+   * Set only when the refusal is a rate-limit rejection thrown by
+   * `~/utils/soundboard-server-fns.ts`'s wrapper gate — same field, same
+   * meaning, as `AudioClientError.retryAfterMs`.
+   */
+  readonly retryAfterMs?: number;
+
+  constructor(message: string, options?: { retryAfterMs?: number }) {
     super(message);
     this.name = 'PackageClientError';
+    this.retryAfterMs = options?.retryAfterMs;
   }
 }
 

--- a/app/server/functions/packages.ts
+++ b/app/server/functions/packages.ts
@@ -5,6 +5,7 @@ import { AudioPackage } from '../db/models/AudioPackage';
 import { serverCaptureException, serverCaptureEvent } from '../utils/telemetry';
 import { serializeAudioAsset } from './audio';
 import type { AudioAssetData } from '~/types/audio';
+import { PACKAGE_STALE_WRITE_ERROR_NAME } from '~/lib/soundboard/stale-write';
 import {
   DEFAULT_VOLUME,
   DEFAULT_FADE_SECONDS,
@@ -53,6 +54,48 @@ export class PackageClientError extends Error {
     super(message);
     this.name = 'PackageClientError';
     this.retryAfterMs = options?.retryAfterMs;
+  }
+}
+
+/**
+ * The optimistic-concurrency refusal: the caller's `expectedUpdatedAt` did
+ * not match the stored document, so somebody else wrote to it between the
+ * caller's read and their save.
+ *
+ * A `PackageClientError` SUBCLASS, deliberately — it is the caller's own
+ * doing in exactly the same sense (a save built on a read that has since gone
+ * out of date), so `reportPackageError` keeps filing no GlitchTip event for
+ * it: a second tab left open on an editor would otherwise author one error
+ * report per Save click. But it is a DIFFERENT identity from the bare
+ * `PackageClientError('Package not found')` its sibling failure throws, and
+ * that separation is the point. "Not found" and "changed underneath you" mean
+ * opposite things — one says the package is gone or was never yours, the
+ * other says it is very much there and newer than you think — and the editor
+ * has to offer completely different affordances for each. Nothing downstream
+ * should have to regex a message to tell them apart; see
+ * `~/lib/soundboard/stale-write.ts` for how the browser recognises this one.
+ */
+export class PackageStaleWriteError extends PackageClientError {
+  /**
+   * The `updatedAt` the stored document actually carries, ISO-encoded the way
+   * `serializePackage` encodes it. This is the token a client needs to retry
+   * the SAME edit as a deliberate overwrite — the editor's "keep my edits"
+   * path replays the identical draft with this value as its
+   * `expectedUpdatedAt`, which is still a compare-and-swap: if a third write
+   * lands in the meantime it is refused again, rather than the retry
+   * degrading into an unfenced write.
+   *
+   * No leak: the update filter this follows is already `ownerId`-scoped, so
+   * this value only ever describes a document the caller owns.
+   */
+  readonly currentUpdatedAt: string;
+
+  constructor(currentUpdatedAt: string) {
+    super(
+      'This package changed somewhere else after you opened it. Nothing has been lost — your unsaved edits are still here, and the saved version is still stored. Choose which one to keep.'
+    );
+    this.name = PACKAGE_STALE_WRITE_ERROR_NAME;
+    this.currentUpdatedAt = currentUpdatedAt;
   }
 }
 
@@ -420,6 +463,83 @@ export async function createPackage({
   }
 }
 
+/**
+ * Server-only, NOT exported — same discipline as `assertPackageBudget` above.
+ * Decides WHICH refusal a failed `updatePackage` filter earned, and it is the
+ * only thing that can: `findOneAndUpdate` returning `null` is a single answer
+ * to three different questions ANDed together (does the id exist, does the
+ * caller own it, is it still at the revision they read), so on its own it
+ * cannot tell "gone or not yours" from "changed underneath you".
+ *
+ * One extra read, on the failure path only, with the precondition dropped and
+ * everything else — `_id` AND `ownerId` — held identical. Holding `ownerId`
+ * is load-bearing: re-reading by `_id` alone would answer "does this document
+ * exist" rather than "does it exist FOR YOU", which would turn a probe against
+ * another user's package id into a stale-write refusal and leak the existence
+ * of documents the caller cannot see. Another owner's package must stay
+ * indistinguishable from an absent one, exactly as it is for every other read
+ * in this file.
+ */
+async function staleWriteOrNotFound(id: string, userId: string): Promise<PackageClientError> {
+  const current = (await AudioPackage.findOne(
+    { _id: id, ownerId: userId },
+    { updatedAt: 1 }
+  ).lean()) as unknown as { updatedAt?: Date } | null;
+  if (!current) return new PackageClientError('Package not found');
+  // Same `instanceof Date` normalisation `serializePackage` applies to the
+  // same field, for the same reason — this value is going to a client that
+  // will hand it straight back as the next `expectedUpdatedAt`.
+  return new PackageStaleWriteError(
+    current.updatedAt instanceof Date ? current.updatedAt.toISOString() : ''
+  );
+}
+
+/**
+ * OPTIMISTIC CONCURRENCY. Every field this function writes is a whole-value
+ * replace — `items` and `moods` most of all — so without a precondition the
+ * write is last-write-wins over entire arrays. That is data loss, not
+ * staleness: an editor tab left open for ten minutes and then saved does not
+ * merely lose the newer edit, it RESURRECTS whatever the newer write removed,
+ * including the items `deleteAudioAsset`'s prune took out because their asset
+ * no longer exists (`app/server/functions/audio.ts`) — putting the document
+ * back into a state the rest of the system has already moved past.
+ *
+ * The fence is `updatedAt`, ANDed into the update filter, and the choice
+ * between it and a dedicated version counter came down to two properties of
+ * THIS collection:
+ *
+ * 1. Every writer of an `AudioPackage` already advances it, and the one that
+ *    matters most already does. `deleteAudioAsset`'s prune (audio.ts) `$set`s
+ *    `updatedAt` on every package it rewrites; `createPackage`/`clonePackage`
+ *    insert with the schema's own default. So the fence closes the
+ *    resurrection case above against the writer that exists today, with no
+ *    change to another module. A `version` counter would have to be threaded
+ *    into that writer by hand, and into every future one.
+ * 2. Every stored document already HAS it. `version: { type: Number, default:
+ *    0 }` does not retro-apply to documents already in Mongo, and `{ version:
+ *    0 }` does not match a document where the field is absent — so a counter
+ *    would have made every package created before this change permanently
+ *    unsaveable, unless paired with a `$exists` special case that then lives
+ *    forever or a backfill this phase has no migration mechanism for.
+ *
+ * The cost is stated honestly: `updatedAt` has millisecond resolution, so two
+ * writes to the same package inside the same clock tick can both satisfy the
+ * precondition and the later one still clobbers. Both writers are behind a
+ * human click, both are scoped to the same single owner, and the outcome in
+ * that window is merely today's behaviour — a bounded, non-escalating
+ * residual, and one a counter would not have paid for at the price above.
+ *
+ * NOT the same mistake as Task 10's. That defect is `updateAudioAsset`
+ * bumping `updatedAt` and thereby resetting a clock the once-upload reaper
+ * reads as "how long since this JOB progressed" — a second, different
+ * question inferred from the field. This asks `updatedAt` exactly the
+ * question it answers: has this document been modified since I read it. A
+ * writer that modifies the document and stamps `updatedAt` is CORRECTLY
+ * invalidating the caller's read, not accidentally defeating a mechanism.
+ * The invariant this does rely on, and which nothing mechanically enforces:
+ * any future writer of an `AudioPackage` must stamp `updatedAt`, or it will
+ * be invisible to this fence.
+ */
 export async function updatePackage({
   data,
   userId,
@@ -439,12 +559,15 @@ export async function updatePackage({
 
     // Owner-scoped, NEVER the visibility filter — see `packageVisibilityFilter`'s
     // doc comment. This is the query that keeps a system package immutable.
+    // `updatedAt` is the precondition; it must be a `Date`, because Mongo
+    // compares a BSON date against a string as a type mismatch that never
+    // matches — which would refuse every save rather than only the stale ones.
     const doc = await AudioPackage.findOneAndUpdate(
-      { _id: data.id, ownerId: userId },
+      { _id: data.id, ownerId: userId, updatedAt: new Date(data.expectedUpdatedAt) },
       { $set: set },
       { new: true }
     ).lean();
-    if (!doc) throw new PackageClientError('Package not found');
+    if (!doc) throw await staleWriteOrNotFound(data.id, userId);
     serverCaptureEvent(telemetryId({ userId, sessionUserId }), 'package_updated', {
       packageId: data.id,
     });

--- a/app/server/functions/soundboard.ts
+++ b/app/server/functions/soundboard.ts
@@ -14,9 +14,17 @@ import type { saveBoardStateSchema, loadBoardStateSchema } from '~/types/schemas
  * save function the client-side GM gating exists to prevent them from calling.
  */
 export class SoundboardClientError extends Error {
-  constructor(message: string) {
+  /**
+   * Set only when the refusal is a rate-limit rejection thrown by
+   * `~/utils/soundboard-server-fns.ts`'s wrapper gate — same field, same
+   * meaning, as `AudioClientError.retryAfterMs`.
+   */
+  readonly retryAfterMs?: number;
+
+  constructor(message: string, options?: { retryAfterMs?: number }) {
     super(message);
     this.name = 'SoundboardClientError';
+    this.retryAfterMs = options?.retryAfterMs;
   }
 }
 

--- a/app/types/schemas/soundboard.ts
+++ b/app/types/schemas/soundboard.ts
@@ -128,6 +128,16 @@ export const updatePackageSchema = z.object({
    * `.datetime()` (the same form `~/types/schemas/sessions.ts` uses) accepts
    * exactly what `Date.prototype.toISOString` produces, which is the only
    * thing that ever populates this field.
+   *
+   * Corollary worth knowing before anyone writes an `AudioPackage` outside the
+   * functions in `~/server/functions/packages`: a stored document whose
+   * `updatedAt` is absent or not a `Date` is UNSAVEABLE through this schema.
+   * `serializePackage` normalises such a value to `''` (the same fallback it
+   * applies to `createdAt`), the editor hands that straight back here, and
+   * `.datetime()` rejects it — on every attempt, with no way for the user to
+   * recover by reloading. Unreachable today (the model defaults the field and
+   * every writer stamps it) and deliberately not special-cased, but it is the
+   * load-side mirror of the same `''` fallback in `staleWriteOrNotFound`.
    */
   expectedUpdatedAt: z.string().datetime(),
   name: z.string().min(1).max(200).optional(),

--- a/app/types/schemas/soundboard.ts
+++ b/app/types/schemas/soundboard.ts
@@ -111,6 +111,25 @@ export const createPackageSchema = z.object({
 
 export const updatePackageSchema = z.object({
   id: objectId,
+  /**
+   * The `updatedAt` the caller last SAW, as the ISO string `serializePackage`
+   * emitted — the optimistic-concurrency precondition. `updatePackage` ANDs
+   * it into the update filter, so a write built from a stale read matches no
+   * document and is refused instead of replacing `items`/`moods` wholesale
+   * over whatever landed in between (see `updatePackage`'s doc comment).
+   *
+   * REQUIRED, not optional. Every field below is a whole-array replace, so an
+   * unfenced update is a last-write-wins clobber by construction; making the
+   * fence opt-in would mean any caller that simply omitted it — a stale
+   * bundle, a hand-rolled request — got the old destructive behaviour back
+   * and the guard would protect only the callers that did not need
+   * protecting.
+   *
+   * `.datetime()` (the same form `~/types/schemas/sessions.ts` uses) accepts
+   * exactly what `Date.prototype.toISOString` produces, which is the only
+   * thing that ever populates this field.
+   */
+  expectedUpdatedAt: z.string().datetime(),
   name: z.string().min(1).max(200).optional(),
   description: z.string().max(2000).optional(),
   items: z.array(packageItemSchema).max(MAX_PACKAGE_ITEMS).optional(),

--- a/app/utils/audio-server-fns.ts
+++ b/app/utils/audio-server-fns.ts
@@ -3,6 +3,7 @@ import {
   audioIngestLimiter,
   libraryMutationLimiter,
   orphanCleanupLimiter,
+  storageUsageReadLimiter,
   rateLimitMessage,
 } from '~/lib/audio-rate-limits';
 import {
@@ -80,7 +81,19 @@ import {
 //
 //  1. It runs AFTER `requireActor()`, so the key is the caller's Mongo `_id`
 //     rather than an IP. An abuser cannot rotate out of their own bucket, and
-//     a shared NAT is not one bucket.
+//     a shared NAT is not one bucket. Note what this does NOT establish, and
+//     what an earlier version of this note wrongly claimed: that a function
+//     added later "cannot silently skip the gate". A gate in this layer only
+//     covers callers that come through this layer, and the phase-3 REST
+//     adapter (`~/routes/api/audio/uploads.ts` and `uploads.$id.confirm.ts`)
+//     already calls `createAudioUpload`/`confirmAudioUpload` directly and so
+//     is not rate-limited at all. The storage quota and the pending-job cap
+//     DO cover it — they live inside `~/server/functions/audio.ts` — so only
+//     these buckets are bypassed, and it is unreachable today because
+//     `resolveApiUser` 401s every request. Phase 3 is the phase that turns
+//     that adapter on: it will need to key these buckets off the bearer
+//     token's resolved user id. Anything that must be bounded for BOTH
+//     adapters belongs next to the quota/cap checks in `audio.ts`.
 //  2. It runs BEFORE the `~/server/functions/audio` call, so a refused
 //     request never reaches Mongo or R2. That is what the
 //     `not.toHaveBeenCalled()` assertions in
@@ -98,7 +111,18 @@ import {
 // bottom. See the note above each, and `~/lib/audio-rate-limits.ts` for the
 // sizing.
 //
-// EXACTLY THREE ENDPOINTS HERE ARE UNGATED, and the reason is specific to each
+// A FOURTH bucket, `storageUsageReadLimiter`, covers `getAudioStorageUsageFn`
+// — the one READ on this surface with a bucket. The final whole-branch review
+// took its exemption away: the old justification said its "cost scales with
+// the caller's own asset count, not with how often they call it", which names
+// the wrong axis (total Atlas CPU is count TIMES frequency, and frequency is
+// the caller's own parameter), and it is the only read here that is a `$group`
+// aggregation rather than a projected `find`. It is also the read that can
+// safely carry a bucket: it feeds ONE indicator (`AudioQuotaBar`, which takes
+// an explicit `error` prop), so a refusal degrades a badge rather than
+// half-loading a page. See `~/lib/audio-rate-limits.ts` for the sizing.
+//
+// EXACTLY TWO ENDPOINTS HERE ARE UNGATED, and the reason is specific to each
 // rather than a blanket claim. An earlier version of this comment asserted
 // that every non-ingest endpoint "enqueues no work, spends no R2, and grows no
 // footprint"; review found that false for `deleteAudioAsset` on both counts,
@@ -106,16 +130,14 @@ import {
 //
 //  - `listAudioAssetsFn` — a read. Bounded by its projection and its `limit`;
 //    a cursor it cannot decode raises `AudioClientError`, which files nothing.
+//    Left open because it is the library's own paging query: `/audio` and the
+//    package editor's asset picker both fire it on mount and on every filter
+//    change and scroll page, so a refusal here is the half-loaded-page failure
+//    the design's no-bucket-on-reads rule exists to avoid.
 //  - `bulkTagAudioAssetsFn` — an `updateMany` that returns `{ modified: 0 }`
 //    when nothing matches. It has NO not-found throw, so unlike its two
 //    single-asset siblings it has no caller-triggerable capture path at all,
 //    and its `ids` array is bounded by `.max(200)` in the schema.
-//  - `getAudioStorageUsageFn` (Task 5) — a read with no caller input at all,
-//    so there is no shape for a caller to vary and nothing to raise
-//    `AudioClientError` over. It runs the one `$group` aggregation the design
-//    doc already costs at "tens of milliseconds" (see
-//    `~/server/functions/audio-quota.ts`), touches no R2, and its cost scales
-//    with the caller's own asset count, not with how often they call it.
 //
 // If a new endpoint is added here, it needs a bucket unless one of those
 // sentences can be written truthfully about it.
@@ -281,13 +303,23 @@ export const deleteAudioAssetFn = createServerFn({ method: 'POST' })
 //    the new value up with no client change at all.
 //
 // No `.inputValidator()` — this takes nothing from the caller, same shape as
-// `listPackagesFn` in `~/utils/soundboard-server-fns.ts`.
+// `listPackagesFn` in `~/utils/soundboard-server-fns.ts`. Gated by
+// `storageUsageReadLimiter` (final-review addition): taking no input bounds
+// the SHAPE of a call, not the NUMBER of them, and this is the only
+// aggregation on the surface. The gate runs before the aggregation, so a
+// refused call costs no Atlas work.
 export const getAudioStorageUsageFn = createServerFn({ method: 'GET' }).handler(async () => {
   const { getUserStorageUsage } = await import('~/server/functions/audio-quota');
-  const { getAudioUserQuotaBytes } = await import('~/server/functions/audio');
+  const { getAudioUserQuotaBytes, AudioClientError } = await import('~/server/functions/audio');
   const { requireActor } = await import('~/utils/require-actor');
-  const { userId } = await requireActor();
-  const usage = await getUserStorageUsage(userId);
+  const actor = await requireActor();
+  const gate = storageUsageReadLimiter.check(actor.userId);
+  if (!gate.allowed) {
+    throw new AudioClientError(rateLimitMessage('storage usage', gate.retryAfterMs), {
+      retryAfterMs: gate.retryAfterMs,
+    });
+  }
+  const usage = await getUserStorageUsage(actor.userId);
   return { ...usage, limitBytes: getAudioUserQuotaBytes() };
 });
 

--- a/app/utils/audio-server-fns.ts
+++ b/app/utils/audio-server-fns.ts
@@ -98,7 +98,7 @@ import {
 // bottom. See the note above each, and `~/lib/audio-rate-limits.ts` for the
 // sizing.
 //
-// EXACTLY TWO ENDPOINTS HERE ARE UNGATED, and the reason is specific to each
+// EXACTLY THREE ENDPOINTS HERE ARE UNGATED, and the reason is specific to each
 // rather than a blanket claim. An earlier version of this comment asserted
 // that every non-ingest endpoint "enqueues no work, spends no R2, and grows no
 // footprint"; review found that false for `deleteAudioAsset` on both counts,
@@ -110,8 +110,14 @@ import {
 //    when nothing matches. It has NO not-found throw, so unlike its two
 //    single-asset siblings it has no caller-triggerable capture path at all,
 //    and its `ids` array is bounded by `.max(200)` in the schema.
+//  - `getAudioStorageUsageFn` (Task 5) — a read with no caller input at all,
+//    so there is no shape for a caller to vary and nothing to raise
+//    `AudioClientError` over. It runs the one `$group` aggregation the design
+//    doc already costs at "tens of milliseconds" (see
+//    `~/server/functions/audio-quota.ts`), touches no R2, and its cost scales
+//    with the caller's own asset count, not with how often they call it.
 //
-// If a new endpoint is added here, it needs a bucket unless one of those two
+// If a new endpoint is added here, it needs a bucket unless one of those
 // sentences can be written truthfully about it.
 //
 // `~/lib/audio-rate-limits` is imported STATICALLY, unlike everything else
@@ -257,6 +263,33 @@ export const deleteAudioAssetFn = createServerFn({ method: 'POST' })
     }
     return deleteAudioAsset({ data, ...actor });
   });
+
+// Task 5: the usage figure `/audio` renders as "X of Y used" near the
+// dropzone. Wraps TWO functions, both already used server-side by
+// `assertUnderStorageQuota` (`~/server/functions/audio.ts`) to enforce the
+// write-side quota:
+//
+//  - `getUserStorageUsage` (`~/server/functions/audio-quota.ts`) — the same
+//    aggregation the quota check runs, scoped to the caller's own `ownerId`.
+//  - `getAudioUserQuotaBytes` (`~/server/functions/audio.ts`) — reads
+//    `AUDIO_USER_QUOTA_BYTES` fresh from server env on every call, the exact
+//    function the enforcement path calls. Returning ITS result, rather than
+//    hand-copying "2 GiB" into a client-side constant, is what keeps the
+//    number this bar shows from ever drifting off the number that actually
+//    refuses an upload — including after Task 11 lets an operator change the
+//    env var without an image rebuild: the next call to this function picks
+//    the new value up with no client change at all.
+//
+// No `.inputValidator()` — this takes nothing from the caller, same shape as
+// `listPackagesFn` in `~/utils/soundboard-server-fns.ts`.
+export const getAudioStorageUsageFn = createServerFn({ method: 'GET' }).handler(async () => {
+  const { getUserStorageUsage } = await import('~/server/functions/audio-quota');
+  const { getAudioUserQuotaBytes } = await import('~/server/functions/audio');
+  const { requireActor } = await import('~/utils/require-actor');
+  const { userId } = await requireActor();
+  const usage = await getUserStorageUsage(userId);
+  return { ...usage, limitBytes: getAudioUserQuotaBytes() };
+});
 
 // ---------------------------------------------------------------------------
 // Owner-scoped orphan cleanup (see ~/server/functions/audio-cleanup.ts).

--- a/app/utils/audio-server-fns.ts
+++ b/app/utils/audio-server-fns.ts
@@ -1,4 +1,5 @@
 import { createServerFn } from '@tanstack/react-start';
+import { audioIngestLimiter, rateLimitMessage } from '~/lib/audio-rate-limits';
 import {
   createAudioUploadSchema,
   confirmAudioUploadSchema,
@@ -65,41 +66,97 @@ import {
 // same human stays one person in GlitchTip and Umami whether they are
 // uploading an image or an audio file. See the `Actor` type in
 // `~/server/functions/audio.ts`.
+//
+// RATE LIMITING. The five ingest handlers below (both upload halves, both
+// once-variant halves, and `retryAudioAssetFn`) share one per-account token
+// bucket, `audioIngestLimiter` — see `~/lib/audio-rate-limits.ts` for the
+// numbers and the legitimate-burst reasoning behind each. Three properties of
+// how it is applied here are load-bearing:
+//
+//  1. It runs AFTER `requireActor()`, so the key is the caller's Mongo `_id`
+//     rather than an IP. An abuser cannot rotate out of their own bucket, and
+//     a shared NAT is not one bucket.
+//  2. It runs BEFORE the `~/server/functions/audio` call, so a refused
+//     request never reaches Mongo or R2. That is what the
+//     `not.toHaveBeenCalled()` assertions in
+//     `tests/utils/audio-server-fns.test.ts` pin: a test that only asserted
+//     the rejection would still pass with this gate deleted, because
+//     something further down throws anyway.
+//  3. It refuses with `AudioClientError`, which `reportAudioError` excludes
+//     from GlitchTip. A limiter that filed an event per rejection would hand
+//     an attacker the exact telemetry-amplification lever this phase exists
+//     to close — the rejection volume is the attacker's parameter.
+//
+// `~/lib/audio-rate-limits` is imported STATICALLY, unlike everything else
+// reached from these handlers, and that is safe precisely because it is
+// import-free apart from `~/lib/rate-limit` (also import-free). Nothing that
+// touches mongoose or `@sentry/node` may be added to it — see
+// `~/utils/require-actor.ts`.
 
 export const createAudioUploadFn = createServerFn({ method: 'POST' })
   .inputValidator(createAudioUploadSchema)
   .handler(async ({ data }) => {
-    const { createAudioUpload } = await import('~/server/functions/audio');
+    const { createAudioUpload, AudioClientError } = await import('~/server/functions/audio');
     const { requireActor } = await import('~/utils/require-actor');
-    return createAudioUpload({ data, ...(await requireActor()) });
+    const actor = await requireActor();
+    const gate = audioIngestLimiter.check(actor.userId);
+    if (!gate.allowed) {
+      throw new AudioClientError(rateLimitMessage('upload', gate.retryAfterMs), {
+        retryAfterMs: gate.retryAfterMs,
+      });
+    }
+    return createAudioUpload({ data, ...actor });
   });
 
 export const confirmAudioUploadFn = createServerFn({ method: 'POST' })
   .inputValidator(confirmAudioUploadSchema)
   .handler(async ({ data }) => {
-    const { confirmAudioUpload } = await import('~/server/functions/audio');
+    const { confirmAudioUpload, AudioClientError } = await import('~/server/functions/audio');
     const { requireActor } = await import('~/utils/require-actor');
-    return confirmAudioUpload({ data, ...(await requireActor()) });
+    const actor = await requireActor();
+    const gate = audioIngestLimiter.check(actor.userId);
+    if (!gate.allowed) {
+      throw new AudioClientError(rateLimitMessage('upload', gate.retryAfterMs), {
+        retryAfterMs: gate.retryAfterMs,
+      });
+    }
+    return confirmAudioUpload({ data, ...actor });
   });
 
 // Task 18: attach a `∞`/`1×` once-variant to an existing `music` asset.
 // Same presign -> PUT -> confirm shape as createAudioUploadFn/
 // confirmAudioUploadFn above, just targeting an existing row instead of
-// creating one.
+// creating one — and so the same ingest bucket: a once-variant confirm
+// enqueues transcode work exactly like a source confirm does, and a bucket
+// that skipped it would leave the queue-starvation lever half-open.
 export const createOnceVariantUploadFn = createServerFn({ method: 'POST' })
   .inputValidator(attachOnceVariantUploadSchema)
   .handler(async ({ data }) => {
-    const { createOnceVariantUpload } = await import('~/server/functions/audio');
+    const { createOnceVariantUpload, AudioClientError } = await import('~/server/functions/audio');
     const { requireActor } = await import('~/utils/require-actor');
-    return createOnceVariantUpload({ data, ...(await requireActor()) });
+    const actor = await requireActor();
+    const gate = audioIngestLimiter.check(actor.userId);
+    if (!gate.allowed) {
+      throw new AudioClientError(rateLimitMessage('upload', gate.retryAfterMs), {
+        retryAfterMs: gate.retryAfterMs,
+      });
+    }
+    return createOnceVariantUpload({ data, ...actor });
   });
 
 export const confirmOnceVariantUploadFn = createServerFn({ method: 'POST' })
   .inputValidator(confirmOnceVariantUploadSchema)
   .handler(async ({ data }) => {
-    const { confirmOnceVariantUpload } = await import('~/server/functions/audio');
+    const { confirmOnceVariantUpload, AudioClientError } = await import('~/server/functions/audio');
     const { requireActor } = await import('~/utils/require-actor');
-    return confirmOnceVariantUpload({ data, ...(await requireActor()) });
+    const actor = await requireActor();
+    const gate = audioIngestLimiter.check(actor.userId);
+    if (!gate.allowed) {
+      throw new AudioClientError(rateLimitMessage('upload', gate.retryAfterMs), {
+        retryAfterMs: gate.retryAfterMs,
+      });
+    }
+    return confirmOnceVariantUpload({ data, ...actor });
   });
 
 export const listAudioAssetsFn = createServerFn({ method: 'POST' })
@@ -126,12 +183,27 @@ export const bulkTagAudioAssetsFn = createServerFn({ method: 'POST' })
     return bulkTagAudioAssets({ data, ...(await requireActor()) });
   });
 
+// On the SAME ingest bucket as the four upload halves above, which the
+// design's table does not name explicitly. It belongs there on effect rather
+// than on name: `retryAudioAsset` flips a `failed` asset back to `pending`
+// with `attempts: 0`, which is precisely what a confirm does — it makes a row
+// claimable by the single-replica worker. Called in a loop against ONE asset
+// it enqueues unbounded transcode work, so a limiter that covered `confirm`
+// but not `retry` would leave the queue-starvation lever the design names
+// open under a different verb.
 export const retryAudioAssetFn = createServerFn({ method: 'POST' })
   .inputValidator(retryAudioAssetSchema)
   .handler(async ({ data }) => {
-    const { retryAudioAsset } = await import('~/server/functions/audio');
+    const { retryAudioAsset, AudioClientError } = await import('~/server/functions/audio');
     const { requireActor } = await import('~/utils/require-actor');
-    return retryAudioAsset({ data, ...(await requireActor()) });
+    const actor = await requireActor();
+    const gate = audioIngestLimiter.check(actor.userId);
+    if (!gate.allowed) {
+      throw new AudioClientError(rateLimitMessage('retry', gate.retryAfterMs), {
+        retryAfterMs: gate.retryAfterMs,
+      });
+    }
+    return retryAudioAsset({ data, ...actor });
   });
 
 export const deleteAudioAssetFn = createServerFn({ method: 'POST' })

--- a/app/utils/audio-server-fns.ts
+++ b/app/utils/audio-server-fns.ts
@@ -1,5 +1,9 @@
 import { createServerFn } from '@tanstack/react-start';
-import { audioIngestLimiter, rateLimitMessage } from '~/lib/audio-rate-limits';
+import {
+  audioIngestLimiter,
+  orphanCleanupLimiter,
+  rateLimitMessage,
+} from '~/lib/audio-rate-limits';
 import {
   createAudioUploadSchema,
   confirmAudioUploadSchema,
@@ -86,6 +90,12 @@ import {
 //     from GlitchTip. A limiter that filed an event per rejection would hand
 //     an attacker the exact telemetry-amplification lever this phase exists
 //     to close — the rejection volume is the attacker's parameter.
+//
+// A SECOND, tighter bucket (`orphanCleanupLimiter`) covers the two orphan-
+// cleanup wrappers at the bottom of this file — see the note above them.
+// Everything else here (reads, and the metadata mutations `updateAudioAsset`
+// / `bulkTagAudioAssets` / `deleteAudioAsset`) is deliberately ungated: none
+// enqueues work, spends R2, or grows the caller's footprint.
 //
 // `~/lib/audio-rate-limits` is imported STATICALLY, unlike everything else
 // reached from these handlers, and that is safe precisely because it is
@@ -219,20 +229,51 @@ export const deleteAudioAssetFn = createServerFn({ method: 'POST' })
 // Neither takes a user id from the client — both are scoped entirely by the
 // session-resolved actor, which is the whole point of them existing separately
 // from the campaign image scanner.
+//
+// Both are gated by `orphanCleanupLimiter`, the tightest bucket on this
+// surface: each call pages an R2 `ListObjectsV2` over the caller's prefix
+// (up to 10,000 keys) and fires a `serverCaptureEvent`, so an ungated loop
+// makes R2 spend AND Umami event volume attacker-controlled. See
+// `~/lib/audio-rate-limits.ts` for the sizing.
+//
+// The refusal is an `AudioClientError` — the audio surface's client-error
+// class — dynamically imported from `~/server/functions/audio` rather than
+// from `audio-cleanup`, which has no client-error class of its own. Note that
+// `audio-cleanup.ts`'s own `catch` calls `serverCaptureException`
+// unconditionally, with no `report*Error`-style exclusion; that is fine here
+// precisely BECAUSE the gate throws before the call, so a rejection never
+// enters that try/catch and no event is filed either way. Anyone later moving
+// this check inside `audio-cleanup.ts` must add the exclusion first.
 // ---------------------------------------------------------------------------
 
 export const scanOrphanAudioFn = createServerFn({ method: 'POST' })
   .inputValidator(scanOrphanAudioSchema)
   .handler(async ({ data }) => {
     const { scanOrphanAudio } = await import('~/server/functions/audio-cleanup');
+    const { AudioClientError } = await import('~/server/functions/audio');
     const { requireActor } = await import('~/utils/require-actor');
-    return scanOrphanAudio({ data, ...(await requireActor()) });
+    const actor = await requireActor();
+    const gate = orphanCleanupLimiter.check(actor.userId);
+    if (!gate.allowed) {
+      throw new AudioClientError(rateLimitMessage('orphan cleanup', gate.retryAfterMs), {
+        retryAfterMs: gate.retryAfterMs,
+      });
+    }
+    return scanOrphanAudio({ data, ...actor });
   });
 
 export const deleteOrphanAudioFn = createServerFn({ method: 'POST' })
   .inputValidator(deleteOrphanAudioSchema)
   .handler(async ({ data }) => {
     const { deleteOrphanAudio } = await import('~/server/functions/audio-cleanup');
+    const { AudioClientError } = await import('~/server/functions/audio');
     const { requireActor } = await import('~/utils/require-actor');
-    return deleteOrphanAudio({ data, ...(await requireActor()) });
+    const actor = await requireActor();
+    const gate = orphanCleanupLimiter.check(actor.userId);
+    if (!gate.allowed) {
+      throw new AudioClientError(rateLimitMessage('orphan cleanup', gate.retryAfterMs), {
+        retryAfterMs: gate.retryAfterMs,
+      });
+    }
+    return deleteOrphanAudio({ data, ...actor });
   });

--- a/app/utils/audio-server-fns.ts
+++ b/app/utils/audio-server-fns.ts
@@ -1,6 +1,7 @@
 import { createServerFn } from '@tanstack/react-start';
 import {
   audioIngestLimiter,
+  libraryMutationLimiter,
   orphanCleanupLimiter,
   rateLimitMessage,
 } from '~/lib/audio-rate-limits';
@@ -91,11 +92,27 @@ import {
 //     an attacker the exact telemetry-amplification lever this phase exists
 //     to close — the rejection volume is the attacker's parameter.
 //
-// A SECOND, tighter bucket (`orphanCleanupLimiter`) covers the two orphan-
-// cleanup wrappers at the bottom of this file — see the note above them.
-// Everything else here (reads, and the metadata mutations `updateAudioAsset`
-// / `bulkTagAudioAssets` / `deleteAudioAsset`) is deliberately ungated: none
-// enqueues work, spends R2, or grows the caller's footprint.
+// TWO MORE buckets cover the rest of this file's writes:
+// `libraryMutationLimiter` on `updateAudioAssetFn`/`deleteAudioAssetFn`, and
+// the tighter `orphanCleanupLimiter` on the two orphan-cleanup wrappers at the
+// bottom. See the note above each, and `~/lib/audio-rate-limits.ts` for the
+// sizing.
+//
+// EXACTLY TWO ENDPOINTS HERE ARE UNGATED, and the reason is specific to each
+// rather than a blanket claim. An earlier version of this comment asserted
+// that every non-ingest endpoint "enqueues no work, spends no R2, and grows no
+// footprint"; review found that false for `deleteAudioAsset` on both counts,
+// so the list below states only what is true of the endpoint it names:
+//
+//  - `listAudioAssetsFn` — a read. Bounded by its projection and its `limit`;
+//    a cursor it cannot decode raises `AudioClientError`, which files nothing.
+//  - `bulkTagAudioAssetsFn` — an `updateMany` that returns `{ modified: 0 }`
+//    when nothing matches. It has NO not-found throw, so unlike its two
+//    single-asset siblings it has no caller-triggerable capture path at all,
+//    and its `ids` array is bounded by `.max(200)` in the schema.
+//
+// If a new endpoint is added here, it needs a bucket unless one of those two
+// sentences can be written truthfully about it.
 //
 // `~/lib/audio-rate-limits` is imported STATICALLY, unlike everything else
 // reached from these handlers, and that is safe precisely because it is
@@ -180,9 +197,16 @@ export const listAudioAssetsFn = createServerFn({ method: 'POST' })
 export const updateAudioAssetFn = createServerFn({ method: 'POST' })
   .inputValidator(updateAudioAssetSchema)
   .handler(async ({ data }) => {
-    const { updateAudioAsset } = await import('~/server/functions/audio');
+    const { updateAudioAsset, AudioClientError } = await import('~/server/functions/audio');
     const { requireActor } = await import('~/utils/require-actor');
-    return updateAudioAsset({ data, ...(await requireActor()) });
+    const actor = await requireActor();
+    const gate = libraryMutationLimiter.check(actor.userId);
+    if (!gate.allowed) {
+      throw new AudioClientError(rateLimitMessage('library edit', gate.retryAfterMs), {
+        retryAfterMs: gate.retryAfterMs,
+      });
+    }
+    return updateAudioAsset({ data, ...actor });
   });
 
 export const bulkTagAudioAssetsFn = createServerFn({ method: 'POST' })
@@ -216,12 +240,22 @@ export const retryAudioAssetFn = createServerFn({ method: 'POST' })
     return retryAudioAsset({ data, ...actor });
   });
 
+// On `libraryMutationLimiter` with `updateAudioAssetFn`: this one spends R2 —
+// up to six `DeleteObjectCommand` calls per request — and both share a
+// caller-triggerable not-found path. See `~/lib/audio-rate-limits.ts`.
 export const deleteAudioAssetFn = createServerFn({ method: 'POST' })
   .inputValidator(deleteAudioAssetSchema)
   .handler(async ({ data }) => {
-    const { deleteAudioAsset } = await import('~/server/functions/audio');
+    const { deleteAudioAsset, AudioClientError } = await import('~/server/functions/audio');
     const { requireActor } = await import('~/utils/require-actor');
-    return deleteAudioAsset({ data, ...(await requireActor()) });
+    const actor = await requireActor();
+    const gate = libraryMutationLimiter.check(actor.userId);
+    if (!gate.allowed) {
+      throw new AudioClientError(rateLimitMessage('library edit', gate.retryAfterMs), {
+        retryAfterMs: gate.retryAfterMs,
+      });
+    }
+    return deleteAudioAsset({ data, ...actor });
   });
 
 // ---------------------------------------------------------------------------

--- a/app/utils/format-bytes.ts
+++ b/app/utils/format-bytes.ts
@@ -1,0 +1,40 @@
+/**
+ * Human-readable byte size, e.g. `512.0 MB` or `2.00 GB`.
+ *
+ * The audio domain had THREE near-identical copies of this (Task 5's review,
+ * phase-B item B2): `AudioQuotaBar.tsx` (the one below, with a GB tier at 2
+ * decimals) and `AudioOrphanCleanup.tsx`/`CleanUpPanel.tsx` (no GB tier,
+ * stopped at MB with 1 decimal) — so a 2 GiB value rendered `2.00 GB` in one
+ * audio panel and `2048.0 MB` in another on the same `/audio` route.
+ *
+ * This is the audio pair's single shared implementation, using the GB-tier
+ * version: `AudioQuotaBar` shows totals against a multi-GiB quota
+ * (`AUDIO_USER_QUOTA_BYTES`), where a bare MB figure is the less readable of
+ * the two, and this file's own `AudioQuotaBar.test.tsx` already pins that
+ * exact "512.0 MB of 2.00 GB used" / "1.00 GB of 2.00 GB used" output — so
+ * that panel's rendering is UNCHANGED by the consolidation.
+ *
+ * `AudioOrphanCleanup`'s rendering DOES change: individual orphan sizes stay
+ * under the MB tier (`AUDIO_MAX_BYTES` caps a single asset at 50 MB, well
+ * under 1 GiB), but its "Delete N files (total)" summary sums every orphan
+ * found, and that aggregate can cross 1 GiB on an account with enough
+ * orphaned files — where it now renders e.g. `1.17 GB` instead of
+ * `1200.0 MB`.
+ *
+ * `CleanUpPanel.tsx` (campaign image orphan cleanup, `~/components/mainview/
+ * settings/`) deliberately keeps its OWN copy rather than importing this one.
+ * It sits outside the audio domain entirely — a different route, a different
+ * actor model (campaign GM, not the audio library's owner), and a different
+ * resource (images, which this task never touched and which have no
+ * observed formatting divergence to fix). Folding it in would widen this
+ * fix's blast radius into an unrelated panel for a cosmetic-only upside (an
+ * even-larger orphaned-image total rendering in GB instead of MB), so it is
+ * left alone; nothing stops a later task from doing the same consolidation
+ * there if a real divergence ever shows up.
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+  return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}

--- a/app/utils/queryKeys.ts
+++ b/app/utils/queryKeys.ts
@@ -234,6 +234,10 @@ export const queryKeys = {
     // of truth instead of a second, driftable definition.
     list: (filters: AudioFilters) => ['audio', 'list', filters] as const,
     detail: (id: string) => ['audio', 'detail', id] as const,
+    // Task 5: per-user storage usage against the quota, shown on `/audio`
+    // near the dropzone. No filters — one key, same fixed shape as
+    // `packages.list`.
+    usage: () => ['audio', 'usage'] as const,
   },
   monsters: {
     all: ['monsters'] as const,

--- a/app/utils/soundboard-server-fns.ts
+++ b/app/utils/soundboard-server-fns.ts
@@ -1,5 +1,10 @@
 import { createServerFn } from '@tanstack/react-start';
-import { packageWriteLimiter, boardStateLimiter, rateLimitMessage } from '~/lib/audio-rate-limits';
+import {
+  packageWriteLimiter,
+  packageEditLimiter,
+  boardStateLimiter,
+  rateLimitMessage,
+} from '~/lib/audio-rate-limits';
 import {
   getPackageSchema,
   createPackageSchema,
@@ -56,11 +61,28 @@ import {
 // event. Two buckets from `~/lib/audio-rate-limits.ts` land here:
 //
 //  - `packageWriteLimiter` on `createPackageFn`/`clonePackageFn` — the two
-//    that MINT a package against the 100-per-user cap. `updatePackageFn` and
-//    `deletePackageFn` are not gated: neither can grow the user's footprint
-//    (delete shrinks it, update is bounded by the schema's `.max()`ed arrays),
-//    and gating a rename would be user-hostile for no abuse benefit.
+//    that MINT a package against the 100-per-user cap.
+//  - `packageEditLimiter` on `updatePackageFn`. This one is a final-review
+//    addition that SUPERSEDES Task 2's decision to leave it open; that
+//    decision was argued on footprint alone, and footprint is not the only
+//    cost. An update is the largest single write on this surface (a
+//    whole-document `$set` of `items` and `moods`, up to ~410 KiB — several
+//    hundred times a `saveBoardState`, which is gated) and fires one
+//    un-awaited `package_updated` Umami event per call at caller-controlled
+//    volume. Task 7's stale-write fence does not bound either: the refusal
+//    carries `currentUpdatedAt`, so a replay loop succeeds every iteration.
+//    The numbers are sized for a human pressing "Save changes" — see
+//    `~/lib/audio-rate-limits.ts`.
 //  - `boardStateLimiter` on `saveBoardStateFn` only.
+//
+// `deletePackageFn` is the one WRITE here with no bucket, and the reason is
+// specific to it rather than shared with update: it is a single `deleteOne`
+// by `{_id, ownerId}` with no document body to amplify, and its
+// `package_deleted` event fires only on a row that really was removed — a
+// replay hits `deletedCount: 0` and throws `PackageClientError`, which files
+// nothing. Its event volume is bounded by the packages the caller owns, and
+// the only ways to get more are the two gated minting endpoints above,
+// behind a 100-package cap.
 //
 // READS ARE UNGATED — `listPackagesFn`, `getPackageFn`,
 // `listPackageAssetsFn`, `loadBoardStateFn`. Per the design: a read bound
@@ -101,9 +123,21 @@ export const createPackageFn = createServerFn({ method: 'POST' })
 export const updatePackageFn = createServerFn({ method: 'POST' })
   .inputValidator(updatePackageSchema)
   .handler(async ({ data }) => {
-    const { updatePackage } = await import('~/server/functions/packages');
+    const { updatePackage, PackageClientError } = await import('~/server/functions/packages');
     const { requireActor } = await import('~/utils/require-actor');
-    return updatePackage({ data, ...(await requireActor()) });
+    const actor = await requireActor();
+    const gate = packageEditLimiter.check(actor.userId);
+    if (!gate.allowed) {
+      // `PackageClientError`, not `PackageStaleWriteError` — a rate-limit
+      // refusal is not a conflict, and the editor's `isStalePackageWriteError`
+      // check must not mistake it for one and offer an "overwrite" button
+      // that would only burn the caller's next token. It files no GlitchTip
+      // event either, same as every other bucket's refusal on this surface.
+      throw new PackageClientError(rateLimitMessage('package edit', gate.retryAfterMs), {
+        retryAfterMs: gate.retryAfterMs,
+      });
+    }
+    return updatePackage({ data, ...actor });
   });
 
 export const deletePackageFn = createServerFn({ method: 'POST' })

--- a/app/utils/soundboard-server-fns.ts
+++ b/app/utils/soundboard-server-fns.ts
@@ -1,4 +1,5 @@
 import { createServerFn } from '@tanstack/react-start';
+import { packageWriteLimiter, boardStateLimiter, rateLimitMessage } from '~/lib/audio-rate-limits';
 import {
   getPackageSchema,
   createPackageSchema,
@@ -47,6 +48,25 @@ import {
 // tagging only. Do not add a second campaign-membership check here — that
 // would duplicate, and could drift from, the one `soundboard.ts` already
 // owns.
+//
+// RATE LIMITING. Applied identically to `~/utils/audio-server-fns.ts` (read
+// that module's note for the full reasoning) — after `requireActor()`, keyed
+// on the Mongo `_id`, before the `~/server/functions/*` call, refusing with
+// the module's own client-error class so a rejection files no GlitchTip
+// event. Two buckets from `~/lib/audio-rate-limits.ts` land here:
+//
+//  - `packageWriteLimiter` on `createPackageFn`/`clonePackageFn` — the two
+//    that MINT a package against the 100-per-user cap. `updatePackageFn` and
+//    `deletePackageFn` are not gated: neither can grow the user's footprint
+//    (delete shrinks it, update is bounded by the schema's `.max()`ed arrays),
+//    and gating a rename would be user-hostile for no abuse benefit.
+//  - `boardStateLimiter` on `saveBoardStateFn` only.
+//
+// READS ARE UNGATED — `listPackagesFn`, `getPackageFn`,
+// `listPackageAssetsFn`, `loadBoardStateFn`. Per the design: a read bound
+// risks breaking a legitimate board reload, which fires several of these at
+// once, and one refused read leaves a half-loaded board. See
+// `~/lib/audio-rate-limits.ts` for the full note.
 // ---------------------------------------------------------------------------
 
 export const listPackagesFn = createServerFn({ method: 'GET' }).handler(async () => {
@@ -66,9 +86,16 @@ export const getPackageFn = createServerFn({ method: 'GET' })
 export const createPackageFn = createServerFn({ method: 'POST' })
   .inputValidator(createPackageSchema)
   .handler(async ({ data }) => {
-    const { createPackage } = await import('~/server/functions/packages');
+    const { createPackage, PackageClientError } = await import('~/server/functions/packages');
     const { requireActor } = await import('~/utils/require-actor');
-    return createPackage({ data, ...(await requireActor()) });
+    const actor = await requireActor();
+    const gate = packageWriteLimiter.check(actor.userId);
+    if (!gate.allowed) {
+      throw new PackageClientError(rateLimitMessage('sound package', gate.retryAfterMs), {
+        retryAfterMs: gate.retryAfterMs,
+      });
+    }
+    return createPackage({ data, ...actor });
   });
 
 export const updatePackageFn = createServerFn({ method: 'POST' })
@@ -90,9 +117,16 @@ export const deletePackageFn = createServerFn({ method: 'POST' })
 export const clonePackageFn = createServerFn({ method: 'POST' })
   .inputValidator(clonePackageSchema)
   .handler(async ({ data }) => {
-    const { clonePackage } = await import('~/server/functions/packages');
+    const { clonePackage, PackageClientError } = await import('~/server/functions/packages');
     const { requireActor } = await import('~/utils/require-actor');
-    return clonePackage({ data, ...(await requireActor()) });
+    const actor = await requireActor();
+    const gate = packageWriteLimiter.check(actor.userId);
+    if (!gate.allowed) {
+      throw new PackageClientError(rateLimitMessage('sound package', gate.retryAfterMs), {
+        retryAfterMs: gate.retryAfterMs,
+      });
+    }
+    return clonePackage({ data, ...actor });
   });
 
 // Task 21: the assets one package's items reference — package-gated, not the
@@ -118,7 +152,14 @@ export const loadBoardStateFn = createServerFn({ method: 'GET' })
 export const saveBoardStateFn = createServerFn({ method: 'POST' })
   .inputValidator(saveBoardStateSchema)
   .handler(async ({ data }) => {
-    const { saveBoardState } = await import('~/server/functions/soundboard');
+    const { saveBoardState, SoundboardClientError } = await import('~/server/functions/soundboard');
     const { requireActor } = await import('~/utils/require-actor');
-    return saveBoardState({ data, ...(await requireActor()) });
+    const actor = await requireActor();
+    const gate = boardStateLimiter.check(actor.userId);
+    if (!gate.allowed) {
+      throw new SoundboardClientError(rateLimitMessage('board save', gate.retryAfterMs), {
+        retryAfterMs: gate.retryAfterMs,
+      });
+    }
+    return saveBoardState({ data, ...actor });
   });

--- a/audio-worker/src/claim.ts
+++ b/audio-worker/src/claim.ts
@@ -388,6 +388,14 @@ async function reapAbandonedOnceUploads(
           status: 'ready',
           variant: 'main',
           onceSourceKey: null,
+          // Paired with `onceSourceKey` above, same reasoning as
+          // `markOnceFailed` in `process.ts`: cartyx-app's Task 3b review
+          // finding requires `onceSourceBytes` reset wherever
+          // `onceSourceKey` is cleared or replaced, so a row abandoned
+          // before it ever reached `confirmOnceVariantUpload` (this reaper's
+          // whole reason to exist) can't leave a PRIOR successful attach's
+          // stale byte count standing against a key that no longer exists.
+          onceSourceBytes: null,
           onceLastError: 'Once-variant upload never completed',
           claimedAt: null,
           claimedBy: null,

--- a/audio-worker/src/claim.ts
+++ b/audio-worker/src/claim.ts
@@ -173,9 +173,14 @@ export async function claimNext<T>(model: ClaimModel, workerId: string): Promise
  * into a real `DeleteObjects` call. The renditions survive untouched, which
  * is what makes it silent: the asset keeps playing right up until someone
  * needs to re-transcode it, at which point the source is already gone.
- * `updatedAt` is what a once-attach actually bumps (the `$set` in
- * `createOnceVariantUpload`), so it reads "how long has THIS attach been
- * stuck" instead of "how old is the row."
+ *
+ * That sibling gates on `onceUploadStartedAt`, a field whose sole writer is
+ * `createOnceVariantUpload`, so it reads "how long has THIS attach been
+ * stuck" instead of "how old is the row." It originally used `updatedAt`,
+ * which was better than `createdAt` but still wrong for the same underlying
+ * reason: `updatedAt` records modification, not progress, and the app's two
+ * unfenced facet editors reset it — see that function's own `$or` for the
+ * whole argument.
  */
 export async function reapStale(
   model: ClaimModel,
@@ -344,10 +349,11 @@ async function reapAbandonedUploads(
  * age check against `createdAt` fires immediately instead of after a real
  * timeout.
  *
- * Gated on `updatedAt` instead — the field `createOnceVariantUpload` (and
- * every subsequent write to this row) actually bumps, so this reads "how
- * long has the CURRENT once-attach been stuck," which is the question that
- * needs answering.
+ * Gated on `onceUploadStartedAt` instead — the app field
+ * `createOnceVariantUpload` stamps, and the only writer of it — so this
+ * reads "how long has the CURRENT once-attach been stuck," which is the
+ * question that needs answering. (It was `updatedAt` until the facet-edit
+ * hole below was found; the `$or` in the query documents both.)
  *
  * Reverts the row to a fully playable state rather than failing it: `status:
  * 'ready'` (the main content was never touched by this abandoned attach),
@@ -371,7 +377,45 @@ async function reapAbandonedOnceUploads(
 ): Promise<void> {
   const abandoned = await model
     .find(
-      { status: 'uploading', variant: 'once', updatedAt: { $lt: cutoff } },
+      {
+        status: 'uploading',
+        variant: 'once',
+        // Gated on `onceUploadStartedAt` — the web app's dedicated
+        // attach-liveness stamp — NOT on `updatedAt`, which is what this
+        // reaper originally used and which cannot answer the question.
+        //
+        // `updatedAt` means "when was this document last modified at all",
+        // and two unfenced facet editors bump it on any row their owner
+        // touches: `updateAudioAsset` and `bulkTagAudioAssets` in
+        // `app/server/functions/audio.ts`. So a GM who retitles or retags a
+        // track whose once-attach died mid-PUT reset this reaper's only
+        // clock and bought the dead attach another full timeout — and there
+        // is no way out from the other side either, because
+        // `createOnceVariantUpload` refuses anything that isn't
+        // `status: 'ready'` and the row is stuck in `uploading`. Edit it
+        // again and it is postponed again: the row can be held out of reach
+        // of the reaper forever by ordinary library housekeeping, with the
+        // asset unplayable the whole time (`status` is shared with the main
+        // pipeline — see `variant` on the app's AudioAsset model).
+        // `onceUploadStartedAt` has exactly one writer, the attach itself,
+        // so nothing unrelated can move it.
+        //
+        // The `$or` is the migration fallback, and its second branch is
+        // deliberately the OLD predicate. `onceUploadStartedAt: null`
+        // matches both an explicit null and a document where the field is
+        // absent (Mongo equality-to-null semantics), i.e. every row written
+        // before the app started stamping it — including any attach that
+        // was in flight across the deploy. Those rows keep exactly today's
+        // behaviour. The alternative, treating a missing stamp as
+        // infinitely stale, would have this reaper revert every in-flight
+        // once-attach in the collection on its first pass after the deploy
+        // and delete their once-source objects: the fix's own failure mode,
+        // inflicted on the users who happened to be mid-upload.
+        $or: [
+          { onceUploadStartedAt: { $lt: cutoff } },
+          { onceUploadStartedAt: null, updatedAt: { $lt: cutoff } },
+        ],
+      },
       { projection: { onceSourceKey: 1 }, limit: REAP_UPLOAD_BATCH }
     )
     .toArray();
@@ -382,7 +426,42 @@ async function reapAbandonedOnceUploads(
     if (shouldContinue && !shouldContinue()) break;
 
     const result = await model.updateOne(
-      { _id: row._id, status: 'uploading', variant: 'once' },
+      {
+        _id: row._id,
+        status: 'uploading',
+        variant: 'once',
+        // `onceSourceKey` identifies WHICH attach this write is reverting —
+        // without it the fence is satisfied by any once-attach on this row,
+        // including one that started after the candidate list was read.
+        //
+        // `{_id, status: 'uploading', variant: 'once'}` describes the state a
+        // SECOND attach puts the row in just as exactly as it describes the
+        // abandoned first one, and this loop runs for real time (bounded
+        // batch, a `beat()` and an Atlas round trip per row). So the
+        // interleave needs no unusual timing: the stale attach ages out, the
+        // GM gives up and re-attaches with a better file, and before this
+        // row's turn comes `createOnceVariantUpload` has minted a NEW
+        // `onceSourceKey` and restamped the row. The unfenced write then
+        // reverted that seconds-old attach to `ready`/`main`, told the user
+        // it "never completed", and — because `row.onceSourceKey` was
+        // projected BEFORE the re-attach — pushed the OLD key into
+        // `DeleteObjects` while the new object, now referenced by nothing,
+        // was stranded. The browser's PUT to the new presigned URL lands on
+        // an object no row points at, the worker never sees the job, and
+        // nothing reports any of it.
+        //
+        // Same class its sibling `reapAbandonedUploads` was hardened against
+        // one review earlier, and the same remedy: make the fence describe
+        // the unit of work, not just the state.
+        //
+        // `?? null` because a projected-but-absent field arrives as
+        // `undefined`, and `{ onceSourceKey: null }` is the filter that
+        // matches null-or-missing in Mongo. Such a row has nothing to delete
+        // anyway (`row.onceSourceKey` is falsy below), but it still has to be
+        // reverted out of `uploading` or it is stuck forever, which is this
+        // reaper's whole purpose.
+        onceSourceKey: row.onceSourceKey ?? null,
+      },
       {
         $set: {
           status: 'ready',

--- a/audio-worker/src/claim.ts
+++ b/audio-worker/src/claim.ts
@@ -437,18 +437,48 @@ async function reapAbandonedOnceUploads(
         // `{_id, status: 'uploading', variant: 'once'}` describes the state a
         // SECOND attach puts the row in just as exactly as it describes the
         // abandoned first one, and this loop runs for real time (bounded
-        // batch, a `beat()` and an Atlas round trip per row). So the
-        // interleave needs no unusual timing: the stale attach ages out, the
-        // GM gives up and re-attaches with a better file, and before this
-        // row's turn comes `createOnceVariantUpload` has minted a NEW
-        // `onceSourceKey` and restamped the row. The unfenced write then
-        // reverted that seconds-old attach to `ready`/`main`, told the user
-        // it "never completed", and — because `row.onceSourceKey` was
-        // projected BEFORE the re-attach — pushed the OLD key into
-        // `DeleteObjects` while the new object, now referenced by nothing,
-        // was stranded. The browser's PUT to the new presigned URL lands on
-        // an object no row points at, the worker never sees the job, and
-        // nothing reports any of it.
+        // batch, a `beat()` and an Atlas round trip per row) — so a second
+        // attach can appear between the `find` above and this row's turn.
+        //
+        // What does NOT get there is the obvious story, and it is worth
+        // saying so because it is the one a reader will assume: the GM
+        // CANNOT simply give up on a stuck attach and start another one.
+        // `createOnceVariantUpload` is fenced on `status: 'ready'`
+        // (app/server/functions/audio.ts), and the stuck row is `uploading`.
+        // Something must return it to `ready` first. Two things do:
+        //
+        //   (a) The browser's PUT finally lands and
+        //       `confirmOnceVariantUpload` REJECTS the file — over
+        //       `AUDIO_MAX_BYTES`, unsupported type, or the pending-job cap.
+        //       Every one of those paths reverts the row to `ready`/`main`
+        //       and records `onceLastError`. The GM sees the failure, picks a
+        //       better file, and attaches again — now permitted, because the
+        //       row is `ready`. All of it can happen while this pass is
+        //       working through earlier rows.
+        //   (b) More than one worker running at once. Replica 1 reverts this
+        //       row (or any of the app paths above does) while replica 2 still
+        //       has it listed from its own `find`, and a re-attach lands in
+        //       the gap. `audioWorker.replicaCount` is 1 today, but that is
+        //       NOT a single-writer guarantee: the chart sets `strategy:
+        //       Recreate` precisely because the default RollingUpdate starts
+        //       the new pod before the old one terminates, so every deploy
+        //       would otherwise run two workers even at `replicas: 1` (see
+        //       deploy/charts/cartyx/values.yaml). A data fence that leans on
+        //       a Deployment strategy is a fence that stops holding the day
+        //       someone changes that strategy, or scales the replica count for
+        //       a bulk import — which values.yaml explicitly contemplates.
+        //       `claimNext` refuses to assume a single writer anywhere else;
+        //       this write must not assume it either.
+        //
+        // Either way, by the time this row's turn comes
+        // `createOnceVariantUpload` has minted a NEW `onceSourceKey` and
+        // restamped the row. The unfenced write then reverted that
+        // seconds-old attach to `ready`/`main`, told the user it "never
+        // completed", and — because `row.onceSourceKey` was projected BEFORE
+        // the re-attach — pushed the OLD key into `DeleteObjects` while the
+        // new object, now referenced by nothing, was stranded. The browser's
+        // PUT to the new presigned URL lands on an object no row points at,
+        // the worker never sees the job, and nothing reports any of it.
         //
         // Same class its sibling `reapAbandonedUploads` was hardened against
         // one review earlier, and the same remedy: make the fence describe

--- a/audio-worker/src/process.ts
+++ b/audio-worker/src/process.ts
@@ -618,6 +618,15 @@ async function markOnceFailed(
       status: 'ready',
       variant: 'main',
       onceSourceKey: null,
+      // Paired with `onceSourceKey` above — cartyx-app's Task 3b review
+      // finding, applied here too: `onceSourceBytes` (the web app's
+      // `AudioAsset` field recording this key's HeadObject-measured size,
+      // set only by `confirmOnceVariantUpload`'s success write) must be
+      // reset wherever `onceSourceKey` is cleared or replaced, or the
+      // storage quota keeps charging this row for an object it no longer
+      // references. The worker doesn't otherwise read or write this field,
+      // but it owns this write, so it owns keeping the pair consistent.
+      onceSourceBytes: null,
       onceLastError: message,
       claimedAt: null,
       claimedBy: null,

--- a/audio-worker/test/claim.test.ts
+++ b/audio-worker/test/claim.test.ts
@@ -848,29 +848,51 @@ describe('reapStale against a real filter-evaluating collection (Task 18 re-revi
    * state, so the fence matched it too.
    *
    * No unusual timing needed: the reap loop is bounded but runs for real
-   * time (a `beat()` and an Atlas round trip per row), and the GM's own
-   * behaviour supplies the interleave — the first attach dies mid-PUT, they
-   * give up and attach again with a better file. If the re-attach lands
-   * after `find` and before this row's turn, the old fence reverted the
-   * seconds-old attach to `ready`/`main`, wrote `onceLastError: 'Once-
-   * variant upload never completed'` about it, and deleted the key it had
-   * projected before the re-attach existed — leaving the browser PUTting to
-   * a presigned URL for an object no row references.
+   * time (a `beat()` and an Atlas round trip per row), so a second attach
+   * can appear between the `find` and this row's turn.
+   *
+   * THE ROUTE MATTERS, and the obvious one does not exist. A GM cannot just
+   * give up on a stuck attach and start another — `createOnceVariantUpload`
+   * is fenced on `status: 'ready'` and the stuck row is `uploading`. Some
+   * write must return it to `ready` first. This fixture therefore stages
+   * the real two-step sequence: the browser's PUT finally lands,
+   * `confirmOnceVariantUpload` REJECTS the file (over `AUDIO_MAX_BYTES`
+   * here) and reverts the row to `ready`/`main`, and only THEN does the
+   * re-attach become permissible. (The other real route is two workers
+   * running at once, which `strategy: Recreate` in the chart exists to
+   * limit but does not forbid — see the fence's own comment in claim.ts.)
+   *
+   * Against the old fence, the reaper's write then matched that
+   * seconds-old attach, reverted it, wrote `onceLastError: 'Once-variant
+   * upload never completed'` over the real reason, and deleted the key it
+   * had projected before any of this happened — leaving the browser PUTting
+   * to a presigned URL for an object no row references.
    *
    * Driven through the real reaper against the filter-evaluating collection
    * and asserted on OUTCOMES — the row's final state and the keys actually
    * handed to `deleteSource` — not on the shape of the filter.
    *
-   * Wrong-reason check: this would prove nothing if row B were not a
-   * genuine reap candidate, so B is listed with a day-old
-   * `onceUploadStartedAt` and only becomes fresh mid-pass; and it would
-   * prove nothing if the fence were satisfiable by timing alone, so the
-   * re-attach leaves `status`/`variant` exactly as they were — the ONLY
-   * thing that differs is `onceSourceKey`.
+   * Wrong-reason checks:
+   * - It would prove nothing if row B were not a genuine reap candidate, so
+   *   B is listed with a day-old `onceUploadStartedAt` and only becomes
+   *   fresh mid-pass.
+   * - It would prove nothing if the fence were satisfiable by timing alone,
+   *   so the staged sequence ENDS with `status`/`variant` back at exactly
+   *   the values the fence tests — the only thing that differs is
+   *   `onceSourceKey`.
+   * - It would prove less than it implies if the staged transition were one
+   *   the real functions would refuse, so the re-attach step asserts its own
+   *   precondition (`status === 'ready'`) rather than assuming the step
+   *   before it left the row there.
    */
   it('does not revert a once-attach that was replaced by a NEWER attach mid-pass', async () => {
     const now = Date.now();
     const yesterday = new Date(now - 24 * 60 * 60 * 1000);
+    // The message `confirmOnceVariantUpload`'s reject path writes. Kept in a
+    // const because the final assertion turns on it SURVIVING: the reaper
+    // overwriting it with its own "never completed" is one of the two
+    // user-visible harms this fence prevents.
+    const REJECT_REASON = 'File too large: 99999999 bytes exceeds 52428800';
 
     const collection = makeRealFilterCollection([
       // Reaped normally. Its write is what the interleave hangs off — it
@@ -903,13 +925,39 @@ describe('reapStale against a real filter-evaluating collection (Task 18 re-revi
     let writes = 0;
     collection.updateOne.mockImplementation(async (filter, update) => {
       if (writes++ === 0) {
-        // Between row A's write and row B's, the GM re-attaches. This is
-        // exactly `createOnceVariantUpload`'s `$set`, minus the fields that
-        // don't matter here: a NEW key, the clock restarted, `status` and
-        // `variant` unchanged because the row was already in that state.
-        Object.assign(collection.docs.get('b-reattached')!, {
+        // Between row A's write and row B's, both app writes land. Each is
+        // the `$set` of the real function named, minus fields irrelevant
+        // here — and they are applied in order because the SECOND is only
+        // reachable through the FIRST.
+        const b = collection.docs.get('b-reattached')!;
+
+        // (1) `confirmOnceVariantUpload`'s tooLarge/badType reject path
+        //     (app/server/functions/audio.ts). The browser's PUT finally
+        //     landed, HeadObject measured it over the cap, the object was
+        //     deleted, and the row went back to a fully playable asset.
+        Object.assign(b, {
+          status: 'ready',
+          variant: 'main',
+          onceSourceKey: null,
+          onceSourceBytes: null,
+          onceLastError: REJECT_REASON,
+          updatedAt: new Date(now),
+        });
+
+        // (2) ...and only NOW can the GM attach a better file:
+        //     `createOnceVariantUpload` is fenced on `status: 'ready'`, so
+        //     without step (1) this write could not happen at all. Asserted
+        //     rather than assumed, so this fixture can never quietly drift
+        //     into staging a transition the real function would refuse.
+        expect(b.status).toBe('ready');
+        Object.assign(b, {
           onceSourceKey: 'uploads/audio/p/b-once-v2.wav',
           onceSourceBytes: null,
+          onceRenditions: {},
+          variant: 'once',
+          status: 'uploading',
+          attempts: 0,
+          nextAttemptAt: null,
           onceUploadStartedAt: new Date(now),
           updatedAt: new Date(now),
         });
@@ -921,13 +969,17 @@ describe('reapStale against a real filter-evaluating collection (Task 18 re-revi
     await reapStale(collection as never, 600_000, UPLOAD_STALE_MS, deleteSource);
 
     // The fresh attach is untouched: still in flight, still pointing at the
-    // object the browser is uploading to, never told it "never completed".
+    // object the browser is uploading to.
     expect(collection.docs.get('b-reattached')).toMatchObject({
       status: 'uploading',
       variant: 'once',
       onceSourceKey: 'uploads/audio/p/b-once-v2.wav',
     });
-    expect(collection.docs.get('b-reattached')).not.toHaveProperty('onceLastError');
+    // And it was never told this attach "never completed" — the error the GM
+    // sees is still the REAL one, from the confirm that actually rejected.
+    // The reaper overwriting it is the second half of the harm: the user is
+    // handed a false explanation for a failure they did not have.
+    expect(collection.docs.get('b-reattached')!.onceLastError).toBe(REJECT_REASON);
 
     // Exactly one key was reclaimed — row A's. Not the superseded
     // `b-once-v1.wav` (the fenced write no-opped, so this pass never earned

--- a/audio-worker/test/claim.test.ts
+++ b/audio-worker/test/claim.test.ts
@@ -695,6 +695,12 @@ describe('reapStale against a real filter-evaluating collection (Task 18 re-revi
         updatedAt: yesterday, // the attach itself is now stale too
         sourceKey: 'uploads/audio/p/main.wav',
         onceSourceKey: 'uploads/audio/p/once.wav',
+        // Task 3b review fix: a PRIOR successful attach set this to a real
+        // number; this abandoned attach (a re-attach after that prior
+        // success) must not leave it standing once its own onceSourceKey is
+        // cleared below — non-null on purpose, so a reset that got deleted
+        // would leave this exact value behind instead of null.
+        onceSourceBytes: 5_000_000,
       },
     ]);
     const deleteSource = vi.fn().mockResolvedValue(undefined);
@@ -707,6 +713,7 @@ describe('reapStale against a real filter-evaluating collection (Task 18 re-revi
       status: 'ready',
       variant: 'main',
       onceSourceKey: null,
+      onceSourceBytes: null,
     });
   });
 

--- a/audio-worker/test/claim.test.ts
+++ b/audio-worker/test/claim.test.ts
@@ -463,7 +463,7 @@ describe('reapStale handles once-variant attaches separately (Task 18 review Cri
     expect(mainUpdateCall![1].$set).not.toHaveProperty('onceSourceKey');
   });
 
-  it('reverts a stale once-attach to ready/main on updatedAt, not createdAt', async () => {
+  it('reverts a stale once-attach to ready/main on the attach clock, not createdAt', async () => {
     const model = reaperModel([], undefined, [
       { _id: 'once-1', onceSourceKey: 'uploads/audio/prefix/once-src.wav' },
     ]);
@@ -477,20 +477,38 @@ describe('reapStale handles once-variant attaches separately (Task 18 review Cri
     expect(onceFindCall).toBeDefined();
     const [filter] = onceFindCall!;
     expect((filter as { status: string }).status).toBe('uploading');
-    // updatedAt, NOT createdAt — the entire fix. A cutoff gated on createdAt
+    // NOT createdAt — the entire Task 18 fix. A cutoff gated on createdAt
     // would match this row (and every other once-attach) immediately, since
     // the MAIN asset's createdAt is whatever it always was.
     expect(filter).not.toHaveProperty('createdAt');
-    const cutoff = (filter as { updatedAt: { $lt: Date } }).updatedAt.$lt;
+    // The clock is `onceUploadStartedAt`, with the legacy `updatedAt`
+    // predicate surviving only as the missing-field fallback branch. Both
+    // branches carry the same cutoff.
+    const branches = (filter as { $or: Record<string, unknown>[] }).$or;
+    expect(branches.map((b) => Object.keys(b).join('+'))).toEqual([
+      'onceUploadStartedAt',
+      'onceUploadStartedAt+updatedAt',
+    ]);
+    const cutoff = (branches[0].onceUploadStartedAt as { $lt: Date }).$lt;
     expect(cutoff).toBeInstanceOf(Date);
     expect(cutoff.getTime()).toBeLessThanOrEqual(before - ONCE_STALE_MS + 1);
+    // The fallback branch is scoped to rows that HAVE no stamp — `null`
+    // matches null-or-missing in Mongo — so a stamped row can never be
+    // reaped on `updatedAt`.
+    expect(branches[1].onceUploadStartedAt).toBeNull();
+    expect((branches[1].updatedAt as { $lt: Date }).$lt).toEqual(cutoff);
 
     const onceUpdateCall = model.updateOne.mock.calls.find(
       ([f]) => (f as { _id: unknown })._id === 'once-1'
     );
     expect(onceUpdateCall).toBeDefined();
     const [updateFilter, update] = onceUpdateCall!;
-    expect(updateFilter).toEqual({ _id: 'once-1', status: 'uploading', variant: 'once' });
+    expect(updateFilter).toEqual({
+      _id: 'once-1',
+      status: 'uploading',
+      variant: 'once',
+      onceSourceKey: 'uploads/audio/prefix/once-src.wav',
+    });
     expect(update.$set).toMatchObject({
       status: 'ready',
       variant: 'main',
@@ -561,16 +579,24 @@ describe('reapStale handles once-variant attaches separately (Task 18 review Cri
  *   driver's projection would expose.
  * - `$lt` returns `false` for anything that isn't a `Date` (see
  *   `matchesFilter` below) — correct for every clause the TWO reapers
- *   tested here actually use (`createdAt`/`updatedAt`/`claimedAt`, all
- *   Dates), but `reapStale`'s OTHER two `updateMany` clauses use `$lt`/
- *   `$gte` on `attempts` (a NUMBER). Nothing in this describe block drives
- *   those branches through `makeRealFilterCollection`, so this gap is
- *   dormant, not exercised — a future test that does route the
- *   `processing`-timeout path through this fake would need `$lt` to handle
- *   numbers too, or it would silently under-match.
+ *   tested here actually use (`createdAt`/`updatedAt`/`onceUploadStartedAt`/
+ *   `claimedAt`, all Dates), but `reapStale`'s OTHER two `updateMany`
+ *   clauses use `$lt`/`$gte` on `attempts` (a NUMBER). Nothing in this
+ *   describe block drives those branches through `makeRealFilterCollection`,
+ *   so this gap is dormant, not exercised — a future test that does route
+ *   the `processing`-timeout path through this fake would need `$lt` to
+ *   handle numbers too, or it would silently under-match.
  */
 function matchesFilter(doc: Record<string, unknown>, filter: Record<string, unknown>): boolean {
   return Object.entries(filter).every(([key, cond]) => {
+    // `$or` is a top-level LOGICAL operator, not a field condition — it takes
+    // an array of whole sub-filters, any one of which may match. Added for
+    // `reapAbandonedOnceUploads`'s `onceUploadStartedAt`-or-legacy-`updatedAt`
+    // gate; without it this fake would throw rather than silently mismatch,
+    // which is the behaviour we want from an unsupported operator.
+    if (key === '$or') {
+      return (cond as Record<string, unknown>[]).some((sub) => matchesFilter(doc, sub));
+    }
     const val = doc[key];
     if (cond !== null && typeof cond === 'object' && !(cond instanceof Date)) {
       return Object.entries(cond as Record<string, unknown>).every(([op, opVal]) => {
@@ -682,6 +708,18 @@ describe('reapStale against a real filter-evaluating collection (Task 18 re-revi
     });
   });
 
+  /**
+   * NOTE, load-bearing after Task 10: this fixture carries NO
+   * `onceUploadStartedAt`, so it is also the coverage for the LEGACY-ROW
+   * fallback branch of `reapAbandonedOnceUploads`'s `$or` — a row written
+   * before the app started stamping the attach clock is still reaped on
+   * `updatedAt`, exactly as it was before. Its sibling above ("does not
+   * delete the main sourceKey of a mid-attach once-variant row") is the
+   * other half: an unstamped row with a FRESH `updatedAt` is still left
+   * alone. Between them, old rows keep precisely today's behaviour, which
+   * is why the fallback exists rather than treating a missing stamp as
+   * infinitely stale.
+   */
   it('reclaims a genuinely STALE once-attach — only its own key, never the main one', async () => {
     const now = Date.now();
     const yesterday = new Date(now - 24 * 60 * 60 * 1000);
@@ -800,5 +838,189 @@ describe('reapStale against a real filter-evaluating collection (Task 18 re-revi
     // fence narrowed the write rather than disabling the reaper.
     expect(deletedKeys).toContain('uploads/audio/p/a.wav');
     expect(collection.docs.get('a-abandoned')).toMatchObject({ status: 'failed' });
+  });
+
+  /**
+   * TASK 10, FIX 1. `reapAbandonedOnceUploads`' fenced write used to be
+   * `{_id, status: 'uploading', variant: 'once'}` — a description of the
+   * STATE a once-attach is in, not of WHICH attach the candidate list
+   * actually saw. A second attach on the same row puts it in the identical
+   * state, so the fence matched it too.
+   *
+   * No unusual timing needed: the reap loop is bounded but runs for real
+   * time (a `beat()` and an Atlas round trip per row), and the GM's own
+   * behaviour supplies the interleave — the first attach dies mid-PUT, they
+   * give up and attach again with a better file. If the re-attach lands
+   * after `find` and before this row's turn, the old fence reverted the
+   * seconds-old attach to `ready`/`main`, wrote `onceLastError: 'Once-
+   * variant upload never completed'` about it, and deleted the key it had
+   * projected before the re-attach existed — leaving the browser PUTting to
+   * a presigned URL for an object no row references.
+   *
+   * Driven through the real reaper against the filter-evaluating collection
+   * and asserted on OUTCOMES — the row's final state and the keys actually
+   * handed to `deleteSource` — not on the shape of the filter.
+   *
+   * Wrong-reason check: this would prove nothing if row B were not a
+   * genuine reap candidate, so B is listed with a day-old
+   * `onceUploadStartedAt` and only becomes fresh mid-pass; and it would
+   * prove nothing if the fence were satisfiable by timing alone, so the
+   * re-attach leaves `status`/`variant` exactly as they were — the ONLY
+   * thing that differs is `onceSourceKey`.
+   */
+  it('does not revert a once-attach that was replaced by a NEWER attach mid-pass', async () => {
+    const now = Date.now();
+    const yesterday = new Date(now - 24 * 60 * 60 * 1000);
+
+    const collection = makeRealFilterCollection([
+      // Reaped normally. Its write is what the interleave hangs off — it
+      // stands in for "any work at all happening before row B's turn".
+      {
+        _id: 'a-stale-attach',
+        status: 'uploading',
+        variant: 'once',
+        createdAt: yesterday,
+        updatedAt: yesterday,
+        onceUploadStartedAt: yesterday,
+        sourceKey: 'uploads/audio/p/a-main.wav',
+        onceSourceKey: 'uploads/audio/p/a-once.wav',
+      },
+      // Listed by the same `find` as a genuinely-abandoned attach, then
+      // superseded by a fresh attach before its own write runs.
+      {
+        _id: 'b-reattached',
+        status: 'uploading',
+        variant: 'once',
+        createdAt: yesterday,
+        updatedAt: yesterday,
+        onceUploadStartedAt: yesterday,
+        sourceKey: 'uploads/audio/p/b-main.wav',
+        onceSourceKey: 'uploads/audio/p/b-once-v1.wav',
+      },
+    ]);
+
+    const realUpdateOne = collection.updateOne.getMockImplementation()!;
+    let writes = 0;
+    collection.updateOne.mockImplementation(async (filter, update) => {
+      if (writes++ === 0) {
+        // Between row A's write and row B's, the GM re-attaches. This is
+        // exactly `createOnceVariantUpload`'s `$set`, minus the fields that
+        // don't matter here: a NEW key, the clock restarted, `status` and
+        // `variant` unchanged because the row was already in that state.
+        Object.assign(collection.docs.get('b-reattached')!, {
+          onceSourceKey: 'uploads/audio/p/b-once-v2.wav',
+          onceSourceBytes: null,
+          onceUploadStartedAt: new Date(now),
+          updatedAt: new Date(now),
+        });
+      }
+      return realUpdateOne(filter, update);
+    });
+
+    const deleteSource = vi.fn().mockResolvedValue(undefined);
+    await reapStale(collection as never, 600_000, UPLOAD_STALE_MS, deleteSource);
+
+    // The fresh attach is untouched: still in flight, still pointing at the
+    // object the browser is uploading to, never told it "never completed".
+    expect(collection.docs.get('b-reattached')).toMatchObject({
+      status: 'uploading',
+      variant: 'once',
+      onceSourceKey: 'uploads/audio/p/b-once-v2.wav',
+    });
+    expect(collection.docs.get('b-reattached')).not.toHaveProperty('onceLastError');
+
+    // Exactly one key was reclaimed — row A's. Not the superseded
+    // `b-once-v1.wav` (the fenced write no-opped, so this pass never earned
+    // the right to delete anything for row B; `createOnceVariantUpload`
+    // already deletes the object it replaced), and never a main source.
+    const deletedKeys = deleteSource.mock.calls.flatMap(([keys]) => keys as string[]);
+    expect(deletedKeys).toEqual(['uploads/audio/p/a-once.wav']);
+
+    // Positive control: the fence narrowed the write, it did not disable the
+    // reaper — the genuinely-abandoned attach was still reverted.
+    expect(collection.docs.get('a-stale-attach')).toMatchObject({
+      status: 'ready',
+      variant: 'main',
+      onceSourceKey: null,
+    });
+  });
+
+  /**
+   * TASK 10, FIX 2. The once reaper's only clock used to be `updatedAt`,
+   * which records "this document was modified", not "this job made
+   * progress". `updateAudioAsset` and `bulkTagAudioAssets` are unfenced
+   * facet editors — retitle, retag, change the mood — so any edit to an
+   * asset whose once-attach had died reset the reaper's clock and bought
+   * the dead attach another full timeout.
+   *
+   * That is not a delay, it is a trap: the row is stuck in
+   * `status: 'uploading'`, and `createOnceVariantUpload` refuses anything
+   * that isn't `status: 'ready'`, so the owner has no way to clear it
+   * themselves — and because `status` is shared with the main pipeline, the
+   * asset reads as un-ready everywhere (the board's play gate included) the
+   * whole time. Every further edit postpones it again.
+   *
+   * Wrong-reason check: the fixture's `updatedAt` is a second old, so the
+   * OLD predicate cannot match it — the row is reaped here if and only if
+   * the reaper reads the dedicated stamp. And the second row is a genuinely
+   * fresh attach, so a reaper that had simply become unconditional would
+   * fail on the `toEqual` below rather than passing.
+   */
+  it('reaps an attach that died a day ago even though a facet edit just bumped updatedAt', async () => {
+    const now = Date.now();
+    const yesterday = new Date(now - 24 * 60 * 60 * 1000);
+    const aSecondAgo = new Date(now - 1_000);
+
+    const collection = makeRealFilterCollection([
+      {
+        _id: 'edited-while-stuck',
+        status: 'uploading',
+        variant: 'once',
+        createdAt: yesterday,
+        // The attach itself died a day ago...
+        onceUploadStartedAt: yesterday,
+        // ...but the owner retitled the track a second ago, which is all
+        // `updatedAt` has ever meant.
+        updatedAt: aSecondAgo,
+        sourceKey: 'uploads/audio/p/main.wav',
+        onceSourceKey: 'uploads/audio/p/stuck-once.wav',
+        onceSourceBytes: 5_000_000,
+      },
+      // A genuinely fresh attach, stamped seconds ago. Nothing about the new
+      // clock may make this one reapable.
+      {
+        _id: 'in-flight',
+        status: 'uploading',
+        variant: 'once',
+        createdAt: yesterday,
+        onceUploadStartedAt: aSecondAgo,
+        updatedAt: aSecondAgo,
+        sourceKey: 'uploads/audio/p/other-main.wav',
+        onceSourceKey: 'uploads/audio/p/in-flight-once.wav',
+      },
+    ]);
+    const deleteSource = vi.fn().mockResolvedValue(undefined);
+
+    await reapStale(collection as never, 600_000, UPLOAD_STALE_MS, deleteSource);
+
+    // The stuck row is finally unstuck: back to a fully playable asset, its
+    // orphaned once-source reclaimed, the reason recorded.
+    expect(collection.docs.get('edited-while-stuck')).toMatchObject({
+      status: 'ready',
+      variant: 'main',
+      onceSourceKey: null,
+      onceSourceBytes: null,
+      onceLastError: 'Once-variant upload never completed',
+    });
+
+    // The in-flight attach is untouched, and only the stuck row's own key
+    // was deleted — never a main source, never the live attach's object.
+    expect(collection.docs.get('in-flight')).toMatchObject({
+      status: 'uploading',
+      variant: 'once',
+      onceSourceKey: 'uploads/audio/p/in-flight-once.wav',
+    });
+    const deletedKeys = deleteSource.mock.calls.flatMap(([keys]) => keys as string[]);
+    expect(deletedKeys).toEqual(['uploads/audio/p/stuck-once.wav']);
   });
 });

--- a/audio-worker/test/once-variant.test.ts
+++ b/audio-worker/test/once-variant.test.ts
@@ -404,6 +404,11 @@ describe('Critical 2 fix: a failed once-variant run reverts to ready, never fail
         onceSourceKey: `${PREFIX_ROOT}silent-once.wav`,
         variant: 'once',
         attempts: 1,
+        // Task 3b review fix: models a row that had a PRIOR successful
+        // once-attach before this (now-failing) re-attach started — real
+        // number, not null, so a reset that got deleted would leave this
+        // exact stale value behind in the $set instead of null.
+        onceSourceBytes: 5_000_000,
       },
       WORKER
     );
@@ -415,6 +420,11 @@ describe('Critical 2 fix: a failed once-variant run reverts to ready, never fail
     expect(update.$set.variant).toBe('main');
     expect(update.$set.onceLastError).toMatch(/silent/i);
     expect(update.$set.onceSourceKey).toBeNull();
+    // Paired with onceSourceKey: cartyx-app Task 3b review fix. The bytes
+    // field describes the object the key points at, so clearing the key
+    // without also clearing this leaves the quota over-counting an asset
+    // that no longer has a once-source at all.
+    expect(update.$set.onceSourceBytes).toBeNull();
     // permanentFailure is not merely false — it is ABSENT from the $set, so
     // a real MongoDB $set leaves whatever the row already had (always
     // `false`, since the asset was `ready` before this attach started)

--- a/deploy/charts/cartyx/README.md
+++ b/deploy/charts/cartyx/README.md
@@ -107,6 +107,25 @@ deploy/cartyx-realtime deploy/cartyx-audio-worker` — the checksum auto-restart
   in the infra repo's `apps/<env>/helmrelease.yaml` values and let Flux apply
   it. That is the durable form; the `kubectl scale` is the thirty-second one.
   Remember to revert it, or audio silently never processes.
+- **Tune an audio hardening limit** (no image rebuild): four `web.env`
+  values, all empty by default (which means "use the code default" — Helm
+  renders `''` for an unset key and the readers guard against that):
+
+  | Env var                                  | Default when unset | What it bounds                                                             |
+  | ----------------------------------------- | ------------------- | --------------------------------------------------------------------------- |
+  | `AUDIO_USER_QUOTA_BYTES`                  | 2 GiB                | Per-user total audio storage (`app/server/functions/audio.ts`).             |
+  | `MAX_PENDING_JOBS_PER_USER`               | 20                   | Per-user `pending`/`processing` transcode jobs at once (same file).         |
+  | `AUDIO_INGEST_RATE_LIMIT_CAPACITY`        | 60                   | Token-bucket burst size for upload/confirm/retry calls (`app/lib/audio-rate-limits.ts`). |
+  | `AUDIO_INGEST_RATE_LIMIT_REFILL_PER_SEC`  | 1                    | Sustained refill rate for the same bucket.                                  |
+
+  Set via `values-<env>.yaml` (or, for the live cluster, the infra repo's
+  `apps/<env>/helmrelease.yaml`) and let Flux/`helm upgrade` roll the pods —
+  a plain env value change in `web.env` changes the Pod template itself, so
+  it triggers a rollout on its own (no checksum-annotation trick needed, that
+  machinery is only for the Secret). The other four rate-limit buckets in
+  `app/lib/audio-rate-limits.ts` (package writes, board-state saves, library
+  mutations, orphan cleanup) are intentionally NOT wired here — see that
+  file's module comment.
 
 ## Troubleshooting
 

--- a/deploy/charts/cartyx/README.md
+++ b/deploy/charts/cartyx/README.md
@@ -113,7 +113,7 @@ deploy/cartyx-realtime deploy/cartyx-audio-worker` — the checksum auto-restart
 
   | Env var                                  | Default when unset | What it bounds                                                             |
   | ----------------------------------------- | ------------------- | --------------------------------------------------------------------------- |
-  | `AUDIO_USER_QUOTA_BYTES`                  | 2 GiB                | Per-user total audio storage (`app/server/functions/audio.ts`).             |
+  | `AUDIO_USER_QUOTA_BYTES`                  | 2 GiB                | Per-user total audio storage (`app/server/functions/audio.ts`). Enforced at both presign and confirm; does **not** count uploaded-but-unconfirmed bytes, which stay invisible for up to `UPLOAD_TIMEOUT_MS` (15 min) before the worker's reaper deletes them — budget the real ceiling as this value plus one account's in-flight uploads. |
   | `MAX_PENDING_JOBS_PER_USER`               | 20                   | Per-user `pending`/`processing` transcode jobs at once (same file).         |
   | `AUDIO_INGEST_RATE_LIMIT_CAPACITY`        | 60                   | Token-bucket burst size for upload/confirm/retry calls (`app/lib/audio-rate-limits.ts`). |
   | `AUDIO_INGEST_RATE_LIMIT_REFILL_PER_SEC`  | 1                    | Sustained refill rate for the same bucket.                                  |

--- a/deploy/charts/cartyx/tests/render-tests.sh
+++ b/deploy/charts/cartyx/tests/render-tests.sh
@@ -295,6 +295,40 @@ if [ "$backoff_max_ms" -ge "$backoff_ms" ] && [ "$backoff_max_ms" -le "$claim_ms
   bad "RETRY_BACKOFF_MAX_MS ($backoff_max_ms) must sit between the base ($backoff_ms) and the claim budget ($claim_ms)"
 fi
 
+# --- Task 11: audio hardening limits (quota, job cap, ingest rate limit) ---
+# All four are optional web.env values, same idiom as CDN_URL/GLITCHTIP_DSN
+# above: Helm renders '' for an unset key and the deployment's `range` drops
+# empty values, so assert BOTH the omission and the render — a name-only
+# check would still pass with the values.yaml entry deleted outright.
+assert_not_contains "empty AUDIO_USER_QUOTA_BYTES is omitted" "name: AUDIO_USER_QUOTA_BYTES"
+assert_not_contains "empty MAX_PENDING_JOBS_PER_USER is omitted" "name: MAX_PENDING_JOBS_PER_USER"
+assert_not_contains "empty AUDIO_INGEST_RATE_LIMIT_CAPACITY is omitted" \
+  "name: AUDIO_INGEST_RATE_LIMIT_CAPACITY"
+assert_not_contains "empty AUDIO_INGEST_RATE_LIMIT_REFILL_PER_SEC is omitted" \
+  "name: AUDIO_INGEST_RATE_LIMIT_REFILL_PER_SEC"
+
+assert_contains "non-empty AUDIO_USER_QUOTA_BYTES renders" 'value: "1073741824"' \
+  --set web.env.AUDIO_USER_QUOTA_BYTES=1073741824
+assert_contains "non-empty MAX_PENDING_JOBS_PER_USER renders" 'value: "5"' \
+  --set web.env.MAX_PENDING_JOBS_PER_USER=5
+assert_contains "non-empty AUDIO_INGEST_RATE_LIMIT_CAPACITY renders" 'value: "120"' \
+  --set web.env.AUDIO_INGEST_RATE_LIMIT_CAPACITY=120
+assert_contains "non-empty AUDIO_INGEST_RATE_LIMIT_REFILL_PER_SEC renders" 'value: "2.5"' \
+  --set web.env.AUDIO_INGEST_RATE_LIMIT_REFILL_PER_SEC=2.5
+
+# Scoped to each manifest specifically: these must reach the web pod (the
+# only reader — app/server/functions/audio.ts and
+# app/lib/audio-rate-limits.ts both run in the web image) and must NOT leak
+# onto the audio-worker pod, which shares the same top-level `.Values` but
+# has its own, separate `env` block.
+web_out=$(render -s templates/web-deployment.yaml --set web.env.AUDIO_USER_QUOTA_BYTES=1073741824)
+echo "$web_out" | grep -q "name: AUDIO_USER_QUOTA_BYTES" && ok ||
+  bad "AUDIO_USER_QUOTA_BYTES reaches the web deployment"
+worker_isolation_out=$(render -s templates/audio-worker-deployment.yaml \
+  --set web.env.AUDIO_USER_QUOTA_BYTES=1073741824)
+echo "$worker_isolation_out" | grep -q "name: AUDIO_USER_QUOTA_BYTES" &&
+  bad "AUDIO_USER_QUOTA_BYTES must not leak onto the audio-worker pod" || ok
+
 # ---- summary ----
 echo "render-tests: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/deploy/charts/cartyx/tests/render-tests.sh
+++ b/deploy/charts/cartyx/tests/render-tests.sh
@@ -298,8 +298,14 @@ fi
 # --- Task 11: audio hardening limits (quota, job cap, ingest rate limit) ---
 # All four are optional web.env values, same idiom as CDN_URL/GLITCHTIP_DSN
 # above: Helm renders '' for an unset key and the deployment's `range` drops
-# empty values, so assert BOTH the omission and the render — a name-only
-# check would still pass with the values.yaml entry deleted outright.
+# empty values. The omission checks below cover "unset stays out of the pod
+# entirely"; they do NOT, on their own, prove a SET value renders correctly
+# (that a `--set` reaches the container with its literal content, not just
+# that some `name:` line exists) — that is what the paired name+value checks
+# further down are for. Note `--set` injects the key regardless of what
+# values.yaml declares, so neither group of checks says anything about the
+# values.yaml defaults specifically — that is exercised implicitly by every
+# OTHER assertion in this file, which renders without ever unsetting these.
 assert_not_contains "empty AUDIO_USER_QUOTA_BYTES is omitted" "name: AUDIO_USER_QUOTA_BYTES"
 assert_not_contains "empty MAX_PENDING_JOBS_PER_USER is omitted" "name: MAX_PENDING_JOBS_PER_USER"
 assert_not_contains "empty AUDIO_INGEST_RATE_LIMIT_CAPACITY is omitted" \
@@ -307,14 +313,28 @@ assert_not_contains "empty AUDIO_INGEST_RATE_LIMIT_CAPACITY is omitted" \
 assert_not_contains "empty AUDIO_INGEST_RATE_LIMIT_REFILL_PER_SEC is omitted" \
   "name: AUDIO_INGEST_RATE_LIMIT_REFILL_PER_SEC"
 
-assert_contains "non-empty AUDIO_USER_QUOTA_BYTES renders" 'value: "1073741824"' \
-  --set web.env.AUDIO_USER_QUOTA_BYTES=1073741824
-assert_contains "non-empty MAX_PENDING_JOBS_PER_USER renders" 'value: "5"' \
-  --set web.env.MAX_PENDING_JOBS_PER_USER=5
-assert_contains "non-empty AUDIO_INGEST_RATE_LIMIT_CAPACITY renders" 'value: "120"' \
-  --set web.env.AUDIO_INGEST_RATE_LIMIT_CAPACITY=120
-assert_contains "non-empty AUDIO_INGEST_RATE_LIMIT_REFILL_PER_SEC renders" 'value: "2.5"' \
-  --set web.env.AUDIO_INGEST_RATE_LIMIT_REFILL_PER_SEC=2.5
+# Name-value pairing, all four vars in one render: `grep -A1 "name: X$"`
+# isolates X's own two-line block (the web-deployment template emits
+# `- name: {{ $key }}` immediately followed by `value: {{ $value | quote }}`)
+# before checking the value, so this binds the assertion to THIS var's entry
+# rather than any line elsewhere in a multi-hundred-line render that happens
+# to contain the same digits. `grep -F` (fixed string) rather than `-E` —
+# a bare `-E` match on `value: "2.5"` would treat the `.` as "any character"
+# and pass even if the rendered value were e.g. "2X5".
+name_value_out=$(render \
+  --set web.env.AUDIO_USER_QUOTA_BYTES=1073741824 \
+  --set web.env.MAX_PENDING_JOBS_PER_USER=5 \
+  --set web.env.AUDIO_INGEST_RATE_LIMIT_CAPACITY=120 \
+  --set web.env.AUDIO_INGEST_RATE_LIMIT_REFILL_PER_SEC=2.5)
+assert_name_value() {
+  local var=$1 val=$2
+  echo "$name_value_out" | grep -A1 "name: $var$" | grep -qF "value: \"$val\"" && ok ||
+    bad "$var renders with its literal value, bound to its own name"
+}
+assert_name_value AUDIO_USER_QUOTA_BYTES 1073741824
+assert_name_value MAX_PENDING_JOBS_PER_USER 5
+assert_name_value AUDIO_INGEST_RATE_LIMIT_CAPACITY 120
+assert_name_value AUDIO_INGEST_RATE_LIMIT_REFILL_PER_SEC 2.5
 
 # Scoped to each manifest specifically: these must reach the web pod (the
 # only reader — app/server/functions/audio.ts and

--- a/deploy/charts/cartyx/values.yaml
+++ b/deploy/charts/cartyx/values.yaml
@@ -54,6 +54,13 @@ web:
     #
     # Per-user storage quota in bytes. Default (when unset): 2 GiB — see
     # DEFAULT_AUDIO_USER_QUOTA_BYTES in app/server/functions/audio.ts.
+    # It is enforced at BOTH the upload presign and the upload confirm, so a
+    # single accepted request can overshoot it by that one asset's eventual
+    # footprint (~126 MB: a 50 MiB source plus its opus/aac renditions).
+    # It does NOT count bytes that have been uploaded but not yet confirmed —
+    # those are invisible to it for up to UPLOAD_TIMEOUT_MS (15 min default)
+    # before the audio-worker's reaper deletes them. Budget the real ceiling
+    # as this value plus whatever one account can hold in flight.
     AUDIO_USER_QUOTA_BYTES: ''
     # Per-user cap on pending/processing transcode jobs at once. Default
     # (when unset): 20 — see DEFAULT_MAX_PENDING_JOBS_PER_USER in

--- a/deploy/charts/cartyx/values.yaml
+++ b/deploy/charts/cartyx/values.yaml
@@ -43,6 +43,29 @@ web:
     GLITCHTIP_DSN: ''
     UMAMI_WEBSITE_ID: ''
     UMAMI_HOST: ''
+    # Audio hardening (phase 1.5) operator-tunable limits — all three are
+    # guarded against an absent/empty value (Helm renders '' for an unset key
+    # here; the readers in app/server/functions/audio.ts and
+    # app/lib/audio-rate-limits.ts treat that the same as "not set" and fall
+    # back to the documented default) and take effect on the next pod
+    # restart, no image rebuild. See deploy/charts/cartyx/README.md's
+    # Operations section for the operator-facing writeup of each default and
+    # where to change it.
+    #
+    # Per-user storage quota in bytes. Default (when unset): 2 GiB — see
+    # DEFAULT_AUDIO_USER_QUOTA_BYTES in app/server/functions/audio.ts.
+    AUDIO_USER_QUOTA_BYTES: ''
+    # Per-user cap on pending/processing transcode jobs at once. Default
+    # (when unset): 20 — see DEFAULT_MAX_PENDING_JOBS_PER_USER in
+    # app/server/functions/audio.ts.
+    MAX_PENDING_JOBS_PER_USER: ''
+    # Token-bucket size/refill for the audio ingest rate limiter (upload
+    # presign, confirm, once-variant, retry). Defaults (when unset): capacity
+    # 60, refill 1/s — see audioIngestLimiter in app/lib/audio-rate-limits.ts.
+    # The other four rate-limit buckets in that file are deliberately NOT
+    # env-wired (see that file's module comment for why).
+    AUDIO_INGEST_RATE_LIMIT_CAPACITY: ''
+    AUDIO_INGEST_RATE_LIMIT_REFILL_PER_SEC: ''
 
 realtime:
   image:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -123,11 +123,11 @@ bypasses checksum auto-restart). Platform-namespace secrets: see
 
 `.env.example` is the authoritative reference. The split that matters:
 
-| Kind                      | Examples                                                                                 | Changed by                                                |
-| ------------------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------- |
-| Client-baked (build-time) | `VITE_PUBLIC_GLITCHTIP_DSN`, `VITE_PUBLIC_UMAMI_WEBSITE_ID`, `VITE_PUBLIC_PARTYKIT_HOST` | `deploy/build/web-<env>.args` + merge (CI rebuilds image) |
-| Server runtime (plain)    | `APP_ENV`, `GLITCHTIP_DSN`, `UMAMI_WEBSITE_ID`, `CDN_URL`, `REALTIME_INTERNAL_HOST`      | chart `values-<env>.yaml` + merge (Flux rolls)            |
-| Server runtime (secret)   | `MONGODB_URI`, `SESSION_SECRET`, OAuth/R2 secrets                                        | `kubectl patch` Secret + rollout restart                  |
+| Kind                      | Examples                                                                                                                                                                       | Changed by                                                |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
+| Client-baked (build-time) | `VITE_PUBLIC_GLITCHTIP_DSN`, `VITE_PUBLIC_UMAMI_WEBSITE_ID`, `VITE_PUBLIC_PARTYKIT_HOST`                                                                                       | `deploy/build/web-<env>.args` + merge (CI rebuilds image) |
+| Server runtime (plain)    | `APP_ENV`, `GLITCHTIP_DSN`, `UMAMI_WEBSITE_ID`, `CDN_URL`, `REALTIME_INTERNAL_HOST`, `AUDIO_USER_QUOTA_BYTES`, `MAX_PENDING_JOBS_PER_USER`, `AUDIO_INGEST_RATE_LIMIT_CAPACITY` | chart `values-<env>.yaml` + merge (Flux rolls)            |
+| Server runtime (secret)   | `MONGODB_URI`, `SESSION_SECRET`, OAuth/R2 secrets                                                                                                                              | `kubectl patch` Secret + rollout restart                  |
 
 ## Troubleshooting
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -123,11 +123,11 @@ bypasses checksum auto-restart). Platform-namespace secrets: see
 
 `.env.example` is the authoritative reference. The split that matters:
 
-| Kind                      | Examples                                                                                                                                                                       | Changed by                                                |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
-| Client-baked (build-time) | `VITE_PUBLIC_GLITCHTIP_DSN`, `VITE_PUBLIC_UMAMI_WEBSITE_ID`, `VITE_PUBLIC_PARTYKIT_HOST`                                                                                       | `deploy/build/web-<env>.args` + merge (CI rebuilds image) |
-| Server runtime (plain)    | `APP_ENV`, `GLITCHTIP_DSN`, `UMAMI_WEBSITE_ID`, `CDN_URL`, `REALTIME_INTERNAL_HOST`, `AUDIO_USER_QUOTA_BYTES`, `MAX_PENDING_JOBS_PER_USER`, `AUDIO_INGEST_RATE_LIMIT_CAPACITY` | chart `values-<env>.yaml` + merge (Flux rolls)            |
-| Server runtime (secret)   | `MONGODB_URI`, `SESSION_SECRET`, OAuth/R2 secrets                                                                                                                              | `kubectl patch` Secret + rollout restart                  |
+| Kind                      | Examples                                                                                                                                                                                                                 | Changed by                                                |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
+| Client-baked (build-time) | `VITE_PUBLIC_GLITCHTIP_DSN`, `VITE_PUBLIC_UMAMI_WEBSITE_ID`, `VITE_PUBLIC_PARTYKIT_HOST`                                                                                                                                 | `deploy/build/web-<env>.args` + merge (CI rebuilds image) |
+| Server runtime (plain)    | `APP_ENV`, `GLITCHTIP_DSN`, `UMAMI_WEBSITE_ID`, `CDN_URL`, `REALTIME_INTERNAL_HOST`, `AUDIO_USER_QUOTA_BYTES`, `MAX_PENDING_JOBS_PER_USER`, `AUDIO_INGEST_RATE_LIMIT_CAPACITY`, `AUDIO_INGEST_RATE_LIMIT_REFILL_PER_SEC` | chart `values-<env>.yaml` + merge (Flux rolls)            |
+| Server runtime (secret)   | `MONGODB_URI`, `SESSION_SECRET`, OAuth/R2 secrets                                                                                                                                                                        | `kubectl patch` Secret + rollout restart                  |
 
 ## Troubleshooting
 

--- a/docs/specs/2026-07-28-soundboard-roadmap.md
+++ b/docs/specs/2026-07-28-soundboard-roadmap.md
@@ -22,11 +22,13 @@ generation tool. Those have different shapes, different risks, and different
 definitions of done. One spec covering all three would be too coarse to plan
 against.
 
-| Phase | Scope                                                                                                              | Spec                                                       |
-| ----- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
-| **1** | **Audio asset library** — bulk upload, server-side transcode/normalize, classification, search                     | [design](./2026-07-28-audio-library-design.md) ✅ approved |
-| **2** | **Packages + soundboard** — collections, moods, Web Audio engine, GM controls, realtime broadcast, player playback | not started                                                |
-| **3** | **`ai-sound-generator`** — Python generate → approve → upload tool                                                 | not started                                                |
+| Phase   | Scope                                                                                                               | Spec                                                                      |
+| ------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| **1**   | **Audio asset library** — bulk upload, server-side transcode/normalize, classification, search                      | [design](./2026-07-28-audio-library-design.md) ✅ approved                |
+| **2a**  | **Packages + the GM board** — collections, moods, ported Web Audio engine, GM controls, playback local to the GM    | [design](./2026-07-30-soundboard-packages-design.md) ✅ shipped to `dev`  |
+| **1.5** | **Audio hardening** — rate limits, per-user storage quota, transcode-queue fairness. Blocks promotion to production | [design](./2026-07-31-audio-hardening-design.md) ✅ approved, not started |
+| **2b**  | **Realtime broadcast + player playback** — command relay, join-audio gesture, position-accurate late join           | not designed                                                              |
+| **3**   | **`ai-sound-generator`** — Python generate → approve → upload tool                                                  | not started                                                               |
 
 **Ordering rationale.** Phase 1 is a hard prerequisite: there is nothing to put
 in a package or play on a board until assets exist, are classified, and are
@@ -200,13 +202,14 @@ hits it.
 
 Deliberately unresolved; each belongs to the phase that first needs it.
 
-| Question                                                   | Phase |
-| ---------------------------------------------------------- | ----- |
-| Per-user storage quota, and behaviour at the limit         | 1     |
-| Facet counts in the filter UI (deferred, not rejected)     | 1     |
-| Whether moods crossfade or hard-cut by default             | 2     |
-| Who owns the random-trigger schedule — GM client or server | 2     |
-| Whether players get per-track volume or only a master      | 2     |
-| Licensing/ToS position on user-uploaded audio              | 2     |
-| Which generation models ship, and their licences           | 3     |
-| Token scope granularity (per-tool vs per-user)             | 3     |
+| Question                                                  | Phase                                                                                                                                                                                                 |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ~~Per-user storage quota, and behaviour at the limit~~    | **1.5 — answered:** aggregate-on-demand, enforced before presign, fail closed. See the [hardening design](./2026-07-31-audio-hardening-design.md).                                                    |
+| Facet counts in the filter UI (deferred, not rejected)    | 1                                                                                                                                                                                                     |
+| ~~Whether moods crossfade or hard-cut by default~~        | **2a — answered:** crossfade, per-item duration. A single global fade cannot serve a 4 s storm swell and a 0 s door slam at once.                                                                     |
+| Late-join fidelity — same items, or same playhead         | **2b — answered:** position-accurate. Needs clock sync and a broadcast playhead; 2a's engine tracks `startedAt` per-browser only, so this is new machinery.                                           |
+| ~~Who owns the random-trigger schedule~~                  | **2a — answered:** the GM's browser, by construction. Players receive fires and never schedule.                                                                                                       |
+| ~~Whether players get per-track volume or only a master~~ | **2b — answered:** master **and** per-track. Inherits a hazard: the GM's mood switches will fight a player's overrides, and 2b must decide explicitly whether a mood change resets or preserves them. |
+| Licensing/ToS position on user-uploaded audio             | 2                                                                                                                                                                                                     |
+| Which generation models ship, and their licences          | 3                                                                                                                                                                                                     |
+| Token scope granularity (per-tool vs per-user)            | 3                                                                                                                                                                                                     |

--- a/docs/specs/2026-07-31-audio-hardening-design.md
+++ b/docs/specs/2026-07-31-audio-hardening-design.md
@@ -1,0 +1,227 @@
+# Audio Hardening — Design (Phase 1.5)
+
+**Date:** 2026-07-31
+**Status:** Approved (design), pending implementation plan
+**Phase:** 1.5 of the [GM Soundboard programme](./2026-07-28-soundboard-roadmap.md) — inserted between phase 2a and 2b
+**Builds on:** [Phase 1 — Audio Asset Library](./2026-07-28-audio-library-design.md), [Phase 2a — Packages and the GM Board](./2026-07-30-soundboard-packages-design.md)
+
+## Summary
+
+Close the abuse surface on the audio ingest and package paths so phase 1 + 2a can
+be promoted to production. Three controls that do not exist today — **request
+rate limiting**, a **per-user storage quota**, and a **bound on how much of the
+transcode queue one user can occupy** — plus a small set of robustness fixes an
+adversarial review of 2a surfaced and deliberately deferred.
+
+Ships no new user-facing feature. Its definition of done is that promoting
+`dev` → `main` is no longer a knowingly bad idea.
+
+## Why this phase exists, and why now
+
+Phase 2a's [adversarial review](https://github.com/biozal/cartyx-app/pull/544)
+ran five hostile passes over the branch. It fixed everything 2a introduced. What
+it could not fix in a merge window was a class of problem inherited from phase 1
+and never closed:
+
+**`origin/main` contains no audio functions at all.** Phase 1 and 2a both live
+only on `dev`. So promotion is not "expanding an existing surface" — it is the
+first time any of this reaches production, and therefore the last moment where
+adding controls costs nothing but a plan.
+
+Three facts make that urgent rather than theoretical:
+
+| Fact                                                                | Where                                                     |
+| ------------------------------------------------------------------- | --------------------------------------------------------- |
+| Registration is **open** — any Google/GitHub account becomes a user | `app/server/utils/oauth.ts:409` creates on first OAuth    |
+| There are **zero role checks** on the ingest surface                | `audio.ts`, `packages.ts`, `require-actor.ts` — 0 matches |
+| The transcode worker is **one replica** with a global FIFO claim    | `values.yaml`, `audio-worker/src/claim.ts:106`            |
+
+A brand-new signup gets `role: 'unknown'`, which blocks `createCampaign` — so
+`saveBoardState` is out of reach for a stranger. **Uploading audio and creating
+packages are not.** Both need only `requireActor()`.
+
+### What an attacker gets today
+
+- **Starve the transcode queue for everyone.** `claimNext` sorts `createdAt`
+  ascending across all users with no fairness term, so a flood of cheap uploads
+  puts every other user's asset behind it for the length of the backlog. One
+  replica, one job at a time.
+- **Drive R2 storage arbitrarily.** ~126 MB per asset at the caps (50 MiB source
+  - ~47 MB opus + ~29 MB aac), no per-user quota. Phase 1's own design lists this
+    as its open question; it was never closed. These are _legitimate_ `ready`
+    assets, so the orphan scanner will never reclaim them.
+- **Amplify Atlas writes.** Every `saveBoardState` costs three round trips
+  (`User.findOne`, `Campaign.findById`, then the upsert). The 200 ms debounce is
+  **client-side only**; the endpoint has none.
+
+2a's fix wave capped packages at 100 per user and projected the list query, which
+closed the one path that could OOM the web pod. That was the acute problem. This
+phase closes the rest.
+
+## Goals
+
+- One authenticated stranger cannot degrade service for anyone else.
+- Storage cost per user is bounded and visible to them before they hit it.
+- The controls are testable without a real Mongo, real R2, or real time.
+- Promotion to production becomes a routine decision rather than a judgement call.
+
+## Non-goals
+
+- Anything from phase 2b — realtime broadcast, player playback, resync.
+- Per-user CPU accounting or billing. A queue-depth bound is the crude control
+  that fits a single-node home lab; metering is not.
+- Reworking the transcode queue into real infrastructure. Phase 1 accepted
+  queue-on-document knowingly and the note stands: _if a second job type is ever
+  added this should become a real queue._ The once-variant made that true, and it
+  remains recorded rather than acted on — a bounded FIFO is enough for one worker.
+- A licensing/ToS position on user-uploaded audio. Still open, still owned by the
+  phase that first makes libraries shareable.
+
+## Key decisions
+
+| Decision                | Choice                                               | Rationale                                                                                                                                                      |
+| ----------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Rate-limit placement    | **In-process, at the server-fn boundary**            | Web runs `replicaCount: 1`. An in-process bucket is honest at that scale and costs no round trip. Becomes per-replica if scaled — stated in code, not assumed. |
+| Rate-limit shape        | **Pure token bucket, time injected**                 | Exactly `app/utils/exception-throttle.ts`'s shape, which was built to be portable and testable for the same reason. Reuse the idiom, not the module.           |
+| Quota accounting        | **Aggregate on demand at upload time**               | A denormalised counter needs maintenance on create, delete, transcode-complete and reap — four writers, and the 2a review found bugs in three of them.         |
+| Quota enforcement point | **`createAudioUpload`, before the presign**          | Refusing before the URL exists means no orphan to reclaim. Refusing at confirm means paying for the bytes first.                                               |
+| Worker fairness         | **Cap pending jobs per user, not round-robin claim** | Bounding queue _depth_ bounds everyone else's wait without touching `claimNext`'s atomicity — the one part of the pipeline nothing has broken.                 |
+| Where limits live       | **Server env, not `VITE_PUBLIC_*`**                  | Changing a limit must not need an image rebuild (see the `deploying` skill's client-baked env rules).                                                          |
+
+### On the rate-limit placement
+
+A Cloudflare rule at the edge would be strictly better — it rejects before the
+request costs anything. It is also infrastructure config rather than code, so it
+cannot be tested in CI, cannot be reviewed in a PR, and does not exist in
+`cartyx-infrastructure` today. The in-process limiter is the version that ships
+with tests. **If a Cloudflare rule is added later, this one stays** — defence in
+depth, and it is the only layer that knows the caller's Mongo `_id` rather than
+their IP.
+
+### On aggregating the quota on demand
+
+The cost is one `$group` aggregation per upload request, over one user's assets,
+served by the existing `{ownerId, createdAt}` index. Uploads are not a
+high-frequency path — the dropzone is multi-file, but each file is one request
+and each request is already doing a presign round trip to R2.
+
+The alternative, a `storageBytes` counter on `User`, is faster and wrong more
+often. It has four writers (`confirmAudioUpload`, `processAsset` on success,
+`deleteAudioAsset`, and both reapers), and 2a's adversarial review found
+correctness bugs in three of those exact functions. A number that drifts is worse
+than a number that costs 40 ms, because a drifted quota either blocks a user who
+is under it or admits one who is over.
+
+## Architecture
+
+### Rate limiting
+
+A pure `createRateLimiter({ capacity, refillPerSec, now })` returning
+`{ check(key): { allowed, retryAfterMs } }`, in `app/lib/rate-limit.ts` —
+`app/lib/` is the framework-free directory 2a established for exactly this.
+
+Applied in `app/utils/*-server-fns.ts` at the wrapper layer, keyed on the Mongo
+`_id` from `requireActor()`. That placement matters: it is after authentication,
+so the key is an account rather than an IP, and it is one layer above every
+server function, so no function can be added later that silently skips it.
+
+Buckets, with the reasoning that sets each:
+
+| Endpoint group                              | Bound         | Why                                                                                             |
+| ------------------------------------------- | ------------- | ----------------------------------------------------------------------------------------------- |
+| `createAudioUpload` / `confirmAudioUpload`  | tight         | Each confirm enqueues transcode work. This is the queue-starvation lever.                       |
+| `createPackage` / `clonePackage`            | tight         | Cheap per call but 100 of them is the cap; no legitimate user creates them in bursts.           |
+| `saveBoardState`                            | moderate      | Debounced to ~1/200 ms legitimately, so the bound only has to catch a scripted caller.          |
+| Reads (`listPackages`, `listPackageAssets`) | loose or none | Bounded by the projection and the `$in`; a read bound risks breaking a legitimate board reload. |
+
+**A rejected request must not file a GlitchTip event.** 2a's review found
+attacker-controlled telemetry amplification twice; a rate limiter that reports
+every rejection is a third instance of the same mistake.
+
+### Storage quota
+
+`AUDIO_USER_QUOTA_BYTES` (server env, with a default). Usage is
+`sourceBytes + renditions.{opus,aac}.bytes + onceRenditions.{opus,aac}.bytes`
+summed across the caller's assets — the same six fields
+`audio-cleanup.ts`'s `referencedKeys` enumerates, which is the list to copy so
+the two cannot drift.
+
+Enforced in `createAudioUpload` **before** the presign, refusing with the current
+usage and the limit so the UI can say something useful. Surfaced on `/audio` as a
+usage indicator, because a quota a user discovers only by hitting it is a support
+ticket.
+
+**A partially-transcoded asset counts what it has so far.** Counting only
+`ready` assets would let a user park unbounded bytes in `pending`.
+
+### Worker fairness
+
+`MAX_PENDING_JOBS_PER_USER`, checked in `confirmAudioUpload` — the point where a
+row becomes claimable. Counting `{ ownerId, status: { $in: ['pending','processing'] } }`
+bounds the depth one user can put in front of everyone else.
+
+`claimNext` is untouched. It is a single atomic `findOneAndUpdate` that nothing
+in three phases has broken, and a fairness term would mean a sort over a computed
+field. Bounding the input is the cheaper correct move.
+
+### Robustness fixes carried from 2a's adversarial review
+
+Each was found by a hostile pass, judged real, and deferred because it was not
+what was blocking that merge:
+
+| Item                                                       | Why it belongs here                                                                                       |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Optimistic concurrency on `updatePackage`                  | The editor blind-`$set`s its whole draft; an idle tab still overwrites a concurrent edit. Data loss.      |
+| Engine decoded-buffer cache never evicts                   | 64 items × 30 min ≈ 44 GB. Self-harm in 2a; a cross-user weapon the moment phase 3's catalogue is shared. |
+| In-flight rendition fetches never aborted                  | Teardown leaves up to 64 downloads running, each filing a GlitchTip event on rejection.                   |
+| `captureException` runs before the mounted check           | Same path, one line, same amplification class.                                                            |
+| `reapAbandonedOnceUploads`' fence can match a later attach | The surviving instance of a class fixed twice elsewhere. One clause.                                      |
+| `updateAudioAsset` resets the once reaper's only clock     | A facet edit indefinitely postpones reaping a stuck attach, with no self-service recovery.                |
+
+## Failure modes
+
+| Failure                             | Handling                                                                                                                       |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Rate limit hit by a legitimate user | 429-shaped error with `retryAfterMs`; the UI says when to retry. Never a silent failure and never a GlitchTip event.           |
+| Quota exceeded mid-batch upload     | Per-file rejection, not batch failure — phase 1's dropzone is already per-file. Files under the line still land.               |
+| Quota aggregation fails             | **Fail closed.** Refuse the upload. An unmeasurable quota that admits the request is not a quota.                              |
+| Pending-job cap hit                 | Refuse at confirm with the count, so the object is deleted rather than stranded. The user's earlier jobs still drain normally. |
+| Web pod restarts                    | In-process buckets reset. Accepted: the window is seconds and the durable controls (quota, job cap) are Mongo-backed.          |
+
+## Testing
+
+- **The limiter is pure** — capacity, refill and clock all injected — so its tests
+  are exhaustive and fast. Model on `exception-throttle.test.ts`.
+- **Quota and job-cap tests assert the actual query**, not a mocked return. Phase 1
+  shipped a security test that passed with its ownership clause deleted; every
+  scoped-count test in this phase names the filter it expects.
+- **The fail-closed path needs its own test.** Make the aggregation reject and
+  assert the upload is refused — the easy bug is a `catch` that logs and continues.
+- **E2E:** upload past the quota and assert the refusal is visible in the UI. The
+  E2E runs against deliberately fake R2 credentials, so the refusal must happen
+  **before** any outbound R2 call or the test cannot distinguish a quota refusal
+  from a credentials failure.
+
+## Open questions
+
+| Question                                      | Disposition                                                              |
+| --------------------------------------------- | ------------------------------------------------------------------------ |
+| Default quota and rate-limit values           | Set in the plan against measured asset sizes; tune after real usage.     |
+| Whether to add a Cloudflare edge rule as well | Out of scope here; the in-process limiter stands either way.             |
+| Licensing/ToS on user-uploaded audio          | Still open. Blocks shareable libraries, not this phase.                  |
+| Per-user CPU/egress accounting                | Deferred. Queue depth is the proxy control until it demonstrably is not. |
+
+## Decisions recorded for phase 2b
+
+Settled while scoping this phase, so 2b's design opens with them rather than
+re-litigating (both update the roadmap's open-questions table):
+
+- **Players get master _and_ per-track volume.** More capable than the master-only
+  option, and it inherits a known hazard: the GM's mood switches will fight a
+  player's per-track overrides. 2b must decide explicitly whether a mood change
+  resets or preserves them — this is the same `mood ?? item` merge that produced
+  2a's subtlest bugs, now with a second writer.
+- **Late join is position-accurate.** A joiner is sample-aligned with the table,
+  not merely playing the same items. This needs clock sync and a broadcast
+  playhead; 2a's engine tracks `startedAt` per-browser only, so this is genuinely
+  new machinery rather than a read of persisted state.

--- a/docs/specs/2026-07-31-audio-hardening-plan.md
+++ b/docs/specs/2026-07-31-audio-hardening-plan.md
@@ -1,0 +1,330 @@
+# Audio Hardening — Implementation Plan (Phase 1.5)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Close the abuse surface on audio ingest and packages so phase 1 + 2a can be promoted to production.
+
+**Design spec:** [2026-07-31-audio-hardening-design.md](./2026-07-31-audio-hardening-design.md)
+**Programme scope:** [2026-07-28-soundboard-roadmap.md](./2026-07-28-soundboard-roadmap.md)
+
+**Branch:** create `audio-hardening` from `dev`. Every PR targets `dev`. NEVER open a PR against `main`.
+
+---
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+- **`npm run lint` runs with `--max-warnings 0`** — one new warning fails CI.
+- **`npm run typecheck` must be clean.**
+- **`npm run build` must pass, and it is NOT implied by the other checks.** Phase 2a broke the client bundle for ten tasks while typecheck, lint, unit and Storybook all stayed green. The trap: server-fn wrapper modules **are** client-bundled and TanStack Start strips only `.handler()` bodies, so a helper referenced solely inside them is tree-shaken — but **exporting** it defeats that and drags mongoose and `@sentry/node` into the browser build. `requireActor` lives in `app/utils/require-actor.ts` and is reached **only** via `await import(...)` inside a handler. Nothing mechanically enforces that.
+- **Unit tests mock mongoose** — per-method model mocks, no in-memory Mongo. **They cannot catch identity-resolution or query-shape bugs**: a mock returns what it was told regardless of what the query asked. Every scoped-count test in this phase must assert on the **actual filter argument**.
+- **Every new component needs a `.stories.tsx`** — `npm run test:storybook` runs stories in a real browser and blocks CI.
+- **Telemetry:** `serverCaptureEvent(distinctId, event, properties)` — distinctId first. Never `await` capture calls. **A rejected request must never file a GlitchTip event** — 2a's review found attacker-controlled telemetry amplification twice.
+- **Identity:** `requireActor()` returns `{ userId, sessionUserId }`. `userId` (Mongo `_id`) is the only value that may scope a query; `sessionUserId` is telemetry-only.
+- **Ids reaching Mongo are ObjectId-validated in the Zod schema.** `objectId` is now **case-canonical** (`.transform(toLowerCase)`) — an uppercase id previously defeated a whole prune because `String(oid)` renders lowercase. Do not compare a client id to a server-derived one without normalising.
+- **Every array field in a Zod schema needs a `.max()`.**
+- **New env vars are server-side only**, never `VITE_PUBLIC_*` — see the `deploying` skill's client-baked env rules.
+
+### On the code in this plan
+
+Snippets are **starting points, not authority**. Phase 1's plan had fourteen wrong ones; 2a's had six plus four requirements assigned to no task at all. Verify every snippet against the actual API. Where a snippet contradicts the codebase, **the codebase wins** — report it rather than making the codebase match.
+
+### On fixtures
+
+Ask what shape would make each test pass for the wrong reason, then use that shape. In 2a this caught: a negative test whose payload was missing three other required fields; a memo test that proved only the wrapper existed; a worker test that passed with the code pointed at the wrong source object.
+
+---
+
+## File Structure
+
+**Create:**
+
+| Path                                     | Responsibility                        |
+| ---------------------------------------- | ------------------------------------- |
+| `app/lib/rate-limit.ts`                  | Pure token bucket, injected clock     |
+| `app/server/functions/audio-quota.ts`    | Usage aggregation and the quota check |
+| `app/components/audio/AudioQuotaBar.tsx` | Usage indicator on `/audio`           |
+
+**Modify:**
+
+| Path                                 | Change                                         |
+| ------------------------------------ | ---------------------------------------------- |
+| `app/utils/audio-server-fns.ts`      | Apply rate limiting                            |
+| `app/utils/soundboard-server-fns.ts` | Apply rate limiting                            |
+| `app/server/functions/audio.ts`      | Quota check, pending-job cap, reaper clock fix |
+| `app/server/functions/packages.ts`   | Optimistic concurrency on `updatePackage`      |
+| `app/lib/soundboard/engine.ts`       | Buffer-cache eviction, fetch abort             |
+| `app/hooks/useSoundboard.ts`         | Abort wiring, telemetry ordering               |
+| `audio-worker/src/claim.ts`          | Once-reaper fence                              |
+| `deploy/charts/cartyx/`              | New env vars — **run `render-tests.sh`**       |
+
+---
+
+## Task 1: The rate limiter
+
+**Files:** create `app/lib/rate-limit.ts`, `tests/lib/rate-limit.test.ts`
+
+**Produces:** `createRateLimiter({ capacity, refillPerSec, now, maxKeys })` → `{ check(key) }` returning `{ allowed, retryAfterMs }`.
+
+**Pure, with the clock injected** — `app/utils/exception-throttle.ts` is the shape to follow and was written portable for exactly this reason. Read it first. `app/lib/` is the framework-free directory 2a established.
+
+**Bound the key map.** An unbounded `Map` keyed by user id is itself a memory leak on the pod this phase exists to protect; evict oldest past `maxKeys`, as `exception-throttle.ts` does.
+
+- [ ] Tests: refills at the stated rate; a burst up to `capacity` passes and the next is refused; `retryAfterMs` is accurate enough to act on; keys are independent; eviction past `maxKeys` does not resurrect a refused key as allowed.
+- [ ] **Teeth-proof:** make refill unconditional (ignore elapsed time) and confirm the refill test fails.
+
+```bash
+git commit -m "feat(audio): pure token-bucket rate limiter"
+```
+
+---
+
+## Task 2: Apply rate limiting at the wrapper layer
+
+**Files:** modify `app/utils/audio-server-fns.ts`, `app/utils/soundboard-server-fns.ts`; tests alongside each
+
+Apply in the **wrapper**, after `requireActor()`, keyed on the Mongo `_id`. That placement is deliberate: the key is an account rather than an IP, and no server function added later can silently skip it.
+
+Buckets per the design's table — tight on `createAudioUpload`/`confirmAudioUpload` and `createPackage`/`clonePackage`, moderate on `saveBoardState`, loose or absent on reads. Pick the numbers, and **justify each against a realistic legitimate burst** (a 20-file dropzone drop is legitimate; 200 confirms in a second is not).
+
+**A rejection must not file a GlitchTip event.** Verify by asserting `serverCaptureException` was not called.
+
+**Run `npm run build`.** This task touches both wrapper modules, which is exactly where 2a's ten-task build regression lived.
+
+- [ ] Test, per bucket: over-limit rejects **and** the underlying server function is `not.toHaveBeenCalled()`. The negative assertion is what protects the gate — asserting only that it rejects passes with the limiter deleted, because a later line throws anyway.
+- [ ] **Teeth-proof:** remove one limiter call, confirm that endpoint's `not.toHaveBeenCalled()` assertion fails.
+
+```bash
+git commit -m "feat(audio): rate-limit the ingest and package endpoints"
+```
+
+---
+
+## Task 3: Storage usage aggregation
+
+**Files:** create `app/server/functions/audio-quota.ts`, `tests/server/functions/audio-quota.test.ts`
+
+**Produces:** `getUserStorageUsage(userId)` → `{ bytes, assetCount }`.
+
+Sum the **same six fields** `audio-cleanup.ts`'s `referencedKeys` enumerates — `sourceBytes`, `renditions.{opus,aac}.bytes`, `onceRenditions.{opus,aac}.bytes`. Copy that list rather than re-deriving it, so the two cannot drift; 2a shipped a bug where a new key field was missing from exactly that enumeration.
+
+**Count every status, not just `ready`.** Counting only `ready` would let a user park unbounded bytes in `pending`.
+
+- [ ] Test: assert the **actual aggregation pipeline**, not a mocked result. A fixture with a `pending` asset carrying only `sourceBytes` and a `ready` one carrying all six proves both halves.
+- [ ] Test: an asset with `null` bytes (never confirmed) contributes 0 rather than `NaN`.
+
+```bash
+git commit -m "feat(audio): per-user storage usage aggregation"
+```
+
+---
+
+## Task 4: Enforce the quota at upload
+
+**Files:** modify `app/server/functions/audio.ts`; test alongside
+
+`AUDIO_USER_QUOTA_BYTES` from server env with a documented default. Check in `createAudioUpload` **before the presign** — refusing after means an object exists that something has to reclaim.
+
+**Fail closed.** If the aggregation throws, refuse. The easy bug is a `catch` that logs and continues, which converts the quota into a suggestion.
+
+Refuse with the current usage and the limit in the error, so the UI can say something useful. Use the client-error type so a refusal does not file a GlitchTip event.
+
+- [ ] Test: over quota refuses **and** no presign is issued (`not.toHaveBeenCalled()` on the R2 client).
+- [ ] Test: the aggregation rejecting refuses the upload — **its own test**, not a branch of another.
+- [ ] Test: exactly at the limit is refused or allowed per your stated rule; say which and be consistent with `MAX_PACKAGES_PER_USER`'s `>=`, which 2a chose deliberately.
+- [ ] **Teeth-proof:** remove the fail-closed `catch`, confirm the aggregation-failure test fails.
+
+```bash
+git commit -m "feat(audio): enforce a per-user storage quota before presign"
+```
+
+---
+
+## Task 5: Surface usage in the UI
+
+**Files:** create `app/components/audio/AudioQuotaBar.tsx` + stories, modify `app/routes/audio.tsx`; tests alongside
+
+A quota a user discovers only by hitting it is a support ticket. Show usage against the limit on `/audio`, near the dropzone.
+
+Needs a server-fn wrapper for `getUserStorageUsage` — follow `soundboard-server-fns.ts`'s shape exactly, including the dynamic `requireActor` import, and add its query key under the existing nested `queryKeys` object.
+
+- [ ] Test: renders usage and limit; a near-limit state is visually distinct from a healthy one.
+- [ ] Stories for each state (healthy, near limit, over). **Check the stories do not throw on missing props** — tasks 14, 15 and 16 of phase 2a each caught their own stories doing exactly that before commit.
+
+```bash
+git commit -m "feat(audio): show storage usage on the library route"
+```
+
+---
+
+## Task 6: Bound the transcode queue per user
+
+**Files:** modify `app/server/functions/audio.ts`; test alongside
+
+`MAX_PENDING_JOBS_PER_USER` from server env. Check in `confirmAudioUpload` — the point where a row becomes claimable — counting `{ ownerId: userId, status: { $in: ['pending','processing'] } }`.
+
+**Do not touch `claimNext`.** It is a single atomic `findOneAndUpdate` that nothing across three phases has broken; bounding its input is the cheaper correct move than adding a fairness term.
+
+Refuse with the count so the user knows to wait. Delete the uploaded object on refusal, or it is stranded — and note the ordering trap 2a's review found in this same function: the R2 delete must not leave a row the caller believes failed.
+
+- [ ] Test: assert the **actual count filter**, including `ownerId`. A test asserting only "it refused" passes with the ownership clause deleted.
+- [ ] Test: a user at the cap is refused while a _different_ user at zero is admitted, in the same test file — a single-user fixture cannot catch a global-count bug.
+- [ ] **Teeth-proof:** drop `ownerId` from the filter, confirm the two-user test fails.
+
+```bash
+git commit -m "feat(audio): cap pending transcode jobs per user"
+```
+
+---
+
+## Task 7: Optimistic concurrency on `updatePackage`
+
+**Files:** modify `app/server/functions/packages.ts`, `app/routes/audio_.packages_.$packageId.tsx`; tests alongside
+
+The editor blind-`$set`s its whole draft, so an idle tab overwrites a concurrent edit and can resurrect items pruned by an asset delete. 2a fixed the invalidation; the underlying write is still last-write-wins over whole arrays.
+
+Add a version or `updatedAt` precondition to the update filter and surface the conflict rather than silently losing the other write. **Decide and state** whether a conflict re-fetches and merges or asks the user — a conflict UI that silently discards is the bug with extra steps.
+
+- [ ] Test: a stale write is refused, and the refusal is distinguishable from a not-found.
+- [ ] Test: a non-stale write still succeeds — the guard must not make every save fail.
+- [ ] **Teeth-proof:** remove the precondition, confirm the stale-write test fails.
+
+```bash
+git commit -m "fix(soundboard): refuse a stale package write instead of clobbering"
+```
+
+---
+
+## Task 8: Bound the engine's decoded-buffer cache
+
+**Files:** modify `app/lib/soundboard/engine.ts`; test in `app/lib/soundboard/engine.browser.test.ts`
+
+`assets` is a `Map` with no eviction and no cap. At the caps — 64 items × 30-minute assets, 48 kHz stereo float32 — that is ~691 MB per asset and ~44 GB total. Today it is self-harm; it becomes a cross-user weapon the moment phase 3's catalogue is shared.
+
+Add an eviction policy. **Never evict a buffer whose track is currently playing** — that is the obvious wrong LRU and it would cut audio mid-scene.
+
+**These tests run in a real browser** (`npm run test:browser`, the third vitest project 2a added). Do not mock Web Audio.
+
+- [ ] Test: past the cap, an idle buffer is evicted and a playing one is not.
+- [ ] Test: an evicted asset re-decodes on next play rather than erroring.
+- [ ] **Teeth-proof:** make eviction ignore the playing check, confirm the playing-buffer test fails.
+
+```bash
+git commit -m "fix(soundboard): bound the engine's decoded-buffer cache"
+```
+
+---
+
+## Task 9: Abort in-flight loads on teardown
+
+**Files:** modify `app/lib/soundboard/engine.ts`, `app/hooks/useSoundboard.ts`; tests alongside
+
+Teardown leaves up to 64 fetch/decode chains running against a closed `AudioContext`. Each rejects, and `captureException` at `useSoundboard.ts` runs **before** the `mountedRef` check — so a board clear files an event per asset.
+
+Two fixes: an `AbortController` per engine, aborted in `dispose()`; and move the capture behind the mounted/disposed check.
+
+- [ ] Test: after `dispose()`, an in-flight load neither throws into the graph nor files a capture.
+- [ ] **Teeth-proof:** move the capture back above the guard, confirm the test fails.
+
+```bash
+git commit -m "fix(soundboard): abort in-flight loads and stop teardown telemetry"
+```
+
+---
+
+## Task 10: The two narrow worker fixes
+
+**Files:** modify `audio-worker/src/claim.ts`, `app/server/functions/audio.ts`; tests alongside
+
+Both were found by 2a's adversarial pass, judged real, deferred as narrow:
+
+1. **`reapAbandonedOnceUploads`' fence can match a later attach.** Its write filter is `{_id, status:'uploading', variant:'once'}` — which a _second_ attach also satisfies, so the reaper can revert an attach seconds old and tell the user it "never completed". Its sibling was hardened for exactly this class. Add `onceSourceKey: row.onceSourceKey` so the fence identifies _which_ attach.
+2. **`updateAudioAsset` resets the once reaper's only clock.** It writes `updatedAt` unfenced, and `claim.ts` gates abandoned-once reaping on `updatedAt < cutoff` — so a facet edit postpones the reap indefinitely, with no self-service recovery because `createOnceVariantUpload` needs `status: 'ready'`. Use a dedicated timestamp for job liveness.
+
+Run `(cd audio-worker && npm run typecheck && npm test)` — the root suite does not cover the worker.
+
+- [ ] Test each against the real mechanism, not a filter-shape assertion. 2a's equivalent used a filter-evaluating fake collection driving the real reaper; reuse it.
+- [ ] **Teeth-proof both.**
+
+```bash
+git commit -m "fix(audio): identify the once-reap by attach, and stop facet edits resetting its clock"
+```
+
+---
+
+## Task 11: Chart and config
+
+**Files:** modify `deploy/charts/cartyx/` (values, deployment env), `docs/observability.md` if alerts change
+
+Wire the new env vars — quota, job cap, rate-limit values — as **server-side env**, never `VITE_PUBLIC_*`, so changing a limit needs no image rebuild.
+
+**`bash deploy/charts/cartyx/tests/render-tests.sh` is REQUIRED whenever anything under `deploy/charts/` changes**, and is a CI job. `deploy/charts/` is prettierignored — do not format it.
+
+- [ ] Add render-test assertions for each new var, matching the existing style.
+- [ ] Document the defaults and where to change them.
+
+```bash
+git commit -m "chore(deploy): wire the audio hardening limits"
+```
+
+---
+
+## Task 12: E2E and the gate
+
+**Files:** extend `e2e/audio-library.spec.ts` or add `e2e/audio-hardening.spec.ts`
+
+**Seed real fixtures.** Do **not** guard assertions behind `if (await x.count())` — with no seed data that condition is always false and the spec reports coverage it does not have.
+
+**The E2E runs against deliberately fake R2 credentials.** A quota refusal must therefore happen **before** any outbound R2 call, or the test cannot distinguish a quota refusal from a credentials failure. That is itself a useful assertion about where the check lives.
+
+- [ ] Cover: a user over quota sees the refusal in the UI, and the usage indicator reflects reality.
+- [ ] **Prove the seed matters:** remove it and confirm the spec fails.
+
+- [ ] **Run the whole gate before opening the PR:**
+
+```bash
+npm run build
+npm run typecheck && npm run lint && npm test && npm run test:storybook && npm run test:browser
+bash deploy/charts/cartyx/tests/render-tests.sh
+(cd audio-worker && npm run typecheck && npm test)
+(cd realtime && npm run typecheck && npm test)
+npx playwright test
+```
+
+- [ ] **Open the PR against `dev`.**
+
+```bash
+git push -u origin audio-hardening
+gh pr create --base dev --title "feat(audio): hardening — rate limits, storage quota, queue fairness"
+```
+
+---
+
+## After this phase
+
+Promoting `dev` → `main` becomes a routine decision. Per `CLAUDE.md`, promotion is a PR `dev`→`main` merged with `gh pr merge --merge --admin`, and the `deploying` skill holds the runbook.
+
+**Verify before promoting:** `origin/main` currently contains no audio functions at all, so this promotion carries phases 1, 2a and 1.5 together. It is a large surface reaching production for the first time — worth watching GlitchTip and the worker's queue depth for the first session.
+
+---
+
+## Self-Review
+
+| Requirement                                     | Task |
+| ----------------------------------------------- | ---- |
+| Rate limiting on ingest and package endpoints   | 1, 2 |
+| Per-user storage quota, enforced before presign | 3, 4 |
+| Quota visible to the user                       | 5    |
+| Transcode queue bounded per user                | 6    |
+| Stale package writes refused                    | 7    |
+| Engine buffer cache bounded                     | 8    |
+| Teardown aborts loads, no telemetry storm       | 9    |
+| Once-reaper identifies its attach               | 10   |
+| Facet edits do not postpone reaping             | 10   |
+| Limits configurable without a rebuild           | 11   |
+| End-to-end proof                                | 12   |
+
+**Not covered, by design:** phase 2b in full; per-user CPU or egress metering; a Cloudflare edge rule; the licensing/ToS position; reworking queue-on-document into real infrastructure.
+
+**Known risk:** Task 2 touches both server-fn wrapper modules, which is precisely where phase 2a's ten-task build regression lived. Run `npm run build` on that task specifically, not just at the gate.

--- a/e2e/audio-hardening.spec.ts
+++ b/e2e/audio-hardening.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * E2E: the audio storage quota (phase 1.5, Task 12).
+ *
+ * `globalSetup.ts` (`seedStorageQuotaFixtures`) upserts three real
+ * `AudioAsset` rows owned by the seeded GM whose byte fields sum past
+ * `AUDIO_USER_QUOTA_BYTES`, so the user this suite signs in as is genuinely
+ * over quota before the first line below runs. Nothing here is guarded behind
+ * `if (await x.count())`: with no seed those conditions are always false and
+ * the spec would report coverage it does not have. Remove the seed and these
+ * tests fail — that was verified, not assumed.
+ *
+ * WHY THE REFUSAL ASSERTION IS ALSO AN ASSERTION ABOUT WHERE THE CHECK LIVES.
+ * This suite runs against deliberately fake R2 credentials (see `ci.yml`'s e2e
+ * job). Anything that reaches the presigned PUT therefore fails — but it fails
+ * as a transport error at `uploadAudioFile`'s `fetch` ("R2 upload failed: …",
+ * or a `TypeError` from an unresolvable host), not as a quota refusal. The
+ * three assertions below distinguish those two outcomes on purpose:
+ *
+ *  1. the message is the quota refusal `assertUnderStorageQuota`
+ *     (`app/server/functions/audio.ts`) raises, byte figures and all;
+ *  2. the browser issues NO `PUT` at all — the presigned upload is the only
+ *     `PUT` this page can make, so its absence means no upload URL was ever
+ *     handed back;
+ *  3. no `uploading` row appears in the library for the refused file —
+ *     `createAudioUpload` creates that row AFTER `resolveAudioStoragePrefix`
+ *     and `getAudioUploadUrl`, so a row here would mean the quota check ran
+ *     too late even if the request still ended in a refusal.
+ *
+ * Together those pin the ordering Task 4 was built for: the quota check
+ * precedes the storage-prefix resolution, the presign, and the row insert.
+ *
+ * NOT covered here: the once-variant upload path (`createOnceVariantUpload`
+ * runs the identical `assertUnderStorageQuota` call — same helper, same
+ * placement before the presign — and driving it needs a `ready` `music` asset
+ * plus the edit modal, for a second copy of the assertion above), and the
+ * rate limiters and pending-job cap (Tasks 1/2/6), whose refusals are
+ * time-and-queue-shaped rather than state-shaped and would need either a
+ * hundred-request loop or a running worker to reach honestly.
+ */
+import { test, expect } from '@playwright/test';
+import { formatBytes } from '../app/utils/format-bytes';
+import { AUDIO_QUOTA_FIXTURE } from './fixtures/audio-fixtures';
+
+/** The exact refusal `assertUnderStorageQuota` throws, with both figures captured. */
+const QUOTA_REFUSAL = /Storage quota exceeded: (\d+) of (\d+) bytes used/;
+
+/** What `seedStorageQuotaFixtures` puts in Mongo, summed the way the server should. */
+const SEEDED_FILLER_BYTES =
+  AUDIO_QUOTA_FIXTURE.count *
+  Object.values(AUDIO_QUOTA_FIXTURE.bytes).reduce((sum, n) => sum + n, 0);
+
+/** Uploaded by the refusal test. Never lands anywhere — the upload is refused before it can. */
+const REFUSED_FILE = {
+  name: 'e2e-quota-refusal.wav',
+  mimeType: 'audio/wav',
+  // A 44-byte RIFF/WAVE header. Content is irrelevant (nothing reads it), but
+  // the size must be > 0: `createAudioUploadSchema` requires a positive
+  // `bytes`, and a zero-length file would be refused by validation rather than
+  // by the quota — the exact "passes for the wrong reason" shape this spec
+  // must avoid.
+  buffer: Buffer.alloc(44),
+};
+
+/**
+ * `titleFromFilename` (`app/server/functions/audio.ts`) strips the extension,
+ * so this is the row that must NOT appear. Addressed through its select
+ * checkbox's `aria-label` rather than by text: a text locator that silently
+ * stopped matching would make the assertion vacuous, and this exact accessible
+ * name was observed in the library during the seed-removal run — i.e. it is
+ * known to resolve when the row IS created, which is what makes its absence
+ * mean something.
+ */
+const REFUSED_ROW_CHECKBOX = 'Select e2e-quota-refusal';
+
+test.describe('Audio storage quota', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/audio');
+    await expect(page.getByRole('heading', { name: /audio library/i })).toBeVisible();
+    // Same reason as `audio-library.spec.ts`'s wait: the heading is
+    // server-rendered, and the file input's onChange is dead until React has
+    // hydrated. Selecting a file before then produces no request at all.
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('the quota bar reports the over-limit state before any upload is attempted', async ({
+    page,
+  }) => {
+    const bar = page.getByRole('progressbar', { name: 'Storage used' });
+    await expect(bar).toBeVisible();
+
+    // Capped at 100 by AudioQuotaBar — the point is that it is not the
+    // "healthy" reading a user would otherwise be surprised by a refusal from.
+    await expect(bar).toHaveAttribute('aria-valuenow', '100');
+    await expect(
+      page.getByText(
+        'Storage limit reached. New uploads will be refused until you delete an asset.'
+      )
+    ).toBeVisible();
+  });
+
+  test('an over-quota upload is refused before any R2 request, and the bar agrees with the refusal', async ({
+    page,
+  }) => {
+    // The presigned upload is the only PUT `/audio` can issue (server fns are
+    // POST/GET). Recording every PUT and asserting none happened is what
+    // separates "refused before the presign" from "presigned, then died on
+    // fake credentials".
+    const putRequests: string[] = [];
+    page.on('request', (req) => {
+      if (req.method() === 'PUT') putRequests.push(req.url());
+    });
+
+    await page.locator('#audio-files').setInputFiles(REFUSED_FILE);
+
+    const dropzone = page.getByTestId('audio-upload-dropzone');
+    const refusal = dropzone.getByText(QUOTA_REFUSAL);
+    // Generous: a server-fn round trip plus the usage aggregation, on a dev
+    // server that may still be compiling the route chunk on a cold first run.
+    await expect(refusal).toBeVisible({ timeout: 20_000 });
+
+    expect(putRequests).toEqual([]);
+
+    // The refused file never became a row. See this file's header for why that
+    // is an ordering assertion, not a duplicate of the one above.
+    await expect(page.getByRole('checkbox', { name: REFUSED_ROW_CHECKBOX })).toHaveCount(0);
+
+    // --- the indicator reflects the same reality the refusal was decided on ---
+    const message = (await refusal.textContent()) ?? '';
+    const match = QUOTA_REFUSAL.exec(message);
+    expect(match, `refusal message did not carry both figures: ${message}`).not.toBeNull();
+    const usageBytes = Number(match![1]);
+    const limitBytes = Number(match![2]);
+
+    // The boundary `assertUnderStorageQuota` enforces (`usage.bytes >= limit`).
+    expect(usageBytes).toBeGreaterThanOrEqual(limitBytes);
+
+    // Every seeded byte was counted. `getUserStorageUsage` sums six fields
+    // across every owned row; the fixtures put a value in all six of them on
+    // each of three rows, so a dropped term or a missing row would land the
+    // reported usage BELOW this figure while still (with 2.4 GB seeded against
+    // a 2 GiB limit) leaving the refusal itself intact.
+    expect(usageBytes).toBeGreaterThanOrEqual(SEEDED_FILLER_BYTES);
+
+    // Task 5's claim is that the number shown and the number enforced cannot
+    // diverge, because both come from one server response. This is that claim
+    // stated as an assertion: the bar's own accessible text, formatted with
+    // the app's `formatBytes`, must be exactly the figures the server just
+    // refused on — no client-side limit constant, no second round trip.
+    await expect(page.getByRole('progressbar', { name: 'Storage used' })).toHaveAttribute(
+      'aria-valuetext',
+      `${formatBytes(usageBytes)} of ${formatBytes(limitBytes)} used`
+    );
+  });
+});

--- a/e2e/audio-hardening.spec.ts
+++ b/e2e/audio-hardening.spec.ts
@@ -139,6 +139,15 @@ test.describe('Audio storage quota', () => {
     // each of three rows, so a dropped term or a missing row would land the
     // reported usage BELOW this figure while still (with 2.4 GB seeded against
     // a 2 GiB limit) leaving the refusal itself intact.
+    //
+    // NOTE this is only a TIGHT bound while the GM's other rows are tiny —
+    // today the five `audio-library.spec.ts` fixtures contribute ~4.5 MB
+    // against 2.4 GB of fillers. Against a database carrying substantial
+    // pre-existing audio for the seeded GM, that slack grows and this
+    // assertion loosens silently: a dropped aggregation term could hide inside
+    // the real rows' bytes. If that ever becomes the situation, compare
+    // against a usage figure computed in `globalSetup` rather than this
+    // constant.
     expect(usageBytes).toBeGreaterThanOrEqual(SEEDED_FILLER_BYTES);
 
     // Task 5's claim is that the number shown and the number enforced cannot

--- a/e2e/fixtures/audio-fixtures.ts
+++ b/e2e/fixtures/audio-fixtures.ts
@@ -21,3 +21,58 @@ export const AUDIO_FIXTURE_TITLES = {
   /** status: ready. Exclusively owned by the delete test, which removes it — globalSetup re-creates it on every run. */
   deleteMe: 'E2E Audio — Delete Me',
 } as const;
+
+/**
+ * The storage-quota fixture `audio-hardening.spec.ts` depends on (phase 1.5,
+ * Task 12): enough seeded bytes, owned by the same GM user, to put that user
+ * OVER `AUDIO_USER_QUOTA_BYTES` before the spec does anything.
+ *
+ * WHY SEEDED BYTES AND NOT A LOWERED LIMIT. The other way to produce an
+ * over-quota user is to set `AUDIO_USER_QUOTA_BYTES` low for the E2E run. That
+ * has to reach the SERVER process, and the only checked-in place to do it is
+ * `playwright.config.ts`'s `webServer.env` — which `reuseExistingServer:
+ * !process.env.CI` skips entirely whenever a developer already has `npm run
+ * dev` on :3000, the normal local working state. The spec's meaning would then
+ * depend on whether a dev server happened to be running: green in CI, red (or
+ * worse, vacuous) locally. Fixture rows are applied by `globalSetup` against
+ * Mongo, so they hold no matter which process serves the request — and the
+ * quota reads Mongo, never R2, so no real stored objects are needed.
+ *
+ * WHY THE BYTES ARE SPREAD, AND WHY THERE IS MORE THAN ONE ROW.
+ * `getUserStorageUsage` (`app/server/functions/audio-quota.ts`) is a `$group`
+ * summing SIX byte fields across every row a user owns. A single row with a
+ * single huge `sourceBytes` would put the user over the limit while exercising
+ * one term of that sum and no grouping at all — it would still pass if five of
+ * the six fields were dropped from the aggregation. Each filler below carries
+ * a value in every one of the six fields, and there are three of them.
+ *
+ * The per-row totals are deliberately larger than a real upload could produce
+ * (`AUDIO_MAX_BYTES` caps one source at 50 MiB): reaching 2 GiB with realistic
+ * per-asset figures takes ~17 rows, which would bury `audio-library.spec.ts`'s
+ * five fixtures in noise for no gain — the quota never re-measures R2, it sums
+ * exactly these fields.
+ */
+export const AUDIO_QUOTA_FIXTURE = {
+  /** How many filler rows `globalSetup` upserts. */
+  count: 3,
+  /**
+   * Per row, spread across the six fields `getUserStorageUsage` sums. Totals
+   * 800,000,000 per row → 2,400,000,000 across the three, comfortably past the
+   * 2 GiB (2,147,483,648) `AUDIO_USER_QUOTA_BYTES` default.
+   */
+  bytes: {
+    source: 300_000_000,
+    onceSource: 200_000_000,
+    opus: 120_000_000,
+    aac: 80_000_000,
+    onceOpus: 60_000_000,
+    onceAac: 40_000_000,
+  },
+  /** `${titlePrefix} N` — visible in the library, so it is obvious what these rows are. */
+  titlePrefix: 'E2E Audio — Quota Filler',
+  /**
+   * `${sourceKeyPrefix}N` — the natural key for the upsert, and the ONLY thing
+   * `globalTeardown.ts` deletes on. Nothing points at a real R2 object.
+   */
+  sourceKeyPrefix: 'e2e/fixtures/audio/quota-filler-',
+} as const;

--- a/e2e/fixtures/audio-fixtures.ts
+++ b/e2e/fixtures/audio-fixtures.ts
@@ -46,6 +46,16 @@ export const AUDIO_FIXTURE_TITLES = {
  * the six fields were dropped from the aggregation. Each filler below carries
  * a value in every one of the six fields, and there are three of them.
  *
+ * READ THIS BEFORE WRITING A SPEC THAT UPLOADS AUDIO. These rows put the
+ * seeded GM over the storage quota for the WHOLE run, in every spec, not just
+ * `audio-hardening.spec.ts` — that user shares one library across the suite.
+ * Any new spec that uploads a file, or attaches a once-variant, will be
+ * refused by `assertUnderStorageQuota` with a message about storage, which is
+ * a confusing thing to meet when your spec is about something else entirely.
+ * No spec is affected today (verified: nothing else in `e2e/` uploads). If
+ * yours needs to, delete these rows for the duration of your test rather than
+ * removing the seed — `audio-hardening.spec.ts` depends on them existing.
+ *
  * The per-row totals are deliberately larger than a real upload could produce
  * (`AUDIO_MAX_BYTES` caps one source at 50 MiB): reaching 2 GiB with realistic
  * per-asset figures takes ~17 rows, which would bury `audio-library.spec.ts`'s

--- a/e2e/globalSetup.ts
+++ b/e2e/globalSetup.ts
@@ -12,6 +12,9 @@
  *    fixtures.ts`) owned by that GM user, so `audio-library.spec.ts` has real
  *    rows — including `ready` ones — without depending on the transcode
  *    worker, which does not run in E2E.
+ * 5b. Idempotently upserts the storage-quota fillers (`seedStorageQuotaFixtures`)
+ *    that put that same GM OVER `AUDIO_USER_QUOTA_BYTES`, which is what
+ *    `audio-hardening.spec.ts` drives. Removed again by `globalTeardown.ts`.
  * 6. Idempotently seeds the soundboard fixtures (`seedSoundboardFixtures`): a
  *    system package to clone, a foreign-owned package that must stay
  *    invisible, and a foreign-owned asset the system package references —
@@ -24,7 +27,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { SignJWT } from 'jose';
 import mongoose from 'mongoose';
-import { AUDIO_FIXTURE_TITLES } from './fixtures/audio-fixtures';
+import { AUDIO_FIXTURE_TITLES, AUDIO_QUOTA_FIXTURE } from './fixtures/audio-fixtures';
 import {
   FOREIGN_ASSET_SOURCE_KEY,
   FOREIGN_OWNER_ID,
@@ -176,6 +179,81 @@ async function seedAudioFixtures(
         { $set: set, $setOnInsert: { createdAt: new Date() } },
         { upsert: true }
       );
+  }
+}
+
+/**
+ * Idempotently upserts the storage-quota fillers `audio-hardening.spec.ts`
+ * depends on — see `AUDIO_QUOTA_FIXTURE` in `e2e/fixtures/audio-fixtures.ts`
+ * for why the over-quota state is produced with seeded BYTES rather than a
+ * lowered `AUDIO_USER_QUOTA_BYTES`, and why the bytes are spread across all
+ * six fields `getUserStorageUsage` sums.
+ *
+ * These rows put the seeded GM OVER the quota for the whole run, which is the
+ * point: every server-side path that presigns an upload must refuse them.
+ * `globalTeardown.ts` deletes them again afterwards, so a local dev database
+ * (the E2E suite runs against the developer's own dev Atlas DB) isn't left
+ * with an account that silently refuses every audio upload with no visible
+ * cause. Nothing else in this file is torn down, because nothing else in this
+ * file DISABLES a feature for the seeded user.
+ *
+ * Shaped like a finished asset — `status: 'ready'`, `confirmedAt` set, both
+ * rendition pairs present, `kind: 'music'` (the only kind a once-variant may
+ * attach to) — so they are rows the real pipeline could have produced, apart
+ * from their deliberately outsized byte counts. Tagged, so they can never
+ * satisfy `audio-library.spec.ts`'s "needs tagging" filter assertions.
+ */
+async function seedStorageQuotaFixtures(
+  db: NonNullable<typeof mongoose.connection.db>,
+  ownerId: unknown
+): Promise<void> {
+  const { bytes } = AUDIO_QUOTA_FIXTURE;
+
+  for (let i = 1; i <= AUDIO_QUOTA_FIXTURE.count; i += 1) {
+    const sourceKey = `${AUDIO_QUOTA_FIXTURE.sourceKeyPrefix}${i}`;
+    const onceSourceKey = `${sourceKey}.once`;
+
+    await db.collection('audioassets').findOneAndUpdate(
+      { ownerId, sourceKey },
+      {
+        $set: {
+          ownerId,
+          title: `${AUDIO_QUOTA_FIXTURE.titlePrefix} ${i}`,
+          kind: 'music',
+          environment: [],
+          mood: [],
+          intensity: null,
+          tags: ['e2e-quota-filler'],
+          sourceKey,
+          sourceBytes: bytes.source,
+          onceSourceKey,
+          onceSourceBytes: bytes.onceSource,
+          confirmedAt: new Date(),
+          status: 'ready',
+          variant: 'main',
+          attempts: 1,
+          lastError: null,
+          claimedAt: null,
+          claimedBy: null,
+          durationMs: 42_000,
+          loudnessTargetLufs: -20,
+          sampleRate: 48_000,
+          channels: 2,
+          peaks: fakePeaks(),
+          renditions: {
+            opus: { ...fakeRendition(sourceKey, 'opus'), bytes: bytes.opus },
+            aac: { ...fakeRendition(sourceKey, 'aac'), bytes: bytes.aac },
+          },
+          onceRenditions: {
+            opus: { ...fakeRendition(onceSourceKey, 'opus'), bytes: bytes.onceOpus },
+            aac: { ...fakeRendition(onceSourceKey, 'aac'), bytes: bytes.onceAac },
+          },
+          updatedAt: new Date(),
+        },
+        $setOnInsert: { createdAt: new Date() },
+      },
+      { upsert: true }
+    );
   }
 }
 
@@ -472,6 +550,7 @@ export default async function globalSetup(): Promise<void> {
   }
 
   await seedAudioFixtures(db, user._id);
+  await seedStorageQuotaFixtures(db, user._id);
   const soundboard = await seedSoundboardFixtures(
     db,
     user._id as mongoose.Types.ObjectId,

--- a/e2e/globalTeardown.ts
+++ b/e2e/globalTeardown.ts
@@ -1,0 +1,60 @@
+/**
+ * Playwright globalTeardown — runs once after all specs.
+ *
+ * Deletes exactly one thing: the storage-quota fillers `globalSetup.ts` upserts
+ * for `audio-hardening.spec.ts` (see `AUDIO_QUOTA_FIXTURE` in
+ * `e2e/fixtures/audio-fixtures.ts`).
+ *
+ * Every other fixture this suite seeds is additive — an extra image on a
+ * location, extra audio rows, a tabletop screen — and leaving it behind costs
+ * a developer nothing. These rows are different in kind: locally the suite runs
+ * against the developer's own dev Atlas database, and while they exist the
+ * seeded GM is over the storage quota, so `/audio` refuses EVERY upload with a
+ * message that gives no hint the E2E suite is why. Cleaning them up is what
+ * keeps "I ran the E2E suite once" from silently disabling a feature.
+ *
+ * Deletion is keyed on `sourceKey`, not owner or title: the prefix is
+ * E2E-specific, so this cannot reach a row the fixture didn't create, and it
+ * still catches rows left by an older run whose GM lookup would resolve
+ * differently.
+ *
+ * Failures are NOT swallowed — they propagate exactly as `globalSetup.ts`'s do.
+ * A silent catch here would restore the precise situation this file exists to
+ * prevent (fillers left behind, uploads refused, no explanation) while
+ * reporting a green run. An interrupted run (Ctrl+C) skips this file entirely
+ * regardless; the next `globalSetup` re-upserts the same three rows either way,
+ * so nothing accumulates.
+ */
+import mongoose from 'mongoose';
+import { AUDIO_QUOTA_FIXTURE } from './fixtures/audio-fixtures';
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export default async function globalTeardown(): Promise<void> {
+  try {
+    process.loadEnvFile('.env');
+  } catch {
+    // .env optional in CI when vars are set in the environment
+  }
+
+  // Without a URI `globalSetup` could not have seeded anything, so there is
+  // nothing here to remove.
+  const mongoUri = process.env.MONGODB_URI;
+  if (!mongoUri) return;
+  // Same guard as globalSetup — it matters more here: this file issues a delete.
+  if (/prod/i.test(mongoUri)) throw new Error('Refusing to use a production-looking MONGODB_URI');
+
+  await mongoose.connect(mongoUri, { dbName: process.env.MONGODB_DB });
+  try {
+    const db = mongoose.connection.db;
+    if (!db) throw new Error('Mongo connection has no db handle');
+
+    await db.collection('audioassets').deleteMany({
+      sourceKey: { $regex: `^${escapeRegExp(AUDIO_QUOTA_FIXTURE.sourceKeyPrefix)}` },
+    });
+  } finally {
+    await mongoose.disconnect();
+  }
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -117,14 +117,30 @@ export default [
     ],
   },
   {
-    // B3 (phase-B deferred finding on Task 4's re-review): `checkPendingJobCap`
-    // and `assertUnderStorageQuota` are guards a caller must `await` for the
-    // guard to mean anything — `assertUnderStorageQuota` throws to refuse,
-    // and a dropped `await` on it does not surface as a thrown error at the
-    // call site at all; the rejection becomes an unhandled promise rejection
-    // elsewhere while the caller's code keeps running as if the check passed.
-    // That is a silent fail-OPEN with no compiler or lint error, and nothing
-    // in this file's structure stops a future edit from introducing one.
+    // B3 (phase-B deferred finding on Task 4's re-review). `assertUnderStorageQuota`
+    // is called as a bare statement at both its call sites (`await
+    // assertUnderStorageQuota(...)`, no assignment). It throws to refuse, and a
+    // dropped `await` there does not surface as a thrown error at the call site
+    // at all — the rejection becomes an unhandled promise rejection elsewhere
+    // while the caller's code keeps running as if the check passed. That is a
+    // silent fail-OPEN with no compiler or lint error, and nothing in this
+    // file's structure stops a future edit from introducing one. THIS rule
+    // structurally closes that gap: `no-floating-promises` flags an unhandled
+    // expression-statement promise, which a dropped `await` on a bare-statement
+    // call produces exactly.
+    //
+    // `checkPendingJobCap` is NOT protected by this rule, and does not need to
+    // be. Every call site assigns its result first (`const cap = await
+    // checkPendingJobCap(userId); if (cap) { throw ...; }`) — `no-floating-
+    // promises` only flags unhandled expression-statement promises, not a
+    // promise bound to a variable, so a dropped `await` there passes lint
+    // clean. But the failure mode is the opposite of `assertUnderStorageQuota`'s:
+    // `cap` would be bound to the Promise object itself, which is truthy, so
+    // `if (cap)` is ALWAYS true and the call ALWAYS throws the refusal — every
+    // request refused, loudly and immediately, not a silent bypass. That
+    // failure is self-announcing (any manual test or the E2E suite catches it
+    // instantly), so a structural guard for it was considered and rejected as
+    // unwarranted machinery for a fail-closed, self-detecting bug class.
     //
     // Repo-wide `no-floating-promises` was measured, not assumed (see the
     // phase-B report): enabling it across the repo surfaces 502 violations
@@ -136,9 +152,10 @@ export default [
     // type-aware parsing to just this file keeps the blast radius to the
     // five pre-existing `serverCaptureException`/`serverCaptureEvent` calls
     // here (each now an explicit `void`, unchanged behaviour) while closing
-    // the actual gap: any future `await` dropped from `checkPendingJobCap`
-    // or `assertUnderStorageQuota` — or any other async helper later added
-    // to this file — fails `npm run lint` instead of shipping silently.
+    // the one gap that was genuinely silent: any future `await` dropped from
+    // a bare-statement async call in this file — `assertUnderStorageQuota`
+    // today, or any other async helper later added and called the same way —
+    // fails `npm run lint` instead of shipping silently.
     files: ['app/server/functions/audio.ts'],
     languageOptions: {
       parserOptions: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -116,6 +116,40 @@ export default [
       '.claude/worktrees/**',
     ],
   },
+  {
+    // B3 (phase-B deferred finding on Task 4's re-review): `checkPendingJobCap`
+    // and `assertUnderStorageQuota` are guards a caller must `await` for the
+    // guard to mean anything — `assertUnderStorageQuota` throws to refuse,
+    // and a dropped `await` on it does not surface as a thrown error at the
+    // call site at all; the rejection becomes an unhandled promise rejection
+    // elsewhere while the caller's code keeps running as if the check passed.
+    // That is a silent fail-OPEN with no compiler or lint error, and nothing
+    // in this file's structure stops a future edit from introducing one.
+    //
+    // Repo-wide `no-floating-promises` was measured, not assumed (see the
+    // phase-B report): enabling it across the repo surfaces 502 violations
+    // spread across ~100 files (mostly the fire-and-forget
+    // `serverCaptureEvent`/`serverCaptureException` calls this codebase's
+    // telemetry convention requires — see CLAUDE.md, "Never `await` capture
+    // calls on request-critical paths"), which is neither small nor
+    // mechanical and is far outside this item's scope to triage. Scoping
+    // type-aware parsing to just this file keeps the blast radius to the
+    // five pre-existing `serverCaptureException`/`serverCaptureEvent` calls
+    // here (each now an explicit `void`, unchanged behaviour) while closing
+    // the actual gap: any future `await` dropped from `checkPendingJobCap`
+    // or `assertUnderStorageQuota` — or any other async helper later added
+    // to this file — fails `npm run lint` instead of shipping silently.
+    files: ['app/server/functions/audio.ts'],
+    languageOptions: {
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'error',
+    },
+  },
   ...pluginQuery.configs['flat/recommended'],
   jsxA11y.flatConfigs.recommended,
   {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "build-storybook:full": "node scripts/build-storybook-with-iframe.mjs",
     "realtime:dev": "npm --prefix realtime run dev",
     "check:deps-age": "node scripts/check-package-age.mjs",
+    "check:client-bundle": "node scripts/check-client-bundle.mjs",
     "db:verify": "tsx scripts/mongo-admin.ts verify",
     "db:sync": "tsx scripts/mongo-admin.ts sync",
     "dev:clear": "node scripts/run-python.cjs dev_clear.py",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,9 @@ const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:3000';
 export default defineConfig({
   testDir: './e2e',
   globalSetup: './e2e/globalSetup.ts',
+  // Removes ONLY the storage-quota fillers globalSetup seeds — see that file's
+  // header for why those specifically can't be left behind.
+  globalTeardown: './e2e/globalTeardown.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/scripts/check-client-bundle.mjs
+++ b/scripts/check-client-bundle.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * Post-build guard: server-only code must not be in the client bundle.
+ *
+ * WHY THIS EXISTS. `app/lib/audio-rate-limits.ts` and
+ * `app/server/functions/audio.ts` read server env (`AUDIO_INGEST_RATE_LIMIT_*`,
+ * `AUDIO_USER_QUOTA_BYTES`, `MAX_PENDING_JOBS_PER_USER`) and are reached only
+ * from inside `.handler()` bodies that TanStack Start strips before the client
+ * build. Nothing mechanically enforces that arrangement: a single static
+ * import edge from a component or route drags the module into the browser
+ * bundle, where `process` does not exist and the chunk throws
+ * `ReferenceError: process is not defined` on load — for every user, on a
+ * build that passed typecheck, lint, unit tests AND `npm run build`, because
+ * it is a runtime failure, not a build error. `~/lib/audio-rate-limits`' own
+ * module comment documents that hazard and records a MANUAL grep as the
+ * verification. This script is that grep, in CI.
+ *
+ * `npm run test:storybook` briefly appeared to be this detector and is not:
+ * Storybook does not strip handler bodies, so it goes red whenever a story
+ * transitively imports a server-fn wrapper — whether or not the real build
+ * drops the module. It cannot distinguish the safe case from the unsafe one.
+ * This can: it reads what the production build actually emitted.
+ *
+ * POSITIVE CONTROLS ARE THE POINT. An absence check that searched the wrong
+ * directory, or matched nothing because the walk silently skipped every file,
+ * would pass while proving nothing — worse than no guard at all, because it
+ * reads as coverage. So every run first asserts that two strings that MUST be
+ * there ARE found, and fails if either is missing.
+ *
+ * Run via `npm run check:client-bundle`, after `npm run build`.
+ */
+import { readdirSync, readFileSync, statSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const PUBLIC_DIR = '.output/public';
+const SERVER_DIR = '.output/server';
+
+/**
+ * Strings that must NOT appear anywhere the browser can load.
+ *
+ * THE ENV-NAME ENTRIES ARE THE LOAD-BEARING ONES — do not drop them thinking
+ * `process.env` covers the class. Measured, by statically importing
+ * `audioIngestLimiter` into `app/routes/audio.tsx` and rebuilding: the module
+ * shipped to the browser, and this list caught it on the two
+ * `AUDIO_INGEST_RATE_LIMIT_*` names while `process.env` stayed absent, because
+ * Vite rewrites the expression to a shim variable during the client build
+ * (`Number(CB[t])` in the emitted chunk). The string literals passed to
+ * `envPositiveNumber` survive minification; `process.env` does not survive
+ * bundling. Every new server-env name read from a module that could be
+ * statically reachable belongs in this list.
+ *
+ * `process.env` is kept anyway as a cheap second net for any code path where
+ * the rewrite does not apply. If a third-party chunk ever legitimately carries
+ * it (a `typeof process !== 'undefined'` guard in a vendored dependency),
+ * NARROW it to exclude that file rather than deleting the entry.
+ */
+const FORBIDDEN_IN_CLIENT = [
+  'process.env',
+  'AUDIO_INGEST_RATE_LIMIT_CAPACITY',
+  'AUDIO_INGEST_RATE_LIMIT_REFILL_PER_SEC',
+  'AUDIO_USER_QUOTA_BYTES',
+  'MAX_PENDING_JOBS_PER_USER',
+  // `rateLimitMessage`'s template-literal fragment — survives minification
+  // (string contents are not mangled), so it proves the FUNCTION did not ship,
+  // not merely that an env name did not.
+  'Try again in ',
+  'mongoose',
+];
+
+/**
+ * Strings that MUST be found, or the search itself is broken.
+ *
+ * - `Storage limit reached` is `AudioQuotaBar`'s over-quota copy: a genuinely
+ *   client-side string from the very route whose server-side siblings this
+ *   script forbids. Finding it proves we are searching a populated client
+ *   bundle that really does contain the audio surface — not an empty
+ *   directory, and not a build where `/audio` was tree-shaken away entirely.
+ * - `mongoose` under `.output/server` is the technique control: the same
+ *   string this script forbids on the client must be present on the server, so
+ *   a search that can never match anything cannot masquerade as a pass.
+ */
+const REQUIRED = [
+  { dir: PUBLIC_DIR, needle: 'Storage limit reached', why: "AudioQuotaBar's client-side copy" },
+  { dir: SERVER_DIR, needle: 'mongoose', why: 'server bundle sanity' },
+];
+
+/** Every file under `dir`, recursively. */
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) out.push(...walk(path));
+    else out.push(path);
+  }
+  return out;
+}
+
+/**
+ * Files containing `needle`. Matched on raw bytes rather than decoded text so
+ * nothing has to be excluded by extension — an image cannot accidentally
+ * contain these ASCII strings, and a filter that skipped the wrong extension
+ * is precisely how this check would go quietly blind.
+ */
+function filesContaining(files, needle) {
+  const bytes = Buffer.from(needle);
+  return files.filter((f) => readFileSync(f).includes(bytes));
+}
+
+function main() {
+  for (const dir of [PUBLIC_DIR, SERVER_DIR]) {
+    if (!existsSync(dir)) {
+      process.stdout.write(`check:client-bundle: ${dir} missing — run \`npm run build\` first\n`);
+      process.exit(1);
+    }
+  }
+
+  const publicFiles = walk(PUBLIC_DIR);
+  const serverFiles = walk(SERVER_DIR);
+  const byDir = { [PUBLIC_DIR]: publicFiles, [SERVER_DIR]: serverFiles };
+  process.stdout.write(
+    `check:client-bundle: scanning ${publicFiles.length} client files, ` +
+      `${serverFiles.length} server files\n`
+  );
+
+  let failed = false;
+
+  // --- positive controls, first: prove the search can find anything at all ---
+  for (const { dir, needle, why } of REQUIRED) {
+    const hits = filesContaining(byDir[dir], needle);
+    if (hits.length === 0) {
+      failed = true;
+      process.stdout.write(
+        `  CONTROL FAILED  "${needle}" not found in ${dir} (${why}).\n` +
+          `                  The absence checks below cannot be trusted — this ` +
+          `search found nothing where something must be.\n`
+      );
+    } else {
+      process.stdout.write(
+        `  control ok      "${needle}" found in ${dir} (${hits.length} file(s)) — ${why}\n`
+      );
+    }
+  }
+
+  // --- the actual guard ---
+  for (const needle of FORBIDDEN_IN_CLIENT) {
+    const hits = filesContaining(publicFiles, needle);
+    if (hits.length > 0) {
+      failed = true;
+      process.stdout.write(
+        `  FORBIDDEN       "${needle}" is in the CLIENT bundle (${hits.length} file(s)):\n` +
+          hits.map((f) => `                    ${f}\n`).join('')
+      );
+    } else {
+      process.stdout.write(`  ok              "${needle}" absent from ${PUBLIC_DIR}\n`);
+    }
+  }
+
+  if (failed) {
+    process.stdout.write(
+      '\ncheck:client-bundle: FAILED. A server-only module reached the browser ' +
+        'bundle.\nUsually a static `import` where a dynamic `await import(...)` ' +
+        'inside a `.handler()` body is required — see app/utils/require-actor.ts ' +
+        'and app/lib/audio-rate-limits.ts.\n'
+    );
+    process.exit(1);
+  }
+
+  process.stdout.write('check:client-bundle: OK\n');
+}
+
+main();

--- a/tests/components/audio/AudioOrphanCleanup.test.tsx
+++ b/tests/components/audio/AudioOrphanCleanup.test.tsx
@@ -105,4 +105,41 @@ describe('AudioOrphanCleanup', () => {
     expect(screen.getByRole('button', { name: /scanning/i })).toBeDisabled();
     expect(screen.getByRole('button', { name: /delete 1 file/i })).toBeDisabled();
   });
+
+  /**
+   * B2 (phase-B): this component now imports the shared `~/utils/format-
+   * bytes` instead of its own copy, which had no GB tier and stopped at MB
+   * with 1 decimal. `ORPHAN.sizeBytes` (2_097_152) is exactly 2.0 MB, so this
+   * pins the per-row size — a fixture picked because it renders identically
+   * under BOTH the old and new implementations, proving the MB tier itself
+   * still works after the switch.
+   */
+  it('formats an individual orphan size in the row list', () => {
+    render(<AudioOrphanCleanup {...BASE} result={scan({ orphans: [ORPHAN] })} />);
+    expect(screen.getByText('2.0 MB')).toBeInTheDocument();
+  });
+
+  /**
+   * This is the assertion that would have passed for the wrong reason before
+   * the consolidation: the old copy of `formatBytes` in this file had no GB
+   * tier at all, so a 1.5 GiB total rendered as "1536.0 MB" — a plain
+   * `/delete 2 files/i` match (the style every other test in this file uses)
+   * would still pass either way. Asserting the exact button name is what
+   * actually pins the shared implementation's GB tier here, mirroring what
+   * `AudioQuotaBar.test.tsx` already pins for its own GB-scale numbers.
+   * Individual assets can never reach this tier (`AUDIO_MAX_BYTES` caps one
+   * asset at 50 MB), but the aggregate this button sums can, on an account
+   * with enough orphaned files.
+   */
+  it('formats the delete total in GB once the orphan set crosses 1 GiB', () => {
+    const GIB = 1024 * 1024 * 1024;
+    const bigOrphans = [
+      { key: 'uploads/audio/a.opus', sizeBytes: 0.75 * GIB, lastModified: null },
+      { key: 'uploads/audio/b.opus', sizeBytes: 0.75 * GIB, lastModified: null },
+    ];
+    render(<AudioOrphanCleanup {...BASE} result={scan({ orphans: bigOrphans })} />);
+    expect(
+      screen.getByRole('button', { name: /delete 2 files \(1\.50 gb\)/i })
+    ).toBeInTheDocument();
+  });
 });

--- a/tests/components/audio/AudioQuotaBar.test.tsx
+++ b/tests/components/audio/AudioQuotaBar.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AudioQuotaBar } from '~/components/audio/AudioQuotaBar';
+
+const GIB = 1024 * 1024 * 1024;
+
+describe('AudioQuotaBar', () => {
+  it('renders usage and the limit', () => {
+    render(<AudioQuotaBar usageBytes={512 * 1024 * 1024} assetCount={12} limitBytes={2 * GIB} />);
+    expect(screen.getByText(/512\.0 MB of 2\.00 GB used/i)).toBeInTheDocument();
+    expect(screen.getByText(/12 assets/i)).toBeInTheDocument();
+  });
+
+  it('renders a singular asset count for exactly one asset', () => {
+    render(<AudioQuotaBar usageBytes={1024} assetCount={1} limitBytes={2 * GIB} />);
+    expect(screen.getByText(/1 asset$/i)).toBeInTheDocument();
+  });
+
+  it('exposes an accessible progressbar with a numeric value and a human-readable value text', () => {
+    render(<AudioQuotaBar usageBytes={GIB} assetCount={10} limitBytes={2 * GIB} />);
+    const bar = screen.getByRole('progressbar', { name: /storage used/i });
+    expect(bar).toHaveAttribute('aria-valuemin', '0');
+    expect(bar).toHaveAttribute('aria-valuemax', '100');
+    expect(bar).toHaveAttribute('aria-valuenow', '50');
+    expect(bar).toHaveAttribute(
+      'aria-valuetext',
+      expect.stringMatching(/1\.00 GB of 2\.00 GB used/i)
+    );
+  });
+
+  /**
+   * The core "near-limit must be visually distinct from healthy" assertion
+   * the brief calls out. A healthy bar (well under 90%) renders no warning
+   * icon and no "approaching" copy at all — checked via `queryBy`, not just
+   * "the near case has one", so this fails if healthy ever grows one too.
+   */
+  it('is visually distinct from healthy once usage crosses the near-limit threshold', () => {
+    const { rerender } = render(
+      <AudioQuotaBar usageBytes={Math.round(2 * GIB * 0.5)} assetCount={20} limitBytes={2 * GIB} />
+    );
+    expect(screen.queryByText(/approaching your storage limit/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/storage limit reached/i)).not.toBeInTheDocument();
+
+    rerender(
+      <AudioQuotaBar usageBytes={Math.round(2 * GIB * 0.91)} assetCount={20} limitBytes={2 * GIB} />
+    );
+    expect(screen.getByText(/approaching your storage limit/i)).toBeInTheDocument();
+  });
+
+  // Not colour alone: the near and over states each carry their own sentence
+  // (not just a different className), so the distinction survives a
+  // stylesheet-stripped or screen-reader read of the DOM.
+  it('gives the over-limit state its own distinct copy, not just a different colour', () => {
+    render(<AudioQuotaBar usageBytes={2 * GIB} assetCount={57} limitBytes={2 * GIB} />);
+    expect(screen.getByText(/storage limit reached/i)).toBeInTheDocument();
+    expect(screen.queryByText(/approaching your storage limit/i)).not.toBeInTheDocument();
+  });
+
+  /**
+   * Matches `assertUnderStorageQuota`'s own boundary in
+   * `~/server/functions/audio.ts`: `usage.bytes >= limitBytes` is refused,
+   * not merely "close". Usage sitting exactly AT the limit must read as
+   * "over", not "near" — a user reading "near" at the exact number the
+   * server already refuses at would be misled about their own state.
+   */
+  it('treats usage exactly at the limit as over, not near', () => {
+    render(<AudioQuotaBar usageBytes={2 * GIB} assetCount={57} limitBytes={2 * GIB} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
+    expect(screen.getByText(/storage limit reached/i)).toBeInTheDocument();
+  });
+
+  it('clamps the progressbar value at 100 when usage has overshot the limit', () => {
+    render(<AudioQuotaBar usageBytes={3 * GIB} assetCount={80} limitBytes={2 * GIB} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
+  });
+
+  it('shows a loading state instead of the bar while usage has not resolved', () => {
+    render(<AudioQuotaBar usageBytes={null} assetCount={0} limitBytes={null} />);
+    expect(screen.getByText(/checking storage usage/i)).toBeInTheDocument();
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+
+  it('surfaces a failed usage query as an alert instead of the bar', () => {
+    render(
+      <AudioQuotaBar
+        usageBytes={null}
+        assetCount={0}
+        limitBytes={null}
+        error="Failed to load storage usage."
+      />
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent(/failed to load storage usage/i);
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+
+  it('renders a zero-usage empty library without warning', () => {
+    render(<AudioQuotaBar usageBytes={0} assetCount={0} limitBytes={2 * GIB} />);
+    expect(screen.getByText(/0 assets/i)).toBeInTheDocument();
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0');
+    expect(screen.queryByText(/approaching your storage limit/i)).not.toBeInTheDocument();
+  });
+});

--- a/tests/components/soundboard/PackageConflictNotice.test.tsx
+++ b/tests/components/soundboard/PackageConflictNotice.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PackageConflictNotice } from '~/components/soundboard/PackageConflictNotice';
+
+const SAVED_AT = '2026-07-31T14:32:07.000Z';
+
+describe('PackageConflictNotice', () => {
+  /**
+   * The requirement this component exists for: a conflict must not be a
+   * one-way door. A notice offering only "reload" would be a discard with a
+   * confirmation button on it, so BOTH outcomes are asserted present in the
+   * same render — a component that dropped the overwrite path would still
+   * pass a test that only looked for the reload one.
+   */
+  it('offers both ways out, and says what each one costs', () => {
+    render(<PackageConflictNotice savedAt={SAVED_AT} onOverwrite={vi.fn()} onDiscard={vi.fn()} />);
+
+    const notice = screen.getByRole('alert');
+    expect(notice).toHaveTextContent(/changed somewhere else/i);
+    // The reassurance is load-bearing copy, not decoration: it is what tells
+    // the user their unsaved work is still there and they are choosing, not
+    // recovering.
+    expect(notice).toHaveTextContent(/nothing has been lost/i);
+
+    expect(screen.getByRole('button', { name: /keep my edits and overwrite/i })).toBeEnabled();
+    expect(
+      screen.getByRole('button', { name: /discard my edits and load the saved version/i })
+    ).toBeEnabled();
+  });
+
+  it('calls the handler for whichever choice was made', async () => {
+    const user = userEvent.setup();
+    const onOverwrite = vi.fn();
+    const onDiscard = vi.fn();
+    render(
+      <PackageConflictNotice savedAt={SAVED_AT} onOverwrite={onOverwrite} onDiscard={onDiscard} />
+    );
+
+    await user.click(screen.getByRole('button', { name: /keep my edits and overwrite/i }));
+    expect(onOverwrite).toHaveBeenCalledTimes(1);
+    expect(onDiscard).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole('button', { name: /discard my edits and load the saved version/i })
+    );
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+    expect(onOverwrite).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * Asserted on the machine-readable `dateTime`, not on the rendered text:
+   * the visible string comes from `toLocaleString()` and would make this test
+   * a function of the runner's timezone and locale.
+   */
+  it('marks the saved-at timestamp up as a real time', () => {
+    const { container } = render(
+      <PackageConflictNotice savedAt={SAVED_AT} onOverwrite={vi.fn()} onDiscard={vi.fn()} />
+    );
+    expect(container.querySelector('time')).toHaveAttribute('dateTime', SAVED_AT);
+  });
+
+  /**
+   * An absent or unparseable timestamp must not become "Invalid Date" on
+   * screen, and must not cost the user their choices — the discard path does
+   * not use this value at all.
+   */
+  it('renders without a timestamp rather than showing "Invalid Date"', () => {
+    const { container } = render(
+      <PackageConflictNotice savedAt="" onOverwrite={vi.fn()} onDiscard={vi.fn()} />
+    );
+    expect(container.querySelector('time')).toBeNull();
+    expect(screen.getByRole('alert')).not.toHaveTextContent(/invalid date/i);
+    expect(
+      screen.getByRole('button', { name: /keep my edits and overwrite/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /discard my edits and load the saved version/i })
+    ).toBeInTheDocument();
+  });
+
+  it('disables both choices while a save is in flight', () => {
+    render(
+      <PackageConflictNotice savedAt={SAVED_AT} onOverwrite={vi.fn()} onDiscard={vi.fn()} busy />
+    );
+    expect(screen.getByRole('button', { name: /saving/i })).toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: /discard my edits and load the saved version/i })
+    ).toBeDisabled();
+  });
+});

--- a/tests/hooks/useSoundboard.test.tsx
+++ b/tests/hooks/useSoundboard.test.tsx
@@ -159,6 +159,15 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
+/**
+ * Stands in for the signal the real engine would pass — these tests call
+ * `loadAsset` directly rather than through `createEngine` (which is mocked),
+ * so most of them have no engine-owned `AbortController` to reach for and
+ * don't care whether it ever fires. A dedicated test below constructs its
+ * own controller to exercise the forwarding itself.
+ */
+const noSignal = new AbortController().signal;
+
 /** The options `useSoundboard` handed `createEngine` on its single call. */
 function engineOptions(): SoundboardEngineOptions {
   expect(createEngine).toHaveBeenCalledTimes(1);
@@ -731,7 +740,7 @@ describe('useSoundboard', () => {
 
     let asset: EngineAsset | null = null;
     await act(async () => {
-      asset = await engineOptions().loadAsset(ASSET_A);
+      asset = await engineOptions().loadAsset(ASSET_A, noSignal);
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -749,8 +758,8 @@ describe('useSoundboard', () => {
       await result.current.enableAudio();
     });
 
-    await expect(engineOptions().loadAsset(ASSET_A)).resolves.toBeNull();
-    await expect(engineOptions().loadAsset(ASSET_B)).resolves.toBeNull();
+    await expect(engineOptions().loadAsset(ASSET_A, noSignal)).resolves.toBeNull();
+    await expect(engineOptions().loadAsset(ASSET_B, noSignal)).resolves.toBeNull();
   });
 
   it('throws — rather than vanishing — for an asset missing from a settled list', async () => {
@@ -763,7 +772,7 @@ describe('useSoundboard', () => {
     // `unplayable` set, but only a throw reaches `onLoadError`. A list that is
     // simply wrong (paginated past 50, or `{ ownerId }`-filtered so no system
     // package's assets are ever in it) must not kill a pad in silence.
-    await expect(engineOptions().loadAsset('507f1f77bcf86cd799439099')).rejects.toThrow(
+    await expect(engineOptions().loadAsset('507f1f77bcf86cd799439099', noSignal)).rejects.toThrow(
       'not in the board'
     );
   });
@@ -774,7 +783,9 @@ describe('useSoundboard', () => {
       await result.current.enableAudio();
     });
 
-    await expect(engineOptions().loadAsset(ASSET_A)).rejects.toThrow('status: processing');
+    await expect(engineOptions().loadAsset(ASSET_A, noSignal)).rejects.toThrow(
+      'status: processing'
+    );
   });
 
   it('throws when the rendition URL 404s', async () => {
@@ -787,8 +798,40 @@ describe('useSoundboard', () => {
       await result.current.enableAudio();
     });
 
-    await expect(engineOptions().loadAsset(ASSET_A)).rejects.toThrow(
+    await expect(engineOptions().loadAsset(ASSET_A, noSignal)).rejects.toThrow(
       'Audio rendition fetch failed (404)'
+    );
+  });
+
+  it('forwards the AbortSignal to fetch so aborting it cancels the in-flight request', async () => {
+    // Stands in for a real `fetch` honouring `signal` — it settles ONLY when
+    // the signal aborts, never on its own. If `loadAsset` dropped the signal
+    // on the floor instead of forwarding it, this promise would just hang
+    // and the test would time out rather than resolve with the wrong thing —
+    // there is no way for this fixture shape to pass without the forwarding
+    // actually happening.
+    const fetchMock = vi.fn(
+      (_url: string, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('The operation was aborted.', 'AbortError'));
+          });
+        })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { result } = renderBoard();
+    await act(async () => {
+      await result.current.enableAudio();
+    });
+
+    const controller = new AbortController();
+    const pending = engineOptions().loadAsset(ASSET_A, controller.signal);
+    controller.abort();
+
+    await expect(pending).rejects.toThrow('aborted');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1]).toEqual(
+      expect.objectContaining({ signal: controller.signal })
     );
   });
 
@@ -810,6 +853,37 @@ describe('useSoundboard', () => {
       campaignId: CAMPAIGN,
       assetId: ASSET_A,
     });
+  });
+
+  // Task 9: teardown leaves up to 64 fetch/decode chains running against a
+  // closed engine. Each used to reject straight into `captureException`
+  // BEFORE the `mountedRef` check, so a single board clear filed one
+  // GlitchTip event per asset. `engine.dispose()` is mocked here, so it
+  // cannot itself stop the callback from firing (that half is the real
+  // engine's `disposed` guard, covered in `engine.browser.test.ts`) — this
+  // proves the hook's OWN half: even if a stale callback does fire after the
+  // component is gone, it must not reach telemetry.
+  it('does not report to telemetry when the engine calls onLoadError after unmount', async () => {
+    const { result, unmount } = renderBoard();
+    await act(async () => {
+      await result.current.enableAudio();
+    });
+    // Captured BEFORE unmount — standing in for a fetch/decode chain that
+    // was already mid-flight when the board cleared and settles afterward,
+    // asynchronously invoking the very callback the disposed engine was
+    // built with. `unmount()` below does not — cannot — retract this
+    // reference; that is exactly why the guard has to live inside it.
+    const onLoadError = engineOptions().onLoadError;
+    captureException.mockClear();
+
+    unmount();
+    expect(engine.dispose).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      onLoadError?.(ASSET_A, new Error('decode failed'));
+    });
+
+    expect(captureException).not.toHaveBeenCalled();
   });
 
   // Telemetry tells ME. `loadErrors` is what tells the GM, and it is the only

--- a/tests/lib/rate-limit.test.ts
+++ b/tests/lib/rate-limit.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { createRateLimiter } from '~/lib/rate-limit';
+
+// The limiter is pure (time is passed in), so no fake timers are needed.
+
+describe('createRateLimiter', () => {
+  it('refills at the stated rate, not merely after "some time"', () => {
+    let t = 0;
+    const limiter = createRateLimiter({ capacity: 1, refillPerSec: 1, now: () => t });
+
+    // Starting bucket is full: the first check consumes the only token.
+    expect(limiter.check('user-1').allowed).toBe(true);
+
+    // Halfway to a full second, only 0.5 tokens have accrued — still refused.
+    t = 500;
+    expect(limiter.check('user-1').allowed).toBe(false);
+
+    // A millisecond short of a full second: still not quite enough.
+    t = 999;
+    expect(limiter.check('user-1').allowed).toBe(false);
+
+    // Exactly one second elapsed at 1 token/sec: the bucket now holds 1 token.
+    t = 1000;
+    expect(limiter.check('user-1').allowed).toBe(true);
+  });
+
+  it('lets a burst up to capacity through and refuses the next call', () => {
+    let t = 0;
+    const limiter = createRateLimiter({ capacity: 3, refillPerSec: 1, now: () => t });
+
+    expect(limiter.check('user-1').allowed).toBe(true);
+    expect(limiter.check('user-1').allowed).toBe(true);
+    expect(limiter.check('user-1').allowed).toBe(true);
+    // Capacity exhausted, no time has passed to refill anything.
+    expect(limiter.check('user-1').allowed).toBe(false);
+  });
+
+  it('reports a retryAfterMs accurate enough to act on', () => {
+    let t = 0;
+    const limiter = createRateLimiter({ capacity: 2, refillPerSec: 2, now: () => t });
+
+    // Drain the burst.
+    limiter.check('user-1');
+    limiter.check('user-1');
+    const refusal = limiter.check('user-1');
+    expect(refusal.allowed).toBe(false);
+    expect(refusal.retryAfterMs).toBeGreaterThan(0);
+
+    // Waiting exactly the reported delay must be enough to succeed again.
+    t += refusal.retryAfterMs;
+    expect(limiter.check('user-1').allowed).toBe(true);
+
+    // One millisecond earlier must NOT have been enough — otherwise the
+    // reported retryAfterMs would be misleadingly generous. Uses a fresh
+    // key so its bucket starts full regardless of how far `t` has moved.
+    limiter.check('user-2');
+    limiter.check('user-2');
+    const refusal2 = limiter.check('user-2');
+    t += refusal2.retryAfterMs - 1;
+    expect(limiter.check('user-2').allowed).toBe(false);
+  });
+
+  it('returns retryAfterMs of 0 whenever a call is allowed', () => {
+    const limiter = createRateLimiter({ capacity: 1, refillPerSec: 1, now: () => 0 });
+    expect(limiter.check('user-1')).toEqual({ allowed: true, retryAfterMs: 0 });
+  });
+
+  it('throttles distinct keys independently', () => {
+    let t = 0;
+    const limiter = createRateLimiter({ capacity: 1, refillPerSec: 1, now: () => t });
+
+    expect(limiter.check('user-1').allowed).toBe(true);
+    // user-1 is now exhausted, but user-2 has never been seen — unaffected.
+    expect(limiter.check('user-1').allowed).toBe(false);
+    expect(limiter.check('user-2').allowed).toBe(true);
+  });
+
+  it('does not resurrect a refused key as allowed once other keys evict past maxKeys', () => {
+    const limiter = createRateLimiter({
+      capacity: 1,
+      refillPerSec: 0.001,
+      maxKeys: 3,
+      now: () => 0,
+    });
+
+    // 'stale' is inserted first and never touched again — it is the true
+    // oldest entry and the natural eviction target.
+    limiter.check('stale');
+
+    // 'attacker' is inserted next and immediately exhausted (burst of 1,
+    // capacity 1) so it is refused from here on.
+    limiter.check('attacker');
+    expect(limiter.check('attacker').allowed).toBe(false);
+
+    // 'filler' brings the map to maxKeys (3): stale, attacker, filler.
+    limiter.check('filler');
+
+    // A brand-new key forces one eviction. It must take the true oldest
+    // entry ('stale'), not the more-recently-touched 'attacker'.
+    limiter.check('newcomer');
+
+    // 'attacker' must still be tracked and still refused — eviction must
+    // not have wiped its bucket and handed it a fresh, full one.
+    expect(limiter.check('attacker').allowed).toBe(false);
+  });
+
+  it('defaults to a real clock when now is omitted', () => {
+    const limiter = createRateLimiter({ capacity: 1, refillPerSec: 1 });
+    expect(limiter.check('user-1').allowed).toBe(true);
+  });
+});

--- a/tests/lib/rate-limit.test.ts
+++ b/tests/lib/rate-limit.test.ts
@@ -108,4 +108,26 @@ describe('createRateLimiter', () => {
     const limiter = createRateLimiter({ capacity: 1, refillPerSec: 1 });
     expect(limiter.check('user-1').allowed).toBe(true);
   });
+
+  /**
+   * Final-review minor #7: the invariant belongs here rather than in every
+   * call site's own env guard. Each of these values would produce a limiter
+   * that refuses EVERY call for EVERY key — silently, at request time, long
+   * after construction — rather than failing where the mistake was made:
+   * `refillPerSec: 0` makes `retryAfterMs` `Infinity` and a bucket that never
+   * refills, and `capacity: 0` starts every bucket empty.
+   *
+   * Enumerated rather than tested with one value, because a guard written as
+   * `!refillPerSec` would pass a `0` test and admit `NaN` and negatives.
+   */
+  it.each([
+    ['refillPerSec zero', { capacity: 5, refillPerSec: 0 }],
+    ['refillPerSec negative', { capacity: 5, refillPerSec: -1 }],
+    ['refillPerSec NaN', { capacity: 5, refillPerSec: Number.NaN }],
+    ['capacity zero', { capacity: 0, refillPerSec: 1 }],
+    ['capacity negative', { capacity: -5, refillPerSec: 1 }],
+    ['capacity NaN', { capacity: Number.NaN, refillPerSec: 1 }],
+  ])('refuses to construct a limiter that could never allow anything: %s', (_label, options) => {
+    expect(() => createRateLimiter(options)).toThrow(/must be > 0/);
+  });
 });

--- a/tests/routes/audio-packages-package-id-route.test.tsx
+++ b/tests/routes/audio-packages-package-id-route.test.tsx
@@ -264,6 +264,36 @@ describe('PackageEditorPage save path', () => {
     expect(call.data.moods).toHaveLength(1);
   });
 
+  /**
+   * Task 7: every save carries the revision it was built on. Asserted on the
+   * VALUE, not merely on the key being present — a save that sent, say, the
+   * draft's own `createdAt`, or a hard-coded `new Date().toISOString()`, would
+   * satisfy the schema and be refused by Mongo on every single save.
+   */
+  it('sends the loaded package revision as the save precondition', async () => {
+    const user = userEvent.setup();
+    const pkg = mkPackage({ items: [mkItem()], updatedAt: '2026-03-04T05:06:07.000Z' });
+
+    getPackageFn.mockResolvedValue(pkg);
+    listAudioAssetsFn.mockResolvedValue({ items: [], nextCursor: null });
+    updatePackageFn.mockResolvedValue(pkg);
+
+    const qc = new QueryClient();
+    render(
+      <QueryClientProvider client={qc}>
+        <PackageEditorPage />
+      </QueryClientProvider>
+    );
+
+    const nameInput = await screen.findByRole('textbox', { name: /package name/i });
+    await user.type(nameInput, '!');
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(updatePackageFn).toHaveBeenCalledTimes(1));
+    const call = updatePackageFn.mock.calls[0][0] as { data: { expectedUpdatedAt: string } };
+    expect(call.data.expectedUpdatedAt).toBe('2026-03-04T05:06:07.000Z');
+  });
+
   it('does not render an editable name field for a system package', async () => {
     const pkg = mkPackage({ ownerId: null, name: 'Storm Basics' });
     getPackageFn.mockResolvedValue(pkg);
@@ -279,5 +309,192 @@ describe('PackageEditorPage save path', () => {
     const nameInput = await screen.findByRole('textbox', { name: /package name/i });
     expect(nameInput).toHaveValue('Storm Basics');
     expect(nameInput).toBeDisabled();
+  });
+});
+
+/**
+ * Task 7's client half. The server refuses a save built on a stale read
+ * (`PackageStaleWriteError`); what matters here is that the refusal costs the
+ * user nothing until they say so.
+ */
+describe('PackageEditorPage stale-write conflict', () => {
+  /**
+   * Built to look exactly like what crosses the server-fn wire, which is NOT
+   * an instance of the server's class: seroval reconstructs a plain `Error`
+   * carrying the original `name` and own properties. A fixture that imported
+   * `PackageStaleWriteError` and threw a real instance would pass even if the
+   * route keyed on `instanceof` — and `instanceof` cannot work in the browser,
+   * because the class lives in a module the client bundle never loads.
+   */
+  function wireStaleWriteError(currentUpdatedAt: string): Error {
+    const e = new Error('This package changed somewhere else after you opened it.');
+    e.name = 'PackageStaleWriteError';
+    return Object.assign(e, { currentUpdatedAt });
+  }
+
+  it('surfaces the conflict, keeps the unsaved draft, and files no client error report', async () => {
+    const user = userEvent.setup();
+    const pkg = mkPackage({ items: [mkItem({ id: 'i1', label: 'Rain' })] });
+
+    getPackageFn.mockResolvedValue(pkg);
+    listAudioAssetsFn.mockResolvedValue({ items: [], nextCursor: null });
+    updatePackageFn.mockRejectedValue(wireStaleWriteError('2026-05-05T05:05:05.000Z'));
+
+    const qc = new QueryClient();
+    render(
+      <QueryClientProvider client={qc}>
+        <PackageEditorPage />
+      </QueryClientProvider>
+    );
+
+    const nameInput = await screen.findByRole('textbox', { name: /package name/i });
+    await user.clear(nameInput);
+    await user.type(nameInput, 'My Renamed Set');
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    // The conflict is surfaced as its own thing, with both ways out.
+    await screen.findByTestId('package-conflict-notice');
+    expect(
+      screen.getByRole('button', { name: /keep my edits and overwrite/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /discard my edits and load the saved version/i })
+    ).toBeInTheDocument();
+
+    // NOTHING SILENTLY DISCARDED: the refusal did not roll the editor back to
+    // the server's version. The rename is still typed in, and the item is
+    // still on the board.
+    expect(screen.getByRole('textbox', { name: /package name/i })).toHaveValue('My Renamed Set');
+    expect(screen.getByRole('button', { name: /remove rain/i })).toBeInTheDocument();
+
+    // A refused write must not file a GlitchTip event — the same rule the
+    // server applies to `PackageStaleWriteError`, applied on the client that
+    // receives it. Two tabs on one package is expected, not a fault.
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  /**
+   * "Keep my edits" is a RETRY against the newer revision, not a force flag:
+   * the same draft, the precondition the refusal reported. Asserting the
+   * second call's `expectedUpdatedAt` is what separates the two — a `force:
+   * true` implementation would resend the ORIGINAL token (or none), and a
+   * test that only checked "it saved again" would not notice.
+   */
+  it('replays the same draft against the revision the refusal reported', async () => {
+    const user = userEvent.setup();
+    const pkg = mkPackage({
+      items: [mkItem({ id: 'i1', label: 'Rain' })],
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    getPackageFn.mockResolvedValue(pkg);
+    listAudioAssetsFn.mockResolvedValue({ items: [], nextCursor: null });
+    updatePackageFn.mockRejectedValueOnce(wireStaleWriteError('2026-05-05T05:05:05.000Z'));
+
+    const qc = new QueryClient();
+    render(
+      <QueryClientProvider client={qc}>
+        <PackageEditorPage />
+      </QueryClientProvider>
+    );
+
+    const nameInput = await screen.findByRole('textbox', { name: /package name/i });
+    await user.clear(nameInput);
+    await user.type(nameInput, 'My Renamed Set');
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await screen.findByTestId('package-conflict-notice');
+    updatePackageFn.mockResolvedValue({ ...pkg, name: 'My Renamed Set' });
+    await user.click(screen.getByRole('button', { name: /keep my edits and overwrite/i }));
+
+    await waitFor(() => expect(updatePackageFn).toHaveBeenCalledTimes(2));
+    const first = updatePackageFn.mock.calls[0][0] as { data: { expectedUpdatedAt: string } };
+    const retry = updatePackageFn.mock.calls[1][0] as {
+      data: { expectedUpdatedAt: string; name: string; items: PackageItemData[] };
+    };
+    expect(first.data.expectedUpdatedAt).toBe('2026-01-01T00:00:00.000Z');
+    expect(retry.data.expectedUpdatedAt).toBe('2026-05-05T05:05:05.000Z');
+    // The draft itself is replayed unchanged — not re-derived from the server
+    // copy, which would be a second chance to lose the edit.
+    expect(retry.data.name).toBe('My Renamed Set');
+    expect(retry.data.items.map((i) => i.id)).toEqual(['i1']);
+
+    // Succeeded: the notice is gone.
+    await waitFor(() =>
+      expect(screen.queryByTestId('package-conflict-notice')).not.toBeInTheDocument()
+    );
+  });
+
+  /**
+   * The other door, and the only one that throws work away — which is why it
+   * is a labelled button and not the automatic consequence of a conflict.
+   */
+  it('discards the local draft only when the user explicitly asks, and reloads the stored version', async () => {
+    const user = userEvent.setup();
+    const pkg = mkPackage({ name: 'Storm Set', items: [mkItem({ id: 'i1', label: 'Rain' })] });
+    const serverVersion = mkPackage({
+      name: 'Renamed By The Other Tab',
+      items: [mkItem({ id: 'i1', label: 'Rain' })],
+      updatedAt: '2026-05-05T05:05:05.000Z',
+    });
+
+    getPackageFn.mockResolvedValueOnce(pkg).mockResolvedValue(serverVersion);
+    listAudioAssetsFn.mockResolvedValue({ items: [], nextCursor: null });
+    updatePackageFn.mockRejectedValue(wireStaleWriteError('2026-05-05T05:05:05.000Z'));
+
+    const qc = new QueryClient();
+    render(
+      <QueryClientProvider client={qc}>
+        <PackageEditorPage />
+      </QueryClientProvider>
+    );
+
+    const nameInput = await screen.findByRole('textbox', { name: /package name/i });
+    await user.clear(nameInput);
+    await user.type(nameInput, 'My Renamed Set');
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+    await screen.findByTestId('package-conflict-notice');
+
+    await user.click(
+      screen.getByRole('button', { name: /discard my edits and load the saved version/i })
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('textbox', { name: /package name/i })).toHaveValue(
+        'Renamed By The Other Tab'
+      )
+    );
+    expect(screen.queryByTestId('package-conflict-notice')).not.toBeInTheDocument();
+    // The refusal is cleared too, not left behind as a red "failed to save"
+    // line describing a conflict that has already been resolved.
+    expect(screen.queryByText(/failed to save changes/i)).not.toBeInTheDocument();
+  });
+
+  /**
+   * The guard must not swallow real failures. A non-conflict rejection still
+   * takes the original path: the plain error line, and a GlitchTip report.
+   */
+  it('leaves an ordinary save failure reported and rendered as before', async () => {
+    const user = userEvent.setup();
+    const pkg = mkPackage({ items: [mkItem()] });
+
+    getPackageFn.mockResolvedValue(pkg);
+    listAudioAssetsFn.mockResolvedValue({ items: [], nextCursor: null });
+    updatePackageFn.mockRejectedValue(new Error('Database unavailable'));
+
+    const qc = new QueryClient();
+    render(
+      <QueryClientProvider client={qc}>
+        <PackageEditorPage />
+      </QueryClientProvider>
+    );
+
+    const nameInput = await screen.findByRole('textbox', { name: /package name/i });
+    await user.type(nameInput, '!');
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await screen.findByText('Database unavailable');
+    expect(screen.queryByTestId('package-conflict-notice')).not.toBeInTheDocument();
+    await waitFor(() => expect(captureException).toHaveBeenCalledTimes(1));
   });
 });

--- a/tests/routes/audio-packages-package-id-route.test.tsx
+++ b/tests/routes/audio-packages-package-id-route.test.tsx
@@ -497,4 +497,64 @@ describe('PackageEditorPage stale-write conflict', () => {
     expect(screen.queryByTestId('package-conflict-notice')).not.toBeInTheDocument();
     await waitFor(() => expect(captureException).toHaveBeenCalledTimes(1));
   });
+
+  /**
+   * The review's Important finding, pinned. The conflict notice SUPPRESSES the
+   * generic error line (`!conflict && saveMutation.error`, in the route), so
+   * if a failed overwrite left the conflict state standing, a retry that fails
+   * with anything other than a stale write would render NOTHING AT ALL: the
+   * button flips back from "Saving…" and the user's only signal that their
+   * click did nothing is the absence of change.
+   *
+   * That is precisely why this test is written against what is ON SCREEN
+   * rather than against state or call counts — the bug's whole signature is
+   * that every other observable stays green (the mutation ran, the error was
+   * captured, the notice is still correct) while the user is told nothing.
+   *
+   * The rejection here is deliberately the reachable one rather than a generic
+   * 500: an empty `currentUpdatedAt` makes the overwrite send
+   * `expectedUpdatedAt: ''`, which `updatePackageSchema`'s `.datetime()`
+   * rejects at the server-fn validator.
+   */
+  it('renders a visible failure when the overwrite retry fails with a non-conflict error', async () => {
+    const user = userEvent.setup();
+    const pkg = mkPackage({ items: [mkItem({ id: 'i1', label: 'Rain' })] });
+
+    getPackageFn.mockResolvedValue(pkg);
+    listAudioAssetsFn.mockResolvedValue({ items: [], nextCursor: null });
+    updatePackageFn.mockRejectedValueOnce(wireStaleWriteError(''));
+
+    const qc = new QueryClient();
+    render(
+      <QueryClientProvider client={qc}>
+        <PackageEditorPage />
+      </QueryClientProvider>
+    );
+
+    const nameInput = await screen.findByRole('textbox', { name: /package name/i });
+    await user.clear(nameInput);
+    await user.type(nameInput, 'My Renamed Set');
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+    await screen.findByTestId('package-conflict-notice');
+
+    // The retry is refused by the input validator, not by the fence.
+    updatePackageFn.mockRejectedValue(
+      new Error('Invalid input: expected ISO datetime, received ""')
+    );
+    await user.click(screen.getByRole('button', { name: /keep my edits and overwrite/i }));
+
+    // SOMETHING the user can see. Without the fix this assertion is the only
+    // one in the file that fails — the notice below is still rendered, the
+    // capture below still happens, and nothing else notices.
+    await screen.findByText(/expected ISO datetime/i);
+    expect(screen.queryByTestId('package-conflict-notice')).not.toBeInTheDocument();
+
+    // Still a real fault, so it is still reported — only the stale-write
+    // refusal is exempt.
+    await waitFor(() => expect(captureException).toHaveBeenCalledTimes(1));
+    // And the draft is STILL intact: a failed overwrite must not cost the user
+    // their edits any more than the original refusal did.
+    expect(screen.getByRole('textbox', { name: /package name/i })).toHaveValue('My Renamed Set');
+    expect(screen.getByRole('button', { name: /remove rain/i })).toBeInTheDocument();
+  });
 });

--- a/tests/routes/audio-packages-package-id-route.test.tsx
+++ b/tests/routes/audio-packages-package-id-route.test.tsx
@@ -294,6 +294,97 @@ describe('PackageEditorPage save path', () => {
     expect(call.data.expectedUpdatedAt).toBe('2026-03-04T05:06:07.000Z');
   });
 
+  /**
+   * FINAL WHOLE-BRANCH REVIEW, Important #2, regression-locked here because
+   * none of the other twelve tests in this file saves TWICE — and one save is
+   * exactly the number that cannot see this defect.
+   *
+   * The failure it pins: if `onSuccess` only invalidated the package branch
+   * and never seeded the mutation's own return value into the detail cache,
+   * then until the refetch landed `pkg` would still be the PRE-save object.
+   * `dirty` (a reference comparison against `pkg.items`/`.moods`/`.name`)
+   * would stay true, the button would still read "Save changes", and a second
+   * Save would send the `updatedAt` the first save had already superseded —
+   * so Task 7's fence would refuse it and the editor would show the user a
+   * conflict notice about THEIR OWN save. A conflict dialog that fires on the
+   * happy path is the fastest way to teach users to click through conflict
+   * dialogs, which defeats the point of the fence.
+   *
+   * THE FIXTURE DETAIL THAT MAKES THIS MEAN ANYTHING: the refetch triggered
+   * by `invalidateQueries` is never allowed to land (`getPackageFn` returns a
+   * forever-pending promise after its first call). In a browser that refetch
+   * is a network round trip the user can easily click through; in a test it
+   * would resolve instantly and hand an unseeded implementation the fresh
+   * document anyway, so the test would pass against the very bug it exists to
+   * catch. With the refetch pinned open, the second save's precondition can
+   * only be the fresh `updatedAt` if `onSuccess` seeded it from the first
+   * save's own response.
+   */
+  it('seeds the save response into the detail cache, so a second consecutive save carries the fresh revision', async () => {
+    const user = userEvent.setup();
+    const pkg = mkPackage({
+      items: [mkItem({ id: 'i1', label: 'Rain' })],
+      updatedAt: '2026-03-04T05:06:07.000Z',
+    });
+    const afterFirstSave = {
+      ...pkg,
+      name: 'Storm Set!',
+      // A NEW revision, the way `updatePackage`'s `{ new: true }` document
+      // does — this is the value the second save must carry.
+      updatedAt: '2026-03-04T05:06:09.000Z',
+    };
+
+    getPackageFn
+      .mockResolvedValueOnce(pkg)
+      // Every subsequent read — i.e. the post-save invalidation's refetch —
+      // hangs. See this test's doc comment for why that is the point.
+      .mockReturnValue(new Promise(() => {}));
+    listAudioAssetsFn.mockResolvedValue({ items: [], nextCursor: null });
+    updatePackageFn.mockResolvedValue(afterFirstSave);
+
+    const qc = new QueryClient();
+    render(
+      <QueryClientProvider client={qc}>
+        <PackageEditorPage />
+      </QueryClientProvider>
+    );
+
+    const nameInput = await screen.findByRole('textbox', { name: /package name/i });
+    await user.type(nameInput, '!');
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(updatePackageFn).toHaveBeenCalledTimes(1));
+    expect(
+      (updatePackageFn.mock.calls[0][0] as { data: { expectedUpdatedAt: string } }).data
+        .expectedUpdatedAt
+    ).toBe('2026-03-04T05:06:07.000Z');
+
+    // The button settles back to "Saved": the draft is no longer dirty,
+    // because the seeded `pkg` and the local drafts are the same objects.
+    // This is the user-visible half of the defect — an unseeded cache leaves
+    // "Save changes" enabled on a package that is already saved.
+    await screen.findByRole('button', { name: 'Saved' });
+
+    // A second, genuinely new edit, saved again.
+    updatePackageFn.mockResolvedValue({
+      ...afterFirstSave,
+      name: 'Storm Set!?',
+      updatedAt: '2026-03-04T05:06:11.000Z',
+    });
+    await user.type(screen.getByRole('textbox', { name: /package name/i }), '?');
+    await user.click(await screen.findByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(updatePackageFn).toHaveBeenCalledTimes(2));
+    const second = updatePackageFn.mock.calls[1][0] as {
+      data: { expectedUpdatedAt: string; name: string };
+    };
+    expect(second.data.expectedUpdatedAt).toBe('2026-03-04T05:06:09.000Z');
+    expect(second.data.name).toBe('Storm Set!?');
+
+    // And no conflict notice was ever rendered for the user's own save.
+    expect(screen.queryByText(/changed somewhere else/i)).toBeNull();
+  });
+
   it('does not render an editable name field for a system package', async () => {
     const pkg = mkPackage({ ownerId: null, name: 'Storm Basics' });
     getPackageFn.mockResolvedValue(pkg);

--- a/tests/routes/audio-route.test.tsx
+++ b/tests/routes/audio-route.test.tsx
@@ -5,12 +5,15 @@ import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { AudioAssetData } from '~/types/audio';
 
+const GIB = 1024 * 1024 * 1024;
+
 const listAudioAssetsFn = vi.fn();
 const bulkTagAudioAssetsFn = vi.fn();
 const updateAudioAssetFn = vi.fn();
 const deleteAudioAssetFn = vi.fn();
 
 const retryAudioAssetFn = vi.fn();
+const getAudioStorageUsageFn = vi.fn();
 
 vi.mock('~/utils/audio-server-fns', () => ({
   listAudioAssetsFn: (...args: unknown[]) => listAudioAssetsFn(...args),
@@ -18,6 +21,7 @@ vi.mock('~/utils/audio-server-fns', () => ({
   updateAudioAssetFn: (...args: unknown[]) => updateAudioAssetFn(...args),
   deleteAudioAssetFn: (...args: unknown[]) => deleteAudioAssetFn(...args),
   retryAudioAssetFn: (...args: unknown[]) => retryAudioAssetFn(...args),
+  getAudioStorageUsageFn: (...args: unknown[]) => getAudioStorageUsageFn(...args),
 }));
 
 // Topbar reads the session through useAuth; stub it so the route can render it
@@ -103,9 +107,15 @@ beforeEach(() => {
   updateAudioAssetFn.mockReset();
   deleteAudioAssetFn.mockReset();
   retryAudioAssetFn.mockReset();
+  getAudioStorageUsageFn.mockReset();
   captureException.mockReset();
   getMe.mockReset();
   listAudioAssetsFn.mockResolvedValue({ items: [], nextCursor: null });
+  // Every test below renders the route, which mounts AudioQuotaBar's query
+  // unconditionally. A resolved default here keeps every EXISTING test (none
+  // of which are about the quota bar) from depending on this query's timing;
+  // the `AudioQuotaBar` describe block below overrides it per test.
+  getAudioStorageUsageFn.mockResolvedValue({ bytes: 0, assetCount: 0, limitBytes: 2 * GIB });
 });
 
 describe('flattenAudioPages', () => {
@@ -561,6 +571,55 @@ describe('AudioLibraryPage', () => {
       renderPage();
       await screen.findByText('Storm');
       expect(listAudioAssetsFn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('storage usage', () => {
+    it('renders the usage the server returned, next to the dropzone', async () => {
+      getAudioStorageUsageFn.mockResolvedValue({
+        bytes: Math.round(0.5 * GIB),
+        assetCount: 12,
+        limitBytes: 2 * GIB,
+      });
+      renderPage();
+      expect(await screen.findByText(/of 2\.00 GB used/i)).toBeInTheDocument();
+      expect(screen.getByText(/12 assets/i)).toBeInTheDocument();
+      // Not a client-side guess: the limit rendered is exactly what the
+      // server call returned, proving there is no hardcoded "2 GiB" in the
+      // route or the component racing/duplicating the server's own value.
+      expect(getAudioStorageUsageFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('surfaces a failed usage query as an alert rather than a stuck loading state', async () => {
+      getAudioStorageUsageFn.mockRejectedValue(new Error('quota fetch boom'));
+      renderPage();
+      expect(await screen.findByRole('alert')).toHaveTextContent(/quota fetch boom/i);
+    });
+
+    /**
+     * `invalidateAudio` invalidates the whole `['audio']` branch, and the
+     * usage query's key (`['audio', 'usage']`) lives under that prefix — so
+     * an upload refetches usage without the route needing a second,
+     * hand-written invalidation call. Proven end-to-end here via a
+     * completed delete (the same `invalidateAudio` call path a completed
+     * upload uses), not by inspecting the query key in isolation.
+     */
+    it('re-fetches usage after a mutation invalidates the audio branch', async () => {
+      listAudioAssetsFn
+        .mockResolvedValueOnce({ items: [mkAsset({ id: 'a1', title: 'Storm' })], nextCursor: null })
+        .mockResolvedValue({ items: [], nextCursor: null });
+      deleteAudioAssetFn.mockResolvedValue({ deleted: true });
+      getAudioStorageUsageFn.mockResolvedValue({ bytes: 100, assetCount: 1, limitBytes: 2 * GIB });
+      renderPage();
+
+      await screen.findByText('Storm');
+      await waitFor(() => expect(getAudioStorageUsageFn).toHaveBeenCalledTimes(1));
+
+      await userEvent.click(await screen.findByRole('button', { name: /delete storm/i }));
+      const dialog = screen.getByRole('alertdialog');
+      await userEvent.click(within(dialog).getByRole('button', { name: /delete/i }));
+
+      await waitFor(() => expect(getAudioStorageUsageFn).toHaveBeenCalledTimes(2));
     });
   });
 });

--- a/tests/server/functions/audio-cross-service-contract.test.ts
+++ b/tests/server/functions/audio-cross-service-contract.test.ts
@@ -132,3 +132,50 @@ describe('audio storage key layout, app vs worker', () => {
     expect(`uploads/audio/${prefix}/renditions/abc`.startsWith(audioUserRoot(prefix))).toBe(true);
   });
 });
+
+describe('the once-attach liveness clock, app vs worker (Task 10, fix 2)', () => {
+  /**
+   * `reapAbandonedOnceUploads` is the ONLY way out of a once-variant attach
+   * that died mid-PUT: the row is parked in `status: 'uploading'` and
+   * `createOnceVariantUpload` refuses anything that isn't `status: 'ready'`,
+   * so the owner cannot clear it themselves. The reaper decides staleness
+   * from `onceUploadStartedAt`, a field this package writes and only that
+   * package reads — the exact shape of cross-package coupling this file
+   * exists for, and neither package's own suite can see the other's literal.
+   *
+   * Drift here is silent AND self-concealing. The reaper's fallback branch
+   * (`onceUploadStartedAt: null`, which in Mongo matches a MISSING field
+   * too) is there so rows predating the field keep being reaped on
+   * `updatedAt`. So renaming the field on either side alone does not make
+   * the reaper stop — it makes EVERY row look like a legacy row and quietly
+   * reinstates the `updatedAt` gate this fix removed, restoring the bug
+   * where an ordinary retitle postpones a dead attach indefinitely. Nothing
+   * throws and nothing logs.
+   */
+  it('writes the field name the worker actually queries', () => {
+    const src = workerSource('claim.ts');
+    // The stamp the app writes on every attach...
+    expect(
+      readFileSync(join(process.cwd(), 'app', 'server', 'functions', 'audio.ts'), 'utf8')
+    ).toContain('onceUploadStartedAt: new Date()');
+    // ...is the field the worker's once-reaper gates on, in both branches of
+    // its `$or` — the primary predicate and the legacy fallback's
+    // "unstamped" guard.
+    expect(src).toContain('{ onceUploadStartedAt: { $lt: cutoff } }');
+    expect(src).toContain('{ onceUploadStartedAt: null, updatedAt: { $lt: cutoff } }');
+  });
+
+  /**
+   * The other half of the same contract: the field must exist on the schema
+   * the app owns, or Mongoose strips it from the `$set` and the worker's
+   * query matches nothing but legacy rows — the same silent reinstatement of
+   * the bug, reached from the schema side.
+   */
+  it('declares the field on the model the app owns', () => {
+    const model = readFileSync(
+      join(process.cwd(), 'app', 'server', 'db', 'models', 'AudioAsset.ts'),
+      'utf8'
+    );
+    expect(model).toMatch(/onceUploadStartedAt:\s*\{\s*type:\s*Date/);
+  });
+});

--- a/tests/server/functions/audio-ingest.test.ts
+++ b/tests/server/functions/audio-ingest.test.ts
@@ -7,7 +7,12 @@ vi.mock('~/server/utils/telemetry', () => ({
   serverCaptureEvent: vi.fn(),
 }));
 vi.mock('~/server/db/models/AudioAsset', () => ({
-  AudioAsset: { create: vi.fn(), findOne: vi.fn(), findOneAndUpdate: vi.fn() },
+  AudioAsset: {
+    create: vi.fn(),
+    findOne: vi.fn(),
+    findOneAndUpdate: vi.fn(),
+    countDocuments: vi.fn(),
+  },
 }));
 
 const send = vi.fn();
@@ -263,7 +268,15 @@ describe('createAudioUpload', () => {
 });
 
 describe('confirmAudioUpload', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Safe default for every pre-existing test below, which predates the
+    // pending-job cap and never mocks it: zero pending jobs is comfortably
+    // under any real cap, so the happy-path/precondition assertions those
+    // tests make are unaffected. Tests that care about the cap itself
+    // override this explicitly.
+    vi.mocked(AudioAsset.countDocuments).mockResolvedValue(0);
+  });
 
   it('flips to pending when the real object matches the declared size', async () => {
     vi.mocked(AudioAsset.findOne).mockResolvedValue({
@@ -507,5 +520,115 @@ describe('confirmAudioUpload', () => {
     // change that dropped the ownerId filter would still return null here from the
     // mock, but this assertion would catch it.
     expect(AudioAsset.findOne).toHaveBeenCalledWith({ _id: 'a1', ownerId: 'u2' });
+  });
+
+  describe('pending job cap', () => {
+    /**
+     * Pins the ACTUAL count filter `AudioAsset.countDocuments` is called
+     * with, not merely that some refusal or admission happened. A fixture
+     * shape that would make a weaker assertion pass for the wrong reason:
+     * asserting only "it was called" (any arguments) would still pass with
+     * `ownerId` dropped from the filter, or with `status` narrowed to just
+     * `'pending'` (silently ignoring `processing` rows), or with the field
+     * name typo'd — `toHaveBeenCalledWith` is a deep-equality check on the
+     * exact object the production code built, so all three mutations fail
+     * it.
+     */
+    it('counts pending+processing jobs scoped to the caller before allowing the row to become claimable', async () => {
+      vi.mocked(AudioAsset.findOne).mockResolvedValue({
+        _id: 'a1',
+        ownerId: 'u1',
+        sourceKey: 'k',
+        status: 'uploading',
+      } as never);
+      send.mockResolvedValue({ ContentLength: 1024, ContentType: 'audio/wav' });
+      vi.mocked(AudioAsset.findOneAndUpdate).mockResolvedValue({
+        _id: 'a1',
+        status: 'pending',
+      } as never);
+      vi.mocked(AudioAsset.countDocuments).mockResolvedValue(0);
+
+      const { confirmAudioUpload } = await import('~/server/functions/audio');
+      await confirmAudioUpload({ data: { assetId: 'a1' }, userId: 'u1' });
+
+      expect(vi.mocked(AudioAsset.countDocuments)).toHaveBeenCalledWith({
+        ownerId: 'u1',
+        status: { $in: ['pending', 'processing'] },
+      });
+    });
+
+    /**
+     * THE global-count catch. A single-user fixture cannot tell "counts
+     * this user's jobs" apart from "counts everyone's jobs" — both shapes
+     * produce the same refuse/admit outcome for one caller. This test uses
+     * a `countDocuments` fake that only ONE of those two implementations
+     * can satisfy: it inspects the filter's `ownerId` and answers per-user
+     * (u1 sits at the cap, u2 sits at zero). A count that is global, or
+     * scoped to the wrong field, cannot route to the right branch here —
+     * see the teeth-proof below, which drops `ownerId` from the production
+     * filter and confirms this exact test fails.
+     *
+     * Also proves: the refusal happens BEFORE `HeadObject` (no wasted R2
+     * round trip on a file that's refused regardless of its contents), the
+     * refusal message carries the count, the refusal is an
+     * `AudioClientError` (no GlitchTip event for the caller's own doing),
+     * and a DIFFERENT user with room in their queue is admitted through the
+     * normal success path in the same run.
+     */
+    it('refuses a user already at the cap while a different user at zero is admitted', async () => {
+      const { getMaxPendingJobsPerUser, confirmAudioUpload, AudioClientError } =
+        await import('~/server/functions/audio');
+      const cap = getMaxPendingJobsPerUser();
+
+      vi.mocked(AudioAsset.countDocuments).mockImplementation((async (
+        filter: Record<string, unknown>
+      ) => {
+        if (filter.ownerId === 'u1') return cap; // already at the cap
+        if (filter.ownerId === 'u2') return 0; // fresh, nothing queued
+        // Any other shape (ownerId missing/wrong, or a global count that
+        // ignores it) cannot be answered correctly for either caller —
+        // failing loudly here is what makes the mutation below fail this
+        // test instead of silently passing it.
+        throw new Error(`unscoped countDocuments filter: ${JSON.stringify(filter)}`);
+      }) as never);
+      send.mockResolvedValue({ ContentLength: 1024, ContentType: 'audio/wav' });
+
+      // u1: at the cap, refused.
+      vi.mocked(AudioAsset.findOne).mockResolvedValueOnce({
+        _id: 'a1',
+        ownerId: 'u1',
+        sourceKey: 'k1',
+        status: 'uploading',
+      } as never);
+      const err = await confirmAudioUpload({ data: { assetId: 'a1' }, userId: 'u1' }).catch(
+        (e: unknown) => e
+      );
+      expect(err).toBeInstanceOf(AudioClientError);
+      expect((err as Error).message).toContain(String(cap));
+      // Exactly one R2 call: the delete of the already-uploaded object.
+      // HeadObject never runs — the cap refusal happens before it.
+      expect(send).toHaveBeenCalledTimes(1);
+      expect(send.mock.calls[0][0]).toBeInstanceOf(DeleteObjectCommand);
+      expect((send.mock.calls[0][0] as DeleteObjectCommand).input).toEqual({
+        Bucket: 'b',
+        Key: 'k1',
+      });
+
+      send.mockClear();
+
+      // u2: a DIFFERENT user, zero pending jobs, admitted normally.
+      vi.mocked(AudioAsset.findOne).mockResolvedValueOnce({
+        _id: 'a2',
+        ownerId: 'u2',
+        sourceKey: 'k2',
+        status: 'uploading',
+      } as never);
+      vi.mocked(AudioAsset.findOneAndUpdate).mockResolvedValue({
+        _id: 'a2',
+        status: 'pending',
+      } as never);
+      const r = await confirmAudioUpload({ data: { assetId: 'a2' }, userId: 'u2' });
+      expect(r.status).toBe('pending');
+    });
   });
 });

--- a/tests/server/functions/audio-ingest.test.ts
+++ b/tests/server/functions/audio-ingest.test.ts
@@ -276,6 +276,13 @@ describe('confirmAudioUpload', () => {
     // tests make are unaffected. Tests that care about the cap itself
     // override this explicitly.
     vi.mocked(AudioAsset.countDocuments).mockResolvedValue(0);
+    // Same, for the confirm-side storage-quota check added in the final
+    // whole-branch review. Required rather than merely tidy: `vi.clearAllMocks`
+    // clears CALLS but not IMPLEMENTATIONS, so without this every test in this
+    // describe would inherit whatever the last `createAudioUpload` quota test
+    // left on the shared mock — which is `mockRejectedValue(new Error('mongo
+    // unreachable'))`, i.e. every confirm below would fail closed.
+    getUserStorageUsage.mockResolvedValue({ bytes: 0, assetCount: 1 });
   });
 
   it('flips to pending when the real object matches the declared size', async () => {
@@ -637,6 +644,176 @@ describe('confirmAudioUpload', () => {
       } as never);
       const r = await confirmAudioUpload({ data: { assetId: 'a2' }, userId: 'u2' });
       expect(r.status).toBe('pending');
+    });
+  });
+
+  /**
+   * FINAL WHOLE-BRANCH REVIEW, Important #1. The quota used to be enforced
+   * in both presign functions and NEITHER confirm — but bytes only become
+   * countable at confirm (`sourceBytes` is written by the success write and
+   * nowhere else), so the presign check reads a number that cannot include
+   * anything the caller has already presigned and PUT. With the shipped
+   * defaults and no concurrency: 30 presigns, 30 PUTs of 50 MiB (every check
+   * still sees the old usage), 30 confirms — ~3.8 GB against a 2 GiB quota.
+   *
+   * These tests pin the fix and the two things that make it correct: the
+   * refusal costs no `HeadObject`, and the object does not survive it.
+   */
+  describe('storage quota at confirm', () => {
+    it('refuses an over-quota confirm before HeadObject, deletes the object, and fails the row on a fenced filter', async () => {
+      const { getAudioUserQuotaBytes, confirmAudioUpload, AudioClientError } =
+        await import('~/server/functions/audio');
+      const { serverCaptureException } = await import('~/server/utils/telemetry');
+      const limit = getAudioUserQuotaBytes();
+
+      vi.mocked(AudioAsset.findOne).mockResolvedValue({
+        _id: 'a1',
+        ownerId: 'u1',
+        sourceKey: 'k1',
+        status: 'uploading',
+      } as never);
+      getUserStorageUsage.mockResolvedValue({ bytes: limit + 1, assetCount: 9 });
+      vi.mocked(AudioAsset.findOneAndUpdate).mockResolvedValue({ _id: 'a1' } as never);
+      // Deliberately a VALID object: if the implementation reached HeadObject
+      // first, the confirm would SUCCEED and this test would fail on the
+      // rejection rather than passing for the wrong reason.
+      send.mockResolvedValue({ ContentLength: 1024, ContentType: 'audio/wav' });
+
+      const err = await confirmAudioUpload({ data: { assetId: 'a1' }, userId: 'u1' }).catch(
+        (e: unknown) => e
+      );
+
+      expect(err).toBeInstanceOf(AudioClientError);
+      expect((err as Error).message).toMatch(/storage quota exceeded/i);
+      // The structured pair, same as the presign refusal carries, so the UI
+      // can render "X of Y used" without re-parsing prose.
+      const clientErr = err as InstanceType<typeof AudioClientError>;
+      expect(clientErr.usageBytes).toBe(limit + 1);
+      expect(clientErr.limitBytes).toBe(limit);
+
+      // NO HeadObject — asserted on the command CLASS specifically, not just
+      // on a call count, because "one R2 call" would also hold for an
+      // implementation that issued the Head and skipped the delete.
+      expect(send.mock.calls.filter(([cmd]) => cmd instanceof HeadObjectCommand)).toHaveLength(0);
+      // The already-PUT object is gone — it is referenced by nothing after
+      // this refusal, so leaving it would strand paid-for storage.
+      const deletes = send.mock.calls.filter(([cmd]) => cmd instanceof DeleteObjectCommand);
+      expect(deletes).toHaveLength(1);
+      expect((deletes[0][0] as DeleteObjectCommand).input).toEqual({ Bucket: 'b', Key: 'k1' });
+
+      // The ACTUAL filter of the revert write, `toEqual` not a subset check:
+      // an identity-only filter is exactly the regression this fence exists
+      // to prevent (a concurrent confirm can legitimately queue the row while
+      // this request sits inside the delete's await).
+      const [filter, update] = vi.mocked(AudioAsset.findOneAndUpdate).mock.calls[0];
+      expect(filter).toEqual({
+        _id: 'a1',
+        ownerId: 'u1',
+        status: 'uploading',
+        variant: { $ne: 'once' },
+      });
+      const set = (update as { $set: Record<string, unknown> }).$set;
+      expect(set.status).toBe('failed');
+      expect(set.lastError).toMatch(/storage quota exceeded/i);
+      // NOT permanent: deleting another asset and re-uploading works, which
+      // is the opposite of what `permanentFailure` claims.
+      expect('permanentFailure' in set).toBe(false);
+
+      // The caller's own doing, reachable at will — no GlitchTip event.
+      expect(vi.mocked(serverCaptureException)).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The boundary and its complement in one run, so neither can be satisfied
+     * by an implementation that simply always refuses (or always admits).
+     */
+    it('refuses exactly at the limit and admits one byte under it', async () => {
+      const { getAudioUserQuotaBytes, confirmAudioUpload } =
+        await import('~/server/functions/audio');
+      const limit = getAudioUserQuotaBytes();
+
+      vi.mocked(AudioAsset.findOne).mockResolvedValue({
+        _id: 'a1',
+        ownerId: 'u1',
+        sourceKey: 'k1',
+        status: 'uploading',
+      } as never);
+      vi.mocked(AudioAsset.findOneAndUpdate).mockResolvedValue({
+        _id: 'a1',
+        status: 'pending',
+      } as never);
+      send.mockResolvedValue({ ContentLength: 1024, ContentType: 'audio/wav' });
+
+      getUserStorageUsage.mockResolvedValue({ bytes: limit, assetCount: 9 });
+      await expect(confirmAudioUpload({ data: { assetId: 'a1' }, userId: 'u1' })).rejects.toThrow(
+        /storage quota exceeded/i
+      );
+
+      getUserStorageUsage.mockResolvedValue({ bytes: limit - 1, assetCount: 9 });
+      await expect(
+        confirmAudioUpload({ data: { assetId: 'a1' }, userId: 'u1' })
+      ).resolves.toMatchObject({ status: 'pending' });
+    });
+
+    /**
+     * The scope of the aggregation the confirm runs. A count that dropped
+     * `ownerId` — or read someone else's usage — would refuse or admit the
+     * wrong caller, and a single-user fixture cannot tell those apart.
+     */
+    it("measures the confirming user's own usage", async () => {
+      const { confirmAudioUpload } = await import('~/server/functions/audio');
+      vi.mocked(AudioAsset.findOne).mockResolvedValue({
+        _id: 'a1',
+        ownerId: 'mongo-id-1',
+        sourceKey: 'k1',
+        status: 'uploading',
+      } as never);
+      vi.mocked(AudioAsset.findOneAndUpdate).mockResolvedValue({
+        _id: 'a1',
+        status: 'pending',
+      } as never);
+      send.mockResolvedValue({ ContentLength: 1024, ContentType: 'audio/wav' });
+
+      await confirmAudioUpload({
+        data: { assetId: 'a1' },
+        userId: 'mongo-id-1',
+        sessionUserId: 'session-provider-id',
+      });
+
+      // The MONGO id — `ownerId` references it; the provider id would
+      // aggregate nobody's rows and report zero usage for everyone.
+      expect(getUserStorageUsage).toHaveBeenCalledWith('mongo-id-1');
+    });
+
+    /**
+     * Fail closed, and deliberately WITHOUT the cleanup an over-quota refusal
+     * performs: a Mongo fault is transient, a retried confirm succeeds once
+     * it clears, and deleting a good object over a blip would destroy an
+     * upload the user could still complete. The reaper reclaims it if they
+     * never do.
+     */
+    it('refuses the confirm when the usage aggregation itself rejects, without deleting the object', async () => {
+      const { confirmAudioUpload } = await import('~/server/functions/audio');
+      const { serverCaptureException } = await import('~/server/utils/telemetry');
+      vi.mocked(AudioAsset.findOne).mockResolvedValue({
+        _id: 'a1',
+        ownerId: 'u1',
+        sourceKey: 'k1',
+        status: 'uploading',
+      } as never);
+      getUserStorageUsage.mockRejectedValue(new Error('mongo unreachable'));
+
+      await expect(confirmAudioUpload({ data: { assetId: 'a1' }, userId: 'u1' })).rejects.toThrow(
+        /unable to verify your storage usage/i
+      );
+      expect(send).not.toHaveBeenCalled();
+      expect(vi.mocked(AudioAsset.findOneAndUpdate)).not.toHaveBeenCalled();
+      // The underlying fault IS captured — nobody can trigger it on demand,
+      // and swallowing it would make the quota's own failure mode invisible.
+      expect(vi.mocked(serverCaptureException)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(serverCaptureException).mock.calls[0][2]).toMatchObject({
+        action: 'confirmAudioUpload.quotaCheck',
+      });
     });
   });
 });

--- a/tests/server/functions/audio-ingest.test.ts
+++ b/tests/server/functions/audio-ingest.test.ts
@@ -578,6 +578,7 @@ describe('confirmAudioUpload', () => {
     it('refuses a user already at the cap while a different user at zero is admitted', async () => {
       const { getMaxPendingJobsPerUser, confirmAudioUpload, AudioClientError } =
         await import('~/server/functions/audio');
+      const { serverCaptureException } = await import('~/server/utils/telemetry');
       const cap = getMaxPendingJobsPerUser();
 
       vi.mocked(AudioAsset.countDocuments).mockImplementation((async (
@@ -613,6 +614,13 @@ describe('confirmAudioUpload', () => {
         Bucket: 'b',
         Key: 'k1',
       });
+      // The comment above CLAIMS "no GlitchTip event" — this is what
+      // actually pins that constraint, rather than the error-class check
+      // above (`toBeInstanceOf(AudioClientError)`) standing in for it.
+      // `AudioClientError` is the MECHANISM `reportAudioError` uses to
+      // decide; asserting on the mechanism is not the same as asserting on
+      // the effect it's supposed to produce.
+      expect(vi.mocked(serverCaptureException)).not.toHaveBeenCalled();
 
       send.mockClear();
 

--- a/tests/server/functions/audio-ingest.test.ts
+++ b/tests/server/functions/audio-ingest.test.ts
@@ -24,6 +24,9 @@ vi.mock('~/server/functions/audio-storage', () => ({
   resolveAudioStoragePrefix: vi.fn(async () => 'a1b2c3d4e5f60718293a4b5c6d7e8f90'),
 }));
 
+const getUserStorageUsage = vi.fn();
+vi.mock('~/server/functions/audio-quota', () => ({ getUserStorageUsage }));
+
 import { AudioAsset } from '~/server/db/models/AudioAsset';
 
 const VALID = {
@@ -37,7 +40,14 @@ const VALID = {
 };
 
 describe('createAudioUpload', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Safe default for every pre-existing test below, which predates the
+    // quota check and never mocks it: comfortably under any real limit, so
+    // the happy-path assertions those tests make are unaffected. Tests that
+    // care about the quota itself override this explicitly.
+    getUserStorageUsage.mockResolvedValue({ bytes: 0, assetCount: 1 });
+  });
 
   it('creates an asset in uploading status and returns the signed url', async () => {
     vi.mocked(AudioAsset.create).mockResolvedValue({ _id: 'a1' } as never);
@@ -119,6 +129,136 @@ describe('createAudioUpload', () => {
     );
     expect(vi.mocked(getAudioUploadUrl)).not.toHaveBeenCalled();
     expect(vi.mocked(AudioAsset.create)).not.toHaveBeenCalled();
+  });
+
+  describe('storage quota', () => {
+    /**
+     * A fixture shape that would make this pass for the wrong reason: `VALID`
+     * missing some other required field. That would throw before the quota
+     * check ever ran (or, worse, before it was ever reached at all), and
+     * `not.toHaveBeenCalled()` on the presign would pass vacuously — the
+     * point of these tests is that the check itself fired, not merely that
+     * SOMETHING threw. `VALID` is the same fully-populated fixture the
+     * pre-existing happy-path tests above use, and every assertion below also
+     * pins the rejection message to quota-specific text (or, for the
+     * aggregation-failure test, to the fail-closed message), so a mutation
+     * that made some unrelated line throw first would fail these tests too.
+     */
+    it('refuses over quota, issues no presign, resolves no storage prefix, and creates no row', async () => {
+      const { getAudioUserQuotaBytes } = await import('~/server/functions/audio');
+      const limit = getAudioUserQuotaBytes();
+      getUserStorageUsage.mockResolvedValue({ bytes: limit + 1, assetCount: 5 });
+      const { createAudioUpload } = await import('~/server/functions/audio');
+      const { getAudioUploadUrl } = await import('~/server/functions/uploads');
+      const { resolveAudioStoragePrefix } = await import('~/server/functions/audio-storage');
+
+      await expect(createAudioUpload({ data: VALID, userId: 'u1' })).rejects.toThrow(
+        /storage quota exceeded/i
+      );
+
+      // The negative assertion is the point: a test that only asserted the
+      // rejection would still pass with the quota check deleted, because
+      // AudioAsset.create's mock (unconfigured in this describe block) would
+      // eventually throw on its own. Asserting no presign AND no prefix
+      // resolution AND no row creation proves the refusal happened FIRST,
+      // before any of the function's other work.
+      expect(vi.mocked(getAudioUploadUrl)).not.toHaveBeenCalled();
+      expect(vi.mocked(resolveAudioStoragePrefix)).not.toHaveBeenCalled();
+      expect(vi.mocked(AudioAsset.create)).not.toHaveBeenCalled();
+    });
+
+    it('carries the current usage and the limit on the refusal, for the UI to render', async () => {
+      const audioModule = await import('~/server/functions/audio');
+      const limit = audioModule.getAudioUserQuotaBytes();
+      getUserStorageUsage.mockResolvedValue({ bytes: limit + 500, assetCount: 3 });
+
+      const err = await audioModule
+        .createAudioUpload({ data: VALID, userId: 'u1' })
+        .catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(audioModule.AudioClientError);
+      const clientErr = err as InstanceType<typeof audioModule.AudioClientError>;
+      expect(clientErr.usageBytes).toBe(limit + 500);
+      expect(clientErr.limitBytes).toBe(limit);
+    });
+
+    it('does not report the quota refusal itself to GlitchTip', async () => {
+      const { getAudioUserQuotaBytes, createAudioUpload } =
+        await import('~/server/functions/audio');
+      const { serverCaptureException } = await import('~/server/utils/telemetry');
+      getUserStorageUsage.mockResolvedValue({ bytes: getAudioUserQuotaBytes(), assetCount: 4 });
+
+      await expect(createAudioUpload({ data: VALID, userId: 'u1' })).rejects.toThrow();
+      expect(vi.mocked(serverCaptureException)).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The stated boundary rule: usage measured BEFORE this upload lands is
+     * checked with `>=` against the limit, exactly matching
+     * `assertPackageBudget`'s deliberate `count >= MAX_PACKAGES_PER_USER` in
+     * `~/server/functions/packages.ts` — a caller already sitting AT the
+     * limit is refused, symmetric with a caller already AT the package cap
+     * being refused a new package.
+     */
+    it('refuses exactly at the limit', async () => {
+      const { getAudioUserQuotaBytes, createAudioUpload } =
+        await import('~/server/functions/audio');
+      const { getAudioUploadUrl } = await import('~/server/functions/uploads');
+      const limit = getAudioUserQuotaBytes();
+      getUserStorageUsage.mockResolvedValue({ bytes: limit, assetCount: 4 });
+
+      await expect(createAudioUpload({ data: VALID, userId: 'u1' })).rejects.toThrow(
+        /storage quota exceeded/i
+      );
+      expect(vi.mocked(getAudioUploadUrl)).not.toHaveBeenCalled();
+    });
+
+    /** The symmetric case: one byte under the limit is allowed through. */
+    it('allows the upload that lands one byte under the limit', async () => {
+      const { getAudioUserQuotaBytes, createAudioUpload } =
+        await import('~/server/functions/audio');
+      const limit = getAudioUserQuotaBytes();
+      getUserStorageUsage.mockResolvedValue({ bytes: limit - 1, assetCount: 4 });
+      vi.mocked(AudioAsset.create).mockResolvedValue({ _id: 'a1' } as never);
+
+      await expect(createAudioUpload({ data: VALID, userId: 'u1' })).resolves.toMatchObject({
+        assetId: 'a1',
+      });
+    });
+
+    /**
+     * Its own test, not a branch of another: this fixture never sets a
+     * bytes value at all, only makes the aggregation call itself reject —
+     * a shape that would pass for the wrong reason if merged into the
+     * over-quota test above (which pins a bytes VALUE, not a rejected
+     * promise) and could pass even if the fail-closed catch were missing,
+     * as long as SOMETHING downstream also happened to throw.
+     */
+    it('refuses the upload when the usage aggregation itself rejects — fail closed', async () => {
+      getUserStorageUsage.mockRejectedValue(new Error('mongo unreachable'));
+      const { createAudioUpload } = await import('~/server/functions/audio');
+      const { getAudioUploadUrl } = await import('~/server/functions/uploads');
+      const { resolveAudioStoragePrefix } = await import('~/server/functions/audio-storage');
+      const { serverCaptureException } = await import('~/server/utils/telemetry');
+
+      await expect(createAudioUpload({ data: VALID, userId: 'u1' })).rejects.toThrow(
+        /unable to verify your storage usage/i
+      );
+      expect(vi.mocked(getAudioUploadUrl)).not.toHaveBeenCalled();
+      expect(vi.mocked(resolveAudioStoragePrefix)).not.toHaveBeenCalled();
+      expect(vi.mocked(AudioAsset.create)).not.toHaveBeenCalled();
+
+      // The UNDERLYING fault is still captured, deliberately, even though the
+      // outward refusal is an AudioClientError the outer catch will not
+      // report a second time: a Mongo/index/connection fault is not
+      // something a caller can trigger on demand the way a guessable
+      // not-found or a resource cap is, and swallowing it entirely would
+      // make the quota's own failure mode invisible in GlitchTip.
+      expect(vi.mocked(serverCaptureException)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(serverCaptureException).mock.calls[0][2]).toMatchObject({
+        action: 'createAudioUpload.quotaCheck',
+      });
+    });
   });
 });
 

--- a/tests/server/functions/audio-mutations.test.ts
+++ b/tests/server/functions/audio-mutations.test.ts
@@ -32,6 +32,7 @@ vi.mock('~/server/db/models/AudioAsset', () => ({
     updateMany: vi.fn(),
     findOne: vi.fn(),
     deleteOne: vi.fn(),
+    countDocuments: vi.fn(),
   },
 }));
 
@@ -320,7 +321,14 @@ describe('bulkTagAudioAssets', () => {
 });
 
 describe('retryAudioAsset', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Safe default for the nested `confirmAudioUpload` calls below (this
+    // describe's property tests drive the real confirm path to build
+    // fixture rows): zero pending jobs is under any real cap, so it does
+    // not interfere with what those tests are actually checking.
+    vi.mocked(AudioAsset.countDocuments).mockResolvedValue(0);
+  });
 
   it('requeues a failed asset and resets the entire queue state', async () => {
     mockUpdateResult({

--- a/tests/server/functions/audio-mutations.test.ts
+++ b/tests/server/functions/audio-mutations.test.ts
@@ -377,6 +377,92 @@ describe('retryAudioAsset', () => {
     );
   });
 
+  describe('pending job cap', () => {
+    /**
+     * Controller-ordered fix (review of Task 6): the cap originally only
+     * gated `confirmAudioUpload`. `retryAudioAsset` is a second, unguarded
+     * door into the same `pending` queue — a caller can push N failed rows
+     * back in one at a time with no depth check, defeating the point of the
+     * cap regardless of how tightly `confirmAudioUpload` is bounded.
+     *
+     * Pins the ACTUAL count filter, same standard as every other cap test
+     * in this phase — a weaker "it was called" assertion would pass with
+     * `ownerId` dropped.
+     */
+    it('counts pending+processing jobs scoped to the caller before requeueing a failed row', async () => {
+      vi.mocked(AudioAsset.countDocuments).mockResolvedValue(0);
+      mockUpdateResult({
+        _id: 'a1',
+        ownerId: 'u1',
+        status: 'pending',
+        createdAt: new Date(0),
+        updatedAt: new Date(0),
+      });
+      const { retryAudioAsset } = await import('~/server/functions/audio');
+      await retryAudioAsset({ data: { id: 'a1' }, userId: 'u1' });
+
+      expect(vi.mocked(AudioAsset.countDocuments)).toHaveBeenCalledWith({
+        ownerId: 'u1',
+        status: { $in: ['pending', 'processing'] },
+      });
+    });
+
+    /**
+     * The global-count catch, same technique as `confirmAudioUpload`'s
+     * equivalent test in `audio-ingest.test.ts` (see that test's comment for
+     * why a single-user fixture cannot distinguish "counts this caller" from
+     * "counts everyone"): a `countDocuments` fake that only answers a
+     * filter carrying the right `ownerId`, and throws otherwise, so an
+     * unscoped or wrongly-scoped count fails loudly instead of silently
+     * routing both users to the same outcome.
+     *
+     * Also proves: retry's refusal writes NOTHING and calls no R2 method —
+     * unlike `confirmAudioUpload`/`confirmOnceVariantUpload`, there is no
+     * fresh R2 object to strand and the row is already `failed`, so the
+     * correct action on refusal is exactly "throw, touch nothing" (see the
+     * production comment on this check for the reasoning). The refusal
+     * message carries the count, is an `AudioClientError`, and files no
+     * GlitchTip event.
+     */
+    it('refuses a user already at the cap while a different user at zero is admitted', async () => {
+      const { getMaxPendingJobsPerUser, retryAudioAsset, AudioClientError } =
+        await import('~/server/functions/audio');
+      const { serverCaptureException } = await import('~/server/utils/telemetry');
+      const cap = getMaxPendingJobsPerUser();
+
+      vi.mocked(AudioAsset.countDocuments).mockImplementation((async (
+        filter: Record<string, unknown>
+      ) => {
+        if (filter.ownerId === 'u1') return cap; // already at the cap
+        if (filter.ownerId === 'u2') return 0; // fresh, nothing queued
+        throw new Error(`unscoped countDocuments filter: ${JSON.stringify(filter)}`);
+      }) as never);
+
+      // u1: at the cap, refused.
+      const err = await retryAudioAsset({ data: { id: 'a1' }, userId: 'u1' }).catch(
+        (e: unknown) => e
+      );
+      expect(err).toBeInstanceOf(AudioClientError);
+      expect((err as Error).message).toContain(String(cap));
+      // Refusal touches neither R2 nor the row.
+      expect(send).not.toHaveBeenCalled();
+      expect(AudioAsset.findOneAndUpdate).not.toHaveBeenCalled();
+      expect(vi.mocked(serverCaptureException)).not.toHaveBeenCalled();
+
+      // u2: a DIFFERENT user, zero pending jobs, admitted through the normal
+      // eligibility write.
+      mockUpdateResult({
+        _id: 'a2',
+        ownerId: 'u2',
+        status: 'pending',
+        createdAt: new Date(0),
+        updatedAt: new Date(0),
+      });
+      const res = await retryAudioAsset({ data: { id: 'a2' }, userId: 'u2' });
+      expect(res.status).toBe('pending');
+    });
+  });
+
   /**
    * The property, not the shape.
    *

--- a/tests/server/functions/audio-mutations.test.ts
+++ b/tests/server/functions/audio-mutations.test.ts
@@ -44,6 +44,48 @@ function mockUpdateResult(doc: Record<string, unknown> | null) {
   } as never);
 }
 
+describe("the 'Audio asset not found' throws", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  /**
+   * These fire when `findOne`/`findOneAndUpdate` misses on
+   * `{ _id: <caller-supplied id>, ownerId }`. The schemas are
+   * `z.object({ id: objectId })`, so any authenticated user can trigger one at
+   * will by generating well-formed ObjectIds — which as a plain `Error` filed
+   * one GlitchTip event per request, making the report volume the caller's
+   * parameter. `AudioClientError` is the class `reportAudioError` excludes, so
+   * the type IS the no-telemetry contract; asserting only that it rejects
+   * would pass with the type reverted.
+   */
+  it('updateAudioAsset: throws AudioClientError and files no GlitchTip event', async () => {
+    mockUpdateResult(null);
+    const { updateAudioAsset, AudioClientError } = await import('~/server/functions/audio');
+    const err = await updateAudioAsset({ data: { id: 'a1', title: 'New' }, userId: 'u1' }).catch(
+      (e: unknown) => e
+    );
+    expect(err).toBeInstanceOf(AudioClientError);
+    // The message is unchanged by the type change — `~/routes/api/audio/
+    // uploads.$id.confirm.ts` classifies these by message regex, and the UI
+    // renders `.message` verbatim.
+    expect((err as Error).message).toBe('Audio asset not found');
+    expect(serverCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('deleteAudioAsset: throws AudioClientError, files no GlitchTip event, and issues no R2 delete', async () => {
+    vi.mocked(AudioAsset.findOne).mockResolvedValue(null as never);
+    const { deleteAudioAsset, AudioClientError } = await import('~/server/functions/audio');
+    const err = await deleteAudioAsset({ data: { id: 'a1' }, userId: 'u1' }).catch(
+      (e: unknown) => e
+    );
+    expect(err).toBeInstanceOf(AudioClientError);
+    expect((err as Error).message).toBe('Audio asset not found');
+    expect(serverCaptureException).not.toHaveBeenCalled();
+    // A miss must not reach the R2 client at all.
+    expect(send).not.toHaveBeenCalled();
+    expect(AudioAsset.deleteOne).not.toHaveBeenCalled();
+  });
+});
+
 describe('updateAudioAsset', () => {
   beforeEach(() => vi.clearAllMocks());
 

--- a/tests/server/functions/audio-mutations.test.ts
+++ b/tests/server/functions/audio-mutations.test.ts
@@ -929,3 +929,119 @@ describe('deleteAudioAsset', () => {
     expect(AudioAsset.deleteOne).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * TASK 10, FIX 2 — the app's half of the once-attach liveness clock.
+ *
+ * `reapAbandonedOnceUploads` (audio-worker/src/claim.ts) is the only thing
+ * that can free a once-variant attach whose upload died mid-PUT: the row is
+ * parked in `status: 'uploading'`, and `createOnceVariantUpload` refuses
+ * anything that isn't `status: 'ready'`, so the owner has no self-service
+ * way out. Until this fix, that reaper's only clock was `updatedAt` — and
+ * `updatedAt` answers "was this document modified", not "did this job make
+ * progress". The two facet editors below are unfenced: they match on
+ * `{_id, ownerId}` alone and bump `updatedAt` on whatever row they touch,
+ * dead attach or not. Retitle the track and the reap is pushed out by a full
+ * timeout; retitle it again and it is pushed out again, forever, on an asset
+ * that reads as un-ready everywhere in the meantime (`status` is shared with
+ * the main pipeline — see `variant` on the model).
+ *
+ * This drives all three REAL server functions in the order a user would hit
+ * them and composes their writes onto one document, rather than asserting
+ * that some `$set` does or doesn't contain a key: the property under test is
+ * what the row LOOKS LIKE to the reaper after a day of ordinary library
+ * housekeeping, and that is a statement about the document, not the update.
+ */
+describe('the once-attach liveness clock (Task 10, fix 2)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  /**
+   * All three writers use plain `$set` for every field that matters here
+   * (`bulkTagAudioAssets` only reaches for `$addToSet` in `add` mode, which
+   * this scenario deliberately avoids), so `Object.assign` is exactly what
+   * Mongo would do to the stored document.
+   */
+  function applySet(row: Record<string, unknown>, update: unknown): void {
+    Object.assign(row, (update as { $set: Record<string, unknown> }).$set);
+  }
+
+  it('is not reset by a retitle or a bulk retag, so a dead attach still ages out', async () => {
+    vi.useFakeTimers();
+    try {
+      const attachedAt = new Date('2026-07-01T00:00:00.000Z');
+      const editedAt = new Date('2026-07-02T00:00:00.000Z');
+      const retaggedAt = new Date('2026-07-02T00:05:00.000Z');
+
+      // The stored document, as Mongo would hold it. Starts as a
+      // fully-transcoded music asset with no once-variant.
+      const row: Record<string, unknown> = {
+        _id: 'a1',
+        ownerId: 'u1',
+        kind: 'music',
+        title: 'Tavern Theme',
+        status: 'ready',
+        variant: 'main',
+        tags: ['tavern'],
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      };
+
+      // 1. The GM attaches a once-variant. Their browser then dies mid-PUT,
+      //    so nothing ever confirms it — the row is stuck from here on.
+      vi.setSystemTime(attachedAt);
+      vi.mocked(AudioAsset.findOne).mockResolvedValue({ ...row } as never);
+      vi.mocked(AudioAsset.findOneAndUpdate).mockResolvedValue({
+        _id: 'a1',
+        status: 'uploading',
+      } as never);
+      const { createOnceVariantUpload, updateAudioAsset, bulkTagAudioAssets } =
+        await import('~/server/functions/audio');
+      await createOnceVariantUpload({
+        data: { assetId: 'a1', filename: 'ending.wav', contentType: 'audio/wav', bytes: 1024 },
+        userId: 'u1',
+      });
+      applySet(row, vi.mocked(AudioAsset.findOneAndUpdate).mock.calls[0][1]);
+
+      // The attach is in flight and the clock has started. If this were
+      // absent the rest of the test would be vacuous, so it is asserted
+      // rather than assumed.
+      expect(row).toMatchObject({ status: 'uploading', variant: 'once' });
+      expect(row.onceUploadStartedAt).toEqual(attachedAt);
+
+      // 2. A day later — long past any upload timeout — the GM tidies their
+      //    library and renames the track.
+      vi.setSystemTime(editedAt);
+      mockUpdateResult({ ...row, title: 'Tavern Theme (night)' });
+      await updateAudioAsset({
+        data: { id: 'a1', title: 'Tavern Theme (night)' },
+        userId: 'u1',
+      });
+      applySet(row, vi.mocked(AudioAsset.findOneAndUpdate).mock.calls[1][1]);
+
+      // 3. And sweeps a new tag across a selection that happens to include it.
+      vi.setSystemTime(retaggedAt);
+      vi.mocked(AudioAsset.updateMany).mockResolvedValue({ modifiedCount: 1 } as never);
+      await bulkTagAudioAssets({
+        data: { ids: ['a1'], tags: ['night'], tagMode: 'replace' },
+        userId: 'u1',
+      });
+      applySet(row, vi.mocked(AudioAsset.updateMany).mock.calls[0][1]);
+
+      // Both edits landed — this row really was written twice, so a clock
+      // that any writer could move would have moved.
+      expect(row.title).toBe('Tavern Theme (night)');
+      expect(row.tags).toEqual(['night']);
+      expect(row.updatedAt).toEqual(retaggedAt);
+
+      // ...and the reaper's clock still reads when the attach began, a full
+      // day earlier. That difference is the entire fix: gated on
+      // `updatedAt` this row looks five minutes old and is skipped; gated on
+      // `onceUploadStartedAt` it is a day stale and is finally freed.
+      expect(row.onceUploadStartedAt).toEqual(attachedAt);
+      // Still stuck, which is why it has to be the reaper that frees it.
+      expect(row).toMatchObject({ status: 'uploading', variant: 'once' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/server/functions/audio-mutations.test.ts
+++ b/tests/server/functions/audio-mutations.test.ts
@@ -18,6 +18,13 @@ vi.mock('~/server/functions/uploads', () => ({
 vi.mock('~/server/functions/audio-storage', () => ({
   resolveAudioStoragePrefix: vi.fn(async () => 'a1b2c3d4e5f60718293a4b5c6d7e8f90'),
 }));
+// Comfortably under any real quota — this file's `createAudioUpload` calls
+// are exercising unrelated behaviour (retry eligibility, the unverified-size
+// guard), not the quota check itself; that check has its own coverage in
+// `audio-ingest.test.ts`.
+vi.mock('~/server/functions/audio-quota', () => ({
+  getUserStorageUsage: vi.fn(async () => ({ bytes: 0, assetCount: 0 })),
+}));
 vi.mock('~/server/db/models/AudioAsset', () => ({
   AudioAsset: {
     create: vi.fn(),

--- a/tests/server/functions/audio-mutations.test.ts
+++ b/tests/server/functions/audio-mutations.test.ts
@@ -369,12 +369,24 @@ describe('retryAudioAsset', () => {
     expect(res.status).toBe('pending');
   });
 
-  it('refuses an asset that is not failed (or belongs to another owner)', async () => {
+  /**
+   * B1 (phase-B deferred finding on Task 2's review): this miss is a single
+   * compound `findOneAndUpdate`, reachable by guessing ids exactly like the
+   * five `'Audio asset not found'` sites — see the `AudioClientError` class
+   * doc comment. Asserting only that it rejects would pass with the type
+   * reverted to a plain `Error`, which is the bug this closes: the class IS
+   * the no-telemetry contract, so the effect (`serverCaptureException` not
+   * called) is what has to be pinned, not just the rejection.
+   */
+  it('refuses an asset that is not failed (or belongs to another owner): AudioClientError, no GlitchTip event', async () => {
     mockUpdateResult(null);
-    const { retryAudioAsset } = await import('~/server/functions/audio');
-    await expect(retryAudioAsset({ data: { id: 'a1' }, userId: 'u1' })).rejects.toThrow(
-      /cannot be retried/i
+    const { retryAudioAsset, AudioClientError } = await import('~/server/functions/audio');
+    const err = await retryAudioAsset({ data: { id: 'a1' }, userId: 'u1' }).catch(
+      (e: unknown) => e
     );
+    expect(err).toBeInstanceOf(AudioClientError);
+    expect((err as Error).message).toMatch(/cannot be retried/i);
+    expect(serverCaptureException).not.toHaveBeenCalled();
   });
 
   describe('pending job cap', () => {

--- a/tests/server/functions/audio-once-variant.test.ts
+++ b/tests/server/functions/audio-once-variant.test.ts
@@ -387,6 +387,12 @@ describe('confirmOnceVariantUpload', () => {
     // under any real cap. Tests that care about the cap itself override
     // this explicitly.
     vi.mocked(AudioAsset.countDocuments).mockResolvedValue(0);
+    // Same, for the confirm-side storage-quota check added in the final
+    // whole-branch review. Required rather than tidy: `vi.clearAllMocks`
+    // clears CALLS but not IMPLEMENTATIONS, so without this every test here
+    // inherits the last `createOnceVariantUpload` quota test's rejected
+    // aggregation mock and fails closed.
+    getUserStorageUsage.mockResolvedValue({ bytes: 0, assetCount: 1 });
   });
 
   /**
@@ -667,6 +673,137 @@ describe('confirmOnceVariantUpload', () => {
 
       // The caller's own doing — must not file a GlitchTip event.
       expect(vi.mocked(serverCaptureException)).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * FINAL WHOLE-BRANCH REVIEW, Important #1 — the once half. Same defect as
+   * `confirmAudioUpload`'s: `onceSourceBytes` is written by the success write
+   * below and nowhere else, so a presign-only quota check cannot see a
+   * once-source that has already been PUT.
+   *
+   * The cleanup is NOT `confirmAudioUpload`'s. This row is the main asset's
+   * own document — a fully-transcoded, previously-`ready` `music` asset — so
+   * a refusal reverts it to `ready`/`main` exactly as the cap refusal and the
+   * tooLarge branch do, rather than writing `status: 'failed'`, which would
+   * brick it.
+   */
+  describe('storage quota at confirm', () => {
+    it('refuses an over-quota once-confirm before HeadObject, deletes the once-source, and reverts to ready/main on a fenced filter', async () => {
+      const { getAudioUserQuotaBytes, confirmOnceVariantUpload, AudioClientError } =
+        await import('~/server/functions/audio');
+      const { serverCaptureException } = await import('~/server/utils/telemetry');
+      const limit = getAudioUserQuotaBytes();
+
+      vi.mocked(AudioAsset.findOne).mockResolvedValue({
+        _id: 'a1',
+        ownerId: 'u1',
+        status: 'uploading',
+        variant: 'once',
+        onceSourceKey: 'uploads/audio/prefix/once-src.wav',
+      } as never);
+      getUserStorageUsage.mockResolvedValue({ bytes: limit + 1, assetCount: 9 });
+      vi.mocked(AudioAsset.findOneAndUpdate).mockResolvedValue({ _id: 'a1' } as never);
+      // A VALID object on purpose: an implementation that measured first
+      // would succeed here, so this fixture cannot pass for the wrong reason.
+      send.mockResolvedValue({ ContentLength: 2048, ContentType: 'audio/wav' });
+
+      const err = await confirmOnceVariantUpload({ data: { assetId: 'a1' }, userId: 'u1' }).catch(
+        (e: unknown) => e
+      );
+
+      expect(err).toBeInstanceOf(AudioClientError);
+      expect((err as Error).message).toMatch(/storage quota exceeded/i);
+      const clientErr = err as InstanceType<typeof AudioClientError>;
+      expect(clientErr.usageBytes).toBe(limit + 1);
+      expect(clientErr.limitBytes).toBe(limit);
+
+      // NO HeadObject — pinned on the command class, not on a bare count.
+      expect(send.mock.calls.filter(([cmd]) => cmd instanceof HeadObjectCommand)).toHaveLength(0);
+      const deletes = send.mock.calls.filter(([cmd]) => cmd instanceof DeleteObjectCommand);
+      expect(deletes).toHaveLength(1);
+      expect((deletes[0][0] as DeleteObjectCommand).input).toEqual({
+        Bucket: 'b',
+        Key: 'uploads/audio/prefix/once-src.wav',
+      });
+
+      // The ACTUAL filter — `variant: 'once'` EXACT, not `$ne`, matching the
+      // two writes around it: only a row still mid-attach may be reverted.
+      const [filter, update] = vi.mocked(AudioAsset.findOneAndUpdate).mock.calls[0];
+      expect(filter).toEqual({
+        _id: 'a1',
+        ownerId: 'u1',
+        status: 'uploading',
+        variant: 'once',
+      });
+      const set = (update as { $set: Record<string, unknown> }).$set;
+      // The load-bearing difference from confirmAudioUpload's refusal.
+      expect(set.status).toBe('ready');
+      expect(set.variant).toBe('main');
+      expect(set.onceSourceKey).toBeNull();
+      expect(set.onceSourceBytes).toBeNull();
+      expect(set.onceLastError).toMatch(/storage quota exceeded/i);
+      expect('permanentFailure' in set).toBe(false);
+      expect('lastError' in set).toBe(false);
+      // The main asset's own playable content is untouched.
+      expect('renditions' in set).toBe(false);
+      expect('onceRenditions' in set).toBe(false);
+      expect('sourceKey' in set).toBe(false);
+
+      expect(vi.mocked(serverCaptureException)).not.toHaveBeenCalled();
+    });
+
+    it('refuses exactly at the limit and admits one byte under it', async () => {
+      const { getAudioUserQuotaBytes, confirmOnceVariantUpload } =
+        await import('~/server/functions/audio');
+      const limit = getAudioUserQuotaBytes();
+
+      vi.mocked(AudioAsset.findOne).mockResolvedValue({
+        _id: 'a1',
+        ownerId: 'u1',
+        status: 'uploading',
+        variant: 'once',
+        onceSourceKey: 'uploads/audio/prefix/once-src.wav',
+      } as never);
+      vi.mocked(AudioAsset.findOneAndUpdate).mockResolvedValue({
+        _id: 'a1',
+        status: 'pending',
+      } as never);
+      send.mockResolvedValue({ ContentLength: 2048, ContentType: 'audio/wav' });
+
+      getUserStorageUsage.mockResolvedValue({ bytes: limit, assetCount: 9 });
+      await expect(
+        confirmOnceVariantUpload({ data: { assetId: 'a1' }, userId: 'u1' })
+      ).rejects.toThrow(/storage quota exceeded/i);
+
+      getUserStorageUsage.mockResolvedValue({ bytes: limit - 1, assetCount: 9 });
+      await expect(
+        confirmOnceVariantUpload({ data: { assetId: 'a1' }, userId: 'u1' })
+      ).resolves.toMatchObject({ status: 'pending' });
+    });
+
+    it('fails closed when the aggregation rejects, leaving the once-source object in place', async () => {
+      const { confirmOnceVariantUpload } = await import('~/server/functions/audio');
+      const { serverCaptureException } = await import('~/server/utils/telemetry');
+      vi.mocked(AudioAsset.findOne).mockResolvedValue({
+        _id: 'a1',
+        ownerId: 'u1',
+        status: 'uploading',
+        variant: 'once',
+        onceSourceKey: 'uploads/audio/prefix/once-src.wav',
+      } as never);
+      getUserStorageUsage.mockRejectedValue(new Error('mongo unreachable'));
+
+      await expect(
+        confirmOnceVariantUpload({ data: { assetId: 'a1' }, userId: 'u1' })
+      ).rejects.toThrow(/unable to verify your storage usage/i);
+      // Nothing deleted and nothing reverted: a transient fault must leave a
+      // retryable attach intact rather than destroying the uploaded object.
+      expect(send).not.toHaveBeenCalled();
+      expect(vi.mocked(AudioAsset.findOneAndUpdate)).not.toHaveBeenCalled();
+      expect(vi.mocked(serverCaptureException).mock.calls[0][2]).toMatchObject({
+        action: 'confirmOnceVariantUpload.quotaCheck',
+      });
     });
   });
 });

--- a/tests/server/functions/audio-once-variant.test.ts
+++ b/tests/server/functions/audio-once-variant.test.ts
@@ -7,7 +7,7 @@ vi.mock('~/server/utils/telemetry', () => ({
   serverCaptureEvent: vi.fn(),
 }));
 vi.mock('~/server/db/models/AudioAsset', () => ({
-  AudioAsset: { findOne: vi.fn(), findOneAndUpdate: vi.fn() },
+  AudioAsset: { findOne: vi.fn(), findOneAndUpdate: vi.fn(), countDocuments: vi.fn() },
 }));
 
 const send = vi.fn();
@@ -380,7 +380,14 @@ describe('createOnceVariantUpload', () => {
 });
 
 describe('confirmOnceVariantUpload', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Safe default for every pre-existing test below, which predates the
+    // pending-job cap and never mocks it: zero pending jobs is comfortably
+    // under any real cap. Tests that care about the cap itself override
+    // this explicitly.
+    vi.mocked(AudioAsset.countDocuments).mockResolvedValue(0);
+  });
 
   /**
    * THE LOAD-BEARING CASE the task brief names explicitly: a once-variant
@@ -565,6 +572,102 @@ describe('confirmOnceVariantUpload', () => {
     await expect(
       confirmOnceVariantUpload({ data: { assetId: 'a1' }, userId: 'u2' })
     ).rejects.toThrow(/not found/i);
+  });
+
+  describe('pending job cap', () => {
+    /**
+     * Pins the ACTUAL count filter, not merely that a refusal happened —
+     * same standard `audio-ingest.test.ts` holds `confirmAudioUpload` to. A
+     * weaker assertion (`toHaveBeenCalled()` with no argument check) would
+     * pass with `ownerId` dropped from the shared `checkPendingJobCap`
+     * filter, or `status` narrowed to just `'pending'`.
+     */
+    it('counts pending+processing jobs scoped to the caller before allowing a once-variant to become claimable', async () => {
+      vi.mocked(AudioAsset.findOne).mockResolvedValue({
+        _id: 'a1',
+        ownerId: 'u1',
+        status: 'uploading',
+        variant: 'once',
+        onceSourceKey: 'uploads/audio/prefix/once-src.wav',
+      } as never);
+      send.mockResolvedValue({ ContentLength: 2048, ContentType: 'audio/wav' });
+      vi.mocked(AudioAsset.findOneAndUpdate).mockResolvedValue({
+        _id: 'a1',
+        status: 'pending',
+      } as never);
+      vi.mocked(AudioAsset.countDocuments).mockResolvedValue(0);
+
+      const { confirmOnceVariantUpload } = await import('~/server/functions/audio');
+      await confirmOnceVariantUpload({ data: { assetId: 'a1' }, userId: 'u1' });
+
+      expect(vi.mocked(AudioAsset.countDocuments)).toHaveBeenCalledWith({
+        ownerId: 'u1',
+        status: { $in: ['pending', 'processing'] },
+      });
+    });
+
+    /**
+     * The load-bearing difference from `confirmAudioUpload`'s cap refusal:
+     * THIS row is the main asset's own document, already `ready` before the
+     * once-attach started, so a cap refusal must revert it the same way the
+     * tooLarge/badType branch above does (`status: 'ready', variant:
+     * 'main'`) — never `status: 'failed'`, which would brick the whole
+     * asset. A fixture shape that would make a weaker version of this test
+     * pass for the wrong reason: asserting only that SOME write happened,
+     * without pinning `set.status`/`set.variant` — that would still pass
+     * against an implementation that copied `confirmAudioUpload`'s
+     * `status: 'failed'` write verbatim, which is exactly the bug this test
+     * exists to catch. Also pins: refusal happens before `HeadObject` (only
+     * one R2 call — the delete), the message carries the count, no
+     * GlitchTip event, and the once-source object is deleted so it isn't
+     * stranded.
+     */
+    it('refuses over the cap by reverting to ready/main (not failed) and deleting the once-source object', async () => {
+      const { getMaxPendingJobsPerUser, confirmOnceVariantUpload, AudioClientError } =
+        await import('~/server/functions/audio');
+      const { serverCaptureException } = await import('~/server/utils/telemetry');
+      const cap = getMaxPendingJobsPerUser();
+
+      vi.mocked(AudioAsset.findOne).mockResolvedValue({
+        _id: 'a1',
+        ownerId: 'u1',
+        status: 'uploading',
+        variant: 'once',
+        onceSourceKey: 'uploads/audio/prefix/once-src.wav',
+      } as never);
+      vi.mocked(AudioAsset.countDocuments).mockResolvedValue(cap);
+      vi.mocked(AudioAsset.findOneAndUpdate).mockResolvedValue({ _id: 'a1' } as never);
+      send.mockResolvedValue({ ContentLength: 2048, ContentType: 'audio/wav' });
+
+      const err = await confirmOnceVariantUpload({ data: { assetId: 'a1' }, userId: 'u1' }).catch(
+        (e: unknown) => e
+      );
+      expect(err).toBeInstanceOf(AudioClientError);
+      expect((err as Error).message).toContain(String(cap));
+
+      // Exactly one R2 call: the delete of the once-source object.
+      // HeadObject never runs — the cap refusal happens before it.
+      expect(send).toHaveBeenCalledTimes(1);
+      expect(send.mock.calls[0][0]).toBeInstanceOf(DeleteObjectCommand);
+      expect((send.mock.calls[0][0] as DeleteObjectCommand).input).toEqual({
+        Bucket: 'b',
+        Key: 'uploads/audio/prefix/once-src.wav',
+      });
+
+      const [filter, update] = vi.mocked(AudioAsset.findOneAndUpdate).mock.calls[0];
+      expect(filter).toEqual({ _id: 'a1', ownerId: 'u1', status: 'uploading', variant: 'once' });
+      const set = (update as { $set: Record<string, unknown> }).$set;
+      expect(set.status).toBe('ready');
+      expect(set.variant).toBe('main');
+      expect(set.onceSourceKey).toBeNull();
+      expect(set.onceSourceBytes).toBeNull();
+      expect(set.onceLastError).toContain(String(cap));
+      expect('permanentFailure' in set).toBe(false);
+      expect('lastError' in set).toBe(false);
+
+      // The caller's own doing — must not file a GlitchTip event.
+      expect(vi.mocked(serverCaptureException)).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/tests/server/functions/audio-once-variant.test.ts
+++ b/tests/server/functions/audio-once-variant.test.ts
@@ -24,6 +24,9 @@ vi.mock('~/server/functions/audio-storage', () => ({
   resolveAudioStoragePrefix: vi.fn(async () => 'a1b2c3d4e5f60718293a4b5c6d7e8f90'),
 }));
 
+const getUserStorageUsage = vi.fn();
+vi.mock('~/server/functions/audio-quota', () => ({ getUserStorageUsage }));
+
 import { AudioAsset } from '~/server/db/models/AudioAsset';
 import { serverCaptureEvent } from '~/server/utils/telemetry';
 
@@ -35,7 +38,13 @@ const READY_MUSIC_ASSET = {
 };
 
 describe('createOnceVariantUpload', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Safe default for every pre-existing test below, which predates the
+    // quota check and never mocks it: comfortably under any real limit.
+    // Tests that care about the quota itself override this explicitly.
+    getUserStorageUsage.mockResolvedValue({ bytes: 0, assetCount: 1 });
+  });
 
   it('presigns and flips the row to uploading with variant: once, for a ready music asset', async () => {
     vi.mocked(AudioAsset.findOne).mockResolvedValue(READY_MUSIC_ASSET as never);
@@ -293,6 +302,80 @@ describe('createOnceVariantUpload', () => {
     });
 
     expect(r.assetId).toBe('a1');
+  });
+
+  /**
+   * Review fix (Important): the quota check originally landed only on
+   * `createAudioUpload`. Task 3b made `onceSourceBytes` the sixth term in
+   * `getUserStorageUsage`'s aggregation specifically so once-variant bytes
+   * COUNT toward the quota — but counting them while leaving THIS path
+   * (the one that creates them) ungated meant a caller already at the
+   * limit could keep attaching once-variants to every `music` asset they
+   * own, roughly doubling the effective ceiling for a music-heavy library.
+   * These two tests hold this path to the same standard as
+   * `createAudioUpload`'s own quota tests in `audio-ingest.test.ts`, via
+   * the shared `assertUnderStorageQuota` helper both now call.
+   */
+  describe('storage quota', () => {
+    it('refuses over quota, issues no presign, and never looks up the asset', async () => {
+      const { getAudioUserQuotaBytes, createOnceVariantUpload } =
+        await import('~/server/functions/audio');
+      const { getAudioUploadUrl } = await import('~/server/functions/uploads');
+      const limit = getAudioUserQuotaBytes();
+      getUserStorageUsage.mockResolvedValue({ bytes: limit + 1, assetCount: 5 });
+
+      await expect(
+        createOnceVariantUpload({
+          data: { assetId: 'a1', filename: 'ending.wav', contentType: 'audio/wav', bytes: 1024 },
+          userId: 'u1',
+        })
+      ).rejects.toThrow(/storage quota exceeded/i);
+
+      // Pinned on the quota message specifically, not merely "it threw": the
+      // asset-lookup mock is never configured to succeed in this test (it
+      // would resolve `undefined` and throw "Audio asset not found" instead
+      // if ever reached), so a version of this test that only asserted
+      // rejection would pass just as well with the quota check deleted.
+      // These negative assertions catch that — they fail unless the quota
+      // check runs BEFORE the asset lookup, not just before the presign.
+      expect(vi.mocked(getAudioUploadUrl)).not.toHaveBeenCalled();
+      expect(vi.mocked(AudioAsset.findOne)).not.toHaveBeenCalled();
+      expect(vi.mocked(AudioAsset.findOneAndUpdate)).not.toHaveBeenCalled();
+    });
+
+    /**
+     * Its own test, not a branch of the one above — this fixture never sets
+     * a bytes value, only makes the aggregation call itself reject. Kept
+     * separate for the same reason `audio-ingest.test.ts`'s equivalent test
+     * is separate: merged into the over-quota case (which pins a resolved
+     * bytes VALUE), a missing fail-closed guard could still pass as long as
+     * something else downstream happened to throw.
+     */
+    it('refuses the attach when the usage aggregation itself rejects — fail closed', async () => {
+      const { createOnceVariantUpload } = await import('~/server/functions/audio');
+      const { getAudioUploadUrl } = await import('~/server/functions/uploads');
+      const { serverCaptureException } = await import('~/server/utils/telemetry');
+      getUserStorageUsage.mockRejectedValue(new Error('mongo unreachable'));
+
+      await expect(
+        createOnceVariantUpload({
+          data: { assetId: 'a1', filename: 'ending.wav', contentType: 'audio/wav', bytes: 1024 },
+          userId: 'u1',
+        })
+      ).rejects.toThrow(/unable to verify your storage usage/i);
+
+      expect(vi.mocked(getAudioUploadUrl)).not.toHaveBeenCalled();
+      expect(vi.mocked(AudioAsset.findOne)).not.toHaveBeenCalled();
+
+      // The underlying fault is still captured, exactly once, tagged for
+      // THIS caller specifically — proves `assertUnderStorageQuota`'s
+      // `action` parameter is actually threaded through, not hardcoded to
+      // `createAudioUpload`'s own string.
+      expect(vi.mocked(serverCaptureException)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(serverCaptureException).mock.calls[0][2]).toMatchObject({
+        action: 'createOnceVariantUpload.quotaCheck',
+      });
+    });
   });
 });
 

--- a/tests/server/functions/audio-once-variant.test.ts
+++ b/tests/server/functions/audio-once-variant.test.ts
@@ -294,8 +294,19 @@ describe('confirmOnceVariantUpload', () => {
     const [filter, update] = vi.mocked(AudioAsset.findOneAndUpdate).mock.calls[0];
     expect(filter).toEqual({ _id: 'a1', ownerId: 'u1', status: 'uploading', variant: 'once' });
     const set = (update as { $set: Record<string, unknown> }).$set;
-    expect(Object.keys(set).sort()).toEqual(['confirmedAt', 'status', 'updatedAt']);
+    expect(Object.keys(set).sort()).toEqual([
+      'confirmedAt',
+      'onceSourceBytes',
+      'status',
+      'updatedAt',
+    ]);
     expect(set.status).toBe('pending');
+    // Task 3b: the HeadObject size already computed for the AUDIO_MAX_BYTES
+    // gate (`ContentLength: 2048` mocked above) must be the exact number
+    // persisted — not re-derived, not a different mocked value threaded
+    // through, and not merely present. This is what makes the byte count
+    // visible to `getUserStorageUsage`.
+    expect(set.onceSourceBytes).toBe(2048);
     expect('renditions' in set).toBe(false);
     expect('onceRenditions' in set).toBe(false);
     expect('sourceKey' in set).toBe(false);

--- a/tests/server/functions/audio-once-variant.test.ts
+++ b/tests/server/functions/audio-once-variant.test.ts
@@ -120,6 +120,45 @@ describe('createOnceVariantUpload', () => {
     expect(set.onceRenditions).toEqual({});
   });
 
+  /**
+   * Task 3b review fix (Important). `onceSourceBytes` mirrors `onceSourceKey`
+   * one field over — the byte count describes the object the key points at —
+   * so the same reset `onceRenditions: {}` gets above is required for this
+   * field too, and for the same reason: a prior SUCCESSFUL attach set it to
+   * a real number, this new attach mints a brand-new key the old number no
+   * longer describes, and the old value must not survive to be
+   * misattributed to the new (not-yet-confirmed) object.
+   *
+   * Fixture starts `onceSourceBytes` at a real non-null number (5,000,000),
+   * not null and not absent — a fixture that started null/absent would pass
+   * this assertion even with the reset deleted from the implementation,
+   * because `undefined === null` reads the same as an explicit reset from
+   * `toBe(null)`'s perspective only if nothing else supplies a value; a
+   * non-null start makes the assertion fail unless the code actually writes
+   * the reset.
+   */
+  it('resets onceSourceBytes to null when re-attaching, so a stale prior measurement cannot survive onto the new key', async () => {
+    vi.mocked(AudioAsset.findOne).mockResolvedValue({
+      ...READY_MUSIC_ASSET,
+      onceSourceKey: 'uploads/audio/prefix/once-old.wav',
+      onceSourceBytes: 5_000_000,
+    } as never);
+    vi.mocked(AudioAsset.findOneAndUpdate).mockResolvedValue({
+      _id: 'a1',
+      status: 'uploading',
+    } as never);
+
+    const { createOnceVariantUpload } = await import('~/server/functions/audio');
+    await createOnceVariantUpload({
+      data: { assetId: 'a1', filename: 'ending2.wav', contentType: 'audio/wav', bytes: 2048 },
+      userId: 'u1',
+    });
+
+    const [, update] = vi.mocked(AudioAsset.findOneAndUpdate).mock.calls[0];
+    const set = (update as { $set: Record<string, unknown> }).$set;
+    expect(set.onceSourceBytes).toBeNull();
+  });
+
   it('refuses a non-music asset, without presigning or touching the row', async () => {
     vi.mocked(AudioAsset.findOne).mockResolvedValue({
       ...READY_MUSIC_ASSET,
@@ -341,6 +380,13 @@ describe('confirmOnceVariantUpload', () => {
       status: 'uploading',
       variant: 'once',
       onceSourceKey: 'uploads/audio/prefix/once-src.wav',
+      // Task 3b review fix: non-null on purpose, modelling a row where
+      // something (in production, always null by this point thanks to
+      // `createOnceVariantUpload`'s own reset — asserted separately above)
+      // left a real number here. This write's own reset must not depend on
+      // that other function having run; a fixture starting at null/absent
+      // would pass this test even if THIS write's reset were deleted.
+      onceSourceBytes: 5_000_000,
     } as never);
     send.mockResolvedValue({ ContentLength: 50 * 1024 * 1024 + 1, ContentType: 'audio/wav' });
     vi.mocked(AudioAsset.findOneAndUpdate).mockResolvedValue({ _id: 'a1' } as never);
@@ -377,6 +423,11 @@ describe('confirmOnceVariantUpload', () => {
     expect(set.status).toBe('ready');
     expect(set.variant).toBe('main');
     expect(set.onceSourceKey).toBeNull();
+    // Paired with onceSourceKey: cartyx-app Task 3b review fix. The rejected
+    // object is deleted (asserted above) and this row no longer has a
+    // once-source of any kind — nothing may describe its size, so this
+    // must reset to null in the same write, not merely stay unmentioned.
+    expect(set.onceSourceBytes).toBeNull();
     expect(set.onceLastError).toMatch(/too large/i);
     expect('permanentFailure' in set).toBe(false);
     expect('lastError' in set).toBe(false);

--- a/tests/server/functions/audio-quota.test.ts
+++ b/tests/server/functions/audio-quota.test.ts
@@ -118,7 +118,7 @@ describe('getUserStorageUsage — scoping', () => {
 });
 
 describe('getUserStorageUsage — pipeline arithmetic (interpreted, not hard-coded)', () => {
-  it('sums a pending asset (source only) and a ready asset (all rendition slots) across both, for both users mixed in the collection', async () => {
+  it('sums a pending asset (source only) and a ready asset (all rendition/once-source slots) across both, for both users mixed in the collection', async () => {
     aggregate.mockResolvedValue([{ assetCount: 2, bytes: 999 }]); // mocked return is deliberately wrong-looking; the assertions below never read it.
 
     await getUserStorageUsage(OWNER);
@@ -139,6 +139,7 @@ describe('getUserStorageUsage — pipeline arithmetic (interpreted, not hard-cod
       ownerId: OWNER,
       status: 'ready',
       sourceBytes: 4_000_000,
+      onceSourceBytes: 250_000,
       renditions: { opus: { bytes: 900_000 }, aac: { bytes: 1_100_000 } },
       onceRenditions: { opus: { bytes: 300_000 }, aac: { bytes: 400_000 } },
     };
@@ -153,10 +154,12 @@ describe('getUserStorageUsage — pipeline arithmetic (interpreted, not hard-cod
     const result = simulate(pipeline, [pendingSourceOnly, readyAllFields, otherUsersAsset]);
 
     expect(result.assetCount).toBe(2); // both statuses counted; the other owner's row excluded
-    expect(result.bytes).toBe(5_000_000 + 4_000_000 + 900_000 + 1_100_000 + 300_000 + 400_000);
+    expect(result.bytes).toBe(
+      5_000_000 + 4_000_000 + 250_000 + 900_000 + 1_100_000 + 300_000 + 400_000
+    );
   });
 
-  it('sums exactly the five byte-bearing fields the brief names, in the schema shape audio-cleanup.ts also reads', async () => {
+  it('sums exactly the six byte-bearing fields — the five from before Task 3b plus onceSourceBytes — in the schema shape audio-cleanup.ts also reads', async () => {
     aggregate.mockResolvedValue([{ assetCount: 1, bytes: 0 }]);
 
     await getUserStorageUsage(OWNER);
@@ -168,6 +171,7 @@ describe('getUserStorageUsage — pipeline arithmetic (interpreted, not hard-cod
 
     expect(fieldRefs).toEqual([
       '$sourceBytes',
+      '$onceSourceBytes',
       '$renditions.opus.bytes',
       '$renditions.aac.bytes',
       '$onceRenditions.opus.bytes',
@@ -197,6 +201,37 @@ describe('getUserStorageUsage — pipeline arithmetic (interpreted, not hard-cod
 
     expect(result.assetCount).toBe(1);
     expect(result.bytes).toBe(0);
+    expect(Number.isNaN(result.bytes)).toBe(false);
+  });
+
+  it('a row written before Task 3b (onceSourceBytes absent entirely, not merely null) contributes 0, not NaN — the backward-compat case', async () => {
+    aggregate.mockResolvedValue([{ assetCount: 1, bytes: 0 }]);
+
+    await getUserStorageUsage(OWNER);
+    const pipeline = aggregate.mock.calls[0][0] as Array<Record<string, unknown>>;
+
+    // Pre-Task-3b row shape: a fully ready, fully populated asset that
+    // predates `onceSourceBytes` landing on the schema. The key is entirely
+    // ABSENT here, not `null` — a fixture that set `onceSourceBytes: 0`
+    // would pass even if the implementation's $ifNull guard were missing
+    // (0 + 0 looks identical to 0 + (null collapsed to 0)), and a fixture
+    // that set it to `null` wouldn't distinguish "never confirmed" from
+    // "the field didn't exist yet on this row" — Mongo treats both the
+    // same, but the fixture should still model the real legacy-row shape.
+    const preTask3bRow = {
+      ownerId: OWNER,
+      status: 'ready',
+      sourceBytes: 4_000_000,
+      renditions: { opus: { bytes: 900_000 }, aac: { bytes: 1_100_000 } },
+      onceRenditions: { opus: { bytes: 300_000 }, aac: { bytes: 400_000 } },
+      // onceSourceKey/onceSourceBytes: absent — no once-variant was ever
+      // attached to this row, and it was written before the field existed.
+    };
+
+    const result = simulate(pipeline, [preTask3bRow]);
+
+    expect(result.assetCount).toBe(1);
+    expect(result.bytes).toBe(4_000_000 + 900_000 + 1_100_000 + 300_000 + 400_000);
     expect(Number.isNaN(result.bytes)).toBe(false);
   });
 

--- a/tests/server/functions/audio-quota.test.ts
+++ b/tests/server/functions/audio-quota.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import mongoose from 'mongoose';
+
+vi.mock('~/server/db/connection', () => ({ connectDB: vi.fn(), isDBConnected: vi.fn(() => true) }));
+
+// The global `tests/setup.ts` mock replaces `mongoose` wholesale and does not
+// carry `Types` (only `Schema.Types.ObjectId = String`), so `new
+// mongoose.Types.ObjectId(...)` would throw under it. `tabletop.test.ts`
+// hits the exact same issue for its own `new mongoose.Types.ObjectId(...)`
+// cast and fixes it the same way: keep the real `Types` so the cast the
+// implementation performs is exercised for real, not stubbed away.
+vi.mock('mongoose', async () => {
+  const actual = await vi.importActual<typeof import('mongoose')>('mongoose');
+  return { default: { Types: actual.Types } };
+});
+
+const { aggregate } = vi.hoisted(() => ({ aggregate: vi.fn() }));
+vi.mock('~/server/db/models/AudioAsset', () => ({ AudioAsset: { aggregate } }));
+
+import { getUserStorageUsage } from '~/server/functions/audio-quota';
+
+const OWNER = '507f1f77bcf86cd799439011';
+const OTHER_OWNER = '507f1f77bcf86cd799439022';
+
+/**
+ * Reads a Mongo aggregation `$ifNull` operand (`{ $ifNull: [fieldRef,
+ * fallback] }`) against a plain-object fixture the way the real MongoDB
+ * aggregation engine would: dotted field ref resolved against the doc, with
+ * `null`/missing collapsing to `fallback`.
+ *
+ * This is what lets the tests below assert against the pipeline object
+ * `aggregate` was actually called with, rather than a hand-typed re-guess of
+ * "the five fields" — if `getUserStorageUsage` used a wrong field name, a
+ * missing `$ifNull` guard, or summed the wrong count of terms, this
+ * interpreter would compute the wrong number from the SAME pipeline object
+ * the implementation built, and the assertion on the total would fail. A
+ * test that instead hard-coded "sum these five named fields" would pass even
+ * if the implementation's pipeline asked Mongo for different fields, because
+ * nothing would ever cross-check the pipeline against the fixture.
+ */
+function readIfNull(expr: unknown, doc: Record<string, unknown>): number {
+  const e = expr as { $ifNull: [string, number] };
+  const path = e.$ifNull[0].replace(/^\$/, '').split('.');
+  let value: unknown = doc;
+  for (const key of path) {
+    if (value == null) {
+      value = undefined;
+      break;
+    }
+    value = (value as Record<string, unknown>)[key];
+  }
+  return value == null ? e.$ifNull[1] : (value as number);
+}
+
+/**
+ * Runs the pipeline `getUserStorageUsage` actually built against a set of
+ * fixture rows, simulating `$match` (equality only, sufficient for the one
+ * `ownerId` clause this pipeline emits) and the `$group`'s `$sum`/`$add`
+ * shape. Returns what a real MongoDB would return for `aggregate.mock.calls`
+ * pipeline against these docs.
+ */
+function simulate(
+  pipeline: Array<Record<string, unknown>>,
+  docs: Array<Record<string, unknown>>
+): { assetCount: number; bytes: number } {
+  const matchStage = pipeline.find((s) => '$match' in s) as {
+    $match: { ownerId: mongoose.Types.ObjectId };
+  };
+  const groupStage = pipeline.find((s) => '$group' in s) as {
+    $group: { bytes: { $sum: { $add: unknown[] } } };
+  };
+  const ownerId = matchStage.$match.ownerId;
+  const matched = docs.filter((d) => String(d.ownerId) === String(ownerId));
+
+  let bytes = 0;
+  for (const doc of matched) {
+    for (const addend of groupStage.$group.bytes.$sum.$add) {
+      bytes += readIfNull(addend, doc);
+    }
+  }
+  return { assetCount: matched.length, bytes };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getUserStorageUsage — scoping', () => {
+  it('matches on ownerId cast to a real ObjectId, not the raw string', async () => {
+    aggregate.mockResolvedValue([{ assetCount: 1, bytes: 100 }]);
+
+    await getUserStorageUsage(OWNER);
+
+    const pipeline = aggregate.mock.calls[0][0] as Array<Record<string, unknown>>;
+    const matchStage = pipeline.find((s) => '$match' in s) as {
+      $match: { ownerId: unknown };
+    };
+    // `.aggregate()` is NOT cast by Mongoose the way `.find()` is — a bare
+    // string here would silently match nothing in a real cluster despite
+    // passing any test that only checked `ownerId === OWNER`.
+    expect(matchStage.$match.ownerId).toBeInstanceOf(mongoose.Types.ObjectId);
+    expect(String(matchStage.$match.ownerId)).toBe(OWNER);
+  });
+
+  it('does not filter by status — every status must be counted', async () => {
+    aggregate.mockResolvedValue([{ assetCount: 1, bytes: 100 }]);
+
+    await getUserStorageUsage(OWNER);
+
+    const pipeline = aggregate.mock.calls[0][0] as Array<Record<string, unknown>>;
+    const matchStage = pipeline.find((s) => '$match' in s) as { $match: Record<string, unknown> };
+    // A shape that would pass for the wrong reason: `{ ownerId, status:
+    // 'ready' }` still has an `ownerId` key equal to the right ObjectId, so
+    // an assertion on ownerId alone wouldn't catch a status filter smuggled
+    // into the same $match. This checks the $match's only key.
+    expect(Object.keys(matchStage.$match)).toEqual(['ownerId']);
+  });
+});
+
+describe('getUserStorageUsage — pipeline arithmetic (interpreted, not hard-coded)', () => {
+  it('sums a pending asset (source only) and a ready asset (all rendition slots) across both, for both users mixed in the collection', async () => {
+    aggregate.mockResolvedValue([{ assetCount: 2, bytes: 999 }]); // mocked return is deliberately wrong-looking; the assertions below never read it.
+
+    await getUserStorageUsage(OWNER);
+    const pipeline = aggregate.mock.calls[0][0] as Array<Record<string, unknown>>;
+
+    const pendingSourceOnly = {
+      ownerId: OWNER,
+      status: 'pending',
+      sourceBytes: 5_000_000,
+      // Never touched by the worker yet — these sub-documents don't exist at
+      // all (schema `default: undefined`), not merely holding zeros. A
+      // fixture that set them to `{ bytes: 0 }` would pass even if the
+      // implementation forgot the `$ifNull` guard, because 0 + 0 looks the
+      // same as 0 + (null collapsed to 0). Omitting the keys entirely is
+      // what actually exercises the guard.
+    };
+    const readyAllFields = {
+      ownerId: OWNER,
+      status: 'ready',
+      sourceBytes: 4_000_000,
+      renditions: { opus: { bytes: 900_000 }, aac: { bytes: 1_100_000 } },
+      onceRenditions: { opus: { bytes: 300_000 }, aac: { bytes: 400_000 } },
+    };
+    // A row belonging to someone else, deliberately shaped to inflate the
+    // total if the $match scoping were ever dropped or widened.
+    const otherUsersAsset = {
+      ownerId: OTHER_OWNER,
+      status: 'ready',
+      sourceBytes: 999_999_999,
+    };
+
+    const result = simulate(pipeline, [pendingSourceOnly, readyAllFields, otherUsersAsset]);
+
+    expect(result.assetCount).toBe(2); // both statuses counted; the other owner's row excluded
+    expect(result.bytes).toBe(5_000_000 + 4_000_000 + 900_000 + 1_100_000 + 300_000 + 400_000);
+  });
+
+  it('sums exactly the five byte-bearing fields the brief names, in the schema shape audio-cleanup.ts also reads', async () => {
+    aggregate.mockResolvedValue([{ assetCount: 1, bytes: 0 }]);
+
+    await getUserStorageUsage(OWNER);
+    const pipeline = aggregate.mock.calls[0][0] as Array<Record<string, unknown>>;
+    const groupStage = pipeline.find((s) => '$group' in s) as {
+      $group: { bytes: { $sum: { $add: Array<{ $ifNull: [string, number] }> } } };
+    };
+    const fieldRefs = groupStage.$group.bytes.$sum.$add.map((op) => op.$ifNull[0]);
+
+    expect(fieldRefs).toEqual([
+      '$sourceBytes',
+      '$renditions.opus.bytes',
+      '$renditions.aac.bytes',
+      '$onceRenditions.opus.bytes',
+      '$onceRenditions.aac.bytes',
+    ]);
+    // Every addend falls back to 0, not left to propagate Mongo's $add-of-null
+    // -> null (which would surface as NaN once coerced to a JS number).
+    for (const op of groupStage.$group.bytes.$sum.$add) {
+      expect(op.$ifNull[1]).toBe(0);
+    }
+  });
+
+  it('an asset with null bytes (never confirmed) contributes 0, not NaN', async () => {
+    aggregate.mockResolvedValue([{ assetCount: 1, bytes: 0 }]);
+
+    await getUserStorageUsage(OWNER);
+    const pipeline = aggregate.mock.calls[0][0] as Array<Record<string, unknown>>;
+
+    const neverConfirmed = {
+      ownerId: OWNER,
+      status: 'uploading',
+      sourceBytes: null, // set by confirmAudioUpload's HeadObject; null until then
+      // renditions/onceRenditions absent entirely at this stage too
+    };
+
+    const result = simulate(pipeline, [neverConfirmed]);
+
+    expect(result.assetCount).toBe(1);
+    expect(result.bytes).toBe(0);
+    expect(Number.isNaN(result.bytes)).toBe(false);
+  });
+
+  it('counts assets, not renditions: an asset counts once even with two rendition slots present', async () => {
+    aggregate.mockResolvedValue([{ assetCount: 1, bytes: 0 }]);
+
+    await getUserStorageUsage(OWNER);
+    const pipeline = aggregate.mock.calls[0][0] as Array<Record<string, unknown>>;
+    const groupStage = pipeline.find((s) => '$group' in s) as {
+      $group: { assetCount: { $sum: number } };
+    };
+
+    // The $group's assetCount accumulator is `{ $sum: 1 }` per document,
+    // never keyed off how many rendition sub-documents that row happens to
+    // carry.
+    expect(groupStage.$group.assetCount).toEqual({ $sum: 1 });
+  });
+});
+
+describe('getUserStorageUsage — empty result', () => {
+  it('returns { bytes: 0, assetCount: 0 } when the user owns no assets at all', async () => {
+    // A real MongoDB aggregate() returns an EMPTY ARRAY when no document
+    // matched $match, not a group row of zeros — there is nothing to group.
+    aggregate.mockResolvedValue([]);
+
+    const result = await getUserStorageUsage(OWNER);
+
+    expect(result).toEqual({ bytes: 0, assetCount: 0 });
+  });
+});

--- a/tests/server/functions/packages.test.ts
+++ b/tests/server/functions/packages.test.ts
@@ -260,24 +260,81 @@ describe('createPackage', () => {
   });
 });
 
+/**
+ * What the stored `p1` is at, and the older revision a second tab would still
+ * be holding. Deliberately an hour apart rather than a millisecond: a fixture
+ * whose two timestamps differed only in sub-second digits would still pass if
+ * the precondition were compared as a truncated string somewhere.
+ */
+const STORED_UPDATED_AT = new Date('2026-07-31T10:00:00.000Z');
+const STALE_UPDATED_AT = new Date('2026-07-31T09:00:00.000Z');
+
+const storedDoc = () => ({ ...baseDoc(), updatedAt: STORED_UPDATED_AT });
+
+/**
+ * A filter-EVALUATING fake, not a canned answer, and that distinction is the
+ * whole test.
+ *
+ * A mock returns whatever it was told regardless of what the query asked, so
+ * `findOneAndUpdateLean.mockResolvedValue(null)` would make a "stale write is
+ * refused" test pass with the precondition deleted from the source — the
+ * function would still see no document, still run the discriminating read,
+ * and still throw the stale-write error. This fake instead applies the filter
+ * it is actually handed to a stored document.
+ *
+ * Note the shape of the `updatedAt` clause specifically: an ABSENT
+ * precondition MATCHES here. That is the property that gives the stale test
+ * teeth — delete `updatedAt` from `updatePackage`'s filter and this fake
+ * happily returns the document, so the write succeeds and the test fails on
+ * its "rejects" assertion. A fake that refused whenever the clause was
+ * missing would fail the same test for the opposite reason, and would prove
+ * nothing about the source.
+ */
+function fenceTheModel() {
+  findOneAndUpdateLean.mockImplementation(async () => {
+    const filter = (vi.mocked(findOneAndUpdate).mock.calls.at(-1)?.[0] ?? {}) as {
+      _id?: string;
+      ownerId?: string;
+      updatedAt?: Date;
+    };
+    if (filter._id !== 'p1' || filter.ownerId !== 'u1') return null;
+    if (
+      filter.updatedAt !== undefined &&
+      filter.updatedAt.getTime() !== STORED_UPDATED_AT.getTime()
+    ) {
+      return null;
+    }
+    return storedDoc();
+  });
+  // The discriminating read `staleWriteOrNotFound` performs on the failure
+  // path: `p1` DOES exist and IS `u1`'s, so a refusal for `u1` can only be a
+  // stale write.
+  findOneLean.mockResolvedValue({ _id: 'p1', updatedAt: STORED_UPDATED_AT });
+}
+
 describe('updatePackage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    fenceTheModel();
   });
 
   it('updates are owner-scoped, so a system package cannot be mutated', async () => {
-    findOneAndUpdateLean.mockResolvedValue(null);
     const { updatePackage } = await import('~/server/functions/packages');
-    await updatePackage({ data: { id: 'p1', name: 'x' }, userId: 'u1' }).catch(() => {});
+    await updatePackage({
+      data: { id: 'p1', expectedUpdatedAt: STORED_UPDATED_AT.toISOString(), name: 'x' },
+      userId: 'u1',
+    }).catch(() => {});
     const filter = vi.mocked(findOneAndUpdate).mock.calls[0][0];
-    expect(filter).toEqual({ _id: 'p1', ownerId: 'u1' });
+    expect(filter).toEqual({ _id: 'p1', ownerId: 'u1', updatedAt: STORED_UPDATED_AT });
     expect(filter).not.toHaveProperty('$or');
   });
 
   it('sets only the fields actually provided', async () => {
-    findOneAndUpdateLean.mockResolvedValue(baseDoc());
     const { updatePackage } = await import('~/server/functions/packages');
-    await updatePackage({ data: { id: 'p1', name: 'New Name' }, userId: 'u1' });
+    await updatePackage({
+      data: { id: 'p1', expectedUpdatedAt: STORED_UPDATED_AT.toISOString(), name: 'New Name' },
+      userId: 'u1',
+    });
     const [, update] = vi.mocked(findOneAndUpdate).mock.calls[0] as [
       unknown,
       { $set: Record<string, unknown> },
@@ -300,7 +357,7 @@ describe('updatePackage', () => {
     findOneAndUpdateLean.mockResolvedValue(baseDoc());
     const { updatePackage } = await import('~/server/functions/packages');
     await updatePackage({
-      data: { id: 'p1', name: 'New Name' },
+      data: { id: 'p1', expectedUpdatedAt: STORED_UPDATED_AT.toISOString(), name: 'New Name' },
       userId: 'mongo-id-1',
       sessionUserId: 'provider-id-1',
     });
@@ -312,11 +369,158 @@ describe('updatePackage', () => {
   });
 
   it('throws "not found" when the model returns no document (does not distinguish absent vs. another owner)', async () => {
-    findOneAndUpdateLean.mockResolvedValue(null);
+    // `u2` fails the fake's ownership clause, and the discriminating read
+    // finds nothing for `u2` either — a package that is not yours must stay
+    // indistinguishable from one that does not exist.
+    findOneLean.mockResolvedValue(null);
     const { updatePackage } = await import('~/server/functions/packages');
-    await expect(updatePackage({ data: { id: 'p1', name: 'x' }, userId: 'u2' })).rejects.toThrow(
-      /not found/i
+    await expect(
+      updatePackage({
+        data: { id: 'p1', expectedUpdatedAt: STORED_UPDATED_AT.toISOString(), name: 'x' },
+        userId: 'u2',
+      })
+    ).rejects.toThrow(/not found/i);
+  });
+});
+
+/**
+ * Task 7: the editor replaces `items` and `moods` wholesale, so an unfenced
+ * update is last-write-wins over entire arrays — an idle tab does not merely
+ * lose the newer edit, it resurrects whatever the newer write removed
+ * (including items `deleteAudioAsset`'s prune took out because their asset is
+ * gone).
+ */
+describe('updatePackage optimistic concurrency', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fenceTheModel();
+  });
+
+  /**
+   * The stale write. Both halves matter:
+   *
+   * - the FILTER assertion pins the precondition actually handed to Mongo, as
+   *   a `Date` (a BSON date never equals a string, so shipping the raw ISO
+   *   would refuse every save rather than only the stale ones — the "guard
+   *   must not make every save fail" failure mode, arriving through the type
+   *   rather than through the logic);
+   * - the REJECTION comes from the filter-evaluating fake above, so it is the
+   *   precondition doing the refusing rather than a canned `null`.
+   */
+  it('refuses a save built on a stale read, and hands Mongo the precondition as a Date', async () => {
+    const { updatePackage } = await import('~/server/functions/packages');
+    await expect(
+      updatePackage({
+        data: {
+          id: 'p1',
+          expectedUpdatedAt: STALE_UPDATED_AT.toISOString(),
+          name: 'From the idle tab',
+          items: [],
+        },
+        userId: 'u1',
+      })
+    ).rejects.toThrow(/changed somewhere else/i);
+
+    const filter = vi.mocked(findOneAndUpdate).mock.calls[0][0] as { updatedAt?: unknown };
+    expect(filter).toEqual({ _id: 'p1', ownerId: 'u1', updatedAt: STALE_UPDATED_AT });
+    expect(filter.updatedAt).toBeInstanceOf(Date);
+  });
+
+  /**
+   * "Distinguishable from a not-found" means two identities, not two
+   * spellings of one. This asserts the identity the BROWSER sees — `.name`,
+   * via the shared predicate — because the server's class does not survive
+   * the server-fn wire and a UI keyed on `instanceof` would silently stop
+   * recognising the refusal in production while every unit test still passed.
+   */
+  it('refuses with an identity distinguishable from a not-found, and files no GlitchTip event', async () => {
+    const { serverCaptureException } = await import('~/server/utils/telemetry');
+    const { isStalePackageWriteError } = await import('~/lib/soundboard/stale-write');
+    const { updatePackage, PackageStaleWriteError, PackageClientError } =
+      await import('~/server/functions/packages');
+
+    const stale = await updatePackage({
+      data: { id: 'p1', expectedUpdatedAt: STALE_UPDATED_AT.toISOString(), name: 'x' },
+      userId: 'u1',
+    }).catch((e: unknown) => e);
+
+    expect(stale).toBeInstanceOf(PackageStaleWriteError);
+    expect(isStalePackageWriteError(stale)).toBe(true);
+    expect((stale as Error).name).toBe('PackageStaleWriteError');
+    // Not a not-found, by message as well as by type: the two failures are
+    // adjacent enough that a copy-paste of the wrong string is the likely
+    // regression.
+    expect((stale as Error).message).not.toMatch(/not found/i);
+    // The token a "keep my edits" retry needs, so the retry is a fresh
+    // compare-and-swap rather than an unfenced force.
+    expect((stale as { currentUpdatedAt?: string }).currentUpdatedAt).toBe(
+      STORED_UPDATED_AT.toISOString()
     );
+
+    // The same run, through the OTHER door: nothing to update because the
+    // package is not this caller's. Same `findOneAndUpdate` miss, different
+    // refusal — which is exactly what the second read exists to decide.
+    findOneLean.mockResolvedValue(null);
+    const missing = await updatePackage({
+      data: { id: 'p1', expectedUpdatedAt: STALE_UPDATED_AT.toISOString(), name: 'x' },
+      userId: 'u2',
+    }).catch((e: unknown) => e);
+
+    expect(missing).toBeInstanceOf(PackageClientError);
+    expect(missing).not.toBeInstanceOf(PackageStaleWriteError);
+    expect(isStalePackageWriteError(missing)).toBe(false);
+    expect((missing as Error).message).toMatch(/not found/i);
+
+    // Neither refusal is a server fault, and both are caller-triggerable at
+    // will (an open second tab; a guessed id) — so neither may author a
+    // GlitchTip event.
+    expect(vi.mocked(serverCaptureException)).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The guard must not make every save fail. Same fixture, same fake, same
+   * code path — only the caller's expectation is current — and this must go
+   * all the way through to the serialized result and the telemetry event, not
+   * merely "not throw".
+   */
+  it('lets a save built on the current revision through', async () => {
+    const { serverCaptureEvent } = await import('~/server/utils/telemetry');
+    const { updatePackage } = await import('~/server/functions/packages');
+
+    const res = await updatePackage({
+      data: {
+        id: 'p1',
+        expectedUpdatedAt: STORED_UPDATED_AT.toISOString(),
+        name: 'Storm Set',
+        items: [],
+      },
+      userId: 'u1',
+    });
+
+    expect(res.id).toBe('p1');
+    expect(vi.mocked(serverCaptureEvent)).toHaveBeenCalledTimes(1);
+    // The success path must NOT pay for the discriminating read — that one
+    // exists only to tell the two refusals apart.
+    expect(vi.mocked(findOne)).not.toHaveBeenCalled();
+    const filter = vi.mocked(findOneAndUpdate).mock.calls[0][0];
+    expect(filter).toEqual({ _id: 'p1', ownerId: 'u1', updatedAt: STORED_UPDATED_AT });
+  });
+
+  /**
+   * The discriminating read must repeat the ownership scope. Re-reading by
+   * `_id` alone would answer "does this document exist" instead of "does it
+   * exist for you", turning a probe against somebody else's package id into a
+   * stale-write refusal — an existence oracle for documents the caller cannot
+   * see. Asserted on the filter argument, because a mock that was told to
+   * return a document returns it whatever the filter said.
+   */
+  it('scopes the discriminating read to the same owner, so another user stays invisible', async () => {
+    const { updatePackage } = await import('~/server/functions/packages');
+    await updatePackage({
+      data: { id: 'p1', expectedUpdatedAt: STALE_UPDATED_AT.toISOString(), name: 'x' },
+      userId: 'u1',
+    }).catch(() => {});
+    expect(vi.mocked(findOne).mock.calls[0][0]).toEqual({ _id: 'p1', ownerId: 'u1' });
   });
 });
 

--- a/tests/types/soundboard-schemas.test.ts
+++ b/tests/types/soundboard-schemas.test.ts
@@ -11,11 +11,53 @@ describe('soundboard schemas', () => {
       fadeSeconds: 1,
       loop: true,
     });
+    // `expectedUpdatedAt` is present and valid so the ONLY invalid thing here
+    // is the item count — otherwise this would reject for a missing required
+    // field and prove nothing about `.max()`.
     const r = updatePackageSchema.safeParse({
       id: '507f1f77bcf86cd799439011',
+      expectedUpdatedAt: '2026-07-31T10:00:00.000Z',
       items: Array.from({ length: MAX_PACKAGE_ITEMS + 1 }, item),
     });
     expect(r.success).toBe(false);
+    // Positive control: the same payload one item shorter parses, so the
+    // rejection above is attributable to the cap.
+    expect(
+      updatePackageSchema.safeParse({
+        id: '507f1f77bcf86cd799439011',
+        expectedUpdatedAt: '2026-07-31T10:00:00.000Z',
+        items: Array.from({ length: MAX_PACKAGE_ITEMS }, item),
+      }).success
+    ).toBe(true);
+  });
+
+  /**
+   * Task 7. `expectedUpdatedAt` is the optimistic-concurrency precondition,
+   * and it is REQUIRED for a reason: every field `updatePackage` writes is a
+   * whole-value replace, so an update that reached the server without a
+   * precondition would be the last-write-wins clobber the fence exists to
+   * stop. An optional fence protects only the callers that did not need it.
+   */
+  it('requires a well-formed expectedUpdatedAt on every package update', async () => {
+    const { updatePackageSchema } = await import('~/types/schemas/soundboard');
+    const base = { id: '507f1f77bcf86cd799439011', name: 'Storm Set' };
+
+    // Omitted entirely — the shape a client written before the fence existed,
+    // or a hand-rolled request, would send.
+    expect(updatePackageSchema.safeParse(base).success).toBe(false);
+    // Present but not a timestamp.
+    expect(updatePackageSchema.safeParse({ ...base, expectedUpdatedAt: 'yesterday' }).success).toBe(
+      false
+    );
+    expect(updatePackageSchema.safeParse({ ...base, expectedUpdatedAt: '' }).success).toBe(false);
+    // Positive control: exactly what `Date.prototype.toISOString` produces,
+    // which is the only thing that ever populates this field.
+    expect(
+      updatePackageSchema.safeParse({
+        ...base,
+        expectedUpdatedAt: new Date('2026-07-31T10:00:00.000Z').toISOString(),
+      }).success
+    ).toBe(true);
   });
 
   it('rejects a non-ObjectId assetId before it can reach Mongo', async () => {

--- a/tests/utils/audio-server-fns.test.ts
+++ b/tests/utils/audio-server-fns.test.ts
@@ -69,6 +69,11 @@ vi.mock('~/server/functions/audio', () => ({
   deleteAudioAsset: vi.fn(),
 }));
 
+vi.mock('~/server/functions/audio-cleanup', () => ({
+  scanOrphanAudio: vi.fn(),
+  deleteOrphanAudio: vi.fn(),
+}));
+
 // Not in the wrapper's import graph at all (the server functions that would
 // call it are mocked above), so this assertion cannot fail today — which is
 // the point. It fails the day someone "helpfully" reports a rate-limit
@@ -94,6 +99,7 @@ import {
   bulkTagAudioAssets,
   deleteAudioAsset,
 } from '~/server/functions/audio';
+import { scanOrphanAudio, deleteOrphanAudio } from '~/server/functions/audio-cleanup';
 import { serverCaptureException } from '~/server/utils/telemetry';
 import {
   createAudioUploadFn,
@@ -101,6 +107,8 @@ import {
   createOnceVariantUploadFn,
   confirmOnceVariantUploadFn,
   retryAudioAssetFn,
+  scanOrphanAudioFn,
+  deleteOrphanAudioFn,
   listAudioAssetsFn,
   updateAudioAssetFn,
   bulkTagAudioAssetsFn,
@@ -438,6 +446,98 @@ describe('ingest rate limit', () => {
       await listAudioAssetsFn({ data: { limit: 50 } });
     }
     expect(listAudioAssets).toHaveBeenCalledTimes(120);
+  });
+});
+
+/**
+ * The orphan-cleanup bucket (`orphanCleanupLimiter`) — the tightest of the
+ * four, and shared by both cleanup endpoints. Same isolation rule as the
+ * ingest tests above: one `DB_USER_ID` per test, because the limiter is a
+ * module-scope singleton `vi.clearAllMocks()` cannot reset.
+ *
+ * The `10` is the capacity, a literal for the same reason: raising it makes
+ * the "11th is refused" assertion fail, lowering it makes the drain loop throw.
+ */
+describe('orphan cleanup rate limit', () => {
+  const FAKE_SCAN = {
+    orphans: [],
+    scannedObjectCount: 0,
+    truncated: false,
+    r2Disabled: false,
+  };
+
+  /** Spends the whole orphan-cleanup bucket for `userId` via `scanOrphanAudioFn`. */
+  async function drainOrphanBucket(userId: string) {
+    vi.mocked(getSession).mockResolvedValue(SESSION_USER);
+    mockDbUser(userId);
+    vi.mocked(scanOrphanAudio).mockResolvedValue(FAKE_SCAN);
+    for (let i = 0; i < 10; i++) {
+      await scanOrphanAudioFn({ data: {} });
+    }
+    expect(scanOrphanAudio).toHaveBeenCalledTimes(10);
+    vi.mocked(scanOrphanAudio).mockClear();
+  }
+
+  it('lets a full 10-call burst through, then refuses the 11th without calling scanOrphanAudio', async () => {
+    await drainOrphanBucket('mongo-orphan-scan');
+
+    await expect(scanOrphanAudioFn({ data: {} })).rejects.toThrow(
+      /Too many orphan cleanup requests/
+    );
+    // The R2 ListObjectsV2 and the `audio_orphan_scan` Umami event both live
+    // inside `scanOrphanAudio`. This assertion is what proves neither happened.
+    expect(scanOrphanAudio).not.toHaveBeenCalled();
+  });
+
+  it('refuses with AudioClientError carrying retryAfterMs, and files no GlitchTip event', async () => {
+    await drainOrphanBucket('mongo-orphan-shape');
+
+    const err = await scanOrphanAudioFn({ data: {} }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(AudioClientError);
+    expect((err as AudioClientError).retryAfterMs).toBeGreaterThan(0);
+    expect(serverCaptureException).not.toHaveBeenCalled();
+    expect(scanOrphanAudio).not.toHaveBeenCalled();
+  });
+
+  it('shares one bucket with deleteOrphanAudioFn, so a drained bucket refuses a delete too', async () => {
+    await drainOrphanBucket('mongo-orphan-delete');
+
+    await expect(deleteOrphanAudioFn({ data: { keys: ['audio/u/1/source.wav'] } })).rejects.toThrow(
+      /Too many orphan cleanup requests/
+    );
+    expect(deleteOrphanAudio).not.toHaveBeenCalled();
+    expect(serverCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('is a separate bucket from the ingest one: a drained cleanup bucket still allows an upload', async () => {
+    await drainOrphanBucket('mongo-orphan-vs-ingest');
+
+    vi.mocked(createAudioUpload).mockResolvedValue({
+      assetId: 'a1',
+      uploadUrl: 'https://put',
+      key: 'k',
+    });
+    await expect(
+      createAudioUploadFn({
+        data: {
+          filename: 'storm.wav',
+          contentType: 'audio/wav',
+          bytes: 1024,
+          kind: 'ambience' as const,
+          environment: [],
+          mood: [],
+          tags: [] as string[],
+        },
+      })
+    ).resolves.toEqual({ assetId: 'a1', uploadUrl: 'https://put', key: 'k' });
+  });
+
+  it('is keyed per account: draining one user does not refuse another', async () => {
+    await drainOrphanBucket('mongo-orphan-victim');
+
+    mockDbUser('mongo-orphan-bystander');
+    vi.mocked(scanOrphanAudio).mockResolvedValue(FAKE_SCAN);
+    await expect(scanOrphanAudioFn({ data: {} })).resolves.toEqual(FAKE_SCAN);
   });
 });
 

--- a/tests/utils/audio-server-fns.test.ts
+++ b/tests/utils/audio-server-fns.test.ts
@@ -721,3 +721,74 @@ describe('getAudioStorageUsageFn', () => {
     expect(getUserStorageUsage).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * FINAL WHOLE-BRANCH REVIEW, minor #5. `getAudioStorageUsageFn` was left
+ * ungated on the reasoning that "its cost scales with the caller's own asset
+ * count, not with how often they call it" — the wrong axis: total Atlas CPU
+ * is count TIMES frequency, and frequency is the caller's own parameter. It
+ * is also the only read on this surface that is a `$group` aggregation
+ * rather than a projected `find`.
+ *
+ * `90` is the capacity, a literal in both directions like every other bucket
+ * test here, and one `DB_USER_ID` per test because the limiter is a
+ * module-scope singleton `vi.clearAllMocks()` cannot reset.
+ */
+describe('storage usage read rate limit', () => {
+  /** Spends the whole storage-usage bucket for `userId`. */
+  async function drainUsageBucket(userId: string) {
+    vi.mocked(getSession).mockResolvedValue(SESSION_USER);
+    mockDbUser(userId);
+    vi.mocked(getUserStorageUsage).mockResolvedValue({ bytes: 512, assetCount: 3 });
+    vi.mocked(getAudioUserQuotaBytes).mockReturnValue(2 * 1024 * 1024 * 1024);
+    for (let i = 0; i < 90; i++) {
+      await getAudioStorageUsageFn();
+    }
+    expect(getUserStorageUsage).toHaveBeenCalledTimes(90);
+    vi.mocked(getUserStorageUsage).mockClear();
+  }
+
+  it('lets a full 90-call burst through, then refuses the 91st without running the aggregation', async () => {
+    await drainUsageBucket('mongo-usage-read');
+
+    await expect(getAudioStorageUsageFn()).rejects.toThrow(/Too many storage usage requests/);
+    // The load-bearing negative: the whole point of gating this endpoint is
+    // that a refused call costs no Atlas aggregation.
+    expect(getUserStorageUsage).not.toHaveBeenCalled();
+  });
+
+  it('refuses with AudioClientError carrying retryAfterMs, and files no GlitchTip event', async () => {
+    await drainUsageBucket('mongo-usage-shape');
+
+    const err = await getAudioStorageUsageFn().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(AudioClientError);
+    expect((err as AudioClientError).retryAfterMs).toBeGreaterThan(0);
+    expect(serverCaptureException).not.toHaveBeenCalled();
+    expect(getUserStorageUsage).not.toHaveBeenCalled();
+  });
+
+  it('is keyed per account: draining one reader does not refuse another', async () => {
+    await drainUsageBucket('mongo-usage-victim');
+
+    mockDbUser('mongo-usage-bystander');
+    vi.mocked(getUserStorageUsage).mockResolvedValue({ bytes: 512, assetCount: 3 });
+    await expect(getAudioStorageUsageFn()).resolves.toMatchObject({ bytes: 512 });
+  });
+
+  it('leaves the library reads ungated: a drained usage bucket still allows listAudioAssetsFn', async () => {
+    await drainUsageBucket('mongo-usage-vs-list');
+
+    vi.mocked(listAudioAssets).mockResolvedValue({ items: [], nextCursor: null });
+    await expect(listAudioAssetsFn({ data: {} })).resolves.toEqual({
+      items: [],
+      nextCursor: null,
+    });
+  });
+
+  it('is a separate bucket from the library mutations that trigger its refetch', async () => {
+    await drainUsageBucket('mongo-usage-vs-library');
+
+    vi.mocked(deleteAudioAsset).mockResolvedValue({ deleted: true });
+    await expect(deleteAudioAssetFn({ data: { id: 'a1' } })).resolves.toEqual({ deleted: true });
+  });
+});

--- a/tests/utils/audio-server-fns.test.ts
+++ b/tests/utils/audio-server-fns.test.ts
@@ -450,6 +450,110 @@ describe('ingest rate limit', () => {
 });
 
 /**
+ * The library-mutation bucket (`libraryMutationLimiter`), shared by
+ * `updateAudioAssetFn` and `deleteAudioAssetFn`.
+ *
+ * Added after review found the original in-code claim that these were safe to
+ * leave ungated was wrong: `deleteAudioAsset` issues up to six R2
+ * `DeleteObjectCommand` calls per request, and both throw on a caller-supplied
+ * id that misses `findOne({ _id, ownerId })` — reachable by generating
+ * well-formed ObjectIds.
+ *
+ * Same isolation rule as the buckets above: one `DB_USER_ID` per test. `60` is
+ * the capacity, a literal so it is pinned in both directions.
+ */
+describe('library mutation rate limit', () => {
+  /** Spends the whole library-mutation bucket for `userId` via `deleteAudioAssetFn`. */
+  async function drainLibraryBucket(userId: string) {
+    vi.mocked(getSession).mockResolvedValue(SESSION_USER);
+    mockDbUser(userId);
+    vi.mocked(deleteAudioAsset).mockResolvedValue({ deleted: true });
+    for (let i = 0; i < 60; i++) {
+      await deleteAudioAssetFn({ data: { id: 'a1' } });
+    }
+    expect(deleteAudioAsset).toHaveBeenCalledTimes(60);
+    vi.mocked(deleteAudioAsset).mockClear();
+  }
+
+  it('lets a full 60-call burst through, then refuses the 61st without calling deleteAudioAsset', async () => {
+    await drainLibraryBucket('mongo-library-delete');
+
+    // The message is pinned, not just "it rejected": every other failure mode
+    // in this handler (no session, no User doc) throws a DIFFERENT message, so
+    // matching the rate-limit text is what stops this passing for the wrong
+    // reason.
+    await expect(deleteAudioAssetFn({ data: { id: 'a1' } })).rejects.toThrow(
+      /Too many library edit requests/
+    );
+    // Up to six R2 DeleteObjectCommand calls live inside `deleteAudioAsset`.
+    // This assertion is what proves none of them were issued.
+    expect(deleteAudioAsset).not.toHaveBeenCalled();
+  });
+
+  it('refuses with AudioClientError carrying retryAfterMs, and files no GlitchTip event', async () => {
+    await drainLibraryBucket('mongo-library-shape');
+
+    const err = await deleteAudioAssetFn({ data: { id: 'a1' } }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(AudioClientError);
+    expect((err as AudioClientError).retryAfterMs).toBeGreaterThan(0);
+    expect(serverCaptureException).not.toHaveBeenCalled();
+    expect(deleteAudioAsset).not.toHaveBeenCalled();
+  });
+
+  it('shares one bucket with updateAudioAssetFn, so a drained bucket refuses an edit too', async () => {
+    await drainLibraryBucket('mongo-library-update');
+
+    await expect(updateAudioAssetFn({ data: { id: 'a1', title: 'New title' } })).rejects.toThrow(
+      /Too many library edit requests/
+    );
+    expect(updateAudioAsset).not.toHaveBeenCalled();
+    expect(serverCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('does not gate bulkTagAudioAssetsFn — an updateMany with no not-found throw', async () => {
+    await drainLibraryBucket('mongo-library-bulktag');
+
+    vi.mocked(bulkTagAudioAssets).mockResolvedValue({ modified: 2 });
+    await expect(
+      bulkTagAudioAssetsFn({
+        data: { ids: ['a1', 'a2'], tags: ['storm'], tagMode: 'add' as const },
+      })
+    ).resolves.toEqual({ modified: 2 });
+  });
+
+  it('is a separate bucket from the ingest one: a drained library bucket still allows an upload', async () => {
+    await drainLibraryBucket('mongo-library-vs-ingest');
+
+    vi.mocked(createAudioUpload).mockResolvedValue({
+      assetId: 'a1',
+      uploadUrl: 'https://put',
+      key: 'k',
+    });
+    await expect(
+      createAudioUploadFn({
+        data: {
+          filename: 'storm.wav',
+          contentType: 'audio/wav',
+          bytes: 1024,
+          kind: 'ambience' as const,
+          environment: [],
+          mood: [],
+          tags: [] as string[],
+        },
+      })
+    ).resolves.toEqual({ assetId: 'a1', uploadUrl: 'https://put', key: 'k' });
+  });
+
+  it('is keyed per account: draining one user does not refuse another', async () => {
+    await drainLibraryBucket('mongo-library-victim');
+
+    mockDbUser('mongo-library-bystander');
+    vi.mocked(deleteAudioAsset).mockResolvedValue({ deleted: true });
+    await expect(deleteAudioAssetFn({ data: { id: 'a1' } })).resolves.toEqual({ deleted: true });
+  });
+});
+
+/**
  * The orphan-cleanup bucket (`orphanCleanupLimiter`) — the tightest of the
  * four, and shared by both cleanup endpoints. Same isolation rule as the
  * ingest tests above: one `DB_USER_ID` per test, because the limiter is a

--- a/tests/utils/audio-server-fns.test.ts
+++ b/tests/utils/audio-server-fns.test.ts
@@ -41,28 +41,66 @@ vi.mock('~/server/db/models/User', () => ({
   User: { findOne: vi.fn() },
 }));
 
+// `AudioClientError` is a real class here rather than a `vi.fn()` because the
+// wrapper's rate-limit gate constructs one (`new AudioClientError(msg, {
+// retryAfterMs })`) and the tests below assert `instanceof` on what comes
+// back — that `instanceof` is the whole GlitchTip proof, since
+// `reportAudioError` in the real module excludes exactly this class. It
+// mirrors the real constructor signature; `npm run typecheck` is what keeps
+// the two from drifting, because the wrapper is typechecked against the real
+// module, not this stand-in.
 vi.mock('~/server/functions/audio', () => ({
+  AudioClientError: class AudioClientError extends Error {
+    readonly retryAfterMs?: number;
+    constructor(message: string, options?: { retryAfterMs?: number }) {
+      super(message);
+      this.name = 'AudioClientError';
+      this.retryAfterMs = options?.retryAfterMs;
+    }
+  },
   createAudioUpload: vi.fn(),
   confirmAudioUpload: vi.fn(),
+  createOnceVariantUpload: vi.fn(),
+  confirmOnceVariantUpload: vi.fn(),
+  retryAudioAsset: vi.fn(),
   listAudioAssets: vi.fn(),
   updateAudioAsset: vi.fn(),
   bulkTagAudioAssets: vi.fn(),
   deleteAudioAsset: vi.fn(),
 }));
 
+// Not in the wrapper's import graph at all (the server functions that would
+// call it are mocked above), so this assertion cannot fail today — which is
+// the point. It fails the day someone "helpfully" reports a rate-limit
+// rejection from the wrapper itself, which is the telemetry-amplification
+// mistake this phase exists to avoid: the rejection volume is the attacker's
+// parameter.
+vi.mock('~/server/utils/telemetry', () => ({
+  serverCaptureException: vi.fn(),
+  serverCaptureEvent: vi.fn(),
+}));
+
 import { getSession } from '~/server/session';
 import { User } from '~/server/db/models/User';
 import {
+  AudioClientError,
   createAudioUpload,
   confirmAudioUpload,
+  createOnceVariantUpload,
+  confirmOnceVariantUpload,
+  retryAudioAsset,
   listAudioAssets,
   updateAudioAsset,
   bulkTagAudioAssets,
   deleteAudioAsset,
 } from '~/server/functions/audio';
+import { serverCaptureException } from '~/server/utils/telemetry';
 import {
   createAudioUploadFn,
   confirmAudioUploadFn,
+  createOnceVariantUploadFn,
+  confirmOnceVariantUploadFn,
+  retryAudioAssetFn,
   listAudioAssetsFn,
   updateAudioAssetFn,
   bulkTagAudioAssetsFn,
@@ -262,6 +300,144 @@ describe('bulkTagAudioAssetsFn', () => {
       sessionUserId: SESSION_USER.id,
     });
     expect(r).toEqual({ modified: 2 });
+  });
+});
+
+/**
+ * The wrapper-layer rate limit (`audioIngestLimiter`, see
+ * `~/lib/audio-rate-limits.ts`).
+ *
+ * Every test here uses its OWN `DB_USER_ID`, because the limiter is a
+ * module-scope singleton with no reset hook — `vi.clearAllMocks()` cannot
+ * empty its buckets, and the bucket key IS the resolved Mongo `_id`. A shared
+ * id would make these tests order-dependent and would poison the pass-through
+ * tests above. A distinct id per test is a fresh, full bucket by construction.
+ *
+ * The `60` below is `audioIngestLimiter`'s capacity, written as a literal on
+ * purpose: raising it makes the "61st is refused" assertion fail, and lowering
+ * it makes the drain loop throw early. The number is pinned in both
+ * directions rather than read from the module under test.
+ */
+describe('ingest rate limit', () => {
+  const uploadData = {
+    filename: 'storm.wav',
+    contentType: 'audio/wav',
+    bytes: 1024,
+    kind: 'ambience' as const,
+    environment: [],
+    mood: [],
+    tags: [] as string[],
+  };
+
+  /** Spends the whole ingest bucket for `userId` via `createAudioUploadFn`. */
+  async function drainIngestBucket(userId: string) {
+    vi.mocked(getSession).mockResolvedValue(SESSION_USER);
+    mockDbUser(userId);
+    vi.mocked(createAudioUpload).mockResolvedValue({
+      assetId: 'a1',
+      uploadUrl: 'https://put',
+      key: 'k',
+    });
+    for (let i = 0; i < 60; i++) {
+      await createAudioUploadFn({ data: uploadData });
+    }
+    expect(createAudioUpload).toHaveBeenCalledTimes(60);
+    vi.mocked(createAudioUpload).mockClear();
+  }
+
+  it('lets a full 60-call burst through, then refuses the 61st without calling createAudioUpload', async () => {
+    await drainIngestBucket('mongo-ingest-create');
+
+    await expect(createAudioUploadFn({ data: uploadData })).rejects.toThrow(
+      /Too many upload requests/
+    );
+    // The gate is the ONLY reason this call failed: the underlying server
+    // function was never reached. Without this assertion the test would still
+    // pass with the limiter deleted, because something further down throws.
+    expect(createAudioUpload).not.toHaveBeenCalled();
+  });
+
+  it('refuses with AudioClientError carrying retryAfterMs, and files no GlitchTip event', async () => {
+    await drainIngestBucket('mongo-ingest-shape');
+
+    const err = await createAudioUploadFn({ data: uploadData }).catch((e: unknown) => e);
+    // `reportAudioError` excludes exactly this class from
+    // `serverCaptureException` — the class is the no-telemetry contract.
+    expect(err).toBeInstanceOf(AudioClientError);
+    expect((err as AudioClientError).retryAfterMs).toBeGreaterThan(0);
+    expect(serverCaptureException).not.toHaveBeenCalled();
+    expect(createAudioUpload).not.toHaveBeenCalled();
+  });
+
+  it('shares one bucket across confirmAudioUploadFn, so a drained bucket refuses a confirm too', async () => {
+    await drainIngestBucket('mongo-ingest-confirm');
+
+    await expect(confirmAudioUploadFn({ data: { assetId: 'a1' } })).rejects.toThrow(
+      /Too many upload requests/
+    );
+    expect(confirmAudioUpload).not.toHaveBeenCalled();
+    expect(serverCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('shares one bucket across createOnceVariantUploadFn, so a drained bucket refuses a once-variant presign too', async () => {
+    await drainIngestBucket('mongo-ingest-once-create');
+
+    await expect(
+      createOnceVariantUploadFn({
+        data: { assetId: 'a1', filename: 'once.wav', contentType: 'audio/wav', bytes: 1024 },
+      })
+    ).rejects.toThrow(/Too many upload requests/);
+    expect(createOnceVariantUpload).not.toHaveBeenCalled();
+    expect(serverCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('shares one bucket across confirmOnceVariantUploadFn, so a drained bucket refuses a once-variant confirm too', async () => {
+    await drainIngestBucket('mongo-ingest-once-confirm');
+
+    await expect(confirmOnceVariantUploadFn({ data: { assetId: 'a1' } })).rejects.toThrow(
+      /Too many upload requests/
+    );
+    expect(confirmOnceVariantUpload).not.toHaveBeenCalled();
+    expect(serverCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('shares one bucket with retryAudioAssetFn, so a drained bucket refuses a retry too', async () => {
+    await drainIngestBucket('mongo-ingest-retry');
+
+    // `retryAudioAsset` makes a `failed` row claimable again — the same act as
+    // a confirm, so it draws on the same bucket. Note the message says "retry"
+    // rather than "upload", which is why this asserts a different string.
+    await expect(retryAudioAssetFn({ data: { id: 'a1' } })).rejects.toThrow(
+      /Too many retry requests/
+    );
+    expect(retryAudioAsset).not.toHaveBeenCalled();
+    expect(serverCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('is keyed per account: draining one user does not refuse another', async () => {
+    await drainIngestBucket('mongo-ingest-victim');
+
+    mockDbUser('mongo-ingest-bystander');
+    vi.mocked(createAudioUpload).mockResolvedValue({
+      assetId: 'a2',
+      uploadUrl: 'https://put',
+      key: 'k',
+    });
+    await expect(createAudioUploadFn({ data: uploadData })).resolves.toEqual({
+      assetId: 'a2',
+      uploadUrl: 'https://put',
+      key: 'k',
+    });
+  });
+
+  it('does not gate reads: listAudioAssetsFn survives far past the ingest capacity', async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_USER);
+    mockDbUser('mongo-ingest-reader');
+    vi.mocked(listAudioAssets).mockResolvedValue({ items: [FAKE_ASSET], nextCursor: null });
+    for (let i = 0; i < 120; i++) {
+      await listAudioAssetsFn({ data: { limit: 50 } });
+    }
+    expect(listAudioAssets).toHaveBeenCalledTimes(120);
   });
 });
 

--- a/tests/utils/audio-server-fns.test.ts
+++ b/tests/utils/audio-server-fns.test.ts
@@ -19,6 +19,11 @@ vi.mock('@tanstack/react-start', () => ({
     inputValidator: () => ({
       handler: (fn: unknown) => fn,
     }),
+    // `getAudioStorageUsageFn` (Task 5) has no `.inputValidator()` call — it
+    // takes no input, same shape as `~/utils/soundboard-server-fns.ts`'s
+    // `listPackagesFn` — so `.handler()` must also be reachable directly off
+    // the builder, mirroring that file's own mock.
+    handler: (fn: unknown) => fn,
   }),
 }));
 
@@ -67,11 +72,16 @@ vi.mock('~/server/functions/audio', () => ({
   updateAudioAsset: vi.fn(),
   bulkTagAudioAssets: vi.fn(),
   deleteAudioAsset: vi.fn(),
+  getAudioUserQuotaBytes: vi.fn(),
 }));
 
 vi.mock('~/server/functions/audio-cleanup', () => ({
   scanOrphanAudio: vi.fn(),
   deleteOrphanAudio: vi.fn(),
+}));
+
+vi.mock('~/server/functions/audio-quota', () => ({
+  getUserStorageUsage: vi.fn(),
 }));
 
 // Not in the wrapper's import graph at all (the server functions that would
@@ -98,8 +108,10 @@ import {
   updateAudioAsset,
   bulkTagAudioAssets,
   deleteAudioAsset,
+  getAudioUserQuotaBytes,
 } from '~/server/functions/audio';
 import { scanOrphanAudio, deleteOrphanAudio } from '~/server/functions/audio-cleanup';
+import { getUserStorageUsage } from '~/server/functions/audio-quota';
 import { serverCaptureException } from '~/server/utils/telemetry';
 import {
   createAudioUploadFn,
@@ -113,6 +125,7 @@ import {
   updateAudioAssetFn,
   bulkTagAudioAssetsFn,
   deleteAudioAssetFn,
+  getAudioStorageUsageFn,
 } from '~/utils/audio-server-fns';
 
 const SESSION_USER = {
@@ -666,5 +679,45 @@ describe('deleteAudioAssetFn', () => {
       sessionUserId: SESSION_USER.id,
     });
     expect(r).toEqual({ deleted: true });
+  });
+});
+
+/**
+ * Task 5: `getAudioStorageUsageFn` takes no input, so it is called directly
+ * (`getAudioStorageUsageFn()`, no `{ data }` wrapper) — same shape as
+ * `listPackagesFn` in `~/utils/soundboard-server-fns.ts`.
+ */
+describe('getAudioStorageUsageFn', () => {
+  it('rejects with "Not authenticated" and never calls getUserStorageUsage when there is no session', async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    await expect(getAudioStorageUsageFn()).rejects.toThrow('Not authenticated');
+    expect(getUserStorageUsage).not.toHaveBeenCalled();
+  });
+
+  it('calls getUserStorageUsage with the resolved Mongo userId, and returns the limit alongside usage', async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_USER);
+    mockDbUser(DB_USER_ID);
+    vi.mocked(getUserStorageUsage).mockResolvedValue({ bytes: 512, assetCount: 3 });
+    vi.mocked(getAudioUserQuotaBytes).mockReturnValue(2 * 1024 * 1024 * 1024);
+
+    const r = await getAudioStorageUsageFn();
+
+    expect(getUserStorageUsage).toHaveBeenCalledTimes(1);
+    // The resolved Mongo `_id`, NOT the session's provider id — passing
+    // `SESSION_USER.id` here would cast-error against a real ObjectId query,
+    // the exact split-identity bug this repo's identity split exists to
+    // prevent.
+    expect(getUserStorageUsage).toHaveBeenCalledWith(DB_USER_ID);
+    // `limitBytes` comes from calling `getAudioUserQuotaBytes()` itself, not
+    // from a value baked into this test or the wrapper — proving the wrapper
+    // returns whatever the server-side quota function says, not a copy of it.
+    expect(r).toEqual({ bytes: 512, assetCount: 3, limitBytes: 2 * 1024 * 1024 * 1024 });
+  });
+
+  it('rejects with "User not found" and never calls getUserStorageUsage when the session has no matching User doc', async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_USER);
+    mockDbUser(null);
+    await expect(getAudioStorageUsageFn()).rejects.toThrow('User not found');
+    expect(getUserStorageUsage).not.toHaveBeenCalled();
   });
 });

--- a/tests/utils/format-bytes.test.ts
+++ b/tests/utils/format-bytes.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { formatBytes } from '~/utils/format-bytes';
+
+const MB = 1024 * 1024;
+const GB = 1024 * 1024 * 1024;
+
+describe('formatBytes', () => {
+  it('renders sub-KB values as whole bytes', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(1023)).toBe('1023 B');
+  });
+
+  it('renders the KB tier with 1 decimal', () => {
+    expect(formatBytes(1024)).toBe('1.0 KB');
+    expect(formatBytes(1536)).toBe('1.5 KB');
+    expect(formatBytes(MB - 1)).toBe('1024.0 KB');
+  });
+
+  it('renders the MB tier with 1 decimal', () => {
+    expect(formatBytes(MB)).toBe('1.0 MB');
+    expect(formatBytes(512 * MB)).toBe('512.0 MB');
+    expect(formatBytes(GB - 1)).toBe('1024.0 MB');
+  });
+
+  /**
+   * The GB tier is the whole point of B2's consolidation (see `~/utils/
+   * format-bytes.ts`'s doc comment): `AudioOrphanCleanup`'s pre-consolidation
+   * copy had no GB tier at all and would have rendered these as
+   * "1024.0 MB"/"2048.0 MB" instead.
+   */
+  it('renders the GB tier with 2 decimals', () => {
+    expect(formatBytes(GB)).toBe('1.00 GB');
+    expect(formatBytes(2 * GB)).toBe('2.00 GB');
+    expect(formatBytes(Math.round(1.5 * GB))).toBe('1.50 GB');
+  });
+});

--- a/tests/utils/soundboard-server-fns.test.ts
+++ b/tests/utils/soundboard-server-fns.test.ts
@@ -29,7 +29,22 @@ vi.mock('~/server/db/models/User', () => ({
   User: { findOne: vi.fn() },
 }));
 
+// `PackageClientError`/`SoundboardClientError` are real classes rather than
+// `vi.fn()`s because the wrappers' rate-limit gates construct one and the
+// tests below assert `instanceof` on what comes back — that `instanceof` is
+// the GlitchTip proof, since `reportPackageError`/`reportSoundboardError` in
+// the real modules exclude exactly these classes. They mirror the real
+// constructor signatures; `npm run typecheck` is what keeps the stand-ins from
+// drifting, because the wrappers are typechecked against the real modules.
 vi.mock('~/server/functions/packages', () => ({
+  PackageClientError: class PackageClientError extends Error {
+    readonly retryAfterMs?: number;
+    constructor(message: string, options?: { retryAfterMs?: number }) {
+      super(message);
+      this.name = 'PackageClientError';
+      this.retryAfterMs = options?.retryAfterMs;
+    }
+  },
   listPackages: vi.fn(),
   getPackage: vi.fn(),
   createPackage: vi.fn(),
@@ -40,13 +55,31 @@ vi.mock('~/server/functions/packages', () => ({
 }));
 
 vi.mock('~/server/functions/soundboard', () => ({
+  SoundboardClientError: class SoundboardClientError extends Error {
+    readonly retryAfterMs?: number;
+    constructor(message: string, options?: { retryAfterMs?: number }) {
+      super(message);
+      this.name = 'SoundboardClientError';
+      this.retryAfterMs = options?.retryAfterMs;
+    }
+  },
   loadBoardState: vi.fn(),
   saveBoardState: vi.fn(),
+}));
+
+// Not in the wrappers' import graph (the server functions that would call it
+// are mocked above), so this assertion cannot fail today — which is the
+// point. It fails the day someone reports a rate-limit rejection from the
+// wrapper itself, which would hand an attacker a telemetry-volume lever.
+vi.mock('~/server/utils/telemetry', () => ({
+  serverCaptureException: vi.fn(),
+  serverCaptureEvent: vi.fn(),
 }));
 
 import { getSession } from '~/server/session';
 import { User } from '~/server/db/models/User';
 import {
+  PackageClientError,
   listPackages,
   getPackage,
   createPackage,
@@ -55,7 +88,12 @@ import {
   clonePackage,
   listPackageAssets,
 } from '~/server/functions/packages';
-import { loadBoardState, saveBoardState } from '~/server/functions/soundboard';
+import {
+  SoundboardClientError,
+  loadBoardState,
+  saveBoardState,
+} from '~/server/functions/soundboard';
+import { serverCaptureException } from '~/server/utils/telemetry';
 import {
   listPackagesFn,
   getPackageFn,
@@ -326,6 +364,166 @@ describe('loadBoardStateFn', () => {
       sessionUserId: SESSION_USER.id,
     });
     expect(r).toEqual(FAKE_BOARD_STATE);
+  });
+});
+
+/**
+ * The wrapper-layer rate limits (`packageWriteLimiter` /`boardStateLimiter`,
+ * see `~/lib/audio-rate-limits.ts`).
+ *
+ * As in `tests/utils/audio-server-fns.test.ts`, every test uses its OWN
+ * `DB_USER_ID`: the limiters are module-scope singletons with no reset hook,
+ * `vi.clearAllMocks()` cannot empty their buckets, and the bucket key IS the
+ * resolved Mongo `_id`. A distinct id per test is a fresh, full bucket.
+ *
+ * The `15` and `40` below are the two capacities, written as literals on
+ * purpose: raising a capacity makes the "next call is refused" assertion
+ * fail, lowering it makes the drain loop throw early. Both directions pinned.
+ */
+describe('package-write rate limit', () => {
+  const createData = { name: 'Storm Set', items: [], moods: [] };
+
+  /** Spends the whole package-write bucket for `userId` via `createPackageFn`. */
+  async function drainPackageBucket(userId: string) {
+    vi.mocked(getSession).mockResolvedValue(SESSION_USER);
+    mockDbUser(userId);
+    vi.mocked(createPackage).mockResolvedValue(FAKE_PACKAGE);
+    for (let i = 0; i < 15; i++) {
+      await createPackageFn({ data: createData });
+    }
+    expect(createPackage).toHaveBeenCalledTimes(15);
+    vi.mocked(createPackage).mockClear();
+  }
+
+  it('lets a full 15-call burst through, then refuses the 16th without calling createPackage', async () => {
+    await drainPackageBucket('mongo-pkg-create');
+
+    await expect(createPackageFn({ data: createData })).rejects.toThrow(
+      /Too many sound package requests/
+    );
+    // Without this, the test would still pass with the gate deleted.
+    expect(createPackage).not.toHaveBeenCalled();
+  });
+
+  it('refuses with PackageClientError carrying retryAfterMs, and files no GlitchTip event', async () => {
+    await drainPackageBucket('mongo-pkg-shape');
+
+    const err = await createPackageFn({ data: createData }).catch((e: unknown) => e);
+    // `reportPackageError` excludes exactly this class from
+    // `serverCaptureException` — the class is the no-telemetry contract.
+    expect(err).toBeInstanceOf(PackageClientError);
+    expect((err as PackageClientError).retryAfterMs).toBeGreaterThan(0);
+    expect(serverCaptureException).not.toHaveBeenCalled();
+    expect(createPackage).not.toHaveBeenCalled();
+  });
+
+  it('shares one bucket with clonePackageFn, so a drained bucket refuses a clone too', async () => {
+    await drainPackageBucket('mongo-pkg-clone');
+
+    await expect(clonePackageFn({ data: { id: 'p1' } })).rejects.toThrow(
+      /Too many sound package requests/
+    );
+    expect(clonePackage).not.toHaveBeenCalled();
+    expect(serverCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('is keyed per account: draining one user does not refuse another', async () => {
+    await drainPackageBucket('mongo-pkg-victim');
+
+    mockDbUser('mongo-pkg-bystander');
+    vi.mocked(createPackage).mockResolvedValue(FAKE_PACKAGE);
+    await expect(createPackageFn({ data: createData })).resolves.toEqual(FAKE_PACKAGE);
+  });
+
+  it('does not gate updatePackageFn or deletePackageFn — neither can grow the footprint', async () => {
+    await drainPackageBucket('mongo-pkg-update-delete');
+
+    vi.mocked(updatePackage).mockResolvedValue(FAKE_PACKAGE);
+    vi.mocked(deletePackage).mockResolvedValue({ deleted: true });
+    await expect(updatePackageFn({ data: { id: 'p1', name: 'Renamed' } })).resolves.toEqual(
+      FAKE_PACKAGE
+    );
+    await expect(deletePackageFn({ data: { id: 'p1' } })).resolves.toEqual({ deleted: true });
+  });
+
+  it('does not gate reads: listPackagesFn/getPackageFn/listPackageAssetsFn survive past the capacity', async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_USER);
+    mockDbUser('mongo-pkg-reader');
+    vi.mocked(listPackages).mockResolvedValue({ items: [FAKE_PACKAGE_SUMMARY] });
+    vi.mocked(getPackage).mockResolvedValue(FAKE_PACKAGE);
+    vi.mocked(listPackageAssets).mockResolvedValue({ items: [] });
+    for (let i = 0; i < 40; i++) {
+      await listPackagesFn();
+      await getPackageFn({ data: { id: 'p1' } });
+      await listPackageAssetsFn({ data: { packageId: 'p1' } });
+    }
+    expect(listPackages).toHaveBeenCalledTimes(40);
+    expect(getPackage).toHaveBeenCalledTimes(40);
+    expect(listPackageAssets).toHaveBeenCalledTimes(40);
+  });
+});
+
+describe('board-save rate limit', () => {
+  const saveData = { campaignId: 'c1', items: [], masterVolume: 1 };
+
+  /** Spends the whole board-state bucket for `userId`. */
+  async function drainBoardBucket(userId: string) {
+    vi.mocked(getSession).mockResolvedValue(SESSION_USER);
+    mockDbUser(userId);
+    vi.mocked(saveBoardState).mockResolvedValue(FAKE_BOARD_STATE);
+    for (let i = 0; i < 40; i++) {
+      await saveBoardStateFn({ data: saveData });
+    }
+    expect(saveBoardState).toHaveBeenCalledTimes(40);
+    vi.mocked(saveBoardState).mockClear();
+  }
+
+  it('lets a full 40-call burst through, then refuses the 41st without calling saveBoardState', async () => {
+    await drainBoardBucket('mongo-board-save');
+
+    await expect(saveBoardStateFn({ data: saveData })).rejects.toThrow(
+      /Too many board save requests/
+    );
+    // Without this, the test would still pass with the gate deleted.
+    expect(saveBoardState).not.toHaveBeenCalled();
+  });
+
+  it('refuses with SoundboardClientError carrying retryAfterMs, and files no GlitchTip event', async () => {
+    await drainBoardBucket('mongo-board-shape');
+
+    const err = await saveBoardStateFn({ data: saveData }).catch((e: unknown) => e);
+    // `reportSoundboardError` excludes exactly this class from
+    // `serverCaptureException` — the class is the no-telemetry contract.
+    expect(err).toBeInstanceOf(SoundboardClientError);
+    expect((err as SoundboardClientError).retryAfterMs).toBeGreaterThan(0);
+    expect(serverCaptureException).not.toHaveBeenCalled();
+    expect(saveBoardState).not.toHaveBeenCalled();
+  });
+
+  it('is a separate bucket from the package writes: a drained board bucket still allows createPackage', async () => {
+    await drainBoardBucket('mongo-board-vs-package');
+
+    vi.mocked(createPackage).mockResolvedValue(FAKE_PACKAGE);
+    await expect(
+      createPackageFn({ data: { name: 'Storm Set', items: [], moods: [] } })
+    ).resolves.toEqual(FAKE_PACKAGE);
+  });
+
+  it('is keyed per account: draining one GM does not refuse another', async () => {
+    await drainBoardBucket('mongo-board-victim');
+
+    mockDbUser('mongo-board-bystander');
+    vi.mocked(saveBoardState).mockResolvedValue(FAKE_BOARD_STATE);
+    await expect(saveBoardStateFn({ data: saveData })).resolves.toEqual(FAKE_BOARD_STATE);
+  });
+
+  it('does not gate loadBoardStateFn — a board reload must not be refused', async () => {
+    await drainBoardBucket('mongo-board-reload');
+
+    vi.mocked(loadBoardState).mockResolvedValue(FAKE_BOARD_STATE);
+    await expect(loadBoardStateFn({ data: { campaignId: 'c1' } })).resolves.toEqual(
+      FAKE_BOARD_STATE
+    );
   });
 });
 

--- a/tests/utils/soundboard-server-fns.test.ts
+++ b/tests/utils/soundboard-server-fns.test.ts
@@ -438,7 +438,16 @@ describe('package-write rate limit', () => {
     await expect(createPackageFn({ data: createData })).resolves.toEqual(FAKE_PACKAGE);
   });
 
-  it('does not gate updatePackageFn or deletePackageFn — neither can grow the footprint', async () => {
+  /**
+   * Retitled in the final whole-branch review, which gave `updatePackageFn`
+   * its own bucket. What this still proves is bucket SEPARATION: a user who
+   * has exhausted their minting budget can still edit and delete the packages
+   * they already have. `deletePackageFn` is genuinely ungated (a `deleteOne`
+   * with no body to amplify, whose telemetry event only fires on a row that
+   * really existed); `updatePackageFn` is gated by `packageEditLimiter`
+   * instead, which the describe block below drains on its own.
+   */
+  it('is separate from the edit/delete path: a drained mint bucket still allows updatePackageFn and deletePackageFn', async () => {
     await drainPackageBucket('mongo-pkg-update-delete');
 
     vi.mocked(updatePackage).mockResolvedValue(FAKE_PACKAGE);
@@ -465,6 +474,97 @@ describe('package-write rate limit', () => {
     expect(listPackages).toHaveBeenCalledTimes(40);
     expect(getPackage).toHaveBeenCalledTimes(40);
     expect(listPackageAssets).toHaveBeenCalledTimes(40);
+  });
+});
+
+/**
+ * FINAL WHOLE-BRANCH REVIEW, Important #3. `updatePackageFn` was ungated on a
+ * justification that only covered footprint. The costs it did not cover: each
+ * call is a whole-document `$set` of `items` and `moods` (~410 KiB, the
+ * largest write on this surface, several hundred times a `saveBoardState` —
+ * which IS gated), and each success fires an un-awaited `package_updated`
+ * Umami event at caller-controlled volume. Task 7's fence bounds neither,
+ * because `PackageStaleWriteError` hands the caller the fresh
+ * `currentUpdatedAt` a replay needs.
+ *
+ * `30` is written as a literal for the same reason the other capacities are:
+ * raising it makes the refusal assertion fail, lowering it makes the drain
+ * loop throw early.
+ */
+describe('package-edit rate limit', () => {
+  const updateData = { id: 'p1', expectedUpdatedAt: '2026-01-01T00:00:00.000Z', name: 'Renamed' };
+
+  /** Spends the whole package-edit bucket for `userId`. */
+  async function drainEditBucket(userId: string) {
+    vi.mocked(getSession).mockResolvedValue(SESSION_USER);
+    mockDbUser(userId);
+    vi.mocked(updatePackage).mockResolvedValue(FAKE_PACKAGE);
+    for (let i = 0; i < 30; i++) {
+      await updatePackageFn({ data: updateData });
+    }
+    expect(updatePackage).toHaveBeenCalledTimes(30);
+    vi.mocked(updatePackage).mockClear();
+  }
+
+  it('lets a full 30-call burst through, then refuses the 31st without calling updatePackage', async () => {
+    await drainEditBucket('mongo-pkg-edit');
+
+    await expect(updatePackageFn({ data: updateData })).rejects.toThrow(
+      /Too many package edit requests/
+    );
+    // The load-bearing negative: without it this passes with the gate
+    // deleted, because nothing else here would throw.
+    expect(updatePackage).not.toHaveBeenCalled();
+  });
+
+  it('refuses with PackageClientError carrying retryAfterMs, and files no GlitchTip event', async () => {
+    await drainEditBucket('mongo-pkg-edit-shape');
+
+    const err = await updatePackageFn({ data: updateData }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(PackageClientError);
+    expect((err as PackageClientError).retryAfterMs).toBeGreaterThan(0);
+    // NOT the stale-write refusal: `PackageStaleWriteError` is a subclass, so
+    // an implementation that threw one here would still satisfy the
+    // `instanceof` above — but the editor keys its conflict UI off the NAME,
+    // and offering "keep my edits and overwrite" for a rate limit would just
+    // burn the caller's next token.
+    expect((err as Error).name).toBe('PackageClientError');
+    expect(serverCaptureException).not.toHaveBeenCalled();
+    expect(updatePackage).not.toHaveBeenCalled();
+  });
+
+  it('leaves room for a second consecutive save — the editor re-seeds its draft and a follow-up Save is legitimate', async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_USER);
+    mockDbUser('mongo-pkg-edit-twice');
+    vi.mocked(updatePackage).mockResolvedValue(FAKE_PACKAGE);
+
+    await expect(updatePackageFn({ data: updateData })).resolves.toEqual(FAKE_PACKAGE);
+    await expect(updatePackageFn({ data: updateData })).resolves.toEqual(FAKE_PACKAGE);
+    expect(updatePackage).toHaveBeenCalledTimes(2);
+  });
+
+  it('is keyed per account: draining one editor does not refuse another', async () => {
+    await drainEditBucket('mongo-pkg-edit-victim');
+
+    mockDbUser('mongo-pkg-edit-bystander');
+    vi.mocked(updatePackage).mockResolvedValue(FAKE_PACKAGE);
+    await expect(updatePackageFn({ data: updateData })).resolves.toEqual(FAKE_PACKAGE);
+  });
+
+  it('does not gate deletePackageFn: a drained edit bucket still allows a delete', async () => {
+    await drainEditBucket('mongo-pkg-edit-vs-delete');
+
+    vi.mocked(deletePackage).mockResolvedValue({ deleted: true });
+    await expect(deletePackageFn({ data: { id: 'p1' } })).resolves.toEqual({ deleted: true });
+  });
+
+  it('is a separate bucket from the package writes: a drained edit bucket still allows createPackage', async () => {
+    await drainEditBucket('mongo-pkg-edit-vs-create');
+
+    vi.mocked(createPackage).mockResolvedValue(FAKE_PACKAGE);
+    await expect(
+      createPackageFn({ data: { name: 'Storm Set', items: [], moods: [] } })
+    ).resolves.toEqual(FAKE_PACKAGE);
   });
 });
 

--- a/tests/utils/soundboard-server-fns.test.ts
+++ b/tests/utils/soundboard-server-fns.test.ts
@@ -248,7 +248,10 @@ describe('createPackageFn', () => {
 });
 
 describe('updatePackageFn', () => {
-  const data = { id: 'p1', name: 'Renamed' };
+  // `expectedUpdatedAt` is required by `updatePackageSchema` (Task 7's
+  // optimistic-concurrency precondition) — this wrapper passes `data` straight
+  // through, so it travels with everything else.
+  const data = { id: 'p1', expectedUpdatedAt: '2026-01-01T00:00:00.000Z', name: 'Renamed' };
 
   it('rejects with "Not authenticated" and never calls updatePackage when there is no session', async () => {
     vi.mocked(getSession).mockResolvedValue(null);
@@ -440,9 +443,11 @@ describe('package-write rate limit', () => {
 
     vi.mocked(updatePackage).mockResolvedValue(FAKE_PACKAGE);
     vi.mocked(deletePackage).mockResolvedValue({ deleted: true });
-    await expect(updatePackageFn({ data: { id: 'p1', name: 'Renamed' } })).resolves.toEqual(
-      FAKE_PACKAGE
-    );
+    await expect(
+      updatePackageFn({
+        data: { id: 'p1', expectedUpdatedAt: '2026-01-01T00:00:00.000Z', name: 'Renamed' },
+      })
+    ).resolves.toEqual(FAKE_PACKAGE);
     await expect(deletePackageFn({ data: { id: 'p1' } })).resolves.toEqual({ deleted: true });
   });
 


### PR DESCRIPTION
Closes the abuse surface on audio ingest and packages so phases 1 and 2a can be promoted to production. Ships no new user-facing feature except the storage-usage indicator; its definition of done is that promoting `dev` → `main` is no longer a knowingly bad idea.

**Design:** [`docs/specs/2026-07-31-audio-hardening-design.md`](docs/specs/2026-07-31-audio-hardening-design.md) · **Plan:** [`docs/specs/2026-07-31-audio-hardening-plan.md`](docs/specs/2026-07-31-audio-hardening-plan.md)

## Why now

`origin/main` contains no audio functions at all, so this promotion is the first time any of it reaches production — and therefore the last moment where adding controls costs only a plan. Registration is open, there are zero role checks on the ingest surface, and the transcode worker is a single replica with a global FIFO claim.

## What's in it

| Control | Where |
| --- | --- |
| Pure token-bucket rate limiter, injected clock, bounded key map | `app/lib/rate-limit.ts` |
| Applied at the server-fn wrapper layer, keyed on the Mongo `_id` | both `*-server-fns.ts` |
| Per-user storage quota, aggregated on demand, **fails closed** | `audio-quota.ts`, enforced in `audio.ts` |
| Usage visible before you hit it | `AudioQuotaBar` on `/audio` |
| Per-user cap on pending transcode jobs | `confirmAudioUpload` + 2 sibling doors |
| Optimistic concurrency on package writes | `packages.ts`, `PackageConflictNotice` |
| Bounded decoded-buffer cache (was unbounded, ~44 GB at the caps) | `soundboard/engine.ts` |
| Teardown aborts in-flight loads; no telemetry storm | `engine.ts`, `useSoundboard.ts` |
| Once-reaper identifies its attach; facet edits no longer reset its clock | `audio-worker/src/claim.ts` |
| Limits tunable without an image rebuild | `deploy/charts/cartyx/` |

## Beyond the plan — and why

The plan's File Structure table names **one** entry point per control; the codebase has several into each resource. Review found this **seven** times: a control landed exactly where its task said, and a sibling path stayed open.

| Control applied where the plan said | Sibling path found open |
| --- | --- |
| rate limits on ingest + packages | `deleteAudioAsset`, `updateAudioAsset` — unbounded GlitchTip levers behind a comment asserting they were safe |
| — | `scanOrphanAudio`/`deleteOrphanAudio` — per-call `serverCaptureEvent` + R2 `ListObjectsV2` |
| `onceSourceBytes` written on success | 3 of 4 `onceSourceKey` writers never reset it |
| quota in `createAudioUpload` | `createOnceVariantUpload` presigns through the same function |
| job cap in `confirmAudioUpload` | `confirmOnceVariantUpload`, `retryAudioAsset` |
| 5 not-found throws converted to `AudioClientError` | a 6th, same id-guessable class |
| **quota at presign** | **never at confirm — and bytes only become countable at confirm** |

The last one was found by the whole-branch review and is the most consequential: with shipped defaults and no concurrency, 30 presigns + 30 PUTs + 30 confirms took usage from 0 to ~3.8 GB against a 2 GiB quota, because every check read a number that could not include anything already presigned. The quota now runs at both confirms too, before `HeadObject`, with per-path refusal cleanup.

Two schema fields were added (`onceSourceBytes`, `onceUploadStartedAt`); both handle documents written before this branch via `$ifNull` / an `$or` fallback that is literally the old predicate, so **no migration is required**.

## Decisions worth a reviewer's attention

- **`AUDIO_USER_QUOTA_BYTES` defaults to 2 GiB** (~16 assets at ~126 MB each) and **`MAX_PENDING_JOBS_PER_USER` to 20**. Both are now chart values — tune without a rebuild.
- **Boundary is `>=` everywhere** — exactly at the limit is refused, matching `MAX_PACKAGES_PER_USER`.
- **A refusal never files a GlitchTip event.** The one deliberate exception is a quota-aggregation *failure*, which is a genuine server fault and is not attacker-inducible (`userId` is server-derived on both call paths).
- **Package concurrency uses `updatedAt`, not a version counter** — `{version: 0}` does not match a missing field, so a counter would have made every pre-existing package permanently unsaveable. This makes `updatedAt` load-bearing: every `AudioPackage` writer must stamp it, verified across all 8.
- **Unconfirmed-but-PUT bytes are invisible to the quota** for up to the upload timeout. The reaper deletes them and keeps ahead of the ingest rate, so it's transient — but the real ceiling is quota + in-flight, and that's now documented where an operator tuning the value will see it.
- **`no-floating-promises` was measured, not guessed**: 502 violations repo-wide, almost all deliberate fire-and-forget telemetry per the `void` convention. Scoped to one file instead.

## New CI check

`npm run check:client-bundle` runs after `npm run build` and asserts no server-only identifiers reach `.output/public`, with positive controls so it can't pass by searching the wrong place. It exists because a module-scope `process.env` read landed mid-branch that `build`, `typecheck`, `lint` and `test` all stayed green through — caught by `test:storybook`, which was never a valid detector for it. Notably `process.env` alone would **not** have caught it: Vite rewrites it to a shim, so the env-name string literals are the load-bearing needles.

## Testing

Full gate green, run directly rather than taken from reports:

`build` · `check:client-bundle` · `typecheck` · `lint` · `test` · `test:storybook` · `test:browser` · `render-tests.sh` · `audio-worker` · `realtime` · `playwright --workers=1` (105 passed, 11 skipped)

Every scoped-count test asserts the **actual filter argument**, since mocked mongoose returns whatever it was told. Engine tests run in a real browser against real Web Audio. The E2E seeds real fixtures and proves the seed matters — and because it runs on deliberately fake R2 credentials, asserting the refusal is also an assertion about *where* the check lives.

## Follow-ups (not blocking)

- Add a `{ownerId, status}` index — the job-cap count is now on three hot paths.
- Extract `checkOrThrow(limiter, key, action)`; the gate block is duplicated ten times.
- Add a test-only limiter reset — `packageWriteLimiter` (capacity 15) is a shared bucket that will bite a future test author confusingly.
- Phase 3: the REST adapter calls the server functions directly, bypassing the **rate limiter** (quota and job cap still apply). Unreachable today; phase 3 turns it on.
- Phase 3: those routes flatten refusals into a generic 500, dropping the structured usage/limit detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcUQ1mR5YFPUhGp3sbSD1q
